### PR TITLE
Allow overriding the license on a per-record basis in the Miro transformer

### DIFF
--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/Main.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/Main.scala
@@ -65,7 +65,8 @@ object Main extends WellcomeTypesafeApp {
     )
   }
 
-  private def getLicenseOverrides(config: Config)(implicit s3Client: AmazonS3): Map[String, License] = {
+  private def getLicenseOverrides(config: Config)(
+    implicit s3Client: AmazonS3): Map[String, License] = {
     val location = S3ObjectLocation(
       bucket = config.requireString("miro.licenseOverride.bucket"),
       key = config.requireString("miro.licenseOverride.key")
@@ -74,7 +75,8 @@ object Main extends WellcomeTypesafeApp {
     val typedStore = S3TypedStore[Map[String, License]]
     typedStore.get(location) match {
       case Right(Identified(_, value)) => value
-      case Left(err) => throw new RuntimeException(s"Unable to load license override: $err")
+      case Left(err) =>
+        throw new RuntimeException(s"Unable to load license override: $err")
     }
   }
 }

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/Main.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/Main.scala
@@ -17,11 +17,15 @@ import uk.ac.wellcome.pipeline_storage.typesafe.{
 import uk.ac.wellcome.platform.transformer.miro.Implicits._
 import uk.ac.wellcome.platform.transformer.miro.services.MiroTransformerWorker
 import uk.ac.wellcome.platform.transformer.miro.source.MiroRecord
+import uk.ac.wellcome.storage.Identified
+import uk.ac.wellcome.storage.s3.S3ObjectLocation
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
 import uk.ac.wellcome.storage.streaming.Codec._
 import uk.ac.wellcome.storage.typesafe.S3Builder
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
+import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
+import weco.catalogue.internal_model.locations.License
 import weco.catalogue.internal_model.work.Work
 
 import scala.concurrent.ExecutionContext
@@ -56,7 +60,21 @@ object Main extends WellcomeTypesafeApp {
       pipelineStream = pipelineStream,
       miroReadable = S3TypedStore[MiroRecord],
       retriever =
-        ElasticSourceRetrieverBuilder.apply[Work[Source]](config, esClient)
+        ElasticSourceRetrieverBuilder.apply[Work[Source]](config, esClient),
+      licenseOverrides = getLicenseOverrides(config)
     )
+  }
+
+  private def getLicenseOverrides(config: Config)(implicit s3Client: AmazonS3): Map[String, License] = {
+    val location = S3ObjectLocation(
+      bucket = config.requireString("miro.licenseOverride.bucket"),
+      key = config.requireString("miro.licenseOverride.key")
+    )
+
+    val typedStore = S3TypedStore[Map[String, License]]
+    typedStore.get(location) match {
+      case Right(Identified(_, value)) => value
+      case Left(err) => throw new RuntimeException(s"Unable to load license override: $err")
+    }
   }
 }

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/MiroRecordTransformer.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/MiroRecordTransformer.scala
@@ -17,13 +17,14 @@ import weco.catalogue.internal_model.identifiers.{
   IdentifierType,
   SourceIdentifier
 }
+import weco.catalogue.internal_model.locations.License
 import weco.catalogue.internal_model.work.DeletedReason.SuppressedFromSource
 import weco.catalogue.internal_model.work.InvisibilityReason.UnableToTransform
 import weco.catalogue.internal_model.work.{Work, WorkData}
 import weco.catalogue.transformer.Transformer
 import weco.catalogue.transformer.result.Result
 
-class MiroRecordTransformer
+class MiroRecordTransformer(val licenseOverrides: Map[String, License])
     extends MiroContributors
     with MiroCreatedDate
     with MiroItems

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroTransformerWorker.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroTransformerWorker.scala
@@ -11,6 +11,7 @@ import uk.ac.wellcome.storage.s3.S3ObjectLocation
 import uk.ac.wellcome.storage.store.Readable
 import uk.ac.wellcome.storage.{Identified, ReadError, Version}
 import uk.ac.wellcome.typesafe.Runnable
+import weco.catalogue.internal_model.locations.License
 import weco.catalogue.internal_model.work.Work
 import weco.catalogue.source_model.MiroSourcePayload
 import weco.catalogue.transformer.{Transformer, TransformerWorker}
@@ -22,7 +23,8 @@ class MiroTransformerWorker[MsgDestination](
                                             Work[Source],
                                             MsgDestination],
   miroReadable: Readable[S3ObjectLocation, MiroRecord],
-  val retriever: Retriever[Work[Source]]
+  val retriever: Retriever[Work[Source]],
+  licenseOverrides: Map[String, License]
 )(
   implicit
   val decoder: Decoder[MiroSourcePayload],
@@ -34,7 +36,7 @@ class MiroTransformerWorker[MsgDestination](
       MsgDestination] {
 
   override val transformer: Transformer[(MiroRecord, MiroMetadata)] =
-    new MiroRecordTransformer
+    new MiroRecordTransformer(licenseOverrides = licenseOverrides)
 
   override def lookupSourceData(p: MiroSourcePayload)
     : Either[ReadError,

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLicenses.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLicenses.scala
@@ -8,25 +8,35 @@ import weco.catalogue.internal_model.locations.License
 
 trait MiroLicenses {
 
-  /** If the image has a non-empty image_use_restrictions field, choose which
-    *  license (if any) we're going to assign to the thumbnail for this work.
-    *
-    *  The mappings in this function are based on a document provided by
-    *  Christy Henshaw (MIRO drop-downs.docx).  There are still some gaps in
-    *  that, we'll have to come back and update this code later.
-    *
-    *  For now, this mapping only covers use restrictions seen in the
-    *  V collection.  We'll need to extend this for other licenses later.
-    *
-    *  TODO: Expand this mapping to cover all of MIRO.
-    *  TODO: Update these mappings based on the final version of Christy's
-    *        document.
-    */
+  // In some cases, the license in the Miro data is incorrect.
+  // We can't edit that data, so we provide a list of overrides that
+  // replace the license.
+  val licenseOverrides: Map[String, License]
+
   def chooseLicense(miroId: String,
                     maybeUseRestrictions: Option[String]): License =
+    licenseOverrides.get(miroId) match {
+      case Some(license) => license
+      case None => chooseLicenseFromUseRestrictions(maybeUseRestrictions)
+    }
+
+  /** If the image has a non-empty image_use_restrictions field, choose which
+   *  license (if any) we're going to assign to the thumbnail for this work.
+   *
+   *  The mappings in this function are based on a document provided by
+   *  Christy Henshaw (MIRO drop-downs.docx).  There are still some gaps in
+   *  that, we'll have to come back and update this code later.
+   *
+   *  For now, this mapping only covers use restrictions seen in the
+   *  V collection.  We'll need to extend this for other licenses later.
+   *
+   *  TODO: Expand this mapping to cover all of MIRO.
+   *  TODO: Update these mappings based on the final version of Christy's
+   *        document.
+   */
+  private def chooseLicenseFromUseRestrictions(maybeUseRestrictions: Option[String]): License =
     maybeUseRestrictions match {
 
-      // These images need more data.
       case None =>
         throw new ShouldNotTransformException(
           "Nothing in the image_use_restrictions field")
@@ -57,5 +67,4 @@ trait MiroLicenses {
               "image_use_restrictions = 'Image withdrawn, see notes'")
         }
     }
-
 }

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLicenses.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLicenses.scala
@@ -17,24 +17,25 @@ trait MiroLicenses {
                     maybeUseRestrictions: Option[String]): License =
     licenseOverrides.get(miroId) match {
       case Some(license) => license
-      case None => chooseLicenseFromUseRestrictions(maybeUseRestrictions)
+      case None          => chooseLicenseFromUseRestrictions(maybeUseRestrictions)
     }
 
   /** If the image has a non-empty image_use_restrictions field, choose which
-   *  license (if any) we're going to assign to the thumbnail for this work.
-   *
-   *  The mappings in this function are based on a document provided by
-   *  Christy Henshaw (MIRO drop-downs.docx).  There are still some gaps in
-   *  that, we'll have to come back and update this code later.
-   *
-   *  For now, this mapping only covers use restrictions seen in the
-   *  V collection.  We'll need to extend this for other licenses later.
-   *
-   *  TODO: Expand this mapping to cover all of MIRO.
-   *  TODO: Update these mappings based on the final version of Christy's
-   *        document.
-   */
-  private def chooseLicenseFromUseRestrictions(maybeUseRestrictions: Option[String]): License =
+    *  license (if any) we're going to assign to the thumbnail for this work.
+    *
+    *  The mappings in this function are based on a document provided by
+    *  Christy Henshaw (MIRO drop-downs.docx).  There are still some gaps in
+    *  that, we'll have to come back and update this code later.
+    *
+    *  For now, this mapping only covers use restrictions seen in the
+    *  V collection.  We'll need to extend this for other licenses later.
+    *
+    *  TODO: Expand this mapping to cover all of MIRO.
+    *  TODO: Update these mappings based on the final version of Christy's
+    *        document.
+    */
+  private def chooseLicenseFromUseRestrictions(
+    maybeUseRestrictions: Option[String]): License =
     maybeUseRestrictions match {
 
       case None =>

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroTransformerWorkerTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroTransformerWorkerTest.scala
@@ -103,7 +103,8 @@ class MiroTransformerWorkerTest
       new MiroTransformerWorker(
         pipelineStream = pipelineStream,
         miroReadable = miroReadable,
-        retriever = retriever
+        retriever = retriever,
+        licenseOverrides = Map()
       )
     )
 }

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroImageDataTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroImageDataTest.scala
@@ -17,7 +17,9 @@ class MiroImageDataTest
     with Matchers
     with IdentifiersGenerators
     with MiroRecordGenerators {
-  val transformer = new MiroImageData {}
+  val transformer = new MiroImageData {
+    override val licenseOverrides: Map[String, License] = Map()
+  }
 
   describe("getImageData") {
     it("extracts the Miro image data") {

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroItemsTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroItemsTest.scala
@@ -13,7 +13,9 @@ class MiroItemsTest
     with Matchers
     with IdentifiersGenerators
     with MiroRecordGenerators {
-  val transformer = new MiroItems {}
+  val transformer = new MiroItems {
+    override val licenseOverrides: Map[String, License] = Map()
+  }
 
   describe("getItems") {
     it("extracts an unidentifiable item") {

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLicensesTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLicensesTest.scala
@@ -35,10 +35,29 @@ class MiroLicensesTest extends AnyFunSpec with Matchers {
     }
   }
 
+  it("uses the license override for a Miro ID") {
+    val miroId = "A0000001"
+    val useRestrictions = "CC-0"
+
+    val transformer1 = new MiroLicenses {
+      override val licenseOverrides: Map[String, License] = Map.empty
+    }
+
+    transformer1.chooseLicense(miroId, Some(useRestrictions)) shouldBe License.CC0
+
+    val transformer2 = new MiroLicenses {
+      override val licenseOverrides: Map[String, License] = Map(miroId -> License.InCopyright)
+    }
+
+    transformer2.chooseLicense(miroId, Some(useRestrictions)) shouldBe License.InCopyright
+  }
+
   private def chooseLicense(maybeUseRestrictions: Option[String]): License =
     transformer.chooseLicense(
       miroId = "A1234567",
       maybeUseRestrictions = maybeUseRestrictions)
 
-  val transformer = new MiroLicenses {}
+  val transformer = new MiroLicenses {
+    override val licenseOverrides: Map[String, License] = Map.empty
+  }
 }

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLicensesTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLicensesTest.scala
@@ -46,7 +46,8 @@ class MiroLicensesTest extends AnyFunSpec with Matchers {
     transformer1.chooseLicense(miroId, Some(useRestrictions)) shouldBe License.CC0
 
     val transformer2 = new MiroLicenses {
-      override val licenseOverrides: Map[String, License] = Map(miroId -> License.InCopyright)
+      override val licenseOverrides: Map[String, License] =
+        Map(miroId -> License.InCopyright)
     }
 
     transformer2.chooseLicense(miroId, Some(useRestrictions)) shouldBe License.InCopyright

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLocationTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLocationTest.scala
@@ -9,7 +9,9 @@ class MiroLocationTest
     extends AnyFunSpec
     with Matchers
     with MiroRecordGenerators {
-  val transformer = new MiroLocation {}
+  val transformer = new MiroLocation {
+    override val licenseOverrides: Map[String, License] = Map()
+  }
   it(
     "extracts the digital location and finds the credit line for an image-specific contributor code") {
     transformer.getLocation(

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroTransformableWrapper.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroTransformableWrapper.scala
@@ -12,7 +12,7 @@ import weco.catalogue.internal_model.work.WorkState.Source
 import scala.util.Try
 
 trait MiroTransformableWrapper extends Matchers { this: Suite =>
-  val transformer = new MiroRecordTransformer
+  val transformer = new MiroRecordTransformer(licenseOverrides = Map())
 
   def transformWork(miroRecord: MiroRecord): Work.Visible[Source] = {
     val triedWork: Try[Work[Source]] =


### PR DESCRIPTION
This is for https://github.com/wellcomecollection/platform/issues/5176

We need to change the license of some Miro works,  where the source data is incorrect. This PR allows the transformer to take a list of license changes which override the source data.

We don't want to make the list of license changes public, so instead we have the transformer fetch it at startup from S3.

It expects to receive a JSON file of the form:

```json
{
    "A0000001": {"id": "cc-by"},
    "A0000002": {"id": "cc-by-nc"}
}
```

which becomes a Scala `Map[String, License]`.

Constructing this file and passing the appropriate Terraform config will come in another commit.