### PR TITLE
Index all the fields on a SourceIdentifier

### DIFF
--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/index/IndexConfigFields.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/index/IndexConfigFields.scala
@@ -2,6 +2,7 @@ package uk.ac.wellcome.models.index
 
 import com.sksamuel.elastic4s.ElasticDsl._
 import WorksAnalysis._
+import com.sksamuel.elastic4s.requests.mappings.KeywordField
 
 /** Mixin for common fields used within an IndexConfig in our internal models.
   */
@@ -58,7 +59,14 @@ trait IndexConfigFields {
 
   val version = intField("version")
 
+  val sourceIdentifierFields: Seq[KeywordField] =
+    Seq(
+      keywordField("identifierType.id"),
+      keywordField("ontologyType"),
+      lowercaseKeyword("value")
+    )
+
   val sourceIdentifier = objectField("sourceIdentifier")
-    .fields(lowercaseKeyword("value"))
+    .fields(sourceIdentifierFields)
     .dynamic("false")
 }

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/index/WorksIndexConfig.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/index/WorksIndexConfig.scala
@@ -112,7 +112,7 @@ object IndexedWorkIndexConfig extends WorksIndexConfig {
         objectField("id").fields(
           canonicalId,
           sourceIdentifier,
-          objectField("otherIdentifiers").fields(lowercaseKeyword("value"))
+          objectField("otherIdentifiers").fields(sourceIdentifierFields)
         )
       ),
       objectField("production").fields(

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocation.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocation.scala
@@ -41,7 +41,7 @@ trait SierraLocation extends SierraQueryOps with Logging {
         locationType = locationType,
         accessConditions = getAccessConditions(bibNumber, bibData),
         label = label,
-        shelfmark = SierraShelfmark(itemData)
+        shelfmark = SierraShelfmark(bibData, itemData)
       )
     } yield physicalLocation
 

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraShelfmark.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraShelfmark.scala
@@ -1,23 +1,38 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
 import uk.ac.wellcome.platform.transformer.sierra.source.{
+  SierraBibData,
   SierraItemData,
+  SierraMaterialType,
   SierraQueryOps
 }
+import weco.catalogue.internal_model.work.Format.ArchivesAndManuscripts
 
 object SierraShelfmark extends SierraQueryOps {
-  def apply(itemData: SierraItemData): Option[String] =
-    // We use the contents of field 949 subfield ǂa for now.  We expect we'll
-    // gradually be pickier about whether we use this value, or whether we
-    // suppress it.
-    //
-    // We used to use the callNumber field on Sierra item records, but this
-    // draws from some MARC fields that we don't want (including 999).
-    itemData.varFields
-      .filter { vf =>
-        vf.marcTag.contains("949")
-      }
-      .subfieldsWithTags("a")
-      .headOption
-      .map { _.content.trim }
+  def apply(bibData: SierraBibData, itemData: SierraItemData): Option[String] =
+    bibData.materialType match {
+      // The shelfmarks for Archives & Manuscripts are a duplicate of the
+      // reference number and the box number, the latter of which we don't
+      // want to expose publicly.
+      //
+      // e.g. PP/ABC/D.2/3:Box 5
+      //
+      case Some(SierraMaterialType(ArchivesAndManuscripts.id)) =>
+        None
+
+      case _ =>
+        // We use the contents of field 949 subfield ǂa for now.  We expect we'll
+        // gradually be pickier about whether we use this value, or whether we
+        // suppress it.
+        //
+        // We used to use the callNumber field on Sierra item records, but this
+        // draws from some MARC fields that we don't want (including 999).
+        itemData.varFields
+          .filter { vf =>
+            vf.marcTag.contains("949")
+          }
+          .subfieldsWithTags("a")
+          .headOption
+          .map { _.content.trim }
+    }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraShelfmarkTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraShelfmarkTest.scala
@@ -72,7 +72,10 @@ class SierraShelfmarkTest
 
     getShelfmark(bibData, itemData) shouldBe Some("PP/BOW/P.1.2.3/10:Box 123,1")
 
-    getShelfmark(bibData.copy(materialType = Some(SierraMaterialType(ArchivesAndManuscripts.id))), itemData) shouldBe None
+    getShelfmark(
+      bibData.copy(
+        materialType = Some(SierraMaterialType(ArchivesAndManuscripts.id))),
+      itemData) shouldBe None
   }
 
   it("ignores any other 949 subfields") {

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraShelfmarkTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraShelfmarkTest.scala
@@ -6,7 +6,13 @@ import uk.ac.wellcome.platform.transformer.sierra.generators.{
   MarcGenerators,
   SierraDataGenerators
 }
-import uk.ac.wellcome.platform.transformer.sierra.source.MarcSubfield
+import uk.ac.wellcome.platform.transformer.sierra.source.{
+  MarcSubfield,
+  SierraBibData,
+  SierraItemData,
+  SierraMaterialType
+}
+import weco.catalogue.internal_model.work.Format.ArchivesAndManuscripts
 
 class SierraShelfmarkTest
     extends AnyFunSpec
@@ -18,7 +24,7 @@ class SierraShelfmarkTest
 
     val itemData = createSierraItemDataWith(varFields = varFields)
 
-    SierraShelfmark(itemData) shouldBe None
+    getShelfmark(itemData = itemData) shouldBe None
   }
 
   it("uses the contents of field 949 subfield ǂa") {
@@ -33,7 +39,7 @@ class SierraShelfmarkTest
 
     val itemData = createSierraItemDataWith(varFields = varFields)
 
-    SierraShelfmark(itemData) shouldBe Some("S7956")
+    getShelfmark(itemData = itemData) shouldBe Some("S7956")
   }
 
   it("strips whitespace from shelfmarks") {
@@ -48,7 +54,25 @@ class SierraShelfmarkTest
 
     val itemData = createSierraItemDataWith(varFields = varFields)
 
-    SierraShelfmark(itemData) shouldBe Some("/LEATHER")
+    getShelfmark(itemData = itemData) shouldBe Some("/LEATHER")
+  }
+
+  it("suppresses shelfmarks for Archives & Manuscripts") {
+    val varFields = List(
+      createVarFieldWith(
+        marcTag = "949",
+        subfields = List(
+          MarcSubfield(tag = "a", content = "PP/BOW/P.1.2.3/10:Box 123,1")
+        )
+      )
+    )
+
+    val bibData = createSierraBibData
+    val itemData = createSierraItemDataWith(varFields = varFields)
+
+    getShelfmark(bibData, itemData) shouldBe Some("PP/BOW/P.1.2.3/10:Box 123,1")
+
+    getShelfmark(bibData.copy(materialType = Some(SierraMaterialType(ArchivesAndManuscripts.id))), itemData) shouldBe None
   }
 
   it("ignores any other 949 subfields") {
@@ -63,6 +87,12 @@ class SierraShelfmarkTest
 
     val itemData = createSierraItemDataWith(varFields = varFields)
 
-    SierraShelfmark(itemData) shouldBe None
+    getShelfmark(itemData = itemData) shouldBe None
   }
+
+  private def getShelfmark(
+    bibData: SierraBibData = createSierraBibData,
+    itemData: SierraItemData
+  ): Option[String] =
+    SierraShelfmark(bibData, itemData)
 }


### PR DESCRIPTION
In the requesting service, we want to be able to find items with a specific SourceIdentifier.  We need to be able to match on all three fields, not just the value (which isn't guaranteed unique).

This patch changes the index config so we'll index all three fields, and will allow us to start querying against them.

For https://github.com/wellcomecollection/catalogue-api/issues/8