### PR TITLE
add ancestors fields and tests for how mappings should work

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -4,3 +4,4 @@ version = "2.0.0"
 align.openParenCallSite = false
 continuationIndent.defnSite = 2
 rewrite.rules = [SortImports]
+trailingCommas = preserve

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -4,4 +4,3 @@ version = "2.0.0"
 align.openParenCallSite = false
 continuationIndent.defnSite = 2
 rewrite.rules = [SortImports]
-trailingCommas = preserve

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/index/ImagesIndexConfig.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/index/ImagesIndexConfig.scala
@@ -42,8 +42,8 @@ object IndexedImageIndexConfig extends IndexConfig with IndexConfigFields {
         objectField("id").fields(canonicalId, sourceIdentifier),
         objectField("data").fields(
           objectField("otherIdentifiers").fields(lowercaseKeyword("value")),
-          multilingualKeywordField("title"),
-          multilingualKeywordField("alternativeTitles"),
+          multilingualFieldWithKeyword("title"),
+          multilingualFieldWithKeyword("alternativeTitles"),
           multilingualField("description"),
           englishTextKeywordField("physicalDescription"),
           multilingualField("lettering"),

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/index/IndexConfigFields.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/index/IndexConfigFields.scala
@@ -25,11 +25,12 @@ trait IndexConfigFields {
       .fields(
         List(
           textField("english").analyzer(englishAnalyzer.name),
-          textField("shingles").analyzer(shingleAsciifoldingAnalyzer.name)) ++
-          languagesTextFields,
+          textField("shingles").analyzer(shingleAsciifoldingAnalyzer.name)
+        ) ++
+          languagesTextFields
       )
 
-  def multilingualKeywordField(name: String) = textField(name).fields(
+  def multilingualFieldWithKeyword(name: String) = textField(name).fields(
     lowercaseKeyword("keyword"),
     // we don't care about the name, we just want to compose the fields parameter
     multilingualField("").fields: _*
@@ -40,7 +41,15 @@ trait IndexConfigFields {
 
   def asciifoldingTextFieldWithKeyword(name: String) =
     textField(name)
-      .fields(keywordField("keyword"))
+      .fields(
+        /**
+          * Having a keyword and lowercaseKeyword allows you to
+          * aggregate accurately on the field i.e. `ID123` does not become `id123`
+          * but also allows you to do keyword searches e.g. `id123` matches `ID123`
+          */
+        keywordField("keyword"),
+        lowercaseKeyword("lowercaseKeyword")
+      )
       .analyzer(asciifoldingAnalyzer.name)
 
   val label = asciifoldingTextFieldWithKeyword("label")

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/index/IndexConfigFieldsTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/index/IndexConfigFieldsTest.scala
@@ -1,0 +1,105 @@
+package uk.ac.wellcome.models.index
+
+import org.scalatest.concurrent.Eventually
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import uk.ac.wellcome.json.utils.JsonAssertions
+import uk.ac.wellcome.models.work.generators.WorkGenerators
+import weco.catalogue.internal_model.generators.ImageGenerators
+import uk.ac.wellcome.elasticsearch.IndexConfig
+import com.sksamuel.elastic4s.ElasticDsl._
+import com.sksamuel.elastic4s.requests.mappings.dynamictemplate.DynamicMapping
+import io.circe._, io.circe.generic.semiauto._, io.circe.syntax._
+import com.sksamuel.elastic4s._
+import com.sksamuel.elastic4s.requests.searches._
+
+case class TestDoc(label: String)
+object TestDoc {
+  implicit val fooDecoder: Decoder[TestDoc] = deriveDecoder
+  implicit val fooEncoder: Encoder[TestDoc] = deriveEncoder
+}
+
+object TestIndexConfig extends IndexConfig with IndexConfigFields {
+  val analysis = WorksAnalysis()
+  val mapping = properties(
+    label
+  ).dynamic(DynamicMapping.Strict)
+}
+
+class IndexConfigFieldsTest
+    extends AnyFunSpec
+    with IndexFixtures
+    with ScalaFutures
+    with Eventually
+    with Matchers
+    with JsonAssertions
+    with ScalaCheckPropertyChecks
+    with WorkGenerators
+    with ImageGenerators {
+
+  def indexDocs(index: Index, docs: TestDoc*) {
+    elasticClient.execute {
+      bulk(
+        docs.map(
+          doc =>
+            indexInto(index.name)
+              .doc(doc.asJson.noSpaces.toString)
+        )
+      ).refreshImmediately
+    }.await
+
+    getSizeOf(index) shouldBe docs.size
+  }
+
+  def expectResultsSize(req: SearchRequest, expectedSize: Int) = {
+    val res = elasticClient.execute(req).await
+    res.isInstanceOf[RequestSuccess[SearchResponse]] shouldBe true
+    res.result.hits.hits.toList.size shouldBe expectedSize
+  }
+
+  describe("label field") {
+    val doc1 = TestDoc("Arkaprakāśa Yōkai Amabié")
+    val doc2 = TestDoc("PM/RT/TYR")
+
+    it("text matches") {
+      withLocalIndex(TestIndexConfig) { index =>
+        indexDocs(index, doc1, doc2)
+        expectResultsSize(search(index).matchQuery("label", "Yōkai"), 1)
+      }
+    }
+
+    it("asciifolds lowercases") {
+      withLocalIndex(TestIndexConfig) { index =>
+        indexDocs(index, doc1, doc2)
+        expectResultsSize(
+          search(index).matchQuery("label", "arkaprakasa yokai"),
+          1
+        )
+      }
+    }
+
+    it("case sensitive keyword on `label.keyword`") {
+      withLocalIndex(TestIndexConfig) { index =>
+        indexDocs(index, doc1, doc2)
+        expectResultsSize(search(index).prefix("label.keyword", "PM/RT"), 1)
+        expectResultsSize(search(index).prefix("label.keyword", "pm/rt"), 0)
+      }
+    }
+
+    it("case insensitive keyword matches on `label.lowercaseKeyword`") {
+      withLocalIndex(TestIndexConfig) { index =>
+        indexDocs(index, doc1, doc2)
+        expectResultsSize(
+          search(index).prefix("label.lowercaseKeyword", "PM/RT"),
+          1
+        )
+        expectResultsSize(
+          search(index).prefix("label.lowercaseKeyword", "pm/rt"),
+          1
+        )
+      }
+    }
+  }
+}

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/index/IndexConfigFieldsTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/index/IndexConfigFieldsTest.scala
@@ -17,8 +17,8 @@ import com.sksamuel.elastic4s.requests.searches._
 
 case class TestDoc(label: String)
 object TestDoc {
-  implicit val fooDecoder: Decoder[TestDoc] = deriveDecoder
-  implicit val fooEncoder: Encoder[TestDoc] = deriveEncoder
+  implicit val testDocDecoder: Decoder[TestDoc] = deriveDecoder
+  implicit val testDocEncoder: Encoder[TestDoc] = deriveEncoder
 }
 
 object TestIndexConfig extends IndexConfig with IndexConfigFields {

--- a/project/metals.sbt
+++ b/project/metals.sbt
@@ -1,4 +1,4 @@
 // DO NOT EDIT! This file is auto-generated.
 // This file enables sbt-bloop to create bloop config files.
 
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.8")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.8-19-4d9f966b")

--- a/project/project/metals.sbt
+++ b/project/project/metals.sbt
@@ -1,4 +1,4 @@
 // DO NOT EDIT! This file is auto-generated.
 // This file enables sbt-bloop to create bloop config files.
 
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.8")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.8-19-4d9f966b")

--- a/project/project/project/metals.sbt
+++ b/project/project/project/metals.sbt
@@ -1,4 +1,4 @@
 // DO NOT EDIT! This file is auto-generated.
 // This file enables sbt-bloop to create bloop config files.
 
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.8")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.8-19-4d9f966b")


### PR DESCRIPTION
* Renames `multilingualKeywordField` => `multilingualFieldWithKeyword` as it was implying it was a `keyword` field
* Adds some tests to help explain what our abstracted index fields are for
* add lowercaseKeyword to allow us to search keywords as `VALUE` or `value` but not loose the ability to aggregate maintaining their case. The aggregation stuff will probably become redundant when we move to IDs for things, but is required for now
* Some bloopiness