### PR TITLE
The field name is CustodialHistory, not CustodHistory

### DIFF
--- a/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/transformers/CalmNotes.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/transformers/CalmNotes.scala
@@ -7,7 +7,7 @@ import weco.catalogue.source_model.calm.CalmRecord
 object CalmNotes extends CalmRecordOps {
   private val notesMapping = List(
     ("AdminHistory", BiographicalNote(_)),
-    ("CustodHistory", OwnershipNote(_)),
+    ("CustodialHistory", OwnershipNote(_)),
     ("Acquisition", AcquisitionNote(_)),
     ("Appraisal", AppraisalNote(_)),
     ("Accruals", AccrualsNote(_)),

--- a/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/transformers/CalmNotesTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/transformers/CalmNotesTest.scala
@@ -9,7 +9,7 @@ class CalmNotesTest extends AnyFunSpec with Matchers with CalmRecordGenerators {
   it("extracts all the notes fields") {
     val record = createCalmRecordWith(
       ("AdminHistory", "Administered by the Active Administrator"),
-      ("CustodHistory", "Collected by the Careful Custodian"),
+      ("CustodialHistory", "Collected by the Careful Custodian"),
       ("Acquisition", "Acquired by the Academic Archivists"),
       ("Appraisal", "Appraised by the Affable Appraiser"),
       ("Accruals", "Accrued by the Alliterative Acquirer"),


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5173

If you look at the data in the reporting cluster, you'll see there's no field `CustodHistory`, but there is one called `CustodialHistory`:

<img width="323" alt="Screenshot 2021-05-14 at 13 05 44" src="https://user-images.githubusercontent.com/301220/118268272-19364780-b4b5-11eb-9976-3d5828c80cc6.png">

That's what we should be using in the Calm transformer.