### PR TITLE
Expose iconographic identifiers in the Miro data

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/IdentifierType.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/IdentifierType.scala
@@ -105,4 +105,9 @@ object IdentifierType extends Enum[IdentifierType] {
     val id = "wellcome-digcode"
     val label = "Wellcome digcode"
   }
+
+  case object IconographicNumber extends IdentifierType {
+    val id = "iconographic-number"
+    val label = "Iconographic number"
+  }
 }

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroIdentifiers.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroIdentifiers.scala
@@ -75,7 +75,9 @@ trait MiroIdentifiers extends MiroTransformableUtils {
           // Note that the "Iconographic Collection" identifiers have a lot of
           // other stuff which isn't an i-number, so we should be careful what
           // we put here.
-          case (Some(label), Some(value)) if label == "Iconographic Collection" && value.matches("^[0-9]+i$") =>
+          case (Some(label), Some(value))
+              if label == "Iconographic Collection" && value.matches(
+                "^[0-9]+i$") =>
             SourceIdentifier(
               identifierType = IdentifierType.IconographicNumber,
               ontologyType = "Work",

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroIdentifiers.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroIdentifiers.scala
@@ -64,14 +64,27 @@ trait MiroIdentifiers extends MiroTransformableUtils {
       case None => List()
     }
 
-    // Add any other legacy identifiers to this record.  Right now we
-    // put them all in the same identifier scheme, because we're not doing
-    // any transformation or cleaning.
     val libraryRefsList: List[SourceIdentifier] =
       zipMiroFields(
         keys = miroRecord.libraryRefDepartment,
         values = miroRecord.libraryRefId).distinct
         .collect {
+          // We have an identifier type for iconographic numbers (e.g. 577895i),
+          // so use that when possible.
+          //
+          // Note that the "Iconographic Collection" identifiers have a lot of
+          // other stuff which isn't an i-number, so we should be careful what
+          // we put here.
+          case (Some(label), Some(value)) if label == "Iconographic Collection" && value.matches("^[0-9]+i$") =>
+            SourceIdentifier(
+              identifierType = IdentifierType.IconographicNumber,
+              ontologyType = "Work",
+              value = value
+            )
+
+          // Put any other identifiers in one catch-all scheme until we come
+          // up with a better way to handle them.  We want them visible and
+          // searchable, but they're not worth spending more time on right now.
           case (Some(label), Some(value)) =>
             SourceIdentifier(
               identifierType = IdentifierType.MiroLibraryReference,

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroIdentifiersTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroIdentifiersTest.scala
@@ -50,5 +50,28 @@ class MiroIdentifiersTest
     )
   }
 
+  it("uses a distinct type for iconographic numbers, but only if they look like i-numbers") {
+    val miroRecord = createMiroRecordWith(
+      libraryRefDepartment = List(Some("Iconographic Collection"), Some("Iconographic Collection")),
+      libraryRefId = List(Some("590947i"), Some("974.1"))
+    )
+
+    val otherIdentifiers =
+      transformer.getOtherIdentifiers(miroRecord = miroRecord)
+
+    otherIdentifiers shouldBe List(
+      SourceIdentifier(
+        identifierType = IdentifierType.IconographicNumber,
+        ontologyType = "Work",
+        value = "590947i"
+      ),
+      SourceIdentifier(
+        identifierType = IdentifierType.MiroLibraryReference,
+        ontologyType = "Work",
+        value = "Iconographic Collection 974.1"
+      )
+    )
+  }
+
   val transformer = new MiroIdentifiers {}
 }

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroIdentifiersTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroIdentifiersTest.scala
@@ -50,9 +50,11 @@ class MiroIdentifiersTest
     )
   }
 
-  it("uses a distinct type for iconographic numbers, but only if they look like i-numbers") {
+  it(
+    "uses a distinct type for iconographic numbers, but only if they look like i-numbers") {
     val miroRecord = createMiroRecordWith(
-      libraryRefDepartment = List(Some("Iconographic Collection"), Some("Iconographic Collection")),
+      libraryRefDepartment =
+        List(Some("Iconographic Collection"), Some("Iconographic Collection")),
       libraryRefId = List(Some("590947i"), Some("974.1"))
     )
 


### PR DESCRIPTION
Part of https://github.com/wellcomecollection/platform/issues/5172

A quick refresher: the Miro data has a whole pile of identifiers from a variety of sources, which we put into the identifier type `wellcome-library-reference`. Some of these are i-numbers from the Iconographic Collection (e.g. `12345i`).

As part of the work to tidy up the shelfmarks, we're going to be moving those i-numbers in the Sierra data into the `identifiers` and `referencePath` fields. We can reuse this number for the Miro identifiers, which should make these numbers more searchable.