### PR TITLE
ensure memory is more than CPU for fargate on reindexer service

### DIFF
--- a/infrastructure/critical/locals.tf
+++ b/infrastructure/critical/locals.tf
@@ -15,6 +15,7 @@ locals {
 
     # Data science
     "arn:aws:iam::964279923020:role/datascience_ec2",
+
     "arn:aws:iam::964279923020:root",
   ]
 }

--- a/reindexer/terraform/reindex_worker/service.tf
+++ b/reindexer/terraform/reindex_worker/service.tf
@@ -10,7 +10,7 @@ module "service" {
   security_group_ids = ["${var.service_egress_security_group_id}"]
 
   cpu    = 1024
-  memory = 1024
+  memory = 2048
 
   env_vars = {
     reindex_jobs_queue_id     = "${module.reindex_worker_queue.id}"


### PR DESCRIPTION
as per
https://docs.aws.amazon.com/en_pv/AmazonECS/latest/developerguide/task-cpu-memory-error.html
