### PR TITLE
Add more fixes for weird Miro encodings

### DIFF
--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/source/MiroRecord.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/source/MiroRecord.scala
@@ -70,8 +70,7 @@ case object MiroRecord {
    * with the correct data.
    */
   private def fixBadUnicode(s: String): String =
-    s
-      .replaceAll(" \\u00cc\\u0081", " ́")
+    s.replaceAll(" \\u00cc\\u0081", " ́")
       .replaceAll("i\\u00cc\\u00a8", "į")
       .replaceAll("\\u00c3&#8224;", "Æ")
       .replaceAll("\\u00c3&#8240;", "É")

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/source/MiroRecord.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/source/MiroRecord.scala
@@ -49,7 +49,8 @@ case object MiroRecord {
   private def unescapeHtml(s: String): String =
     StringEscapeUtils.unescapeHtml3(s)
 
-  /* Fix a couple of names that got mangled in the Miro exports:
+  /* Some of the Unicode characters got mangled in the Miro exports, which
+   * corrupt names like:
    *
    *    Adêle Mongrédien
    *    Hermann von Schlagintweit-Sakünlünski
@@ -59,15 +60,51 @@ case object MiroRecord {
    *
    * This presents as ugly nonsense in the API.
    *
-   * These checks are deliberately conservative to avoid introducing more
-   * problems than they fix.  The long-term fix is for these Miro records to
-   * get paired with Sierra records with the correct data.
+   * Because we can't edit the Miro data, we have to fix this Unicode mangling
+   * in the transformer.  I ran the transformed Works through a Python library
+   * ftfy ("fixes text for you"), which is designed to detect and fix this sort
+   * of mojibake.  I'm hard-coding the substitutions rather than running something
+   * like that on every transform so I don't introduce more problems than I solve.
+   *
+   * The long-term fix is for these Miro records to get paired with Sierra records
+   * with the correct data.
    */
   private def fixBadUnicode(s: String): String =
-    s.replaceAll("\\u00c3\\u00aa", "ê")
-      .replaceAll("\\u00c3\\u00a9", "é")
-      .replaceAll("\\u00c3\\u00bc", "ü")
+    s
+      .replaceAll(" \\u00cc\\u0081", " ́")
+      .replaceAll("i\\u00cc\\u00a8", "į")
+      .replaceAll("\\u00c3&#8224;", "Æ")
       .replaceAll("\\u00c3&#8240;", "É")
+      .replaceAll("\\u00c3\\u00a0", "à")
+      .replaceAll("\\u00c3\\u00a1", "á")
+      .replaceAll("\\u00c3\\u00a2", "â")
+      .replaceAll("\\u00c3\\u00a4", "ä")
+      .replaceAll("\\u00c3\\u00a6", "æ")
+      .replaceAll("\\u00c3\\u00a7", "ç")
+      .replaceAll("\\u00c3\\u00a8", "è")
+      .replaceAll("\\u00c3\\u00a9", "é")
+      .replaceAll("\\u00c3\\u00aa", "ê")
+      .replaceAll("\\u00c3\\u00ab", "ë")
+      .replaceAll("\\u00c3\\u00ad", "í")
+      .replaceAll("\\u00c3\\u00b3", "ó")
+      .replaceAll("\\u00c3\\u00b4", "ô")
+      .replaceAll("\\u00c3\\u00b6", "ö")
+      .replaceAll("\\u00c3\\u00ba", "ú")
+      .replaceAll("\\u00c3\\u00bb", "û")
+      .replaceAll("\\u00c3\\u00bc", "ü")
+      .replaceAll("\\u00c4&#402;", "ă")
+      .replaceAll("\\u00c4\\u0081", "ā")
+      .replaceAll("\\u00c4\\u008d", "č")
+      .replaceAll("\\u00c5&#376;", "ş")
+      .replaceAll("\\u00c5&#8220;", "œ")
+      .replaceAll("\\u00c5\\u008d", "ō")
+      .replaceAll("\\u00c5\\u008f", "ŏ")
+      .replaceAll("\\u00c5\\u00a3", "ţ")
+      .replaceAll("\\u00c5\\u00ab", "ū")
+      .replaceAll("\\u00cc\\u0081", " ́")
+      .replaceAll("\\u00e1\\u00b8\\u00a7", "ḧ")
+      .replaceAll("\\u00e2\\u20ac\\u02dc", "‘")
+      .replaceAll("\\u00e2\\u20ac\\u2122", "’")
 
   def create(jsonString: String): MiroRecord = {
     val unescapedData = fixBadUnicode(unescapeHtml(jsonString))


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/3152

It's pretty easy to build the list of substitutions when you combine the easy snapshot analysis and the [ftfy ("fix text for you") library](https://pypi.org/project/ftfy/). I'd already fixed one I happened to run into last week, and that made me realise we could extend this to all the Miro encoding bugs.

This affects ~254 works.