### PR TITLE
Add a Python API for adding Miro overrides and suppressing/opening images

### DIFF
--- a/reindexer/start_reindex.py
+++ b/reindexer/start_reindex.py
@@ -17,7 +17,7 @@ SOURCES = {
     "calm": "vhs-calm-adapter",
 }
 
-DESTINATIONS = ["catalogue", "reporting"]
+DESTINATIONS = ["catalogue", "catalogue_miro_updates", "reporting"]
 
 
 def how_many_segments(table_name):

--- a/reindexer/terraform/locals.tf
+++ b/reindexer/terraform/locals.tf
@@ -7,17 +7,18 @@ locals {
   mets_dynamo_table_name        = data.terraform_remote_state.mets_adapter.outputs.mets_dynamo_table_name
   vhs_calm_table_name           = data.terraform_remote_state.calm_adapter.outputs.vhs_table_name
 
-  reporting_miro_hybrid_records_topic_arn           = data.terraform_remote_state.shared_infra.outputs.reporting_miro_reindex_topic_arn
-  reporting_miro_inventory_hybrid_records_topic_arn = data.terraform_remote_state.shared_infra.outputs.reporting_miro_inventory_reindex_topic_arn
-  reporting_sierra_hybrid_records_topic_arn         = data.terraform_remote_state.shared_infra.outputs.reporting_sierra_reindex_topic_arn
-  catalogue_miro_hybrid_records_topic_arn           = data.terraform_remote_state.shared_infra.outputs.catalogue_miro_reindex_topic_arn
-  catalogue_sierra_hybrid_records_topic_arn         = data.terraform_remote_state.shared_infra.outputs.catalogue_sierra_reindex_topic_arn
-  mets_reindexer_topic_name                         = module.mets_reindexer_topic.name
-  mets_reindexer_topic_arn                          = module.mets_reindexer_topic.arn
-  calm_reindexer_topic_name                         = module.calm_reindexer_topic.name
-  calm_reindexer_topic_arn                          = module.calm_reindexer_topic.arn
-  calm_deletion_checker_topic_name                  = module.calm_deletion_checker_topic.name
-  calm_deletion_checker_topic_arn                   = module.calm_deletion_checker_topic.arn
+  reporting_miro_reindex_topic_arn           = data.terraform_remote_state.shared_infra.outputs.reporting_miro_reindex_topic_arn
+  reporting_miro_inventory_reindex_topic_arn = data.terraform_remote_state.shared_infra.outputs.reporting_miro_inventory_reindex_topic_arn
+  reporting_sierra_reindex_topic_arn         = data.terraform_remote_state.shared_infra.outputs.reporting_sierra_reindex_topic_arn
+  catalogue_miro_reindex_topic_arn           = data.terraform_remote_state.shared_infra.outputs.catalogue_miro_reindex_topic_arn
+  catalogue_sierra_reindex_topic_arn         = data.terraform_remote_state.shared_infra.outputs.catalogue_sierra_reindex_topic_arn
+  mets_reindexer_topic_name                  = module.mets_reindexer_topic.name
+  mets_reindexer_topic_arn                   = module.mets_reindexer_topic.arn
+  calm_reindexer_topic_name                  = module.calm_reindexer_topic.name
+  calm_reindexer_topic_arn                   = module.calm_reindexer_topic.arn
+  calm_deletion_checker_topic_name           = module.calm_deletion_checker_topic.name
+  calm_deletion_checker_topic_arn            = module.calm_deletion_checker_topic.arn
+  miro_updates_topic_arn                     = data.terraform_remote_state.shared_infra.outputs.miro_updates_topic_arn
 
   vpc_id          = local.catalogue_vpcs["catalogue_vpc_delta_id"]
   private_subnets = local.catalogue_vpcs["catalogue_vpc_delta_private_subnets"]
@@ -36,31 +37,37 @@ locals {
       source      = "sierra"
       destination = "reporting"
       table       = local.vhs_sierra_table_name
-      topic       = local.reporting_sierra_hybrid_records_topic_arn
+      topic       = local.reporting_sierra_reindex_topic_arn
     },
     {
       source      = "sierra"
       destination = "catalogue"
       table       = local.vhs_sierra_table_name
-      topic       = local.catalogue_sierra_hybrid_records_topic_arn
+      topic       = local.catalogue_sierra_reindex_topic_arn
     },
     {
       source      = "miro"
       destination = "reporting"
       table       = local.vhs_miro_table_name
-      topic       = local.reporting_miro_hybrid_records_topic_arn
+      topic       = local.reporting_miro_reindex_topic_arn
     },
     {
       source      = "miro"
       destination = "catalogue"
       table       = local.vhs_miro_table_name
-      topic       = local.catalogue_miro_hybrid_records_topic_arn
+      topic       = local.catalogue_miro_reindex_topic_arn
+    },
+    {
+      source      = "miro"
+      destination = "catalogue_miro_updates"
+      table       = local.vhs_miro_table_name
+      topic       = local.miro_updates_topic_arn
     },
     {
       source      = "miro_inventory"
       destination = "reporting"
       table       = local.vhs_miro_inventory_table_name
-      topic       = local.reporting_miro_inventory_hybrid_records_topic_arn
+      topic       = local.reporting_miro_inventory_reindex_topic_arn
     },
     {
       source      = "mets"

--- a/scripts/_common.py
+++ b/scripts/_common.py
@@ -1,0 +1,39 @@
+import boto3
+from elasticsearch import Elasticsearch
+
+
+def get_session(*, role_arn):
+    """
+    Returns a boto3 Session authenticated with the current role ARN.
+    """
+    sts_client = boto3.client("sts")
+    assumed_role_object = sts_client.assume_role(
+        RoleArn=role_arn, RoleSessionName="AssumeRoleSession1"
+    )
+    credentials = assumed_role_object["Credentials"]
+    return boto3.Session(
+        aws_access_key_id=credentials["AccessKeyId"],
+        aws_secret_access_key=credentials["SecretAccessKey"],
+        aws_session_token=credentials["SessionToken"],
+    )
+
+
+def get_secret_string(session, *, secret_id):
+    """
+    Look up the value of a SecretString in Secrets Manager.
+    """
+    secrets = session.client("secretsmanager")
+    return secrets.get_secret_value(SecretId=secret_id)["SecretString"]
+
+
+def get_api_es_client(session):
+    """
+    Returns an Elasticsearch client for the catalogue cluster.
+    """
+    host = get_secret_string(session, secret_id="catalogue/api/es_host")
+    port = get_secret_string(session, secret_id="catalogue/api/es_port")
+    protocol = get_secret_string(session, secret_id="catalogue/api/es_protocol")
+    username = get_secret_string(session, secret_id="catalogue/api/es_username")
+    password = get_secret_string(session, secret_id="catalogue/api/es_password")
+
+    return Elasticsearch(f"{protocol}://{username}:{password}@{host}:{port}")

--- a/scripts/miro_updates.py
+++ b/scripts/miro_updates.py
@@ -55,10 +55,7 @@ def _request_reindex_for(miro_id):
         "parameters": {"ids": [miro_id], "type": "SpecificReindexParameters"},
     }
 
-    sns_client.publish(
-        TopicArn=_get_reindexer_topic_arn(),
-        Message=json.dumps(message),
-    )
+    sns_client.publish(TopicArn=_get_reindexer_topic_arn(), Message=json.dumps(message))
 
 
 def _get_timestamp():

--- a/scripts/miro_updates.py
+++ b/scripts/miro_updates.py
@@ -1,0 +1,132 @@
+import datetime
+import json
+
+import boto3
+
+from _common import get_session
+
+
+SESSION = get_session(role_arn="arn:aws:iam::760097843905:role/platform-developer")
+DYNAMO_CLIENT = SESSION.resource("dynamodb").meta.client
+
+TABLE_NAME = "vhs-sourcedata-miro"
+
+
+def _read_from_s3(bucket, key):
+    s3 = SESSION.client("s3")
+    obj = s3.get_object(Bucket=bucket, Key=key)
+    return obj["Body"].read()
+
+
+def _get_reindexer_topic_arn():
+    statefile_body = _read_from_s3(
+        bucket="wellcomecollection-platform-infra",
+        key="terraform/catalogue/reindexer.tfstate",
+    )
+
+    # The structure of the interesting bits of the statefile is:
+    #
+    #   {
+    #       ...
+    #       "outputs": {
+    #          "name_of_output": {
+    #              "value": "1234567890x",
+    #              ...
+    #          },
+    #          ...
+    #      }
+    #   }
+    #
+    statefile_data = json.loads(statefile_body)
+    outputs = statefile_data["outputs"]
+    return outputs["topic_arn"]["value"]
+
+
+def _request_reindex_for(miro_id):
+    sns_client = SESSION.client("sns")
+
+    message = {
+        "jobConfigId": "miro--catalogue_miro_updates",
+        "parameters": {"ids": [miro_id], "type": "SpecificReindexParameters"},
+    }
+
+    sns_client.publish(
+        TopicArn=_get_reindexer_topic_arn(),
+        Message=json.dumps(message),
+    )
+
+
+def _get_timestamp():
+    # DynamoDB formats timestamps as milliseconds past the epoch
+    return int(datetime.datetime.now().timestamp() * 1000)
+
+
+def _get_user():
+    """
+    Returns the original role ARN.
+    e.g. at Wellcome we have a base role, but then we assume roles into different
+    accounts.  This returns the ARN of the base role.
+    """
+    client = boto3.client("sts")
+    return client.get_caller_identity()["Arn"]
+
+
+def _set_image_availability(*, miro_id, message: str, is_available: bool):
+    item = DYNAMO_CLIENT.get_item(TableName=TABLE_NAME, Key={"id": miro_id})["Item"]
+
+    new_event = {
+        "description": "Change isClearedForCatalogueAPI from %r to %r"
+        % (item["isClearedForCatalogueAPI"], is_available),
+        "message": message,
+        "date": _get_timestamp(),
+        "user": _get_user(),
+    }
+
+    try:
+        events = item["events"] + [new_event]
+    except KeyError:
+        events = [new_event]
+
+    DYNAMO_CLIENT.update_item(
+        TableName=TABLE_NAME,
+        Key={"id": miro_id},
+        UpdateExpression="SET #version = :newVersion, #events = :events, #isClearedForCatalogueAPI = :is_available",
+        ConditionExpression="#version = :oldVersion",
+        ExpressionAttributeNames={
+            "#version": "version",
+            "#events": "events",
+            "#isClearedForCatalogueAPI": "isClearedForCatalogueAPI",
+        },
+        ExpressionAttributeValues={
+            ":oldVersion": item["version"],
+            ":newVersion": item["version"] + 1,
+            ":events": events,
+            ":is_available": is_available,
+        },
+    )
+
+    _request_reindex_for(miro_id)
+
+
+def make_image_available(*, miro_id, message: str):
+    """
+    Make a Miro image available on wellcomecollection.org.
+    """
+    _set_image_availability(miro_id=miro_id, message=message, is_available=True)
+
+
+def suppress_image(*, miro_id, message: str):
+    """
+    Hide a Miro image from wellcomecollection.org.
+    """
+    _set_image_availability(miro_id=miro_id, message=message, is_available=False)
+#
+# def set_license_override(image_id, license_code: str, message: str)
+#
+# def remove_license_override(image_id, message: str)
+
+if __name__ == "__main__":
+    suppress_image(
+        miro_id="AS0000081FH23",
+        message="Testing the Miro update Python on an image that's already unavailable",
+    )

--- a/scripts/remove_work/run.py
+++ b/scripts/remove_work/run.py
@@ -438,4 +438,17 @@ def main(catalogue_id, index, dry_run):
 
 
 if __name__ == "__main__":
+    # This script is outdated, in particular:
+    #
+    #  - it should use the new mechanism for updating Miro images in VHS
+    #    (see miro_updates.py in the parent directory)
+    #
+    #    That script will remove it from VHS and send it to the Miro
+    #    transformer to remove it from our indexes.
+    #
+    #  - it assumes the use of Loris, which we've stopped using
+    #
+    # The idea behind this script is sound -- but I don't want to fix
+    # it right now.
+    assert 0, "This script is outdated and needs to be rewritten"
     main()

--- a/scripts/save_miro_vhs_snapshot.py
+++ b/scripts/save_miro_vhs_snapshot.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+"""
+Save a complete copy of the Miro VHS table in S3.
+"""
+
+import datetime
+import decimal
+import gzip
+import json
+
+import tqdm
+
+from _common import get_session
+
+
+class DecimalEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, decimal.Decimal) and int(obj) == obj:
+            return int(obj)
+
+
+def scan_table(session, *, TableName, **kwargs):
+    """
+    Generates all the items in a DynamoDB table.
+
+    :param dynamo_client: A boto3 client for DynamoDB.
+    :param TableName: The name of the table to scan.
+
+    Other keyword arguments will be passed directly to the Scan operation.
+    See https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb.html#DynamoDB.Client.scan
+
+    """
+    dynamodb_client = session.resource("dynamodb").meta.client
+    paginator = dynamodb_client.get_paginator("scan")
+
+    for page in paginator.paginate(TableName=TableName, **kwargs):
+        yield from page["Items"]
+
+
+if __name__ == "__main__":
+    read_only_session = get_session(role_arn="arn:aws:iam::760097843905:role/platform-read_only")
+    dev_session = get_session(role_arn="arn:aws:iam::760097843905:role/platform-developer")
+
+    today = datetime.date.today()
+
+    out_path = f"vhs-sourcedata-miro-{today}.json.gz"
+
+    with gzip.open(out_path, "w") as outfile:
+        for item in tqdm.tqdm(scan_table(read_only_session, TableName="vhs-sourcedata-miro")):
+            line = json.dumps(item, cls=DecimalEncoder) + "\n"
+            outfile.write(line.encode("utf8"))
+
+    s3_client = dev_session.client("s3")
+
+    s3_client.upload_file(
+        Filename=out_path,
+        Bucket="wellcomecollection-platform-infra",
+        Key=f"dynamodb_backups/{out_path}",
+    )

--- a/scripts/save_miro_vhs_snapshot.py
+++ b/scripts/save_miro_vhs_snapshot.py
@@ -38,15 +38,21 @@ def scan_table(session, *, TableName, **kwargs):
 
 
 if __name__ == "__main__":
-    read_only_session = get_session(role_arn="arn:aws:iam::760097843905:role/platform-read_only")
-    dev_session = get_session(role_arn="arn:aws:iam::760097843905:role/platform-developer")
+    read_only_session = get_session(
+        role_arn="arn:aws:iam::760097843905:role/platform-read_only"
+    )
+    dev_session = get_session(
+        role_arn="arn:aws:iam::760097843905:role/platform-developer"
+    )
 
     today = datetime.date.today()
 
     out_path = f"vhs-sourcedata-miro-{today}.json.gz"
 
     with gzip.open(out_path, "w") as outfile:
-        for item in tqdm.tqdm(scan_table(read_only_session, TableName="vhs-sourcedata-miro")):
+        for item in tqdm.tqdm(
+            scan_table(read_only_session, TableName="vhs-sourcedata-miro")
+        ):
             line = json.dumps(item, cls=DecimalEncoder) + "\n"
             outfile.write(line.encode("utf8"))
 


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5176. This implements something close to the Python API described in https://github.com/wellcomecollection/docs/pull/61

```
def make_image_available(miro_id: str, message: str)

def suppress_image(miro_id: str, message: str)

def set_license_override(miro_id: str, license_code: str, message: str)

def remove_license_override(miro_id: str, message: str)
```

This will allow us to write scripts that override values in the Miro metadata. That override is written to DynamoDB with:

* An explanation of the change written by the person making it (the `message` parameter)
* An automatically-generated note about the old/new value
* The timestamp
* The ARN of the person making the request (similar to weco-deploy)

It then triggers an update in the Miro transformer, by asking the reindexer to send a message to the Miro updates topic. I did consider sending it directly, but this way ensures we get a consistent serialisation of payloads.

I've also added a script for backing up the Miro VHS table, which is becoming an increasingly important resource.