### PR TITLE
Plumb the Miro source overrides into the reindexer and the Miro transformer

### DIFF
--- a/.sbt_metadata/source_model.json
+++ b/.sbt_metadata/source_model.json
@@ -2,5 +2,6 @@
   "id" : "source_model",
   "folder" : "common/source_model",
   "dependencyIds" : [
+    "internal_model"
   ]
 }

--- a/build.sbt
+++ b/build.sbt
@@ -49,6 +49,7 @@ lazy val flows = setupProject(
 lazy val source_model = setupProject(
   project,
   folder = "common/source_model",
+  localDependencies = Seq(internal_model),
   externalDependencies = CatalogueDependencies.sourceModelDependencies
 )
 

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/License.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/License.scala
@@ -28,7 +28,8 @@ object License extends Enum[License] {
 
   implicit val format: DynamoFormat[License] =
     DynamoFormat.coercedXmap[License, String, NoSuchElementException](
-      License.withName, _.id
+      License.withName,
+      _.id
     )
 
   case object CCBY extends License {

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/License.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/License.scala
@@ -3,6 +3,7 @@ package weco.catalogue.internal_model.locations
 import enumeratum.EnumEntry
 import enumeratum.Enum
 import io.circe.{Decoder, Encoder}
+import org.scanamo.DynamoFormat
 
 sealed trait License extends EnumEntry {
   val id: String
@@ -24,6 +25,11 @@ object License extends Enum[License] {
 
   implicit val licenseDecoder: Decoder[License] =
     Decoder.forProduct1("id")(License.withName)
+
+  implicit val format: DynamoFormat[License] =
+    DynamoFormat.coercedXmap[License, String, NoSuchElementException](
+      License.withName, _.id
+    )
 
   case object CCBY extends License {
     val id = "cc-by"

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/SourcePayload.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/SourcePayload.scala
@@ -2,6 +2,7 @@ package weco.catalogue.source_model
 
 import uk.ac.wellcome.storage.s3.S3ObjectLocation
 import weco.catalogue.source_model.mets.MetsSourceData
+import weco.catalogue.source_model.miro.{MiroSourceOverrides, MiroUpdateEvent}
 
 sealed trait SourcePayload {
   val id: String
@@ -25,6 +26,8 @@ case class MiroSourcePayload(
   id: String,
   isClearedForCatalogueAPI: Boolean,
   location: S3ObjectLocation,
+  events: List[MiroUpdateEvent] = Nil,
+  overrides: Option[MiroSourceOverrides] = None,
   version: Int
 ) extends SourcePayload
 

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/SourcePayload.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/SourcePayload.scala
@@ -26,8 +26,8 @@ case class MiroSourcePayload(
   id: String,
   isClearedForCatalogueAPI: Boolean,
   location: S3ObjectLocation,
-  events: List[MiroUpdateEvent] = Nil,
-  overrides: Option[MiroSourceOverrides] = None,
+  events: List[MiroUpdateEvent],
+  overrides: Option[MiroSourceOverrides],
   version: Int
 ) extends SourcePayload
 

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/miro/MiroSourceOverrides.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/miro/MiroSourceOverrides.scala
@@ -1,0 +1,7 @@
+package weco.catalogue.source_model.miro
+
+import weco.catalogue.internal_model.locations.License
+
+case class MiroSourceOverrides(
+  license: Option[License]
+)

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/miro/MiroSourceOverrides.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/miro/MiroSourceOverrides.scala
@@ -5,3 +5,10 @@ import weco.catalogue.internal_model.locations.License
 case class MiroSourceOverrides(
   license: Option[License]
 )
+
+object MiroSourceOverrides {
+  def empty: MiroSourceOverrides =
+    MiroSourceOverrides(
+      license = None
+    )
+}

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/miro/MiroUpdateEvent.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/miro/MiroUpdateEvent.scala
@@ -1,0 +1,10 @@
+package weco.catalogue.source_model.miro
+
+import java.time.Instant
+
+case class MiroUpdateEvent(
+  description: String,
+  message: String,
+  date: Instant,
+  user: String
+)

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/MiroRecordTransformer.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/MiroRecordTransformer.scala
@@ -38,8 +38,9 @@ class MiroRecordTransformer
     with Logging
     with Transformer[(MiroRecord, MiroSourceOverrides, MiroMetadata)] {
 
-  override def apply(sourceData: (MiroRecord, MiroSourceOverrides, MiroMetadata),
-                     version: Int): Result[Work[Source]] = {
+  override def apply(
+    sourceData: (MiroRecord, MiroSourceOverrides, MiroMetadata),
+    version: Int): Result[Work[Source]] = {
     val (miroRecord, overrides, miroMetadata) = sourceData
 
     transform(miroRecord, overrides, miroMetadata, version).toEither
@@ -49,9 +50,10 @@ class MiroRecordTransformer
                 overrides: MiroSourceOverrides,
                 miroMetadata: MiroMetadata,
                 version: Int): Try[Work[Source]] =
-    doTransform(miroRecord, overrides, miroMetadata, version) map { transformed =>
-      debug(s"Transformed record to $transformed")
-      transformed
+    doTransform(miroRecord, overrides, miroMetadata, version) map {
+      transformed =>
+        debug(s"Transformed record to $transformed")
+        transformed
     } recover {
       case e: Throwable =>
         error("Failed to perform transform to unified item", e)
@@ -120,7 +122,8 @@ class MiroRecordTransformer
           contributors = getContributors(miroRecord),
           thumbnail = Some(getThumbnail(miroRecord, overrides)),
           items = getItems(miroRecord, overrides),
-          imageData = List(getImageData(miroRecord, overrides = overrides, version = version))
+          imageData = List(
+            getImageData(miroRecord, overrides = overrides, version = version))
         )
 
         Work.Visible[Source](

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroTransformerWorker.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroTransformerWorker.scala
@@ -34,12 +34,14 @@ class MiroTransformerWorker[MsgDestination](
       (MiroRecord, MiroSourceOverrides, MiroMetadata),
       MsgDestination] {
 
-  override val transformer: Transformer[(MiroRecord, MiroSourceOverrides, MiroMetadata)] =
+  override val transformer
+    : Transformer[(MiroRecord, MiroSourceOverrides, MiroMetadata)] =
     new MiroRecordTransformer
 
   override def lookupSourceData(p: MiroSourcePayload)
     : Either[ReadError,
-             Identified[Version[String, Int], (MiroRecord, MiroSourceOverrides, MiroMetadata)]] =
+             Identified[Version[String, Int],
+                        (MiroRecord, MiroSourceOverrides, MiroMetadata)]] =
     miroReadable
       .get(p.location)
       .map {
@@ -50,6 +52,7 @@ class MiroTransformerWorker[MsgDestination](
               miroRecord,
               p.overrides.getOrElse(MiroSourceOverrides.empty),
               MiroMetadata(
-                isClearedForCatalogueAPI = p.isClearedForCatalogueAPI)))
+                isClearedForCatalogueAPI = p.isClearedForCatalogueAPI))
+          )
       }
 }

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroImageData.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroImageData.scala
@@ -7,10 +7,12 @@ import weco.catalogue.internal_model.identifiers.{
   SourceIdentifier
 }
 import weco.catalogue.internal_model.image.ImageData
+import weco.catalogue.source_model.miro.MiroSourceOverrides
 
 trait MiroImageData extends MiroLocation {
 
   def getImageData(miroRecord: MiroRecord,
+                   overrides: MiroSourceOverrides,
                    version: Int): ImageData[IdState.Identifiable] =
     ImageData[IdState.Identifiable](
       id = IdState.Identifiable(
@@ -21,6 +23,6 @@ trait MiroImageData extends MiroLocation {
         )
       ),
       version = version,
-      locations = List(getLocation(miroRecord))
+      locations = List(getLocation(miroRecord, overrides))
     )
 }

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroItems.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroItems.scala
@@ -7,7 +7,8 @@ import weco.catalogue.source_model.miro.MiroSourceOverrides
 
 trait MiroItems extends MiroLocation {
 
-  def getItems(miroRecord: MiroRecord, overrides: MiroSourceOverrides): List[Item[IdState.Unminted]] =
+  def getItems(miroRecord: MiroRecord,
+               overrides: MiroSourceOverrides): List[Item[IdState.Unminted]] =
     List(
       Item(
         id = IdState.Unidentifiable,

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroItems.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroItems.scala
@@ -3,12 +3,13 @@ package uk.ac.wellcome.platform.transformer.miro.transformers
 import uk.ac.wellcome.platform.transformer.miro.source.MiroRecord
 import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.work.Item
+import weco.catalogue.source_model.miro.MiroSourceOverrides
 
 trait MiroItems extends MiroLocation {
 
-  def getItems(miroRecord: MiroRecord): List[Item[IdState.Unminted]] =
+  def getItems(miroRecord: MiroRecord, overrides: MiroSourceOverrides): List[Item[IdState.Unminted]] =
     List(
       Item(
         id = IdState.Unidentifiable,
-        locations = List(getLocation(miroRecord))))
+        locations = List(getLocation(miroRecord, overrides))))
 }

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLicenses.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLicenses.scala
@@ -5,6 +5,7 @@ import uk.ac.wellcome.platform.transformer.miro.exceptions.{
   ShouldSuppressException
 }
 import weco.catalogue.internal_model.locations.License
+import weco.catalogue.source_model.miro.MiroSourceOverrides
 
 trait MiroLicenses {
 
@@ -22,7 +23,14 @@ trait MiroLicenses {
     *  TODO: Update these mappings based on the final version of Christy's
     *        document.
     */
-  def chooseLicense(maybeUseRestrictions: Option[String]): License =
+  def chooseLicense(maybeUseRestrictions: Option[String],
+                    overrides: MiroSourceOverrides): License =
+    overrides.license match {
+      case Some(license) => license
+      case None => chooseLicenseFromUseRestrictions(maybeUseRestrictions)
+    }
+
+  private def chooseLicenseFromUseRestrictions(maybeUseRestrictions: Option[String]): License =
     maybeUseRestrictions match {
 
       // These images need more data.

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLicenses.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLicenses.scala
@@ -27,10 +27,11 @@ trait MiroLicenses {
                     overrides: MiroSourceOverrides): License =
     overrides.license match {
       case Some(license) => license
-      case None => chooseLicenseFromUseRestrictions(maybeUseRestrictions)
+      case None          => chooseLicenseFromUseRestrictions(maybeUseRestrictions)
     }
 
-  private def chooseLicenseFromUseRestrictions(maybeUseRestrictions: Option[String]): License =
+  private def chooseLicenseFromUseRestrictions(
+    maybeUseRestrictions: Option[String]): License =
     maybeUseRestrictions match {
 
       // These images need more data.

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLicenses.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLicenses.scala
@@ -22,8 +22,7 @@ trait MiroLicenses {
     *  TODO: Update these mappings based on the final version of Christy's
     *        document.
     */
-  def chooseLicense(miroId: String,
-                    maybeUseRestrictions: Option[String]): License =
+  def chooseLicense(maybeUseRestrictions: Option[String]): License =
     maybeUseRestrictions match {
 
       // These images need more data.
@@ -57,5 +56,4 @@ trait MiroLicenses {
               "image_use_restrictions = 'Image withdrawn, see notes'")
         }
     }
-
 }

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLocation.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLocation.scala
@@ -35,7 +35,6 @@ trait MiroLocation extends MiroLicenses with MiroContributorCodes {
       credit = getCredit(miroRecord),
       license = Some(
         chooseLicense(
-          miroId = miroRecord.imageNumber,
           maybeUseRestrictions = miroRecord.useRestrictions
         )
       ),

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLocation.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLocation.scala
@@ -7,6 +7,7 @@ import weco.catalogue.internal_model.locations.{
   DigitalLocation,
   LocationType
 }
+import weco.catalogue.source_model.miro.MiroSourceOverrides
 
 trait MiroLocation extends MiroLicenses with MiroContributorCodes {
 
@@ -25,7 +26,7 @@ trait MiroLocation extends MiroLicenses with MiroContributorCodes {
     imageUriTemplate.format(iiifImageApiBaseUri, miroId)
   }
 
-  def getLocation(miroRecord: MiroRecord): DigitalLocation =
+  def getLocation(miroRecord: MiroRecord, overrides: MiroSourceOverrides): DigitalLocation =
     DigitalLocation(
       locationType = LocationType.IIIFImageAPI,
       url = buildImageApiURL(
@@ -35,7 +36,8 @@ trait MiroLocation extends MiroLicenses with MiroContributorCodes {
       credit = getCredit(miroRecord),
       license = Some(
         chooseLicense(
-          maybeUseRestrictions = miroRecord.useRestrictions
+          maybeUseRestrictions = miroRecord.useRestrictions,
+          overrides = overrides
         )
       ),
       accessConditions = List(

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLocation.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLocation.scala
@@ -26,7 +26,8 @@ trait MiroLocation extends MiroLicenses with MiroContributorCodes {
     imageUriTemplate.format(iiifImageApiBaseUri, miroId)
   }
 
-  def getLocation(miroRecord: MiroRecord, overrides: MiroSourceOverrides): DigitalLocation =
+  def getLocation(miroRecord: MiroRecord,
+                  overrides: MiroSourceOverrides): DigitalLocation =
     DigitalLocation(
       locationType = LocationType.IIIFImageAPI,
       url = buildImageApiURL(

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroThumbnail.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroThumbnail.scala
@@ -12,7 +12,6 @@ trait MiroThumbnail extends MiroImageData with MiroLicenses {
         templateName = "thumbnail"),
       license = Some(
         chooseLicense(
-          miroId = miroRecord.imageNumber,
           maybeUseRestrictions = miroRecord.useRestrictions
         )
       )

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroThumbnail.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroThumbnail.scala
@@ -2,9 +2,10 @@ package uk.ac.wellcome.platform.transformer.miro.transformers
 
 import uk.ac.wellcome.platform.transformer.miro.source.MiroRecord
 import weco.catalogue.internal_model.locations.{DigitalLocation, LocationType}
+import weco.catalogue.source_model.miro.MiroSourceOverrides
 
 trait MiroThumbnail extends MiroImageData with MiroLicenses {
-  def getThumbnail(miroRecord: MiroRecord): DigitalLocation =
+  def getThumbnail(miroRecord: MiroRecord, overrides: MiroSourceOverrides): DigitalLocation =
     DigitalLocation(
       locationType = LocationType.ThumbnailImage,
       url = buildImageApiURL(
@@ -12,7 +13,8 @@ trait MiroThumbnail extends MiroImageData with MiroLicenses {
         templateName = "thumbnail"),
       license = Some(
         chooseLicense(
-          maybeUseRestrictions = miroRecord.useRestrictions
+          maybeUseRestrictions = miroRecord.useRestrictions,
+          overrides = overrides
         )
       )
     )

--- a/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroThumbnail.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroThumbnail.scala
@@ -5,7 +5,8 @@ import weco.catalogue.internal_model.locations.{DigitalLocation, LocationType}
 import weco.catalogue.source_model.miro.MiroSourceOverrides
 
 trait MiroThumbnail extends MiroImageData with MiroLicenses {
-  def getThumbnail(miroRecord: MiroRecord, overrides: MiroSourceOverrides): DigitalLocation =
+  def getThumbnail(miroRecord: MiroRecord,
+                   overrides: MiroSourceOverrides): DigitalLocation =
     DigitalLocation(
       locationType = LocationType.ThumbnailImage,
       url = buildImageApiURL(

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroTransformerWorkerTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroTransformerWorkerTest.scala
@@ -16,6 +16,7 @@ import uk.ac.wellcome.storage.store.memory.MemoryTypedStore
 import weco.catalogue.internal_model.identifiers.IdentifierType
 import weco.catalogue.internal_model.work.{Work, WorkState}
 import weco.catalogue.source_model.MiroSourcePayload
+import weco.catalogue.source_model.miro.MiroSourceOverrides
 import weco.catalogue.transformer.{
   TransformerWorker,
   TransformerWorkerTestCases
@@ -27,7 +28,7 @@ class MiroTransformerWorkerTest
     extends TransformerWorkerTestCases[
       MemoryTypedStore[S3ObjectLocation, MiroRecord],
       MiroSourcePayload,
-      (MiroRecord, MiroMetadata)]
+      (MiroRecord, MiroSourceOverrides, MiroMetadata)]
     with MiroRecordGenerators
     with S3ObjectLocationGenerators
     with EitherValues {
@@ -96,7 +97,7 @@ class MiroTransformerWorkerTest
                                           String],
     retriever: Retriever[Work[WorkState.Source]])(
     testWith: TestWith[
-      TransformerWorker[MiroSourcePayload, (MiroRecord, MiroMetadata), String],
+      TransformerWorker[MiroSourcePayload, (MiroRecord, MiroSourceOverrides, MiroMetadata), String],
       R])(
     implicit miroReadable: MemoryTypedStore[S3ObjectLocation, MiroRecord]): R =
     testWith(

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroTransformerWorkerTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroTransformerWorkerTest.scala
@@ -57,6 +57,8 @@ class MiroTransformerWorkerTest
       id = id,
       version = version,
       location = location,
+      events = List(),
+      overrides = None,
       isClearedForCatalogueAPI = chooseFrom(true, false)
     )
   }
@@ -79,6 +81,8 @@ class MiroTransformerWorkerTest
       id = randomAlphanumeric(),
       version = 1,
       location = createS3ObjectLocation,
+      events = List(),
+      overrides = None,
       isClearedForCatalogueAPI = chooseFrom(true, false)
     )
 

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroTransformerWorkerTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/services/MiroTransformerWorkerTest.scala
@@ -96,9 +96,12 @@ class MiroTransformerWorkerTest
                                           Work[WorkState.Source],
                                           String],
     retriever: Retriever[Work[WorkState.Source]])(
-    testWith: TestWith[
-      TransformerWorker[MiroSourcePayload, (MiroRecord, MiroSourceOverrides, MiroMetadata), String],
-      R])(
+    testWith: TestWith[TransformerWorker[MiroSourcePayload,
+                                         (MiroRecord,
+                                          MiroSourceOverrides,
+                                          MiroMetadata),
+                                         String],
+                       R])(
     implicit miroReadable: MemoryTypedStore[S3ObjectLocation, MiroRecord]): R =
     testWith(
       new MiroTransformerWorker(

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroImageDataTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroImageDataTest.scala
@@ -11,6 +11,7 @@ import weco.catalogue.internal_model.identifiers.{
 }
 import weco.catalogue.internal_model.image.ImageData
 import weco.catalogue.internal_model.locations._
+import weco.catalogue.source_model.miro.MiroSourceOverrides
 
 class MiroImageDataTest
     extends AnyFunSpec
@@ -21,14 +22,17 @@ class MiroImageDataTest
 
   describe("getImageData") {
     it("extracts the Miro image data") {
-      transformer.getImageData(
-        createMiroRecordWith(
+      val imageData = transformer.getImageData(
+        miroRecord = createMiroRecordWith(
           imageNumber = "B0011308",
           useRestrictions = Some("CC-0"),
           sourceCode = Some("FDN")
         ),
+        overrides = MiroSourceOverrides.empty,
         version = 1
-      ) shouldBe ImageData[IdState.Identifiable](
+      )
+
+      imageData shouldBe ImageData[IdState.Identifiable](
         id = IdState.Identifiable(
           sourceIdentifier = SourceIdentifier(
             identifierType = IdentifierType.MiroImageNumber,
@@ -48,6 +52,28 @@ class MiroImageDataTest
             )
           ))
       )
+    }
+
+    it("uses the source overrides") {
+      val miroRecord = createMiroRecordWith(useRestrictions = Some("CC-0"))
+
+      val imageData1 = transformer.getImageData(
+        miroRecord = miroRecord,
+        overrides = MiroSourceOverrides.empty,
+        version = 1
+      )
+
+      imageData1.locations.head.license shouldBe Some(License.CC0)
+
+      val imageData2 = transformer.getImageData(
+        miroRecord = miroRecord,
+        overrides = MiroSourceOverrides(
+          license = Some(License.InCopyright)
+        ),
+        version = 1
+      )
+
+      imageData2.locations.head.license shouldBe Some(License.InCopyright)
     }
   }
 }

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroItemsTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroItemsTest.scala
@@ -7,6 +7,7 @@ import weco.catalogue.internal_model.generators.IdentifiersGenerators
 import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.locations._
 import weco.catalogue.internal_model.work.Item
+import weco.catalogue.source_model.miro.MiroSourceOverrides
 
 class MiroItemsTest
     extends AnyFunSpec
@@ -17,12 +18,16 @@ class MiroItemsTest
 
   describe("getItems") {
     it("extracts an unidentifiable item") {
-      transformer.getItems(
-        createMiroRecordWith(
+      val items  = transformer.getItems(
+        miroRecord = createMiroRecordWith(
           sourceCode = Some("FDN"),
           useRestrictions = Some("CC-0"),
           imageNumber = "B0011308"
-        )) shouldBe List(
+        ),
+        overrides = MiroSourceOverrides.empty
+      )
+
+      items shouldBe List(
         Item(
           id = IdState.Unidentifiable,
           locations = List(DigitalLocation(

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroItemsTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroItemsTest.scala
@@ -18,7 +18,7 @@ class MiroItemsTest
 
   describe("getItems") {
     it("extracts an unidentifiable item") {
-      val items  = transformer.getItems(
+      val items = transformer.getItems(
         miroRecord = createMiroRecordWith(
           sourceCode = Some("FDN"),
           useRestrictions = Some("CC-0"),

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLicensesTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLicensesTest.scala
@@ -7,6 +7,7 @@ import uk.ac.wellcome.platform.transformer.miro.exceptions.{
   ShouldSuppressException
 }
 import weco.catalogue.internal_model.locations.License
+import weco.catalogue.source_model.miro.MiroSourceOverrides
 
 class MiroLicensesTest extends AnyFunSpec with Matchers {
   it("finds a recognised license") {
@@ -35,8 +36,25 @@ class MiroLicensesTest extends AnyFunSpec with Matchers {
     }
   }
 
+  it("uses the license override, if set") {
+    val maybeUseRestrictions = Some("CC-0")
+
+    transformer.chooseLicense(
+      maybeUseRestrictions = maybeUseRestrictions,
+      overrides = MiroSourceOverrides.empty
+    ) shouldBe License.CC0
+
+    transformer.chooseLicense(
+      maybeUseRestrictions = maybeUseRestrictions,
+      overrides = MiroSourceOverrides(license = Some(License.InCopyright))
+    ) shouldBe License.InCopyright
+  }
+
   private def chooseLicense(maybeUseRestrictions: Option[String]): License =
-    transformer.chooseLicense(maybeUseRestrictions = maybeUseRestrictions)
+    transformer.chooseLicense(
+      maybeUseRestrictions = maybeUseRestrictions,
+      overrides = MiroSourceOverrides.empty
+    )
 
   val transformer = new MiroLicenses {}
 }

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLicensesTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLicensesTest.scala
@@ -36,9 +36,7 @@ class MiroLicensesTest extends AnyFunSpec with Matchers {
   }
 
   private def chooseLicense(maybeUseRestrictions: Option[String]): License =
-    transformer.chooseLicense(
-      miroId = "A1234567",
-      maybeUseRestrictions = maybeUseRestrictions)
+    transformer.chooseLicense(maybeUseRestrictions = maybeUseRestrictions)
 
   val transformer = new MiroLicenses {}
 }

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLocationTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroLocationTest.scala
@@ -4,6 +4,7 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.platform.transformer.miro.generators.MiroRecordGenerators
 import weco.catalogue.internal_model.locations._
+import weco.catalogue.source_model.miro.MiroSourceOverrides
 
 class MiroLocationTest
     extends AnyFunSpec
@@ -12,13 +13,16 @@ class MiroLocationTest
   val transformer = new MiroLocation {}
   it(
     "extracts the digital location and finds the credit line for an image-specific contributor code") {
-    transformer.getLocation(
-      createMiroRecordWith(
+    val location = transformer.getLocation(
+      miroRecord = createMiroRecordWith(
         sourceCode = Some("FDN"),
         useRestrictions = Some("CC-0"),
         imageNumber = "B0011308"
-      )
-    ) shouldBe DigitalLocation(
+      ),
+      overrides = MiroSourceOverrides.empty
+    )
+
+    location shouldBe DigitalLocation(
       url = "https://iiif.wellcomecollection.org/image/B0011308/info.json",
       locationType = LocationType.IIIFImageAPI,
       license = Some(License.CC0),

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroRecordTransformerTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroRecordTransformerTest.scala
@@ -15,6 +15,7 @@ import weco.catalogue.internal_model.locations._
 import weco.catalogue.internal_model.work.DeletedReason.SuppressedFromSource
 import weco.catalogue.internal_model.work.InvisibilityReason.UnableToTransform
 import weco.catalogue.internal_model.work._
+import weco.catalogue.source_model.miro.MiroSourceOverrides
 
 class MiroRecordTransformerTest
     extends AnyFunSpec
@@ -360,6 +361,30 @@ class MiroRecordTransformerTest
     )
   }
 
+  describe("it uses the MiroSourceOverrides") {
+    it("to set the license") {
+      val miroRecord = createMiroRecordWith(useRestrictions = Some("CC-0"))
+
+      val work1 = transformWork(
+        miroRecord = miroRecord,
+        overrides = MiroSourceOverrides.empty
+      )
+
+      val license1 = work1.data.items.head.locations.head.license
+      license1 shouldBe Some(License.CC0)
+
+      val work2 = transformWork(
+        miroRecord = miroRecord,
+        overrides = MiroSourceOverrides(
+          license = Some(License.InCopyright)
+        )
+      )
+
+      val license2 = work2.data.items.head.locations.head.license
+      license2 shouldBe Some(License.InCopyright)
+    }
+  }
+
   private def assertTransformReturnsInvisibleWork(
     miroRecord: MiroRecord,
     miroMetadata: MiroMetadata = MiroMetadata(isClearedForCatalogueAPI = true),
@@ -367,6 +392,7 @@ class MiroRecordTransformerTest
   ): Assertion = {
     val triedMaybeWork = transformer.transform(
       miroRecord = miroRecord,
+      overrides = MiroSourceOverrides.empty,
       miroMetadata = miroMetadata,
       version = 1
     )
@@ -393,6 +419,7 @@ class MiroRecordTransformerTest
   ): Assertion = {
     val triedMaybeWork = transformer.transform(
       miroRecord = miroRecord,
+      overrides = MiroSourceOverrides.empty,
       miroMetadata = miroMetadata,
       version = 1
     )

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroThumbnailTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroThumbnailTest.scala
@@ -1,0 +1,31 @@
+package uk.ac.wellcome.platform.transformer.miro.transformers
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.platform.transformer.miro.generators.MiroRecordGenerators
+import weco.catalogue.internal_model.locations.License
+import weco.catalogue.source_model.miro.MiroSourceOverrides
+
+class MiroThumbnailTest extends AnyFunSpec with Matchers with MiroRecordGenerators {
+  val transformer = new MiroThumbnail {}
+
+  it("uses the source overrides") {
+    val miroRecord = createMiroRecordWith(useRestrictions = Some("CC-0"))
+
+    val thumbnail1 = transformer.getThumbnail(
+      miroRecord = miroRecord,
+      overrides = MiroSourceOverrides.empty
+    )
+
+    thumbnail1.license shouldBe Some(License.CC0)
+
+    val thumbnail2 = transformer.getThumbnail(
+      miroRecord = miroRecord,
+      overrides = MiroSourceOverrides(
+        license = Some(License.InCopyright)
+      )
+    )
+
+    thumbnail2.license shouldBe Some(License.InCopyright)
+  }
+}

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroThumbnailTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroThumbnailTest.scala
@@ -6,7 +6,10 @@ import uk.ac.wellcome.platform.transformer.miro.generators.MiroRecordGenerators
 import weco.catalogue.internal_model.locations.License
 import weco.catalogue.source_model.miro.MiroSourceOverrides
 
-class MiroThumbnailTest extends AnyFunSpec with Matchers with MiroRecordGenerators {
+class MiroThumbnailTest
+    extends AnyFunSpec
+    with Matchers
+    with MiroRecordGenerators {
   val transformer = new MiroThumbnail {}
 
   it("uses the source overrides") {

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroTransformableWrapper.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroTransformableWrapper.scala
@@ -8,16 +8,18 @@ import uk.ac.wellcome.platform.transformer.miro.models.MiroMetadata
 import uk.ac.wellcome.platform.transformer.miro.source.MiroRecord
 import weco.catalogue.internal_model.work.Work
 import weco.catalogue.internal_model.work.WorkState.Source
+import weco.catalogue.source_model.miro.MiroSourceOverrides
 
 import scala.util.Try
 
 trait MiroTransformableWrapper extends Matchers { this: Suite =>
   val transformer = new MiroRecordTransformer
 
-  def transformWork(miroRecord: MiroRecord): Work.Visible[Source] = {
+  def transformWork(miroRecord: MiroRecord, overrides: MiroSourceOverrides = MiroSourceOverrides.empty): Work.Visible[Source] = {
     val triedWork: Try[Work[Source]] =
       transformer.transform(
         miroRecord = miroRecord,
+        overrides = overrides,
         miroMetadata = MiroMetadata(isClearedForCatalogueAPI = true),
         version = 1
       )
@@ -39,6 +41,7 @@ trait MiroTransformableWrapper extends Matchers { this: Suite =>
     transformer
       .transform(
         miroRecord = miroRecord,
+        overrides = MiroSourceOverrides.empty,
         miroMetadata = MiroMetadata(isClearedForCatalogueAPI = true),
         version = 1
       )

--- a/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroTransformableWrapper.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/uk/ac/wellcome/platform/transformer/miro/transformers/MiroTransformableWrapper.scala
@@ -15,7 +15,9 @@ import scala.util.Try
 trait MiroTransformableWrapper extends Matchers { this: Suite =>
   val transformer = new MiroRecordTransformer
 
-  def transformWork(miroRecord: MiroRecord, overrides: MiroSourceOverrides = MiroSourceOverrides.empty): Work.Visible[Source] = {
+  def transformWork(miroRecord: MiroRecord,
+                    overrides: MiroSourceOverrides = MiroSourceOverrides.empty)
+    : Work.Visible[Source] = {
     val triedWork: Try[Work[Source]] =
       transformer.transform(
         miroRecord = miroRecord,

--- a/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/models/source/ReindexPayload.scala
+++ b/reindexer/reindex_worker/src/main/scala/uk/ac/wellcome/platform/reindex/reindex_worker/models/source/ReindexPayload.scala
@@ -10,6 +10,7 @@ import weco.catalogue.source_model.{
   SourcePayload
 }
 import weco.catalogue.source_model.mets.MetsSourceData
+import weco.catalogue.source_model.miro.{MiroSourceOverrides, MiroUpdateEvent}
 
 sealed trait ReindexPayload {
   val id: String
@@ -43,11 +44,20 @@ case class MiroReindexPayload(
   id: String,
   isClearedForCatalogueAPI: Boolean,
   location: S3ObjectLocation,
+  events: List[MiroUpdateEvent] = Nil,
+  overrides: Option[MiroSourceOverrides] = None,
   version: Int
 ) extends ReindexPayload {
 
   override def toSourcePayload: SourcePayload =
-    MiroSourcePayload(id, isClearedForCatalogueAPI, location, version)
+    MiroSourcePayload(
+      id = id,
+      isClearedForCatalogueAPI = isClearedForCatalogueAPI,
+      location = location,
+      events = events,
+      overrides = overrides,
+      version = version
+    )
 }
 
 case class MetsReindexPayload(

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/ReindexWorkerServiceTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/ReindexWorkerServiceTest.scala
@@ -333,7 +333,8 @@ class ReindexWorkerServiceTest
           events = List(
             MiroUpdateEvent(
               description = "Change license override from 'None' to 'cc-by-nc'",
-              message = "An email from Jane Smith (the contributor) explained we can use CC-BY-NC",
+              message =
+                "An email from Jane Smith (the contributor) explained we can use CC-BY-NC",
               date = Instant.parse("2021-05-19T09:37:13.533Z"),
               user = "Henry Wellcome <wellcomeh@wellcomecloud.onmicrosoft.com>"
             )

--- a/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/ReindexWorkerServiceTest.scala
+++ b/reindexer/reindex_worker/src/test/scala/uk/ac/wellcome/platform/reindex/reindex_worker/services/ReindexWorkerServiceTest.scala
@@ -279,6 +279,8 @@ class ReindexWorkerServiceTest
           id = miroID,
           isClearedForCatalogueAPI = isClearedForCatalogueAPI,
           location = location,
+          events = List(),
+          overrides = None,
           version = version
         )
 


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5176, the first part of https://github.com/wellcomecollection/docs/pull/61

The broad strokes: this PR adds a new model `MiroSourceOverrides`, which will be stored directly in the DynamoDB table of the Miro VHS. Values set here will override anything in the source data, e.g. if we want to mark a particular image as "in copyright" instead of CC BY.

This patch modifies:

* the reindexer to send these overrides to the transformer, if there are any
* the transformer to pay attention to these overrides, if there are any

I'll get these deployed, then write the Python that actually updates these values.