### PR TITLE
Use the iconographic number as a reference number, not a shelfmark

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/ReferenceNumber.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/ReferenceNumber.scala
@@ -2,6 +2,18 @@ package weco.catalogue.internal_model.identifiers
 
 import io.circe.{Decoder, Encoder, HCursor, Json}
 
+/** A reference number is a special type of identifier.
+  *
+  *     when [the identifier is] the reference we have written on the actual item, they
+  *     should be the referenceNumber
+
+  *     Ie there is a number written in pencil on the old piece of paper and it is XXXXX -
+  *     that's the reference number, as it's what people will see when they have the
+  *     object in their hands
+  *
+  * See https://wellcome.slack.com/archives/C294K7D5M/p1620733997159000 for more
+  *
+  */
 class ReferenceNumber(val underlying: String) {
   override def toString: String = underlying
 

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/ReferenceNumber.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/ReferenceNumber.scala
@@ -1,0 +1,35 @@
+package weco.catalogue.internal_model.identifiers
+
+import io.circe.{Decoder, Encoder, HCursor, Json}
+
+class ReferenceNumber(val underlying: String) {
+  override def toString: String = underlying
+
+  // Normally we use case classes for immutable data, which provide these
+  // methods for us.
+  //
+  // We deliberately don't use case classes here so we skip automatic
+  // case class derivation for JSON encoding/DynamoDB in Scanamo,
+  // and force callers to intentionally import the implicits below.
+  def canEqual(a: Any): Boolean = a.isInstanceOf[ReferenceNumber]
+
+  override def equals(that: Any): Boolean =
+    that match {
+      case that: ReferenceNumber =>
+        that.canEqual(this) && this.underlying == that.underlying
+      case _ => false
+    }
+
+  override def hashCode: Int = underlying.hashCode
+}
+
+object ReferenceNumber {
+  def apply(underlying: String): ReferenceNumber =
+    new ReferenceNumber(underlying)
+
+  implicit val encoder: Encoder[ReferenceNumber] =
+    (value: ReferenceNumber) => Json.fromString(value.toString)
+
+  implicit val decoder: Decoder[ReferenceNumber] = (cursor: HCursor) =>
+    cursor.value.as[String].map(ReferenceNumber(_))
+}

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Work.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Work.scala
@@ -4,6 +4,7 @@ import weco.catalogue.internal_model.identifiers.{
   CanonicalId,
   DataState,
   IdState,
+  ReferenceNumber,
   SourceIdentifier
 }
 import weco.catalogue.internal_model.image.ImageData
@@ -107,9 +108,23 @@ case class WorkData[State <: DataState](
   items: List[Item[State#MaybeId]] = Nil,
   holdings: List[Holdings] = Nil,
   collectionPath: Option[CollectionPath] = None,
+  referenceNumber: Option[ReferenceNumber] = None,
   imageData: List[ImageData[State#Id]] = Nil,
   workType: WorkType = WorkType.Standard,
-)
+) {
+
+  // We have separate fields for collectionPath and referenceNumber so we
+  // can set a referenceNumber which isn't part of a collection.
+  // (e.g. an Iconographic number on Sierra records.)
+  //
+  // If a collectionPath is set, we should always require a referenceNumber
+  // to be set, based on its value.
+  collectionPath match {
+    case Some(CollectionPath(_, Some(label))) =>
+      require(referenceNumber.contains(ReferenceNumber(label)))
+    case _ => ()
+  }
+}
 
 /** WorkState represents the state of the work in the pipeline, and contains
   * different data depending on what state it is. This allows us to consider the

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Work.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Work.scala
@@ -111,20 +111,7 @@ case class WorkData[State <: DataState](
   referenceNumber: Option[ReferenceNumber] = None,
   imageData: List[ImageData[State#Id]] = Nil,
   workType: WorkType = WorkType.Standard,
-) {
-
-  // We have separate fields for collectionPath and referenceNumber so we
-  // can set a referenceNumber which isn't part of a collection.
-  // (e.g. an Iconographic number on Sierra records.)
-  //
-  // If a collectionPath is set, we should always require a referenceNumber
-  // to be set, based on its value.
-  collectionPath match {
-    case Some(CollectionPath(_, Some(label))) =>
-      require(referenceNumber.contains(ReferenceNumber(label)))
-    case _ => ()
-  }
-}
+)
 
 /** WorkState represents the state of the work in the pipeline, and contains
   * different data depending on what state it is. This allows us to consider the

--- a/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformer.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformer.scala
@@ -20,6 +20,7 @@ import weco.catalogue.internal_model.identifiers.{
   DataState,
   IdState,
   IdentifierType,
+  ReferenceNumber,
   SourceIdentifier
 }
 import weco.catalogue.internal_model.locations.UnknownAccessStatus
@@ -158,6 +159,7 @@ object CalmTransformer
         otherIdentifiers = otherIdentifiers(record),
         format = Some(Format.ArchivesAndManuscripts),
         collectionPath = Some(collectionPath),
+        referenceNumber = collectionPath.label.map(ReferenceNumber(_)),
         subjects = subjects(record),
         languages = languages,
         mergeCandidates = mergeCandidates(record),

--- a/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformerTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/CalmTransformerTest.scala
@@ -49,6 +49,7 @@ class CalmTransformerTest
               label = Some("a.b.c")
             )
           ),
+          referenceNumber = Some(ReferenceNumber("a.b.c")),
           otherIdentifiers = List(
             SourceIdentifier(
               value = "a/b/c",

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformer.scala
@@ -96,21 +96,9 @@ class SierraTransformer(sierraTransformable: SierraTransformable, version: Int)
       }
   }
 
-  def workDataFromBibData(bibId: SierraBibNumber, bibData: SierraBibData) = {
-    val iconographicNumber = SierraIconographicNumber(bibData)
-
-    val iconographicIdentifier =
-      List(iconographicNumber)
-        .collect { case Some(value) =>
-          SourceIdentifier(
-            identifierType = IdentifierType.IconographicNumber,
-            ontologyType = "Work",
-            value = value
-          )
-        }
-
+  def workDataFromBibData(bibId: SierraBibNumber, bibData: SierraBibData) =
     WorkData[DataState.Unidentified](
-      otherIdentifiers = SierraIdentifiers(bibId, bibData) ++ iconographicIdentifier,
+      otherIdentifiers = SierraIdentifiers(bibId, bibData),
       mergeCandidates = SierraMergeCandidates(bibId, bibData),
       title = SierraTitle(bibData),
       alternativeTitles = SierraAlternativeTitles(bibData),
@@ -131,9 +119,8 @@ class SierraTransformer(sierraTransformable: SierraTransformable, version: Int)
           SierraItems(bibId, bibData, itemDataMap) ++
           SierraElectronicResources(bibId, varFields = bibData.varFields),
       holdings = SierraHoldings(bibId, holdingsDataMap),
-      referenceNumber = iconographicNumber.map { ReferenceNumber(_) }
+      referenceNumber = SierraReferenceNumber(bibData)
     )
-  }
 
   lazy val bibId = sierraTransformable.sierraId
 

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformer.scala
@@ -96,9 +96,21 @@ class SierraTransformer(sierraTransformable: SierraTransformable, version: Int)
       }
   }
 
-  def workDataFromBibData(bibId: SierraBibNumber, bibData: SierraBibData) =
+  def workDataFromBibData(bibId: SierraBibNumber, bibData: SierraBibData) = {
+    val iconographicNumber = SierraIconographicNumber(bibData)
+
+    val iconographicIdentifier =
+      List(iconographicNumber)
+        .collect { case Some(value) =>
+          SourceIdentifier(
+            identifierType = IdentifierType.IconographicNumber,
+            ontologyType = "Work",
+            value = value
+          )
+        }
+
     WorkData[DataState.Unidentified](
-      otherIdentifiers = SierraIdentifiers(bibId, bibData),
+      otherIdentifiers = SierraIdentifiers(bibId, bibData) ++ iconographicIdentifier,
       mergeCandidates = SierraMergeCandidates(bibId, bibData),
       title = SierraTitle(bibData),
       alternativeTitles = SierraAlternativeTitles(bibData),
@@ -118,8 +130,10 @@ class SierraTransformer(sierraTransformable: SierraTransformable, version: Int)
         SierraItemsOnOrder(bibId, hasItems = hasItems, orderDataMap) ++
           SierraItems(bibId, bibData, itemDataMap) ++
           SierraElectronicResources(bibId, varFields = bibData.varFields),
-      holdings = SierraHoldings(bibId, holdingsDataMap)
+      holdings = SierraHoldings(bibId, holdingsDataMap),
+      referenceNumber = iconographicNumber.map { ReferenceNumber(_) }
     )
+  }
 
   lazy val bibId = sierraTransformable.sierraId
 

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIconographicNumber.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIconographicNumber.scala
@@ -6,7 +6,9 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{
   SierraQueryOps
 }
 
-object SierraIconographicNumber extends SierraDataTransformer with SierraQueryOps {
+object SierraIconographicNumber
+    extends SierraDataTransformer
+    with SierraQueryOps {
   override type Output = Option[String]
 
   private val IconographicNumberMatch = "^([0-9]+i)$".r
@@ -29,9 +31,9 @@ object SierraIconographicNumber extends SierraDataTransformer with SierraQueryOp
   private implicit class VisualCollectionOps(bibData: SierraBibData) {
     def isVisualCollections: Boolean =
       bibData.materialType match {
-        case Some(SierraMaterialType("k")) => true  // Pictures
-        case Some(SierraMaterialType("r")) => true  // 3D-Objects
-        case _ => false
+        case Some(SierraMaterialType("k")) => true // Pictures
+        case Some(SierraMaterialType("r")) => true // 3D-Objects
+        case _                             => false
       }
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIconographicNumber.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIconographicNumber.scala
@@ -12,17 +12,18 @@ object SierraIconographicNumber extends SierraDataTransformer with SierraQueryOp
   private val IconographicNumberMatch = "^([0-9]+i)$".r
 
   override def apply(bibData: SierraBibData): Option[String] =
-    if (bibData.isVisualCollections) {
-      bibData
-        .varfieldsWithTag("001")
-        .flatMap { _.content }
-        .collectFirst {
-          // There are a handful of cases where the value in this field doesn't
-          // look like an i-number, in which case we discard it.
-          case IconographicNumberMatch(number) => number
-        }
-    } else {
-      None
+    bibData match {
+      case _ if bibData.isVisualCollections =>
+        bibData
+          .varfieldsWithTag("001")
+          .flatMap { _.content }
+          .collectFirst {
+            // There are a handful of cases where the value in this field doesn't
+            // look like an i-number, in which case we discard it.
+            case IconographicNumberMatch(number) => number
+          }
+
+      case _ => None
     }
 
   private implicit class VisualCollectionOps(bibData: SierraBibData) {

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIconographicNumber.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIconographicNumber.scala
@@ -1,0 +1,36 @@
+package uk.ac.wellcome.platform.transformer.sierra.transformers
+
+import uk.ac.wellcome.platform.transformer.sierra.source.{
+  SierraBibData,
+  SierraMaterialType,
+  SierraQueryOps
+}
+
+object SierraIconographicNumber extends SierraDataTransformer with SierraQueryOps {
+  override type Output = Option[String]
+
+  private val IconographicNumberMatch = "^([0-9]+i)$".r
+
+  override def apply(bibData: SierraBibData): Option[String] =
+    if (bibData.isVisualCollections) {
+      bibData
+        .varfieldsWithTag("001")
+        .flatMap { _.content }
+        .collectFirst {
+          // There are a handful of cases where the value in this field doesn't
+          // look like an i-number, in which case we discard it.
+          case IconographicNumberMatch(number) => number
+        }
+    } else {
+      None
+    }
+
+  private implicit class VisualCollectionOps(bibData: SierraBibData) {
+    def isVisualCollections: Boolean =
+      bibData.materialType match {
+        case Some(SierraMaterialType("k")) => true  // Pictures
+        case Some(SierraMaterialType("r")) => true  // 3D-Objects
+        case _ => false
+      }
+  }
+}

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiers.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiers.scala
@@ -114,14 +114,13 @@ object SierraIdentifiers
       }
   }
 
-  private def getIconographicNumbers(bibData: SierraBibData): List[SourceIdentifier] =
-    SierraIconographicNumber(bibData)
-      .map { iconographicNumber =>
-        SourceIdentifier(
-          identifierType = IdentifierType.IconographicNumber,
-          ontologyType = "Work",
-          value = iconographicNumber
-        )
-      }
-      .toList
+  private def getIconographicNumbers(
+    bibData: SierraBibData): List[SourceIdentifier] =
+    SierraIconographicNumber(bibData).map { iconographicNumber =>
+      SourceIdentifier(
+        identifierType = IdentifierType.IconographicNumber,
+        ontologyType = "Work",
+        value = iconographicNumber
+      )
+    }.toList
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiers.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiers.scala
@@ -40,7 +40,7 @@ object SierraIdentifiers
     )
 
     List(sierraIdentifier) ++ getIsbnIdentifiers(bibData) ++ getIssnIdentifiers(
-      bibData) ++ getDigcodes(bibData)
+      bibData) ++ getDigcodes(bibData) ++ getIconographicNumbers(bibData)
   }
 
   // Find ISBN (International Serial Book Number) identifiers from MARC 020 ǂa.
@@ -113,4 +113,15 @@ object SierraIdentifiers
         )
       }
   }
+
+  private def getIconographicNumbers(bibData: SierraBibData): List[SourceIdentifier] =
+    SierraIconographicNumber(bibData)
+      .map { iconographicNumber =>
+        SourceIdentifier(
+          identifierType = IdentifierType.IconographicNumber,
+          ontologyType = "Work",
+          value = iconographicNumber
+        )
+      }
+      .toList
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraReferenceNumber.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraReferenceNumber.scala
@@ -1,0 +1,11 @@
+package uk.ac.wellcome.platform.transformer.sierra.transformers
+
+import uk.ac.wellcome.platform.transformer.sierra.source.SierraBibData
+import weco.catalogue.internal_model.identifiers.ReferenceNumber
+
+object SierraReferenceNumber extends SierraDataTransformer {
+  override type Output = Option[ReferenceNumber]
+
+  override def apply(bibData: SierraBibData): Option[ReferenceNumber] =
+    SierraIconographicNumber(bibData).map { ReferenceNumber(_) }
+}

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIconographicNumberTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIconographicNumberTest.scala
@@ -1,0 +1,82 @@
+package uk.ac.wellcome.platform.transformer.sierra.transformers
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.platform.transformer.sierra.generators.SierraDataGenerators
+import uk.ac.wellcome.platform.transformer.sierra.source.{
+  SierraMaterialType,
+  VarField
+}
+
+class SierraIconographicNumberTest extends AnyFunSpec with Matchers with SierraDataGenerators {
+  it("uses the i-number from 001 if materialType = Pictures") {
+    val bibData = createSierraBibDataWith(
+      materialType = Some(SierraMaterialType("k")),
+      varFields = List(
+        VarField(
+          marcTag = Some("001"),
+          content = Some("12345i")
+        )
+      )
+    )
+
+    SierraIconographicNumber(bibData) shouldBe Some("12345i")
+  }
+
+  it("uses the i-number from 001 if materialType = 3-D Objects") {
+    val bibData = createSierraBibDataWith(
+      materialType = Some(SierraMaterialType("r")),
+      varFields = List(
+        VarField(
+          marcTag = Some("001"),
+          content = Some("56789i")
+        )
+      )
+    )
+
+    SierraIconographicNumber(bibData) shouldBe Some("56789i")
+  }
+
+  it("ignores the contents of 001 for other material types") {
+    val bibData = createSierraBibDataWith(
+      materialType = Some(SierraMaterialType("a")),
+      varFields = List(
+        VarField(
+          marcTag = Some("001"),
+          content = Some("56789i")
+        )
+      )
+    )
+
+    SierraIconographicNumber(bibData) shouldBe None
+  }
+
+  it("returns nothing if there is no 001") {
+    val bibData = createSierraBibDataWith(
+      materialType = Some(SierraMaterialType("r")),
+      varFields = List()
+    )
+
+    SierraIconographicNumber(bibData) shouldBe None
+  }
+
+  it("ignores a value that doesn't look like an i-number") {
+    def getIconographicNumber(s: String): Option[String] = {
+      val bibData = createSierraBibDataWith(
+        materialType = Some(SierraMaterialType("k")),
+        varFields = List(
+          VarField(
+            marcTag = Some("001"),
+            content = Some(s)
+          )
+        )
+      )
+
+      SierraIconographicNumber(bibData)
+    }
+
+    getIconographicNumber("12345i") shouldBe Some("12345i")
+    getIconographicNumber("12345") shouldBe None
+    getIconographicNumber("i") shouldBe None
+  }
+}

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIconographicNumberTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIconographicNumberTest.scala
@@ -8,7 +8,10 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{
   VarField
 }
 
-class SierraIconographicNumberTest extends AnyFunSpec with Matchers with SierraDataGenerators {
+class SierraIconographicNumberTest
+    extends AnyFunSpec
+    with Matchers
+    with SierraDataGenerators {
   it("uses the i-number from 001 if materialType = Pictures") {
     val bibData = createSierraBibDataWith(
       materialType = Some(SierraMaterialType("k")),

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiersTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiersTest.scala
@@ -8,6 +8,7 @@ import uk.ac.wellcome.platform.transformer.sierra.generators.{
 }
 import uk.ac.wellcome.platform.transformer.sierra.source.{
   MarcSubfield,
+  SierraMaterialType,
   VarField
 }
 import weco.catalogue.internal_model.identifiers.{
@@ -281,6 +282,24 @@ class SierraIdentifiersTest
       }
       digcodeIdentifiers should have size 1
     }
+  }
+
+  it("finds the iconographic number from field 001 on visual collections") {
+    val bibData = createSierraBibDataWith(
+      materialType = Some(SierraMaterialType("r")),
+      varFields = List(
+        VarField(marcTag = Some("001"), content = Some("12345i"))
+      )
+    )
+
+    val otherIdentifiers = SierraIdentifiers(createSierraBibNumber, bibData)
+    otherIdentifiers should contain(
+      SourceIdentifier(
+        identifierType = IdentifierType.IconographicNumber,
+        value = "12345i",
+        ontologyType = "Work"
+      )
+    )
   }
 
   private def createVarFieldWith(marcTag: String, subfieldA: String): VarField =

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraShelfmarkTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraShelfmarkTest.scala
@@ -10,7 +10,8 @@ import uk.ac.wellcome.platform.transformer.sierra.source.{
   MarcSubfield,
   SierraBibData,
   SierraItemData,
-  SierraMaterialType
+  SierraMaterialType,
+  VarField
 }
 import weco.catalogue.internal_model.work.Format.ArchivesAndManuscripts
 
@@ -91,6 +92,33 @@ class SierraShelfmarkTest
     val itemData = createSierraItemDataWith(varFields = varFields)
 
     getShelfmark(itemData = itemData) shouldBe None
+  }
+
+  it("suppresses the shelfmark if the bib has an iconographic number") {
+    def getShelfmarkWith001(s: String): Option[String] = {
+      val bibData = createSierraBibDataWith(
+        materialType = Some(SierraMaterialType("k")),
+        varFields = List(
+          VarField(marcTag = Some("001"), content = Some(s))
+        )
+      )
+
+      val varFields = List(
+        createVarFieldWith(
+          marcTag = "949",
+          subfields = List(
+            MarcSubfield(tag = "a", content = "S7956")
+          )
+        )
+      )
+
+      val itemData = createSierraItemDataWith(varFields = varFields)
+
+      getShelfmark(bibData = bibData, itemData = itemData)
+    }
+
+    getShelfmarkWith001(s = "3") shouldBe Some("S7956")
+    getShelfmarkWith001(s = "12345i") shouldBe None
   }
 
   private def getShelfmark(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
@@ -11,7 +11,12 @@ import uk.ac.wellcome.platform.transformer.sierra.source.MarcSubfield
 import uk.ac.wellcome.json.JsonUtil._
 import weco.catalogue.internal_model.work.WorkState.Source
 import org.scalatest.Assertion
-import weco.catalogue.internal_model.identifiers.IdState
+import weco.catalogue.internal_model.identifiers.{
+  IdState,
+  IdentifierType,
+  ReferenceNumber,
+  SourceIdentifier
+}
 import weco.catalogue.internal_model.identifiers.IdState.Unidentifiable
 import weco.catalogue.internal_model.languages.Language
 import weco.catalogue.internal_model.locations.AccessStatus.LicensedResources
@@ -367,7 +372,7 @@ class SierraTransformerTest
     deletedWork.deletedReason shouldBe DeletedFromSource("Sierra")
   }
 
-  it("deletes works with 'suppressed': true") {
+  it("suppresses works with 'suppressed': true") {
     val id = createSierraBibNumber
     val title = "Hi Diddle Dee Dee"
     val data =
@@ -1031,6 +1036,78 @@ class SierraTransformerTest
         )
       )
     )
+  }
+
+  it("suppresses the shelfmark from 949 ǂa if there's an iconographic number") {
+    val bibId = createSierraBibNumber
+    val bibData =
+      s"""
+         |{
+         |  "id": "$bibId",
+         |  "materialType": {"code": "k", "label": "Pictures"},
+         |  "varFields": [
+         |    ${createTitleVarfield()},
+         |    {
+         |      "marcTag": "001",
+         |      "content": "12345i"
+         |    }
+         |  ]
+         |}
+       """.stripMargin
+
+    val itemId = createSierraItemNumber
+    val itemData =
+      s"""
+         |{
+         |  "id": "$itemId",
+         |  "location": {
+         |    "code": "sgicon",
+         |    "name": "Closed stores Iconographic"
+         |  },
+         |  "varFields": [
+         |    {
+         |      "marcTag": "949",
+         |      "subfields": [
+         |        {"tag": "a", "content": "12345i"}
+         |      ]
+         |    }
+         |  ]
+         |}
+         |""".stripMargin
+
+    val transformable = createSierraTransformableWith(
+      maybeBibRecord = Some(SierraBibRecord(id = bibId, data = bibData, modifiedDate = Instant.now())),
+      itemRecords = List(
+        SierraItemRecord(
+          id = itemId,
+          data = itemData,
+          modifiedDate = Instant.now(),
+          bibIds = List()
+        )
+      )
+    )
+
+    val work = transformToWork(transformable)
+    println(work)
+
+    work.data.referenceNumber shouldBe Some(ReferenceNumber("12345i"))
+    work.data.collectionPath shouldBe None
+
+    work.data.otherIdentifiers should contain(
+      SourceIdentifier(
+        identifierType = IdentifierType.IconographicNumber,
+        value = "12345i",
+        ontologyType = "Work"
+      )
+    )
+
+    work.data.items should have size 1
+
+    val item = work.data.items.head
+    item.locations should have size 1
+
+    val location = item.locations.head.asInstanceOf[PhysicalLocation]
+    location.shelfmark shouldBe None
   }
 
   describe("throws a TransformerException when passed invalid data") {

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
@@ -1076,7 +1076,11 @@ class SierraTransformerTest
          |""".stripMargin
 
     val transformable = createSierraTransformableWith(
-      maybeBibRecord = Some(SierraBibRecord(id = bibId, data = bibData, modifiedDate = Instant.now())),
+      maybeBibRecord = Some(
+        SierraBibRecord(
+          id = bibId,
+          data = bibData,
+          modifiedDate = Instant.now())),
       itemRecords = List(
         SierraItemRecord(
           id = itemId,


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/platform/issues/5172. Follows #1606 

If a bib is part of the Visual Collections (=material type `k`/Pictures or `r`/3D Objects) and it has something that looks like an i-number in field 001, we:

* Use that value as the `referenceNumber`
* Add an identifier with identifier type `iconographic-number`
* Hide the shelfmark on any associated items

This might need further refinement (e.g. if a bib has two items, and we only want to hide the shelfmark on one of them) – but this takes us in the right direction.

I've also separated the `referenceNumber` type on the WorkData model from `collectionPath` – I don't want works with an iconographic number to wait for the relation embedder, which will do nothing for them.