### PR TITLE
Tidy up some access status-related things

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessCondition.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessCondition.scala
@@ -15,3 +15,8 @@ case class AccessCondition(
 
   def hasRestrictions: Boolean = status.exists(_.hasRestrictions)
 }
+
+case object AccessCondition {
+  def apply(status: AccessStatus): AccessCondition =
+    AccessCondition(status = Some(status))
+}

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessStatus.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessStatus.scala
@@ -1,8 +1,10 @@
 package weco.catalogue.internal_model.locations
 
+import enumeratum.{Enum, EnumEntry}
+
 class UnknownAccessStatus(status: String) extends Exception(status)
 
-sealed trait AccessStatus { this: AccessStatus =>
+sealed trait AccessStatus extends EnumEntry { this: AccessStatus =>
 
   def name: String = this.getClass.getSimpleName.stripSuffix("$")
 
@@ -23,7 +25,12 @@ sealed trait AccessStatus { this: AccessStatus =>
   }
 }
 
-object AccessStatus {
+object AccessStatus extends Enum[License] {
+  val values = findValues
+  assert(
+    values.size == values.map { _.id }.toSet.size,
+    "IDs for AccessStatus are not unique!"
+  )
 
   // These types should reflect our collections access framework, as described in
   // Wellcome Collection's Access Policy.

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessStatus.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessStatus.scala
@@ -95,7 +95,8 @@ object AccessStatus {
       case lowerCaseStatus
           if lowerCaseStatus.startsWith(
             "missing",
-            "deaccessioned"
+            "deaccessioned",
+            "not available",
           ) =>
         Right(AccessStatus.Unavailable)
 
@@ -113,7 +114,10 @@ object AccessStatus {
             "permission required",
             "permission is required",
             "donor permission",
-            "permission must be obtained"
+            "permission must be obtained",
+            "apply for permission",
+            "only with permission",
+            "with prior permission",
           ) =>
         Right(AccessStatus.PermissionRequired)
 

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ItemsGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ItemsGenerators.scala
@@ -10,6 +10,7 @@ import weco.catalogue.internal_model.identifiers.{
   SourceIdentifier
 }
 import weco.catalogue.internal_model.locations.{
+  AccessCondition,
   AccessStatus,
   License,
   Location,
@@ -62,7 +63,7 @@ trait ItemsGenerators extends IdentifiersGenerators with LocationGenerators {
     createDigitalItemWith(
       locations = List(
         createDigitalLocationWith(accessConditions =
-          List(createAccessConditionWith(status = Some(accessStatus))))))
+          List(AccessCondition(status = accessStatus)))))
 
   def createDigitalItemWith(
     locations: List[Location]): Item[IdState.Unidentifiable.type] =

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ItemsGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/ItemsGenerators.scala
@@ -62,8 +62,8 @@ trait ItemsGenerators extends IdentifiersGenerators with LocationGenerators {
     accessStatus: AccessStatus): Item[IdState.Unidentifiable.type] =
     createDigitalItemWith(
       locations = List(
-        createDigitalLocationWith(accessConditions =
-          List(AccessCondition(status = accessStatus)))))
+        createDigitalLocationWith(
+          accessConditions = List(AccessCondition(status = accessStatus)))))
 
   def createDigitalItemWith(
     locations: List[Location]): Item[IdState.Unidentifiable.type] =

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/generators/LocationGenerators.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/generators/LocationGenerators.scala
@@ -55,12 +55,4 @@ trait LocationGenerators extends RandomGenerators {
     createDigitalLocationWith(
       locationType = LocationType.IIIFPresentationAPI
     )
-
-  def createAccessConditionWith(
-    status: Option[AccessStatus] = Some(AccessStatus.Open)
-  ): AccessCondition = AccessCondition(
-    status = status,
-    terms = None,
-    to = None
-  )
 }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
@@ -819,8 +819,7 @@ class PlatformMergerTest
                   url = "http://www.scope.org.uk",
                   locationType = LocationType.OnlineResource,
                   accessConditions = List(
-                    AccessCondition(
-                      status = Some(AccessStatus.LicensedResources))
+                    AccessCondition(status = AccessStatus.LicensedResources)
                   )
                 )
               )

--- a/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsDataTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsDataTest.scala
@@ -372,9 +372,7 @@ class MetsDataTest
     inside(result.right.get.data.items.head.locations.head) {
       case DigitalLocation(_, _, _, _, _, accessConditions) =>
         accessConditions shouldBe List(
-          AccessCondition(
-            status = Some(AccessStatus.OpenWithAdvisory)
-          )
+          AccessCondition(status = AccessStatus.OpenWithAdvisory)
         )
 
     }
@@ -455,9 +453,7 @@ class MetsDataTest
       case DigitalLocation(_, _, _, _, _, accessConditions) =>
         accessConditions shouldBe
           List(
-            AccessCondition(
-              status = Some(AccessStatus.Restricted)
-            )
+            AccessCondition(status = AccessStatus.Restricted)
           )
     }
   }

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLocation.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLocation.scala
@@ -40,9 +40,7 @@ trait MiroLocation extends MiroLicenses with MiroContributorCodes {
         )
       ),
       accessConditions = List(
-        AccessCondition(
-          status = Some(AccessStatus.Open)
-        )
+        AccessCondition(status = AccessStatus.Open)
       )
     )
 

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroImageDataTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroImageDataTest.scala
@@ -44,7 +44,7 @@ class MiroImageDataTest
             license = Some(License.CC0),
             credit = Some("Ezra Feilden"),
             accessConditions = List(
-              AccessCondition(status = Some(AccessStatus.Open))
+              AccessCondition(status = AccessStatus.Open)
             )
           ))
       )

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroItemsTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroItemsTest.scala
@@ -31,7 +31,7 @@ class MiroItemsTest
             license = Some(License.CC0),
             credit = Some("Ezra Feilden"),
             accessConditions = List(
-              AccessCondition(status = Some(AccessStatus.Open))
+              AccessCondition(status = AccessStatus.Open)
             )
           ))
         ))

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLocationTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLocationTest.scala
@@ -24,7 +24,7 @@ class MiroLocationTest
       license = Some(License.CC0),
       credit = Some("Ezra Feilden"),
       accessConditions = List(
-        AccessCondition(status = Some(AccessStatus.Open))
+        AccessCondition(status = AccessStatus.Open)
       )
     )
   }

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroRecordTransformerTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroRecordTransformerTest.scala
@@ -313,7 +313,7 @@ class MiroRecordTransformerTest
       credit = Some("Ezra Feilden"),
       locationType = LocationType.IIIFImageAPI,
       accessConditions = List(
-        AccessCondition(status = Some(AccessStatus.Open))
+        AccessCondition(status = AccessStatus.Open)
       )
     )
     work.data.items.head.locations shouldBe List(expectedDigitalLocation)
@@ -330,7 +330,7 @@ class MiroRecordTransformerTest
       license = Some(License.CCBY),
       credit = None,
       accessConditions = List(
-        AccessCondition(status = Some(AccessStatus.Open))
+        AccessCondition(status = AccessStatus.Open)
       )
     )
     work.data.items shouldBe List(

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraElectronicResources.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraElectronicResources.scala
@@ -95,7 +95,7 @@ object SierraElectronicResources extends SierraQueryOps with Logging {
             // See https://github.com/wellcomecollection/platform/issues/5062 for
             // more discussion and conversations about this.
             accessConditions = List(
-              AccessCondition(status = Some(LicensedResources))
+              AccessCondition(status = LicensedResources)
             )
           )
         )

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraElectronicResourcesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraElectronicResourcesTest.scala
@@ -39,7 +39,7 @@ class SierraElectronicResourcesTest
             url = "https://example.org/journal",
             locationType = OnlineResource,
             accessConditions = List(
-              AccessCondition(status = Some(LicensedResources))
+              AccessCondition(status = LicensedResources)
             )
           )
         )
@@ -73,7 +73,7 @@ class SierraElectronicResourcesTest
             url = "https://example.org/journal",
             locationType = OnlineResource,
             accessConditions = List(
-              AccessCondition(status = Some(LicensedResources))
+              AccessCondition(status = LicensedResources)
             )
           )
         )
@@ -85,7 +85,7 @@ class SierraElectronicResourcesTest
             url = "https://example.org/another-journal",
             locationType = OnlineResource,
             accessConditions = List(
-              AccessCondition(status = Some(LicensedResources))
+              AccessCondition(status = LicensedResources)
             )
           )
         )
@@ -118,7 +118,7 @@ class SierraElectronicResourcesTest
               url = "https://example.org/journal",
               locationType = OnlineResource,
               accessConditions = List(
-                AccessCondition(status = Some(LicensedResources))
+                AccessCondition(status = LicensedResources)
               )
             )
           )
@@ -161,7 +161,7 @@ class SierraElectronicResourcesTest
               linkText = Some("View online"),
               locationType = OnlineResource,
               accessConditions = List(
-                AccessCondition(status = Some(LicensedResources))
+                AccessCondition(status = LicensedResources)
               )
             )
           )
@@ -174,7 +174,7 @@ class SierraElectronicResourcesTest
               linkText = Some("Access resource"),
               locationType = OnlineResource,
               accessConditions = List(
-                AccessCondition(status = Some(LicensedResources))
+                AccessCondition(status = LicensedResources)
               )
             )
           )
@@ -187,7 +187,7 @@ class SierraElectronicResourcesTest
               linkText = Some("Connect to journal"),
               locationType = OnlineResource,
               accessConditions = List(
-                AccessCondition(status = Some(LicensedResources))
+                AccessCondition(status = LicensedResources)
               )
             )
           )
@@ -215,7 +215,7 @@ class SierraElectronicResourcesTest
               url = "https://example.org/oxford",
               locationType = OnlineResource,
               accessConditions = List(
-                AccessCondition(status = Some(LicensedResources))
+                AccessCondition(status = LicensedResources)
               )
             )
           )
@@ -243,7 +243,7 @@ class SierraElectronicResourcesTest
               linkText = Some("View resource"),
               locationType = OnlineResource,
               accessConditions = List(
-                AccessCondition(status = Some(LicensedResources))
+                AccessCondition(status = LicensedResources)
               )
             )
           )
@@ -271,7 +271,7 @@ class SierraElectronicResourcesTest
               linkText = Some("View resource"),
               locationType = OnlineResource,
               accessConditions = List(
-                AccessCondition(status = Some(LicensedResources))
+                AccessCondition(status = LicensedResources)
               )
             )
           )
@@ -299,7 +299,7 @@ class SierraElectronicResourcesTest
               linkText = Some("View resource"),
               locationType = OnlineResource,
               accessConditions = List(
-                AccessCondition(status = Some(LicensedResources))
+                AccessCondition(status = LicensedResources)
               )
             )
           )
@@ -329,7 +329,7 @@ class SierraElectronicResourcesTest
               linkText = Some("You can view this resource online"),
               locationType = OnlineResource,
               accessConditions = List(
-                AccessCondition(status = Some(LicensedResources))
+                AccessCondition(status = LicensedResources)
               )
             )
           )

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsTest.scala
@@ -108,9 +108,7 @@ class SierraHoldingsTest
               locationType = OnlineResource,
               linkText = Some("Connect to Example Journals"),
               accessConditions = List(
-                AccessCondition(
-                  status = Some(AccessStatus.LicensedResources)
-                )
+                AccessCondition(status = AccessStatus.LicensedResources)
               )
             )
           )
@@ -156,9 +154,7 @@ class SierraHoldingsTest
               locationType = OnlineResource,
               linkText = Some("Connect to Example Journals"),
               accessConditions = List(
-                AccessCondition(
-                  status = Some(AccessStatus.LicensedResources)
-                )
+                AccessCondition(status = AccessStatus.LicensedResources)
               )
             )
           ),
@@ -171,9 +167,7 @@ class SierraHoldingsTest
               url = "https://example.org/subscriptions",
               locationType = OnlineResource,
               accessConditions = List(
-                AccessCondition(
-                  status = Some(AccessStatus.LicensedResources)
-                )
+                AccessCondition(status = AccessStatus.LicensedResources)
               )
             )
           ),
@@ -225,9 +219,7 @@ class SierraHoldingsTest
               locationType = OnlineResource,
               linkText = Some("Connect to Example Journals"),
               accessConditions = List(
-                AccessCondition(
-                  status = Some(AccessStatus.LicensedResources)
-                )
+                AccessCondition(status = AccessStatus.LicensedResources)
               )
             )
           ),
@@ -240,9 +232,7 @@ class SierraHoldingsTest
               url = "https://example.org/subscriptions",
               locationType = OnlineResource,
               accessConditions = List(
-                AccessCondition(
-                  status = Some(AccessStatus.LicensedResources)
-                )
+                AccessCondition(status = AccessStatus.LicensedResources)
               )
             )
           ),

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocationTest.scala
@@ -197,7 +197,7 @@ class SierraLocationTest
         PhysicalLocation(
           locationType = locationType,
           label = label,
-          accessConditions = List(AccessCondition(Some(AccessStatus.Open)))
+          accessConditions = List(AccessCondition(status = AccessStatus.Open))
         )
       )
     }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
@@ -935,7 +935,7 @@ class SierraTransformerTest
             linkText = Some("View this journal"),
             locationType = OnlineResource,
             accessConditions = List(
-              AccessCondition(status = Some(LicensedResources))
+              AccessCondition(status = LicensedResources)
             )
           )
         )


### PR DESCRIPTION
I was going to do a more radical change here (hiding some useless access terms), but I've opted to send the list to #collections-info so it can be fixed at source.

This also brings in one half of the changes from https://github.com/wellcomecollection/catalogue-pipeline/pull/1577. I've confirmed that it doesn't affect the JSON serialisation of AccessStatus.