### PR TITLE
If a bib doesn't have any items but does have CAT DATE, it's not on order

### DIFF
--- a/common/source_model/src/test/scala/weco/catalogue/source_model/generators/SierraGenerators.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/generators/SierraGenerators.scala
@@ -128,6 +128,9 @@ trait SierraGenerators extends RandomGenerators {
     )
   }
 
+  def createSierraOrderRecord: SierraOrderRecord =
+    createSierraOrderRecordWith()
+
   private def defaultItemData(id: SierraItemNumber,
                               modifiedDate: Instant,
                               bibIds: List[SierraBibNumber]): String =

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformer.scala
@@ -115,7 +115,7 @@ class SierraTransformer(sierraTransformable: SierraTransformable, version: Int)
       notes = SierraNotes(bibData),
       duration = SierraDuration(bibData),
       items =
-        SierraItemsOnOrder(bibId, hasItems = hasItems, orderDataMap) ++
+        SierraItemsOnOrder(bibId, bibData = bibData, hasItems = hasItems, orderDataMap) ++
           SierraItems(bibId, bibData, itemDataMap) ++
           SierraElectronicResources(bibId, varFields = bibData.varFields),
       holdings = SierraHoldings(bibId, holdingsDataMap),

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/SierraTransformer.scala
@@ -115,7 +115,11 @@ class SierraTransformer(sierraTransformable: SierraTransformable, version: Int)
       notes = SierraNotes(bibData),
       duration = SierraDuration(bibData),
       items =
-        SierraItemsOnOrder(bibId, bibData = bibData, hasItems = hasItems, orderDataMap) ++
+        SierraItemsOnOrder(
+          bibId,
+          bibData = bibData,
+          hasItems = hasItems,
+          orderDataMap) ++
           SierraItems(bibId, bibData, itemDataMap) ++
           SierraElectronicResources(bibId, varFields = bibData.varFields),
       holdings = SierraHoldings(bibId, holdingsDataMap),

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrder.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrder.scala
@@ -1,7 +1,10 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
 import grizzled.slf4j.Logging
-import uk.ac.wellcome.platform.transformer.sierra.source.SierraOrderData
+import uk.ac.wellcome.platform.transformer.sierra.source.{
+  SierraBibData,
+  SierraOrderData
+}
 import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.locations.{LocationType, PhysicalLocation}
 import weco.catalogue.internal_model.work.Item
@@ -39,10 +42,11 @@ import scala.util.Try
 object SierraItemsOnOrder extends Logging {
   def apply(
     id: TypedSierraRecordNumber,
+    bibData: SierraBibData,
     hasItems: Boolean,
     orderDataMap: Map[SierraOrderNumber, SierraOrderData]
   ): List[Item[IdState.Unidentifiable.type]] =
-    if (!hasItems) {
+    if (!hasItems && !bibData.hasCatDate) {
       orderDataMap.toList
         .filterNot {
           case (_, orderData) => orderData.suppressed || orderData.deleted
@@ -147,4 +151,10 @@ object SierraItemsOnOrder extends Logging {
       case None =>
         "Ordered for Wellcome Collection"
     }
+
+  implicit class BibDataCatDateOps(bibData: SierraBibData) {
+    // See https://documentation.iii.com/sierrahelp/Default.htm#sril/sril_records_fixed_field_types_biblio.html%3FTocPath%3DSierra%2520Reference%7CHow%2520Innovative%2520Systems%2520Store%2520Information%7CFixed-length%2520Fields%7C_____3
+    def hasCatDate: Boolean =
+      bibData.fixedFields.contains("28")
+  }
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrder.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrder.scala
@@ -35,6 +35,10 @@ import scala.util.Try
   *   3)  At some point after that, an item record is created.  This supercedes
   *       the order record.
   *
+  * Note that born-digital objects do not necessarily get item records: that can be
+  * supplied separately, e.g. from the METS.  In this case, we should look at the CAT DATE
+  * (cataloguing date) fixed field to see we shouldn't add any order items.
+  *
   * The Sierra documentation for fixed fields on order records is useful reading:
   * https://documentation.iii.com/sierrahelp/Default.htm#sril/sril_records_fixed_field_types_order.html%3FTocPath%3DSierra%2520Reference%7CHow%2520Innovative%2520Systems%2520Store%2520Information%7CFixed-length%2520Fields%7C_____11
   *

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrderTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrderTest.scala
@@ -360,7 +360,8 @@ class SierraItemsOnOrderTest
       val bibData = createSierraBibData
       val bibDataWithCatDate =
         bibData.copy(
-          fixedFields = Map("28" -> FixedField(label = "CAT DATE", value = "2021-05-17"))
+          fixedFields =
+            Map("28" -> FixedField(label = "CAT DATE", value = "2021-05-17"))
         )
 
       // Note: we test both with and without CAT DATE here, so we'll
@@ -521,7 +522,8 @@ class SierraItemsOnOrderTest
       val bibData = createSierraBibData
       val bibDataWithCatDate =
         bibData.copy(
-          fixedFields = Map("28" -> FixedField(label = "CAT DATE", value = "2021-05-17"))
+          fixedFields =
+            Map("28" -> FixedField(label = "CAT DATE", value = "2021-05-17"))
         )
 
       // Note: we test both with and without CAT DATE here, so we'll
@@ -552,10 +554,9 @@ class SierraItemsOnOrderTest
     }
   }
 
-  def getOrders(
-    hasItems: Boolean = false,
-    bibData: SierraBibData = createSierraBibData,
-    orderData: List[SierraOrderData])
+  def getOrders(hasItems: Boolean = false,
+                bibData: SierraBibData = createSierraBibData,
+                orderData: List[SierraOrderData])
     : List[Item[IdState.Unidentifiable.type]] = {
     val id = createSierraBibNumber
 

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrderTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsOnOrderTest.scala
@@ -5,6 +5,7 @@ import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.platform.transformer.sierra.generators.SierraDataGenerators
 import uk.ac.wellcome.platform.transformer.sierra.source.{
   FixedField,
+  SierraBibData,
   SierraOrderData
 }
 import weco.catalogue.internal_model.identifiers.IdState
@@ -337,6 +338,36 @@ class SierraItemsOnOrderTest
       getOrders(hasItems = false, orderData = orderData) should not be empty
       getOrders(hasItems = true, orderData = orderData) shouldBe empty
     }
+
+    it("unless there is a CAT DATE") {
+      val orderData = List(
+        createSierraOrderDataWith(
+          fixedFields = Map(
+            "5" -> FixedField(label = "COPIES", value = "1"),
+            "13" -> FixedField(label = "ODATE", value = "2001-01-01"),
+            "20" -> FixedField(label = "STATUS", value = "o")
+          )
+        ),
+        createSierraOrderDataWith(
+          fixedFields = Map(
+            "5" -> FixedField(label = "COPIES", value = "2"),
+            "13" -> FixedField(label = "ODATE", value = "2002-02-02"),
+            "20" -> FixedField(label = "STATUS", value = "o")
+          )
+        )
+      )
+
+      val bibData = createSierraBibData
+      val bibDataWithCatDate =
+        bibData.copy(
+          fixedFields = Map("28" -> FixedField(label = "CAT DATE", value = "2021-05-17"))
+        )
+
+      // Note: we test both with and without CAT DATE here, so we'll
+      // spot if the lack of output is unrelated to the items.
+      getOrders(bibData = bibData, orderData = orderData) should not be empty
+      getOrders(bibData = bibDataWithCatDate, orderData = orderData) shouldBe empty
+    }
   }
 
   describe("returns 'awaiting cataloguing' items") {
@@ -475,6 +506,29 @@ class SierraItemsOnOrderTest
       getOrders(hasItems = false, orderData = orderData) should not be empty
       getOrders(hasItems = true, orderData = orderData) shouldBe empty
     }
+
+    it("unless there is a CAT DATE") {
+      val orderData = List(
+        createSierraOrderDataWith(
+          fixedFields = Map(
+            "5" -> FixedField(label = "COPIES", value = "1"),
+            "17" -> FixedField(label = "RDATE", value = "2001-01-01"),
+            "20" -> FixedField(label = "STATUS", value = "a")
+          )
+        )
+      )
+
+      val bibData = createSierraBibData
+      val bibDataWithCatDate =
+        bibData.copy(
+          fixedFields = Map("28" -> FixedField(label = "CAT DATE", value = "2021-05-17"))
+        )
+
+      // Note: we test both with and without CAT DATE here, so we'll
+      // spot if the lack of output is unrelated to the items.
+      getOrders(bibData = bibData, orderData = orderData) should not be empty
+      getOrders(bibData = bibDataWithCatDate, orderData = orderData) shouldBe empty
+    }
   }
 
   describe("skips unrecognised order records") {
@@ -498,7 +552,10 @@ class SierraItemsOnOrderTest
     }
   }
 
-  def getOrders(hasItems: Boolean, orderData: List[SierraOrderData])
+  def getOrders(
+    hasItems: Boolean = false,
+    bibData: SierraBibData = createSierraBibData,
+    orderData: List[SierraOrderData])
     : List[Item[IdState.Unidentifiable.type]] = {
     val id = createSierraBibNumber
 
@@ -510,6 +567,6 @@ class SierraItemsOnOrderTest
 
     val orderDataMap = orderIds.zip(orderData).toMap
 
-    SierraItemsOnOrder(id, hasItems, orderDataMap)
+    SierraItemsOnOrder(id, bibData, hasItems, orderDataMap)
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
@@ -1038,6 +1038,33 @@ class SierraTransformerTest
     )
   }
 
+  // This test is based on a real failure, when we were adding an item for
+  // b32496485.  This Work didn't have any items in Sierra, but it did get
+  // a digitised item from the METS.
+  it("does not create an item from the order record if there are no items but there is a CAT DATE on the bib") {
+    val id = createSierraBibNumber
+
+    val transformable = createSierraTransformableWith(
+      maybeBibRecord = Some(
+        createSierraBibRecordWith(
+          data =
+            s"""
+               |{
+               |  "id": "$id",
+               |  "fixedFields": {
+               |    "28": {"label": "CAT DATE", "value": "2021-05-17"}
+               |  }
+               |}
+               |""".stripMargin
+        )
+      ),
+      orderRecords = List(createSierraOrderRecord)
+    )
+
+    val work = transformToWork(transformable)
+    work.data.items shouldBe empty
+  }
+
   it("suppresses the shelfmark from 949 ǂa if there's an iconographic number") {
     val bibId = createSierraBibNumber
     val bibData =

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
@@ -1041,14 +1041,14 @@ class SierraTransformerTest
   // This test is based on a real failure, when we were adding an item for
   // b32496485.  This Work didn't have any items in Sierra, but it did get
   // a digitised item from the METS.
-  it("does not create an item from the order record if there are no items but there is a CAT DATE on the bib") {
+  it(
+    "does not create an item from the order record if there are no items but there is a CAT DATE on the bib") {
     val id = createSierraBibNumber
 
     val transformable = createSierraTransformableWith(
       maybeBibRecord = Some(
         createSierraBibRecordWith(
-          data =
-            s"""
+          data = s"""
                |{
                |  "id": "$id",
                |  "fixedFields": {


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5179

This is a bug spotted by Nicola in Slack. If it's a born-digital record, then we get the items come from the METS transformer instead of the Sierra transformer – we should look at the CAT DATE fixed field to see this record has been catalogued. This field is not present on uncatalogued records.