### PR TITLE
Bump the visibility timeout in a flaky merger test

### DIFF
--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
@@ -81,7 +81,7 @@ class MergerFeatureTest
 
     val workSender = new MemoryMessageSender
 
-    withLocalSqsQueuePair() {
+    withLocalSqsQueuePair(visibilityTimeout = 5) {
       case QueuePair(queue, dlq) =>
         withWorkerService(retriever, queue, workSender, index = index) { _ =>
           // 2) Now we update all four works at times t=1, t=2, t=3 and t=4.


### PR DESCRIPTION
The failure mode is pretty clear if you look at a failing test in CI:

    [package$] DEBUG created test resource=[SQS.Queue(url = http://localhost:9324/queue/o8eiq7-dlq, name = o8eiq7-dlq)]
    [package$] DEBUG created test resource=[SQS.Queue(url = http://localhost:9324/queue/o8eiq7, name = o8eiq7)]
    [Slf4jLogger] INFO  Slf4jLogger started
    [package$] DEBUG created test resource=[akka://default]
    [MergerFeatureTest] DEBUG Sending message to http://localhost:9324/queue/o8eiq7: {"Message":"{\"works\":[{\"identifiers\":[{\"identifier\":\"AAAAAAAA\",\"version\":48},{\"identifier\":\"BBBBBBBB\",\"version\":61},{\"identifier\":\"CCCCCCCC\",\"version\":19},{\"identifier\":\"DDDDDDDD\",\"version\":3}]}],\"createdTime\":\"1970-01-01T00:00:05Z\"}"}
    [PipelineStorageStream$] DEBUG Processing message 3c50ec9f-3b93-4b1d-8bcd-03c1f4b02592
    [PlatformMerger$] INFO  Attempting to merge target(id=sierra-system-number/lGuSJSklp2) with sources[(id=miro-image-number/nydXFRrrGR),(id=miro-image-number/0HxljKfA8t),(id=miro-image-number/xrZWz59aoI)]
    [PipelineStorageStream$] DEBUG Processing message 3c50ec9f-3b93-4b1d-8bcd-03c1f4b02592
    [PlatformMerger$] INFO  Attempting to merge target(id=sierra-system-number/lGuSJSklp2) with sources[(id=miro-image-number/nydXFRrrGR),(id=miro-image-number/0HxljKfA8t),(id=miro-image-number/xrZWz59aoI)]
    [SQSStream] DEBUG Deleting message 3c50ec9f-3b93-4b1d-8bcd-03c1f4b02592
    [PipelineStorageStream$] DEBUG Processing message 3c50ec9f-3b93-4b1d-8bcd-03c1f4b02592
    [PlatformMerger$] INFO  Attempting to merge target(id=sierra-system-number/lGuSJSklp2) with sources[(id=miro-image-number/nydXFRrrGR),(id=miro-image-number/0HxljKfA8t),(id=miro-image-number/xrZWz59aoI)]
    [SQSStream] DEBUG Deleting message 3c50ec9f-3b93-4b1d-8bcd-03c1f4b02592
    [package$] DEBUG cleaning up resource=[akka://default]
    [SQSStream] INFO  SQSStream finished processing with error: akka.stream.AbruptStageTerminationException: GraphStage [akka.stream.impl.fusing.GraphStages$IgnoreSink$$anon$10@108693f9] terminated abruptly, caused by for example materializer or actor system termination.
    [package$] DEBUG cleaning up resource=[SQS.Queue(url = http://localhost:9324/queue/o8eiq7, name = o8eiq7)]
    [package$] DEBUG cleaning up resource=[SQS.Queue(url = http://localhost:9324/queue/o8eiq7-dlq, name = o8eiq7-dlq)]

    [info] MergerFeatureTest:
    [info] - switches how a pair of works are matched *** FAILED ***
    [info]   The code passed to eventually never returned normally. Attempted 6 times over 16.02325075 seconds. Last failure message: Buffer(Message(MessageId=3c50ec9f-3b93-4b1d-8bcd-03c1f4b02592, ReceiptHandle=3c50ec9f-3b93-4b1d-8bcd-03c1f4b02592#fd0ee9b6-d791-4af3-bd01-11638c20c1c5, MD5OfBody=e270c9b760d728374e5e18097ea7b872, Body={"Message":"{\"works\":[{\"identifiers\":[{\"identifier\":\"AAAAAAAA\",\"version\":48},{\"identifier\":\"BBBBBBBB\",\"version\":61},{\"identifier\":\"CCCCCCCC\",\"version\":19},{\"identifier\":\"DDDDDDDD\",\"version\":3}]}],\"createdTime\":\"1970-01-01T00:00:05Z\"}"}, Attributes={}, MessageAttributes={})) was not empty Expected not to get any messages from http://localhost:9324/queue/o8eiq7-dlq, actually got Buffer(Message(MessageId=3c50ec9f-3b93-4b1d-8bcd-03c1f4b02592, ReceiptHandle=3c50ec9f-3b93-4b1d-8bcd-03c1f4b02592#fd0ee9b6-d791-4af3-bd01-11638c20c1c5, MD5OfBody=e270c9b760d728374e5e18097ea7b872, Body={"Message":"{\"works\":[{\"identifiers\":[{\"identifier\":\"AAAAAAAA\",\"version\":48},{\"identifier\":\"BBBBBBBB\",\"version\":61},{\"identifier\":\"CCCCCCCC\",\"version\":19},{\"identifier\":\"DDDDDDDD\",\"version\":3}]}],\"createdTime\":\"1970-01-01T00:00:05Z\"}"}, Attributes={}, MessageAttributes={})). (MergerFeatureTest.scala:125)

(From https://buildkite.com/wellcomecollection/catalogue-pipeline/builds/3888#a2842a91-1e15-47a0-98c0-e7c3810290fb)

The merger tries to process the same message three times -- so it isn't successfully processing it within the visibility timeout.  This means the message lands on the DLQ, and the test fails.  Bumping the visibility timeout should fix it.