### PR TITLE
Only use the shelfmark from 949 subfield $a; trim whitespace

### DIFF
--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraItemData.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/source/SierraItemData.scala
@@ -6,7 +6,6 @@ case class SierraItemData(
   deleted: Boolean = false,
   suppressed: Boolean = false,
   location: Option[SierraSourceLocation] = None,
-  callNumber: Option[String] = None,
   fixedFields: Map[String, FixedField] = Map(),
   varFields: List[VarField] = List()
 )

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItems.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItems.scala
@@ -64,7 +64,7 @@ object SierraItems extends Logging with SierraLocation with SierraQueryOps {
     val otherLocations =
       sierraItemDataMap
         .collect {
-          case (id, SierraItemData(_, _, Some(location), _, _, _)) =>
+          case (id, SierraItemData(_, _, Some(location), _, _)) =>
             id -> location
         }
         .filterNot {

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocation.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocation.scala
@@ -41,10 +41,7 @@ trait SierraLocation extends SierraQueryOps with Logging {
         locationType = locationType,
         accessConditions = getAccessConditions(bibNumber, bibData),
         label = label,
-        // This is meant to be a "good enough" implementation of a shelfmark.
-        // We may revisit this in future, and populate it directly from the
-        // MARC fields if we want to be more picky about our rules.
-        shelfmark = itemData.callNumber
+        shelfmark = SierraShelfmark(itemData)
       )
     } yield physicalLocation
 

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraShelfmark.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraShelfmark.scala
@@ -17,5 +17,5 @@ object SierraShelfmark extends SierraQueryOps {
       .filter { vf => vf.marcTag.contains("949") }
       .subfieldsWithTags("a")
       .headOption
-      .map { _.content }
+      .map { _.content.trim }
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraShelfmark.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraShelfmark.scala
@@ -1,0 +1,11 @@
+package uk.ac.wellcome.platform.transformer.sierra.transformers
+
+import uk.ac.wellcome.platform.transformer.sierra.source.SierraItemData
+
+object SierraShelfmark {
+  def apply(itemData: SierraItemData): Option[String] =
+    // This is meant to be a "good enough" implementation of a shelfmark.
+    // We may revisit this in future, and populate it directly from the
+    // MARC fields if we want to be more picky about our rules.
+    itemData.callNumber
+}

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraShelfmark.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraShelfmark.scala
@@ -1,11 +1,21 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
-import uk.ac.wellcome.platform.transformer.sierra.source.SierraItemData
+import uk.ac.wellcome.platform.transformer.sierra.source.{
+  SierraItemData,
+  SierraQueryOps
+}
 
-object SierraShelfmark {
+object SierraShelfmark extends SierraQueryOps {
   def apply(itemData: SierraItemData): Option[String] =
-    // This is meant to be a "good enough" implementation of a shelfmark.
-    // We may revisit this in future, and populate it directly from the
-    // MARC fields if we want to be more picky about our rules.
-    itemData.callNumber
+    // We use the contents of field 949 subfield ǂa for now.  We expect we'll
+    // gradually be pickier about whether we use this value, or whether we
+    // suppress it.
+    //
+    // We used to use the callNumber field on Sierra item records, but this
+    // draws from some MARC fields that we don't want (including 999).
+    itemData.varFields
+      .filter { vf => vf.marcTag.contains("949") }
+      .subfieldsWithTags("a")
+      .headOption
+      .map { _.content }
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraShelfmark.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraShelfmark.scala
@@ -14,7 +14,9 @@ object SierraShelfmark extends SierraQueryOps {
     // We used to use the callNumber field on Sierra item records, but this
     // draws from some MARC fields that we don't want (including 999).
     itemData.varFields
-      .filter { vf => vf.marcTag.contains("949") }
+      .filter { vf =>
+        vf.marcTag.contains("949")
+      }
       .subfieldsWithTags("a")
       .headOption
       .map { _.content.trim }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/generators/SierraDataGenerators.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/generators/SierraDataGenerators.scala
@@ -26,12 +26,10 @@ trait SierraDataGenerators extends IdentifiersGenerators with SierraGenerators {
 
   def createSierraItemDataWith(
     location: Option[SierraSourceLocation] = None,
-    callNumber: Option[String] = None,
     varFields: List[VarField] = Nil
   ): SierraItemData =
     SierraItemData(
       location = location,
-      callNumber = callNumber,
       varFields = varFields
     )
 

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocationTest.scala
@@ -8,7 +8,10 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{
   SierraItemData,
   VarField
 }
-import uk.ac.wellcome.platform.transformer.sierra.generators.SierraDataGenerators
+import uk.ac.wellcome.platform.transformer.sierra.generators.{
+  MarcGenerators,
+  SierraDataGenerators
+}
 import weco.catalogue.internal_model.locations.{
   AccessCondition,
   AccessStatus,
@@ -19,6 +22,7 @@ import weco.catalogue.internal_model.locations.{
 class SierraLocationTest
     extends AnyFunSpec
     with Matchers
+    with MarcGenerators
     with SierraDataGenerators {
 
   private val transformer = new SierraLocation {}
@@ -113,10 +117,17 @@ class SierraLocationTest
       )
     }
 
-    it("uses the callNumber as the shelfmark") {
+    it("uses 949 subfield ǂa as the shelfmark") {
       val itemData: SierraItemData = createSierraItemDataWith(
         location = Some(SierraSourceLocation("info", "Open shelves")),
-        callNumber = Some("AX1234:Box 1")
+        varFields = List(
+          createVarFieldWith(
+            marcTag = "949",
+            subfields = List(
+              MarcSubfield(tag = "a", content = "AX1234:Box 1")
+            )
+          )
+        )
       )
 
       val location =

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraShelfmarkTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraShelfmarkTest.scala
@@ -1,0 +1,49 @@
+package uk.ac.wellcome.platform.transformer.sierra.transformers
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.platform.transformer.sierra.generators.{
+  MarcGenerators,
+  SierraDataGenerators
+}
+import uk.ac.wellcome.platform.transformer.sierra.source.MarcSubfield
+
+class SierraShelfmarkTest extends AnyFunSpec with Matchers with MarcGenerators with SierraDataGenerators {
+  it("returns no shelfmark if there is no 949") {
+    val varFields = List()
+
+    val itemData = createSierraItemDataWith(varFields = varFields)
+
+    SierraShelfmark(itemData) shouldBe None
+  }
+
+  it("uses the contents of field 949 subfield ǂa") {
+    val varFields = List(
+      createVarFieldWith(
+        marcTag = "949",
+        subfields = List(
+          MarcSubfield(tag = "a", content = "S7956")
+        )
+      )
+    )
+
+    val itemData = createSierraItemDataWith(varFields = varFields)
+
+    SierraShelfmark(itemData) shouldBe Some("S7956")
+  }
+
+  it("ignores any other 949 subfields") {
+    val varFields = List(
+      createVarFieldWith(
+        marcTag = "949",
+        subfields = List(
+          MarcSubfield(tag = "d", content = "X42461")
+        )
+      )
+    )
+
+    val itemData = createSierraItemDataWith(varFields = varFields)
+
+    SierraShelfmark(itemData) shouldBe None
+  }
+}

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraShelfmarkTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraShelfmarkTest.scala
@@ -8,7 +8,11 @@ import uk.ac.wellcome.platform.transformer.sierra.generators.{
 }
 import uk.ac.wellcome.platform.transformer.sierra.source.MarcSubfield
 
-class SierraShelfmarkTest extends AnyFunSpec with Matchers with MarcGenerators with SierraDataGenerators {
+class SierraShelfmarkTest
+    extends AnyFunSpec
+    with Matchers
+    with MarcGenerators
+    with SierraDataGenerators {
   it("returns no shelfmark if there is no 949") {
     val varFields = List()
 

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraShelfmarkTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraShelfmarkTest.scala
@@ -32,6 +32,21 @@ class SierraShelfmarkTest extends AnyFunSpec with Matchers with MarcGenerators w
     SierraShelfmark(itemData) shouldBe Some("S7956")
   }
 
+  it("strips whitespace from shelfmarks") {
+    val varFields = List(
+      createVarFieldWith(
+        marcTag = "949",
+        subfields = List(
+          MarcSubfield(tag = "a", content = "/LEATHER            ")
+        )
+      )
+    )
+
+    val itemData = createSierraItemDataWith(varFields = varFields)
+
+    SierraShelfmark(itemData) shouldBe Some("/LEATHER")
+  }
+
   it("ignores any other 949 subfields") {
     val varFields = List(
       createVarFieldWith(


### PR DESCRIPTION
This is the first in what will likely be a series of improvements to the shelfmark data, tracked by https://github.com/wellcomecollection/platform/issues/5147

Two changes here:

- Previously we used the `callNumber` field from the Sierra API responses. This isn't quite right – e.g., it includes 999, which describes stuff like exhibition location – so now we're going to look at the MARC fields directly.
- Now we're trimming whitespace from the value. This prevents weirdness like [in fetp6ws5](https://api.wellcomecollection.org/catalogue/v2/works/fetp6ws5?include=items):

    ```
    {
      "id": "bx64hhbu",
      "locations": [
        {
          "locationType": {
            "id": "closed-stores",
            "label": "Closed stores",
            "type": "LocationType"
          },
          "label": "Closed stores",
          "shelfmark": "/LEATHER                                                                       ",
          //                                                              what's this doing over here ^^
          "accessConditions": [],
          "type": "PhysicalLocation"
        }
      ],
      "type": "Item"
    }
    ```