### PR TITLE
Track when a source record was updated, and when it was indexed

### DIFF
--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/index/WorksIndexConfig.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/index/WorksIndexConfig.scala
@@ -153,7 +153,9 @@ object IndexedWorkIndexConfig extends WorksIndexConfig {
     .fields(
       canonicalId,
       sourceIdentifier,
-      dateField("modifiedTime"),
+      dateField("sourceModifiedTime"),
+      dateField("mergedTime"),
+      dateField("indexedTime"),
       objectField("availabilities").fields(keywordField("id")),
       objectField("relations")
         .fields(

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Work.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Work.scala
@@ -152,7 +152,7 @@ object WorkState {
 
   case class Source(
     sourceIdentifier: SourceIdentifier,
-    modifiedTime: Instant
+    sourceModifiedTime: Instant
   ) extends WorkState {
 
     type WorkDataState = DataState.Unidentified
@@ -160,12 +160,14 @@ object WorkState {
 
     def id = sourceIdentifier.toString
     val relations = Relations.none
+
+    override val modifiedTime: Instant = sourceModifiedTime
   }
 
   case class Identified(
     sourceIdentifier: SourceIdentifier,
     canonicalId: CanonicalId,
-    modifiedTime: Instant,
+    sourceModifiedTime: Instant,
   ) extends WorkState {
 
     type WorkDataState = DataState.Identified
@@ -173,6 +175,8 @@ object WorkState {
 
     def id = canonicalId.toString
     val relations = Relations.none
+
+    override val modifiedTime: Instant = sourceModifiedTime
   }
 
   case class Merged(
@@ -275,7 +279,7 @@ object WorkFsm {
         sourceIdentifier = state.sourceIdentifier,
         canonicalId = state.canonicalId,
         mergedTime = mergedTime,
-        sourceModifiedTime = state.modifiedTime,
+        sourceModifiedTime = state.sourceModifiedTime,
         availabilities = Availabilities.forWorkData(data),
       )
 

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Work.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Work.scala
@@ -1,5 +1,6 @@
 package weco.catalogue.internal_model.work
 
+import io.circe.generic.extras.JsonKey
 import weco.catalogue.internal_model.identifiers.{
   CanonicalId,
   DataState,
@@ -152,7 +153,7 @@ object WorkState {
 
   case class Source(
     sourceIdentifier: SourceIdentifier,
-    sourceModifiedTime: Instant
+    @JsonKey("modifiedTime") sourceModifiedTime: Instant
   ) extends WorkState {
 
     type WorkDataState = DataState.Unidentified
@@ -167,7 +168,7 @@ object WorkState {
   case class Identified(
     sourceIdentifier: SourceIdentifier,
     canonicalId: CanonicalId,
-    sourceModifiedTime: Instant,
+    @JsonKey("modifiedTime") sourceModifiedTime: Instant,
   ) extends WorkState {
 
     type WorkDataState = DataState.Identified
@@ -182,7 +183,7 @@ object WorkState {
   case class Merged(
     sourceIdentifier: SourceIdentifier,
     canonicalId: CanonicalId,
-    mergedTime: Instant,
+    @JsonKey("modifiedTime") mergedTime: Instant,
     sourceModifiedTime: Instant,
     availabilities: Set[Availability] = Set.empty,
   ) extends WorkState {
@@ -201,7 +202,7 @@ object WorkState {
   case class Denormalised(
     sourceIdentifier: SourceIdentifier,
     canonicalId: CanonicalId,
-    mergedTime: Instant,
+    @JsonKey("modifiedTime") mergedTime: Instant,
     sourceModifiedTime: Instant,
     availabilities: Set[Availability],
     relations: Relations = Relations.none
@@ -233,7 +234,7 @@ object WorkState {
   case class Indexed(
     sourceIdentifier: SourceIdentifier,
     canonicalId: CanonicalId,
-    mergedTime: Instant,
+    @JsonKey("modifiedTime") mergedTime: Instant,
     sourceModifiedTime: Instant,
     indexedTime: Instant,
     availabilities: Set[Availability],

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Work.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Work.scala
@@ -1,6 +1,5 @@
 package weco.catalogue.internal_model.work
 
-import io.circe.generic.extras.JsonKey
 import weco.catalogue.internal_model.identifiers.{
   CanonicalId,
   DataState,
@@ -153,7 +152,7 @@ object WorkState {
 
   case class Source(
     sourceIdentifier: SourceIdentifier,
-    @JsonKey("modifiedTime") sourceModifiedTime: Instant
+    sourceModifiedTime: Instant
   ) extends WorkState {
 
     type WorkDataState = DataState.Unidentified
@@ -168,7 +167,7 @@ object WorkState {
   case class Identified(
     sourceIdentifier: SourceIdentifier,
     canonicalId: CanonicalId,
-    @JsonKey("modifiedTime") sourceModifiedTime: Instant,
+    sourceModifiedTime: Instant,
   ) extends WorkState {
 
     type WorkDataState = DataState.Identified
@@ -183,7 +182,7 @@ object WorkState {
   case class Merged(
     sourceIdentifier: SourceIdentifier,
     canonicalId: CanonicalId,
-    @JsonKey("modifiedTime") mergedTime: Instant,
+    mergedTime: Instant,
     sourceModifiedTime: Instant,
     availabilities: Set[Availability] = Set.empty,
   ) extends WorkState {
@@ -202,7 +201,7 @@ object WorkState {
   case class Denormalised(
     sourceIdentifier: SourceIdentifier,
     canonicalId: CanonicalId,
-    @JsonKey("modifiedTime") mergedTime: Instant,
+    mergedTime: Instant,
     sourceModifiedTime: Instant,
     availabilities: Set[Availability],
     relations: Relations = Relations.none
@@ -234,7 +233,7 @@ object WorkState {
   case class Indexed(
     sourceIdentifier: SourceIdentifier,
     canonicalId: CanonicalId,
-    @JsonKey("modifiedTime") mergedTime: Instant,
+    mergedTime: Instant,
     sourceModifiedTime: Instant,
     indexedTime: Instant,
     availabilities: Set[Availability],

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/index/WorksIndexConfigTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/index/WorksIndexConfigTest.scala
@@ -17,7 +17,11 @@ import uk.ac.wellcome.json.utils.JsonAssertions
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.models.work.generators.WorkGenerators
 import weco.catalogue.internal_model.generators.ImageGenerators
-import weco.catalogue.internal_model.identifiers.{CanonicalId, IdState, SourceIdentifier}
+import weco.catalogue.internal_model.identifiers.{
+  CanonicalId,
+  IdState,
+  SourceIdentifier
+}
 import weco.catalogue.internal_model.locations.{AccessCondition, AccessStatus}
 import weco.catalogue.internal_model.work._
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -44,7 +48,8 @@ class WorksIndexConfigTest
   // With IdentifiedWork, that means that it never actually completes.
   implicit val noShrinkSource = Shrink.shrinkAny[Work[WorkState.Source]]
   implicit val noShrinkMerged = Shrink.shrinkAny[Work[WorkState.Merged]]
-  implicit val noShrinkDenormalised = Shrink.shrinkAny[Work[WorkState.Denormalised]]
+  implicit val noShrinkDenormalised =
+    Shrink.shrinkAny[Work[WorkState.Denormalised]]
   implicit val noShrinkIdentified = Shrink.shrinkAny[Work[WorkState.Identified]]
   implicit val noShrinkIndexed = Shrink.shrinkAny[Work[WorkState.Indexed]]
 

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
@@ -47,7 +47,8 @@ trait WorkGenerators extends IdentifiersGenerators with InstantGenerators {
         canonicalId = canonicalId,
         mergedTime = modifiedTime,
         sourceModifiedTime = modifiedTime,
-        availabilities = Availabilities.forWorkData(data)),
+        availabilities = Availabilities.forWorkData(data)
+      ),
       data = data,
       version = createVersion
     )

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
@@ -27,10 +27,10 @@ trait WorkGenerators extends IdentifiersGenerators with InstantGenerators {
 
   def sourceWork(
     sourceIdentifier: SourceIdentifier = createSourceIdentifier,
-    modifiedTime: Instant = instantInLast30Days
+    sourceModifiedTime: Instant = instantInLast30Days
   ): Work.Visible[Source] =
     Work.Visible[Source](
-      state = Source(sourceIdentifier, modifiedTime),
+      state = Source(sourceIdentifier, sourceModifiedTime),
       data = initData,
       version = createVersion
     )
@@ -77,13 +77,13 @@ trait WorkGenerators extends IdentifiersGenerators with InstantGenerators {
   def identifiedWork(
     sourceIdentifier: SourceIdentifier = createSourceIdentifier,
     canonicalId: CanonicalId = createCanonicalId,
-    modifiedTime: Instant = instantInLast30Days,
+    sourceModifiedTime: Instant = instantInLast30Days,
   ): Work.Visible[Identified] =
     Work.Visible[Identified](
       state = Identified(
         sourceIdentifier = sourceIdentifier,
         canonicalId = canonicalId,
-        modifiedTime = modifiedTime,
+        sourceModifiedTime = sourceModifiedTime,
       ),
       data = initData,
       version = createVersion
@@ -92,7 +92,7 @@ trait WorkGenerators extends IdentifiersGenerators with InstantGenerators {
   def indexedWork(
     sourceIdentifier: SourceIdentifier = createSourceIdentifier,
     canonicalId: CanonicalId = createCanonicalId,
-    modifiedTime: Instant = instantInLast30Days,
+    mergedTime: Instant = instantInLast30Days,
     relations: Relations = Relations.none
   ): Work.Visible[Indexed] = {
     val data = initData[DataState.Identified]
@@ -100,8 +100,8 @@ trait WorkGenerators extends IdentifiersGenerators with InstantGenerators {
       state = Indexed(
         sourceIdentifier = sourceIdentifier,
         canonicalId = canonicalId,
-        mergedTime = modifiedTime,
-        sourceModifiedTime = modifiedTime,
+        mergedTime = mergedTime,
+        sourceModifiedTime = mergedTime,
         indexedTime = Instant.now(),
         availabilities = Availabilities.forWorkData(data),
         derivedData = DerivedWorkData(data),

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
@@ -43,9 +43,10 @@ trait WorkGenerators extends IdentifiersGenerators with InstantGenerators {
     val data = initData[DataState.Identified]
     Work.Visible[Merged](
       state = Merged(
-        sourceIdentifier,
-        canonicalId,
-        modifiedTime,
+        sourceIdentifier = sourceIdentifier,
+        canonicalId = canonicalId,
+        modifiedTime = modifiedTime,
+        sourceModifiedTime = modifiedTime,
         availabilities = Availabilities.forWorkData(data)),
       data = data,
       version = createVersion
@@ -64,6 +65,7 @@ trait WorkGenerators extends IdentifiersGenerators with InstantGenerators {
         sourceIdentifier = sourceIdentifier,
         canonicalId = canonicalId,
         modifiedTime = modifiedTime,
+        sourceModifiedTime = modifiedTime,
         availabilities = Availabilities.forWorkData(data),
         relations = relations
       ),
@@ -99,6 +101,8 @@ trait WorkGenerators extends IdentifiersGenerators with InstantGenerators {
         sourceIdentifier = sourceIdentifier,
         canonicalId = canonicalId,
         modifiedTime = modifiedTime,
+        sourceModifiedTime = modifiedTime,
+        indexedTime = Instant.now(),
         availabilities = Availabilities.forWorkData(data),
         derivedData = DerivedWorkData(data),
         relations = relations

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/work/generators/WorkGenerators.scala
@@ -45,7 +45,7 @@ trait WorkGenerators extends IdentifiersGenerators with InstantGenerators {
       state = Merged(
         sourceIdentifier = sourceIdentifier,
         canonicalId = canonicalId,
-        modifiedTime = modifiedTime,
+        mergedTime = modifiedTime,
         sourceModifiedTime = modifiedTime,
         availabilities = Availabilities.forWorkData(data)),
       data = data,
@@ -64,7 +64,7 @@ trait WorkGenerators extends IdentifiersGenerators with InstantGenerators {
       state = Denormalised(
         sourceIdentifier = sourceIdentifier,
         canonicalId = canonicalId,
-        modifiedTime = modifiedTime,
+        mergedTime = modifiedTime,
         sourceModifiedTime = modifiedTime,
         availabilities = Availabilities.forWorkData(data),
         relations = relations
@@ -100,7 +100,7 @@ trait WorkGenerators extends IdentifiersGenerators with InstantGenerators {
       state = Indexed(
         sourceIdentifier = sourceIdentifier,
         canonicalId = canonicalId,
-        modifiedTime = modifiedTime,
+        mergedTime = modifiedTime,
         sourceModifiedTime = modifiedTime,
         indexedTime = Instant.now(),
         availabilities = Availabilities.forWorkData(data),

--- a/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/WorkIndexableTest.scala
+++ b/common/pipeline_storage/src/test/scala/uk/ac/wellcome/pipeline_storage/WorkIndexableTest.scala
@@ -32,7 +32,7 @@ class WorkIndexableTest
 
       val newWork: Work.Visible[Identified] = originalWork.copy(
         state = originalWork.state.copy(
-          modifiedTime = originalWork.state.modifiedTime + (2 days)))
+          sourceModifiedTime = originalWork.state.sourceModifiedTime + (2 days)))
 
       withWorksIndexAndIndexer {
         case (index, indexer) =>
@@ -77,7 +77,7 @@ class WorkIndexableTest
 
       val olderWork: Work.Visible[Identified] = originalWork.copy(
         state = originalWork.state.copy(
-          modifiedTime = originalWork.state.modifiedTime - (2 days)))
+          sourceModifiedTime = originalWork.state.sourceModifiedTime - (2 days)))
 
       withWorksIndexAndIndexer {
         case (index, indexer) =>

--- a/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/IngestorFeatureTest.scala
+++ b/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/IngestorFeatureTest.scala
@@ -1,20 +1,21 @@
 package uk.ac.wellcome.platform.ingestor.works
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.elastic4s.Index
 import org.scalatest.funspec.AnyFunSpec
-import uk.ac.wellcome.models.index.IndexedWorkIndexConfig
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.json.utils.JsonAssertions
+import uk.ac.wellcome.messaging.fixtures.SQS.Queue
+import uk.ac.wellcome.models.Implicits._
+import uk.ac.wellcome.models.index.IndexedWorkIndexConfig
 import uk.ac.wellcome.models.work.generators.WorkGenerators
 import uk.ac.wellcome.pipeline_storage.ElasticIndexer
 import uk.ac.wellcome.pipeline_storage.Indexable.workIndexable
-import uk.ac.wellcome.models.Implicits._
-import weco.catalogue.internal_model.work.WorkState.{Denormalised, Indexed}
-import com.sksamuel.elastic4s.Index
-import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.pipeline_storage.elastic.ElasticSourceRetriever
 import weco.catalogue.internal_model.work.Work
+import weco.catalogue.internal_model.work.WorkState.{Denormalised, Indexed}
+
+import scala.concurrent.ExecutionContext.Implicits.global
 
 class IngestorFeatureTest
     extends AnyFunSpec
@@ -35,9 +36,7 @@ class IngestorFeatureTest
           withWorkIngestorWorkerService(queue, indexedIndex, denormalisedIndex) {
             _ =>
               sendNotificationToSQS(queue = queue, body = work.id)
-              assertElasticsearchEventuallyHasWork[Indexed](
-                indexedIndex,
-                WorkTransformer.deriveData(work))
+              assertWorkIndexed(indexedIndex, work)
           }
         }
       }
@@ -56,9 +55,7 @@ class IngestorFeatureTest
           withWorkIngestorWorkerService(queue, indexedIndex, denormalisedIndex) {
             _ =>
               sendNotificationToSQS(queue = queue, body = work.id)
-              assertElasticsearchEventuallyHasWork[Indexed](
-                indexedIndex,
-                WorkTransformer.deriveData(work))
+              assertWorkIndexed(indexedIndex, work)
           }
         }
       }

--- a/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/IngestorFixtures.scala
+++ b/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/IngestorFixtures.scala
@@ -28,7 +28,8 @@ trait IngestorFixtures
       .between(instant, Instant.now)
       .getSeconds should be <= recentSeconds.toLong
 
-  def assertWorkIndexed(index: Index, work: Work[WorkState.Denormalised]): Assertion =
+  def assertWorkIndexed(index: Index,
+                        work: Work[WorkState.Denormalised]): Assertion =
     eventually {
       val response: Response[GetResponse] = elasticClient.execute {
         get(index, work.state.canonicalId.toString)
@@ -38,7 +39,8 @@ trait IngestorFixtures
 
       getResponse.exists shouldBe true
 
-      val storedWork = fromJson[Work[WorkState.Indexed]](getResponse.sourceAsString).get
+      val storedWork =
+        fromJson[Work[WorkState.Indexed]](getResponse.sourceAsString).get
       val expectedWork = WorkTransformer.deriveData(work)
 
       storedWork.data shouldBe expectedWork.data

--- a/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/IngestorFixtures.scala
+++ b/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/IngestorFixtures.scala
@@ -1,19 +1,59 @@
 package uk.ac.wellcome.platform.ingestor.works
 
+import com.sksamuel.elastic4s.ElasticDsl._
+import com.sksamuel.elastic4s.{Index, Response}
+import com.sksamuel.elastic4s.requests.get.GetResponse
+
 import scala.concurrent.ExecutionContext.Implicits.global
-import org.scalatest.Suite
+import org.scalatest.{Assertion, Suite}
 import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
+import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.models.index.IndexFixtures
 import weco.catalogue.internal_model.work.WorkState.{Denormalised, Indexed}
 import uk.ac.wellcome.pipeline_storage.fixtures.PipelineStorageStreamFixtures
 import uk.ac.wellcome.pipeline_storage.{Indexer, Retriever}
-import weco.catalogue.internal_model.work.Work
+import weco.catalogue.internal_model.work.{Work, WorkState}
+
+import java.time.{Duration, Instant}
 
 trait IngestorFixtures
     extends IndexFixtures
     with PipelineStorageStreamFixtures {
   this: Suite =>
+
+  def assertRecent(instant: Instant, recentSeconds: Int = 1): Assertion =
+    Duration
+      .between(instant, Instant.now)
+      .getSeconds should be <= recentSeconds.toLong
+
+  def assertWorkIndexed(index: Index, work: Work[WorkState.Denormalised]): Assertion =
+    eventually {
+      val response: Response[GetResponse] = elasticClient.execute {
+        get(index, work.state.canonicalId.toString)
+      }.await
+
+      val getResponse = response.result
+
+      getResponse.exists shouldBe true
+
+      val storedWork = fromJson[Work[WorkState.Indexed]](getResponse.sourceAsString).get
+      val expectedWork = WorkTransformer.deriveData(work)
+
+      storedWork.data shouldBe expectedWork.data
+      storedWork.version shouldBe expectedWork.version
+
+      storedWork.state.sourceIdentifier shouldBe expectedWork.state.sourceIdentifier
+      storedWork.state.canonicalId shouldBe expectedWork.state.canonicalId
+      storedWork.state.mergedTime shouldBe expectedWork.state.mergedTime
+      storedWork.state.sourceModifiedTime shouldBe expectedWork.state.sourceModifiedTime
+      storedWork.state.availabilities shouldBe expectedWork.state.availabilities
+      storedWork.state.derivedData shouldBe expectedWork.state.derivedData
+      storedWork.state.relations shouldBe expectedWork.state.relations
+
+      assertRecent(storedWork.state.indexedTime)
+    }
 
   def withWorkerService[R](queue: Queue,
                            retriever: Retriever[Work[Denormalised]],
@@ -22,9 +62,9 @@ trait IngestorFixtures
     withPipelineStream(
       queue,
       indexer,
-      pipelineStorageConfig = pipelineStorageConfig) { msgStream =>
+      pipelineStorageConfig = pipelineStorageConfig) { pipelineStream =>
       val workerService = new WorkIngestorWorkerService(
-        pipelineStream = msgStream,
+        pipelineStream = pipelineStream,
         workRetriever = retriever
       )
 

--- a/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/IngestorWorkerServiceTest.scala
+++ b/pipeline/ingestor/ingestor_works/src/test/scala/uk/ac/wellcome/platform/ingestor/works/IngestorWorkerServiceTest.scala
@@ -138,9 +138,9 @@ class IngestorWorkerServiceTest
                 sendNotificationToSQS(queue = queue, body = work.id)
               }
 
-              assertElasticsearchEventuallyHasWork[Indexed](
-                index = indexedIndex,
-                works.map(WorkTransformer.deriveData): _*)
+              works.foreach {
+                assertWorkIndexed(indexedIndex, _)
+              }
 
               assertQueueEmpty(queue)
               assertQueueEmpty(dlq)

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
@@ -126,7 +126,7 @@ trait Merger extends MergerLogging {
       state = Identified(
         source.sourceIdentifier,
         source.state.canonicalId,
-        source.state.modifiedTime),
+        source.state.sourceModifiedTime),
       redirectTarget =
         IdState.Identified(target.state.canonicalId, target.sourceIdentifier)
     )

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
@@ -213,6 +213,6 @@ class MergerFeatureTest
   private def getModifiedTimes(
     index: mutable.Map[String, WorkOrImage]): Map[CanonicalId, Instant] =
     index.values.collect {
-      case Left(work) => work.state.canonicalId -> work.state.modifiedTime
+      case Left(work) => work.state.canonicalId -> work.state.mergedTime
     }.toMap
 }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
@@ -56,10 +56,10 @@ class MergerFeatureTest
     //
     //      D <--> C
     //
-    val workA_t0 = identifiedWork(canonicalId = idA, modifiedTime = time(t = 0))
-    val workB_t0 = identifiedWork(canonicalId = idB, modifiedTime = time(t = 0))
-    val workC_t0 = identifiedWork(canonicalId = idC, modifiedTime = time(t = 0))
-    val workD_t0 = identifiedWork(canonicalId = idD, modifiedTime = time(t = 0))
+    val workA_t0 = identifiedWork(canonicalId = idA, sourceModifiedTime = time(t = 0))
+    val workB_t0 = identifiedWork(canonicalId = idB, sourceModifiedTime = time(t = 0))
+    val workC_t0 = identifiedWork(canonicalId = idC, sourceModifiedTime = time(t = 0))
+    val workD_t0 = identifiedWork(canonicalId = idD, sourceModifiedTime = time(t = 0))
 
     val index = mutable.Map[String, WorkOrImage](
       idA.underlying -> Left(workA_t0.transition[Merged](time(t = 0))),
@@ -87,16 +87,16 @@ class MergerFeatureTest
           // However, due to best-effort ordering, we don't process these updates
           // in the correct order.
           val workA_t1 =
-            identifiedWork(canonicalId = idA, modifiedTime = time(t = 1))
+            identifiedWork(canonicalId = idA, sourceModifiedTime = time(t = 1))
               .title("I was updated at t = 1")
           val workB_t2 =
-            identifiedWork(canonicalId = idB, modifiedTime = time(t = 2))
+            identifiedWork(canonicalId = idB, sourceModifiedTime = time(t = 2))
               .title("I was updated at t = 2")
           val workC_t3 =
-            identifiedWork(canonicalId = idC, modifiedTime = time(t = 3))
+            identifiedWork(canonicalId = idC, sourceModifiedTime = time(t = 3))
               .title("I was updated at t = 3")
           val workD_t4 =
-            identifiedWork(canonicalId = idD, modifiedTime = time(t = 4))
+            identifiedWork(canonicalId = idD, sourceModifiedTime = time(t = 4))
               .title("I was updated at t = 4")
 
           // 3) Suppose the update to D gets processed by the matcher at

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerFeatureTest.scala
@@ -56,10 +56,14 @@ class MergerFeatureTest
     //
     //      D <--> C
     //
-    val workA_t0 = identifiedWork(canonicalId = idA, sourceModifiedTime = time(t = 0))
-    val workB_t0 = identifiedWork(canonicalId = idB, sourceModifiedTime = time(t = 0))
-    val workC_t0 = identifiedWork(canonicalId = idC, sourceModifiedTime = time(t = 0))
-    val workD_t0 = identifiedWork(canonicalId = idD, sourceModifiedTime = time(t = 0))
+    val workA_t0 =
+      identifiedWork(canonicalId = idA, sourceModifiedTime = time(t = 0))
+    val workB_t0 =
+      identifiedWork(canonicalId = idB, sourceModifiedTime = time(t = 0))
+    val workC_t0 =
+      identifiedWork(canonicalId = idC, sourceModifiedTime = time(t = 0))
+    val workD_t0 =
+      identifiedWork(canonicalId = idD, sourceModifiedTime = time(t = 0))
 
     val index = mutable.Map[String, WorkOrImage](
       idA.underlying -> Left(workA_t0.transition[Merged](time(t = 0))),

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerManagerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/MergerManagerTest.scala
@@ -64,7 +64,7 @@ class MergerManagerTest extends AnyFunSpec with Matchers with WorkGenerators {
           state = Identified(
             work.sourceIdentifier,
             work.state.canonicalId,
-            work.state.modifiedTime),
+            work.state.sourceModifiedTime),
           version = work.version,
           redirectTarget = IdState.Identified(
             works.head.state.canonicalId,

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
@@ -165,7 +165,7 @@ class PlatformMergerTest
         state = Merged(
           canonicalId = miroWork.state.canonicalId,
           sourceIdentifier = miroWork.sourceIdentifier,
-          modifiedTime = now
+          mergedTime = now
         ),
         version = miroWork.version,
         redirectTarget = IdState.Identified(
@@ -216,7 +216,7 @@ class PlatformMergerTest
         state = Merged(
           canonicalId = miroWork.state.canonicalId,
           sourceIdentifier = miroWork.sourceIdentifier,
-          modifiedTime = now),
+          mergedTime = now),
         version = miroWork.version,
         redirectTarget = IdState.Identified(
           canonicalId = zeroItemSierraWork.state.canonicalId,
@@ -276,7 +276,7 @@ class PlatformMergerTest
         state = Merged(
           canonicalId = miroWork.state.canonicalId,
           sourceIdentifier = miroWork.sourceIdentifier,
-          modifiedTime = now),
+          mergedTime = now),
         version = miroWork.version,
         redirectTarget = IdState.Identified(
           canonicalId = sierraDigitalWork.state.canonicalId,
@@ -322,7 +322,7 @@ class PlatformMergerTest
       state = Merged(
         canonicalId = miroWork.state.canonicalId,
         sourceIdentifier = miroWork.sourceIdentifier,
-        modifiedTime = now),
+        mergedTime = now),
       version = miroWork.version,
       redirectTarget = IdState.Identified(
         canonicalId = multipleItemsSierraWork.state.canonicalId,
@@ -360,7 +360,7 @@ class PlatformMergerTest
         state = Merged(
           canonicalId = metsWork.state.canonicalId,
           sourceIdentifier = metsWork.sourceIdentifier,
-          modifiedTime = now),
+          mergedTime = now),
         version = metsWork.version,
         redirectTarget = IdState.Identified(
           canonicalId = sierraPhysicalWork.state.canonicalId,
@@ -431,7 +431,7 @@ class PlatformMergerTest
         state = Merged(
           canonicalId = metsWork.state.canonicalId,
           sourceIdentifier = metsWork.sourceIdentifier,
-          modifiedTime = now),
+          mergedTime = now),
         version = metsWork.version,
         redirectTarget = IdState.Identified(
           canonicalId = sierraPictureWork.state.canonicalId,
@@ -497,7 +497,7 @@ class PlatformMergerTest
         state = Merged(
           canonicalId = sierraDigitisedWork.state.canonicalId,
           sourceIdentifier = sierraDigitisedWork.sourceIdentifier,
-          modifiedTime = now),
+          mergedTime = now),
         version = sierraDigitisedWork.version,
         redirectTarget = IdState.Identified(
           canonicalId = sierraPhysicalWork.state.canonicalId,
@@ -509,7 +509,7 @@ class PlatformMergerTest
         state = Merged(
           canonicalId = miroWork.state.canonicalId,
           sourceIdentifier = miroWork.sourceIdentifier,
-          modifiedTime = now),
+          mergedTime = now),
         version = miroWork.version,
         redirectTarget = IdState.Identified(
           canonicalId = sierraPhysicalWork.state.canonicalId,
@@ -521,7 +521,7 @@ class PlatformMergerTest
         state = Merged(
           canonicalId = metsWork.state.canonicalId,
           sourceIdentifier = metsWork.sourceIdentifier,
-          modifiedTime = now),
+          mergedTime = now),
         version = metsWork.version,
         redirectTarget = IdState.Identified(
           canonicalId = sierraPhysicalWork.state.canonicalId,
@@ -575,7 +575,7 @@ class PlatformMergerTest
         state = Merged(
           canonicalId = metsWork.state.canonicalId,
           sourceIdentifier = metsWork.sourceIdentifier,
-          modifiedTime = now),
+          mergedTime = now),
         version = metsWork.version,
         redirectTarget = IdState.Identified(
           canonicalId = multipleItemsSierraWork.state.canonicalId,
@@ -621,7 +621,7 @@ class PlatformMergerTest
         state = Merged(
           canonicalId = sierraDigitisedWork.state.canonicalId,
           sourceIdentifier = sierraDigitisedWork.sourceIdentifier,
-          modifiedTime = now),
+          mergedTime = now),
         version = sierraDigitisedWork.version,
         redirectTarget = IdState.Identified(
           canonicalId = multipleItemsSierraWork.state.canonicalId,
@@ -633,7 +633,7 @@ class PlatformMergerTest
         state = Merged(
           canonicalId = metsWork.state.canonicalId,
           sourceIdentifier = metsWork.sourceIdentifier,
-          modifiedTime = now),
+          mergedTime = now),
         version = metsWork.version,
         redirectTarget = IdState.Identified(
           canonicalId = multipleItemsSierraWork.state.canonicalId,

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
@@ -504,7 +504,8 @@ class PlatformMergerTest
           canonicalId = sierraDigitisedWork.state.canonicalId,
           sourceIdentifier = sierraDigitisedWork.sourceIdentifier,
           sourceModifiedTime = sierraDigitisedWork.state.sourceModifiedTime,
-          mergedTime = now),
+          mergedTime = now
+        ),
         version = sierraDigitisedWork.version,
         redirectTarget = IdState.Identified(
           canonicalId = sierraPhysicalWork.state.canonicalId,
@@ -632,7 +633,8 @@ class PlatformMergerTest
           canonicalId = sierraDigitisedWork.state.canonicalId,
           sourceIdentifier = sierraDigitisedWork.sourceIdentifier,
           sourceModifiedTime = sierraDigitisedWork.state.sourceModifiedTime,
-          mergedTime = now),
+          mergedTime = now
+        ),
         version = sierraDigitisedWork.version,
         redirectTarget = IdState.Identified(
           canonicalId = multipleItemsSierraWork.state.canonicalId,

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
@@ -165,6 +165,7 @@ class PlatformMergerTest
         state = Merged(
           canonicalId = miroWork.state.canonicalId,
           sourceIdentifier = miroWork.sourceIdentifier,
+          sourceModifiedTime = miroWork.state.sourceModifiedTime,
           mergedTime = now
         ),
         version = miroWork.version,
@@ -216,6 +217,7 @@ class PlatformMergerTest
         state = Merged(
           canonicalId = miroWork.state.canonicalId,
           sourceIdentifier = miroWork.sourceIdentifier,
+          sourceModifiedTime = miroWork.state.sourceModifiedTime,
           mergedTime = now),
         version = miroWork.version,
         redirectTarget = IdState.Identified(
@@ -276,6 +278,7 @@ class PlatformMergerTest
         state = Merged(
           canonicalId = miroWork.state.canonicalId,
           sourceIdentifier = miroWork.sourceIdentifier,
+          sourceModifiedTime = miroWork.state.sourceModifiedTime,
           mergedTime = now),
         version = miroWork.version,
         redirectTarget = IdState.Identified(
@@ -322,6 +325,7 @@ class PlatformMergerTest
       state = Merged(
         canonicalId = miroWork.state.canonicalId,
         sourceIdentifier = miroWork.sourceIdentifier,
+        sourceModifiedTime = miroWork.state.sourceModifiedTime,
         mergedTime = now),
       version = miroWork.version,
       redirectTarget = IdState.Identified(
@@ -360,6 +364,7 @@ class PlatformMergerTest
         state = Merged(
           canonicalId = metsWork.state.canonicalId,
           sourceIdentifier = metsWork.sourceIdentifier,
+          sourceModifiedTime = metsWork.state.sourceModifiedTime,
           mergedTime = now),
         version = metsWork.version,
         redirectTarget = IdState.Identified(
@@ -431,6 +436,7 @@ class PlatformMergerTest
         state = Merged(
           canonicalId = metsWork.state.canonicalId,
           sourceIdentifier = metsWork.sourceIdentifier,
+          sourceModifiedTime = metsWork.state.sourceModifiedTime,
           mergedTime = now),
         version = metsWork.version,
         redirectTarget = IdState.Identified(
@@ -497,6 +503,7 @@ class PlatformMergerTest
         state = Merged(
           canonicalId = sierraDigitisedWork.state.canonicalId,
           sourceIdentifier = sierraDigitisedWork.sourceIdentifier,
+          sourceModifiedTime = sierraDigitisedWork.state.sourceModifiedTime,
           mergedTime = now),
         version = sierraDigitisedWork.version,
         redirectTarget = IdState.Identified(
@@ -509,6 +516,7 @@ class PlatformMergerTest
         state = Merged(
           canonicalId = miroWork.state.canonicalId,
           sourceIdentifier = miroWork.sourceIdentifier,
+          sourceModifiedTime = miroWork.state.sourceModifiedTime,
           mergedTime = now),
         version = miroWork.version,
         redirectTarget = IdState.Identified(
@@ -521,6 +529,7 @@ class PlatformMergerTest
         state = Merged(
           canonicalId = metsWork.state.canonicalId,
           sourceIdentifier = metsWork.sourceIdentifier,
+          sourceModifiedTime = metsWork.state.sourceModifiedTime,
           mergedTime = now),
         version = metsWork.version,
         redirectTarget = IdState.Identified(
@@ -575,6 +584,7 @@ class PlatformMergerTest
         state = Merged(
           canonicalId = metsWork.state.canonicalId,
           sourceIdentifier = metsWork.sourceIdentifier,
+          sourceModifiedTime = metsWork.state.sourceModifiedTime,
           mergedTime = now),
         version = metsWork.version,
         redirectTarget = IdState.Identified(
@@ -621,6 +631,7 @@ class PlatformMergerTest
         state = Merged(
           canonicalId = sierraDigitisedWork.state.canonicalId,
           sourceIdentifier = sierraDigitisedWork.sourceIdentifier,
+          sourceModifiedTime = sierraDigitisedWork.state.sourceModifiedTime,
           mergedTime = now),
         version = sierraDigitisedWork.version,
         redirectTarget = IdState.Identified(
@@ -633,6 +644,7 @@ class PlatformMergerTest
         state = Merged(
           canonicalId = metsWork.state.canonicalId,
           sourceIdentifier = metsWork.sourceIdentifier,
+          sourceModifiedTime = metsWork.state.sourceModifiedTime,
           mergedTime = now),
         version = metsWork.version,
         redirectTarget = IdState.Identified(

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/MiroRecordTransformer.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/MiroRecordTransformer.scala
@@ -68,7 +68,7 @@ class MiroRecordTransformer
     val state = Source(
       sourceIdentifier = sourceIdentifier,
       // Miro records are static so we just send 0 as a last modification timestamp
-      modifiedTime = Instant.EPOCH
+      sourceModifiedTime = Instant.EPOCH
     )
 
     if (!miroMetadata.isClearedForCatalogueAPI) {

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroRecordTransformerTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroRecordTransformerTest.scala
@@ -378,7 +378,7 @@ class MiroRecordTransformerTest
         createMiroSourceIdentifierWith(
           value = miroRecord.imageNumber
         ),
-        modifiedTime = Instant.EPOCH
+        sourceModifiedTime = Instant.EPOCH
       ),
       version = 1,
       data = WorkData(),
@@ -404,7 +404,7 @@ class MiroRecordTransformerTest
         createMiroSourceIdentifierWith(
           value = miroRecord.imageNumber
         ),
-        modifiedTime = Instant.EPOCH
+        sourceModifiedTime = Instant.EPOCH
       ),
       version = 1,
       data = WorkData(),


### PR DESCRIPTION
We don't know how long it takes for an update in a source system to become visible in the pipeline.

I suspect it's slower than we'd like, but I don't really know. I think it's ~45 minutes for a Sierra update, but I have no real clue. I have some ideas we could try to make it faster, but that's purely speculative unless we can see the impact of our changes.

This PR updates the WorkState model to start tracking:

* When was a record modified in the source system? (`sourceModifiedTime`)
* When was the corresponding Work indexed into the API? (`indexedTime`)

in addition to the `modifiedTime`, which is actually when a Work went through the matcher/merger.

This will start to collect data about how long it takes for an update in a source system to appear in the API. I won't act on this immediately, but we can start collecting the data now to establish a baseline.

Some initial work for https://github.com/wellcomecollection/platform/issues/5149