### PR TITLE
Make our parsing of access conditions more conservative

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessStatus.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessStatus.scala
@@ -55,81 +55,40 @@ object AccessStatus extends Enum[License] {
 
   case object PermissionRequired extends AccessStatus
 
-  def apply(status: String): Either[Exception, AccessStatus] =
-    status.toLowerCase match {
-      case lowerCaseStatus
-          if lowerCaseStatus.startsWith(
-            "open with advisory",
-            "requires registration"
-          ) =>
+  def apply(status: String): Either[Exception, AccessStatus] = {
+    val normalisedStatus = status.trim.stripSuffix(".").trim.toLowerCase()
+
+    normalisedStatus match {
+      case value if value == "open with advisory" =>
         Right(AccessStatus.OpenWithAdvisory)
 
-      case lowerCaseStatus
-          if lowerCaseStatus.startsWith(
-            "unrestricted",
-            "open"
-          ) =>
+      // This has to come after the "OpenWithAdvisory" branch so we don't
+      // match on the partial open.
+      case value if value == "open" || value == "unrestricted" || value == "unrestricted / open" || value == "unrestricted (open)" || value == "open access" =>
         Right(AccessStatus.Open)
 
-      case lowerCaseStatus
-          if lowerCaseStatus.startsWith(
-            "restricted",
-            "cannot be produced",
-            "certain restrictions apply",
-            "clinical images",
-            "the file is restricted",
-            "this file is restricted"
-          ) =>
+      case value if value == "restricted" || value == "certain restrictions apply" || value.startsWith("restricted access") =>
         Right(AccessStatus.Restricted)
 
-      case lowerCaseStatus
-          if lowerCaseStatus.startsWith(
-            "by appointment"
-          ) =>
+      case value if value.startsWith("by appointment") =>
         Right(AccessStatus.ByAppointment)
 
-      case lowerCaseStatus
-          if lowerCaseStatus.startsWith(
-            "closed",
-            "the file is closed",
-            "this file is closed",
-            "the papers are closed",
-            "the files in this series are closed"
-          ) =>
+      case value if value == "closed" =>
         Right(AccessStatus.Closed)
 
-      case lowerCaseStatus
-          if lowerCaseStatus.startsWith(
-            "missing",
-            "deaccessioned",
-            "not available",
-          ) =>
+      case value if value == "cannot be produced" || value == "missing" || value == "deaccessioned" =>
         Right(AccessStatus.Unavailable)
 
-      case lowerCaseStatus
-          if lowerCaseStatus.startsWith(
-            "temporarily unavailable"
-          ) =>
+      case value if value == "temporarily unavailable" =>
         Right(AccessStatus.TemporarilyUnavailable)
 
-      case lowerCaseStatus if lowerCaseStatus.startsWith("in copyright") =>
-        Right(AccessStatus.LicensedResources)
-
-      case lowerCaseStatus
-          if lowerCaseStatus.startsWith(
-            "permission required",
-            "permission is required",
-            "donor permission",
-            "permission must be obtained",
-            "apply for permission",
-            "only with permission",
-            "with prior permission",
-          ) =>
+      case value if value == "donor permission" || value == "permission is required to view these item" || value == "permission is required to view this item" =>
         Right(AccessStatus.PermissionRequired)
 
       case _ =>
         Left(new UnknownAccessStatus(status))
     }
+  }
 
   implicit class StringOps(s: String) {
     def startsWith(prefixes: String*): Boolean =

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessStatus.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessStatus.scala
@@ -64,10 +64,13 @@ object AccessStatus extends Enum[License] {
 
       // This has to come after the "OpenWithAdvisory" branch so we don't
       // match on the partial open.
-      case value if value == "open" || value == "unrestricted" || value == "unrestricted / open" || value == "unrestricted (open)" || value == "open access" =>
+      case value
+          if value == "open" || value == "unrestricted" || value == "unrestricted / open" || value == "unrestricted (open)" || value == "open access" =>
         Right(AccessStatus.Open)
 
-      case value if value == "restricted" || value == "certain restrictions apply" || value.startsWith("restricted access") =>
+      case value
+          if value == "restricted" || value == "certain restrictions apply" || value
+            .startsWith("restricted access") =>
         Right(AccessStatus.Restricted)
 
       case value if value.startsWith("by appointment") =>
@@ -76,13 +79,15 @@ object AccessStatus extends Enum[License] {
       case value if value == "closed" =>
         Right(AccessStatus.Closed)
 
-      case value if value == "cannot be produced" || value == "missing" || value == "deaccessioned" =>
+      case value
+          if value == "cannot be produced" || value == "missing" || value == "deaccessioned" =>
         Right(AccessStatus.Unavailable)
 
       case value if value == "temporarily unavailable" =>
         Right(AccessStatus.TemporarilyUnavailable)
 
-      case value if value == "donor permission" || value == "permission is required to view these item" || value == "permission is required to view this item" =>
+      case value
+          if value == "donor permission" || value == "permission is required to view these item" || value == "permission is required to view this item" =>
         Right(AccessStatus.PermissionRequired)
 
       case _ =>

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/locations/AccessStatusTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/locations/AccessStatusTest.scala
@@ -12,9 +12,6 @@ class AccessStatusTest extends AnyFunSpec with Matchers {
   it("creates the Closed AccessStatus") {
     val closedValues = List(
       "Closed",
-      "The file is closed until 2059",
-      "This file is closed until 2060",
-      "The papers are closed until some future date"
     )
     closedValues.foreach { str =>
       AccessStatus.apply(str) shouldBe Right(AccessStatus.Closed)
@@ -25,11 +22,6 @@ class AccessStatusTest extends AnyFunSpec with Matchers {
     val restrictedValues = List(
       "Restricted",
       "Restricted access (Data Protection Act)",
-      "Cannot Be Produced - View Digitised Version",
-      "Certain restrictions apply.",
-      "Restricted: currently undergoing conservation.",
-      "The file is restricted for data protection reasons",
-      "This file is restricted for sensitivity reasons"
     )
     restrictedValues.foreach { str =>
       AccessStatus.apply(str) shouldBe Right(AccessStatus.Restricted)
@@ -39,7 +31,7 @@ class AccessStatusTest extends AnyFunSpec with Matchers {
   it("creates the Unavailable AccessStatus") {
     val unavailableValues = List(
       "Missing.",
-      "Deaccessioned on 01/01/2001"
+      "Deaccessioned"
     )
     unavailableValues.foreach { str =>
       AccessStatus.apply(str) shouldBe Right(AccessStatus.Unavailable)
@@ -48,10 +40,8 @@ class AccessStatusTest extends AnyFunSpec with Matchers {
 
   it("creates the PermissionRequired AccessStatus") {
     val permissionRequiredValues = List(
-      "Permission Required.",
       "Donor Permission.",
       "Permission is required to view this item.",
-      "Permission must be obtained from the Winnicott Trust before access can be granted"
     )
     permissionRequiredValues.foreach { str =>
       AccessStatus.apply(str) shouldBe Right(AccessStatus.PermissionRequired)
@@ -72,19 +62,9 @@ class AccessStatusTest extends AnyFunSpec with Matchers {
   it("creates the OpenWithAdvisory AccessStatus") {
     val openWithAdvisoryValues = List(
       "Open with advisory",
-      "Requires registration to view"
     )
     openWithAdvisoryValues.foreach { str =>
       AccessStatus.apply(str) shouldBe Right(AccessStatus.OpenWithAdvisory)
-    }
-  }
-
-  it("creates the LicensedResources AccessStatus") {
-    val licensedResourcesValues = List(
-      "In copyright to the Earl of Ownership"
-    )
-    licensedResourcesValues.foreach { str =>
-      AccessStatus.apply(str) shouldBe Right(AccessStatus.LicensedResources)
     }
   }
 

--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsData.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsData.scala
@@ -5,6 +5,7 @@ import cats.syntax.traverse._
 import cats.instances.either._
 import cats.instances.option._
 import org.apache.commons.lang3.StringUtils.equalsIgnoreCase
+import uk.ac.wellcome.platform.transformer.mets.transformers.MetsAccessStatus
 import weco.catalogue.internal_model.work.WorkState.Source
 import weco.catalogue.internal_model.identifiers._
 import weco.catalogue.internal_model.image.ImageData
@@ -38,7 +39,7 @@ case class MetsData(
       case false =>
         for {
           license <- parseLicense
-          accessStatus <- parseAccessStatus
+          accessStatus <- MetsAccessStatus(accessConditionStatus)
           item = Item[IdState.Unminted](
             id = IdState.Unidentifiable,
             locations = List(digitalLocation(license, accessStatus)))
@@ -122,11 +123,6 @@ case class MetsData(
             Left(new Exception(s"Couldn't match $accessCondition to a license"))
         }
     }.sequence
-
-  private val parseAccessStatus: Either[Exception, Option[AccessStatus]] =
-    accessConditionStatus
-      .map(AccessStatus(_))
-      .sequence
 
   private def sourceIdentifier =
     SourceIdentifier(

--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/transformers/MetsAccessStatus.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/transformers/MetsAccessStatus.scala
@@ -3,21 +3,26 @@ package uk.ac.wellcome.platform.transformer.mets.transformers
 import weco.catalogue.internal_model.locations.AccessStatus
 
 object MetsAccessStatus {
-  def apply(accessConditionStatus: Option[String]): Either[Throwable, Option[AccessStatus]] =
+  def apply(accessConditionStatus: Option[String])
+    : Either[Throwable, Option[AccessStatus]] =
     accessConditionStatus match {
       // e.g. b21718969
       case Some(s) if s == "Open" => Right(Some(AccessStatus.Open))
 
       // e.g. b30468115 / b19912730
-      case Some(s) if s == "Open with advisory" || s == "Requires registration" => Right(Some(AccessStatus.OpenWithAdvisory))
+      case Some(s)
+          if s == "Open with advisory" || s == "Requires registration" =>
+        Right(Some(AccessStatus.OpenWithAdvisory))
 
       // e.g. b16469434 / b21072061
-      case Some(s) if s == "Restricted files" || s == "Clinical images" => Right(Some(AccessStatus.Restricted))
+      case Some(s) if s == "Restricted files" || s == "Clinical images" =>
+        Right(Some(AccessStatus.Restricted))
 
       // e.g. b16751875
       case Some(s) if s == "Closed" => Right(Some(AccessStatus.Closed))
 
       case None => Right(None)
-      case Some(s) => Left(new Throwable(s"Couldn't match $s to an access status"))
+      case Some(s) =>
+        Left(new Throwable(s"Couldn't match $s to an access status"))
     }
 }

--- a/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/transformers/MetsAccessStatus.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/uk/ac/wellcome/platform/transformer/mets/transformers/MetsAccessStatus.scala
@@ -1,0 +1,23 @@
+package uk.ac.wellcome.platform.transformer.mets.transformers
+
+import weco.catalogue.internal_model.locations.AccessStatus
+
+object MetsAccessStatus {
+  def apply(accessConditionStatus: Option[String]): Either[Throwable, Option[AccessStatus]] =
+    accessConditionStatus match {
+      // e.g. b21718969
+      case Some(s) if s == "Open" => Right(Some(AccessStatus.Open))
+
+      // e.g. b30468115 / b19912730
+      case Some(s) if s == "Open with advisory" || s == "Requires registration" => Right(Some(AccessStatus.OpenWithAdvisory))
+
+      // e.g. b16469434 / b21072061
+      case Some(s) if s == "Restricted files" || s == "Clinical images" => Right(Some(AccessStatus.Restricted))
+
+      // e.g. b16751875
+      case Some(s) if s == "Closed" => Right(Some(AccessStatus.Closed))
+
+      case None => Right(None)
+      case Some(s) => Left(new Throwable(s"Couldn't match $s to an access status"))
+    }
+}

--- a/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsDataTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformer/MetsDataTest.scala
@@ -281,7 +281,7 @@ class MetsDataTest
     val metsData = MetsData(
       recordIdentifier = createBibNumber,
       accessConditionDz = Some("CC-BY-NC"),
-      accessConditionStatus = Some("restricted"),
+      accessConditionStatus = Some("Restricted files"),
       fileReferencesMapping = List(
         "id" -> FileReference("l", "location.jp2", Some("image/jp2"))
       )
@@ -416,7 +416,7 @@ class MetsDataTest
   it("creates a work with a single accessCondition including usage terms") {
     val result = MetsData(
       recordIdentifier = "ID",
-      accessConditionStatus = Some("Clinical Images"),
+      accessConditionStatus = Some("Clinical images"),
       accessConditionUsage = Some("Please ask nicely")
     ).toWork(1, Instant.now())
     result shouldBe a[Right[_, _]]

--- a/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformers/MetsAccessStatusTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformers/MetsAccessStatusTest.scala
@@ -5,7 +5,10 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
 import weco.catalogue.internal_model.locations.AccessStatus
 
-class MetsAccessStatusTest extends AnyFunSpec with Matchers with TableDrivenPropertyChecks {
+class MetsAccessStatusTest
+    extends AnyFunSpec
+    with Matchers
+    with TableDrivenPropertyChecks {
   val testCases = Table(
     ("accessConditionStatus", "expectedStatus"),
     ("Restricted files", AccessStatus.Restricted),
@@ -17,8 +20,10 @@ class MetsAccessStatusTest extends AnyFunSpec with Matchers with TableDrivenProp
   )
 
   it("creates an access status") {
-    forAll(testCases) { case (accessConditionStatus, expectedStatus) =>
-      MetsAccessStatus(Some(accessConditionStatus)) shouldBe Right(Some(expectedStatus))
+    forAll(testCases) {
+      case (accessConditionStatus, expectedStatus) =>
+        MetsAccessStatus(Some(accessConditionStatus)) shouldBe Right(
+          Some(expectedStatus))
     }
   }
 

--- a/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformers/MetsAccessStatusTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/uk/ac/wellcome/platform/transformer/mets/transformers/MetsAccessStatusTest.scala
@@ -1,0 +1,32 @@
+package uk.ac.wellcome.platform.transformer.mets.transformers
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks
+import weco.catalogue.internal_model.locations.AccessStatus
+
+class MetsAccessStatusTest extends AnyFunSpec with Matchers with TableDrivenPropertyChecks {
+  val testCases = Table(
+    ("accessConditionStatus", "expectedStatus"),
+    ("Restricted files", AccessStatus.Restricted),
+    ("Clinical images", AccessStatus.Restricted),
+    ("Open", AccessStatus.Open),
+    ("Open with advisory", AccessStatus.OpenWithAdvisory),
+    ("Requires registration", AccessStatus.OpenWithAdvisory),
+    ("Closed", AccessStatus.Closed)
+  )
+
+  it("creates an access status") {
+    forAll(testCases) { case (accessConditionStatus, expectedStatus) =>
+      MetsAccessStatus(Some(accessConditionStatus)) shouldBe Right(Some(expectedStatus))
+    }
+  }
+
+  it("returns None if there are no access conditions") {
+    MetsAccessStatus(None) shouldBe Right(None)
+  }
+
+  it("returns a Left if it can't parse the access conditions") {
+    MetsAccessStatus(Some("unintelligible")) shouldBe a[Left[_, _]]
+  }
+}

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraAccessConditions.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraAccessConditions.scala
@@ -10,11 +10,7 @@ object SierraAccessConditions extends SierraQueryOps {
     bibData
       .varfieldsWithTag("506")
       .map { varfield =>
-        // MARC 506 subfield ǂa contains "terms governing access".  This is a
-        // non-repeatable field.  See https://www.loc.gov/marc/bibliographic/bd506.html
-        val terms = varfield
-          .nonrepeatableSubfieldWithTag("a")
-          .map { _.content.trim }
+        val terms = getTerms(varfield)
 
         AccessCondition(
           status = getAccessStatus(bibId, varfield, terms),
@@ -26,6 +22,14 @@ object SierraAccessConditions extends SierraQueryOps {
         case AccessCondition(None, None, None) => false
         case _                                 => true
       }
+
+  // MARC 506 subfield ǂa contains "terms governing access".  This is a
+  // non-repeatable field.  See https://www.loc.gov/marc/bibliographic/bd506.html
+  private def getTerms(varfield: VarField): Option[String] =
+    varfield
+      .nonrepeatableSubfieldWithTag("a")
+      .map { _.content.trim }
+      .filter { _.nonEmpty }
 
   // Get an AccessStatus that draws from our list of types.
   //

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraAccessConditions.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraAccessConditions.scala
@@ -34,35 +34,8 @@ object SierraAccessConditions extends SierraQueryOps {
       .map { _.content.trim }
       .filter { _.nonEmpty }
 
-  private def statusFromTerms(terms: Option[String]): Option[AccessStatus] = {
-    val normalisedTerms = terms
-      .map { _.stripSuffix(".").trim.toLowerCase() }
-
-    // Now we do some matching.  Note that we are very conservative here --
-    // we don't want to be tripped up by phrases like
-    //
-    //      This item was previously restricted, then reassessed in 2020 and opened.
-    //
-    // We are looking for specific matches that we can map to an access status.
-    normalisedTerms match {
-      case Some(value) if value == "unrestricted" || value == "open" || value == "unrestricted / open" || value == "unrestricted (open)" || value == "open access" =>
-        Some(AccessStatus.Open)
-
-      case Some(value) if value == "restricted" =>
-        Some(AccessStatus.Restricted)
-
-      case Some(value) if value == "closed" =>
-        Some(AccessStatus.Closed)
-
-      case Some(value) if value == "open with advisory" =>
-        Some(AccessStatus.OpenWithAdvisory)
-
-      case Some(value) if value == "permission is required to view these item" || value == "permission is required to view this item" =>
-        Some(AccessStatus.PermissionRequired)
-
-      case _ => None
-    }
-  }
+  private def statusFromTerms(terms: Option[String]): Option[AccessStatus] =
+    terms.flatMap { AccessStatus(_).toOption }
 
   // Get an AccessStatus that draws from our list of types.
   //

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraAccessConditions.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraAccessConditions.scala
@@ -1,0 +1,85 @@
+package uk.ac.wellcome.platform.transformer.sierra.transformers
+
+import uk.ac.wellcome.platform.transformer.sierra.source.{SierraBibData, SierraQueryOps, VarField}
+import weco.catalogue.internal_model.locations.{AccessCondition, AccessStatus}
+import weco.catalogue.source_model.sierra.SierraBibNumber
+
+object SierraAccessConditions extends SierraQueryOps {
+  def apply(bibId: SierraBibNumber,
+            bibData: SierraBibData): List[AccessCondition] =
+    bibData
+      .varfieldsWithTag("506")
+      .map { varfield =>
+        // MARC 506 subfield ǂa contains "terms governing access".  This is a
+        // non-repeatable field.  See https://www.loc.gov/marc/bibliographic/bd506.html
+        val terms = varfield
+          .nonrepeatableSubfieldWithTag("a")
+          .map { _.content.trim }
+
+        AccessCondition(
+          status = getAccessStatus(bibId, varfield, terms),
+          terms = terms,
+          to = varfield.subfieldsWithTag("g").contents.headOption
+        )
+      }
+      .filter {
+        case AccessCondition(None, None, None) => false
+        case _                                 => true
+      }
+
+  // Get an AccessStatus that draws from our list of types.
+  //
+  // Rules:
+  //  - if the first indicator is 0, then there are no restrictions
+  //  - look in subfield ǂf for the standardised terminology
+  //  - look at the "terms governing access" from 506 ǂa
+  //
+  // See https://www.loc.gov/marc/bibliographic/bd506.html
+  private def getAccessStatus(bibId: SierraBibNumber,
+                              varfield: VarField,
+                              terms: Option[String]): Option[AccessStatus] = {
+
+    // If the first indicator is 0, then there are no restrictions
+    val indicator0 =
+      if (varfield.indicator1.contains("0"))
+        Some(AccessStatus.Open)
+      else
+        None
+
+    // Look in subfield ǂf for the standardised terminology
+    val subfieldF =
+      varfield
+        .subfieldsWithTag("f")
+        .contents
+        .headOption
+        .flatMap { contents =>
+          AccessStatus(contents) match {
+            case Right(status) => Some(status)
+            case Left(err) =>
+              warn(
+                s"$bibId: Unable to parse access status from subfield ǂf: $contents ($err)")
+              None
+          }
+        }
+
+    // Look at the terms for the standardised terminology
+    val termsStatus =
+      terms.map { AccessStatus(_) }.collect { case Right(status) => status }
+
+    // Finally, we look at all three fields together.  If the data is inconsistent
+    // we should drop a warning and not set an access status, rather than set one that's
+    // wrong.  This presumes that:
+    //
+    //  1. The data in the "terms" field is more likely to be accurate
+    //  2. Sins of omission (skipping the field) are better than sins of commission
+    //     (e.g. claiming an Item is open when it's actually restricted)
+    //
+    Seq(indicator0, subfieldF, termsStatus).flatten.distinct match {
+      case Nil         => None
+      case Seq(status) => Some(status)
+      case multiple =>
+        warn(s"$bibId: Multiple, conflicting access statuses: $multiple")
+        None
+    }
+  }
+}

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraAccessConditions.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraAccessConditions.scala
@@ -1,6 +1,10 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
-import uk.ac.wellcome.platform.transformer.sierra.source.{SierraBibData, SierraQueryOps, VarField}
+import uk.ac.wellcome.platform.transformer.sierra.source.{
+  SierraBibData,
+  SierraQueryOps,
+  VarField
+}
 import weco.catalogue.internal_model.locations.{AccessCondition, AccessStatus}
 import weco.catalogue.source_model.sierra.SierraBibNumber
 
@@ -17,7 +21,8 @@ object SierraAccessConditions extends SierraQueryOps {
 
         AccessCondition(
           status = status,
-          terms = if (termsStatus.isDefined && termsStatus == status) None else terms,
+          terms =
+            if (termsStatus.isDefined && termsStatus == status) None else terms,
           to = varfield.subfieldsWithTag("g").contents.headOption
         )
       }
@@ -45,9 +50,10 @@ object SierraAccessConditions extends SierraQueryOps {
   //  - look at the "terms governing access" from 506 ǂa
   //
   // See https://www.loc.gov/marc/bibliographic/bd506.html
-  private def getAccessStatus(bibId: SierraBibNumber,
-                              varfield: VarField,
-                              termsStatus: Option[AccessStatus]): Option[AccessStatus] = {
+  private def getAccessStatus(
+    bibId: SierraBibNumber,
+    varfield: VarField,
+    termsStatus: Option[AccessStatus]): Option[AccessStatus] = {
 
     // If the first indicator is 0, then there are no restrictions
     val indicator0 =

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocation.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocation.scala
@@ -1,12 +1,10 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
-import grizzled.slf4j.Logging
 import uk.ac.wellcome.platform.transformer.sierra.source._
 import weco.catalogue.internal_model.locations._
 import weco.catalogue.source_model.sierra.{SierraBibNumber, SierraItemNumber}
 
-trait SierraLocation extends SierraQueryOps with Logging {
-
+trait SierraLocation {
   def getPhysicalLocation(
     bibNumber: SierraBibNumber,
     itemNumber: SierraItemNumber,
@@ -39,88 +37,9 @@ trait SierraLocation extends SierraQueryOps with Logging {
 
       physicalLocation = PhysicalLocation(
         locationType = locationType,
-        accessConditions = getAccessConditions(bibNumber, bibData),
+        accessConditions = SierraAccessConditions(bibNumber, bibData),
         label = label,
         shelfmark = SierraShelfmark(bibData, itemData)
       )
     } yield physicalLocation
-
-  private def getAccessConditions(
-    bibId: SierraBibNumber,
-    bibData: SierraBibData): List[AccessCondition] =
-    bibData
-      .varfieldsWithTag("506")
-      .map { varfield =>
-        // MARC 506 subfield ǂa contains "terms governing access".  This is a
-        // non-repeatable field.  See https://www.loc.gov/marc/bibliographic/bd506.html
-        val terms = varfield
-          .nonrepeatableSubfieldWithTag("a")
-          .map { _.content.trim }
-
-        AccessCondition(
-          status = getAccessStatus(bibId, varfield, terms),
-          terms = terms,
-          to = varfield.subfieldsWithTag("g").contents.headOption
-        )
-      }
-      .filter {
-        case AccessCondition(None, None, None) => false
-        case _                                 => true
-      }
-
-  // Get an AccessStatus that draws from our list of types.
-  //
-  // Rules:
-  //  - if the first indicator is 0, then there are no restrictions
-  //  - look in subfield ǂf for the standardised terminology
-  //  - look at the "terms governing access" from 506 ǂa
-  //
-  // See https://www.loc.gov/marc/bibliographic/bd506.html
-  private def getAccessStatus(bibId: SierraBibNumber,
-                              varfield: VarField,
-                              terms: Option[String]): Option[AccessStatus] = {
-
-    // If the first indicator is 0, then there are no restrictions
-    val indicator0 =
-      if (varfield.indicator1.contains("0"))
-        Some(AccessStatus.Open)
-      else
-        None
-
-    // Look in subfield ǂf for the standardised terminology
-    val subfieldF =
-      varfield
-        .subfieldsWithTag("f")
-        .contents
-        .headOption
-        .flatMap { contents =>
-          AccessStatus(contents) match {
-            case Right(status) => Some(status)
-            case Left(err) =>
-              warn(
-                s"$bibId: Unable to parse access status from subfield ǂf: $contents ($err)")
-              None
-          }
-        }
-
-    // Look at the terms for the standardised terminology
-    val termsStatus =
-      terms.map { AccessStatus(_) }.collect { case Right(status) => status }
-
-    // Finally, we look at all three fields together.  If the data is inconsistent
-    // we should drop a warning and not set an access status, rather than set one that's
-    // wrong.  This presumes that:
-    //
-    //  1. The data in the "terms" field is more likely to be accurate
-    //  2. Sins of omission (skipping the field) are better than sins of commission
-    //     (e.g. claiming an Item is open when it's actually restricted)
-    //
-    Seq(indicator0, subfieldF, termsStatus).flatten.distinct match {
-      case Nil         => None
-      case Seq(status) => Some(status)
-      case multiple =>
-        warn(s"$bibId: Multiple, conflicting access statuses: $multiple")
-        None
-    }
-  }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraAccessConditionsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraAccessConditionsTest.scala
@@ -1,0 +1,30 @@
+package uk.ac.wellcome.platform.transformer.sierra.transformers
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.platform.transformer.sierra.generators.{MarcGenerators, SierraDataGenerators}
+import uk.ac.wellcome.platform.transformer.sierra.source.{MarcSubfield, VarField}
+import weco.catalogue.internal_model.locations.AccessCondition
+
+class SierraAccessConditionsTest extends AnyFunSpec with Matchers with MarcGenerators with SierraDataGenerators {
+  it("drops an empty string in 506 subfield ǂa") {
+    val accessConditions = getAccessConditions(
+      bibVarFields = List(
+        VarField(
+          marcTag = Some("506"),
+          subfields = List(
+            MarcSubfield(tag = "a", content = "")
+          )
+        )
+      )
+    )
+
+    accessConditions shouldBe empty
+  }
+  
+  private def getAccessConditions(bibVarFields: List[VarField]): List[AccessCondition] =
+    SierraAccessConditions(
+      bibId = createSierraBibNumber,
+      bibData = createSierraBibDataWith(varFields = bibVarFields)
+    )
+}

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraAccessConditionsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraAccessConditionsTest.scala
@@ -2,11 +2,12 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks
 import uk.ac.wellcome.platform.transformer.sierra.generators.{MarcGenerators, SierraDataGenerators}
 import uk.ac.wellcome.platform.transformer.sierra.source.{MarcSubfield, VarField}
-import weco.catalogue.internal_model.locations.AccessCondition
+import weco.catalogue.internal_model.locations.{AccessCondition, AccessStatus}
 
-class SierraAccessConditionsTest extends AnyFunSpec with Matchers with MarcGenerators with SierraDataGenerators {
+class SierraAccessConditionsTest extends AnyFunSpec with Matchers with MarcGenerators with SierraDataGenerators with TableDrivenPropertyChecks {
   it("drops an empty string in 506 subfield ǂa") {
     val accessConditions = getAccessConditions(
       bibVarFields = List(
@@ -21,7 +22,111 @@ class SierraAccessConditionsTest extends AnyFunSpec with Matchers with MarcGener
 
     accessConditions shouldBe empty
   }
-  
+
+  val testCases = Table(
+    ("text", "expectedStatus"),
+    ("Unrestricted", AccessStatus.Open),
+    ("Unrestricted.", AccessStatus.Open),
+    ("Restricted", AccessStatus.Restricted),
+    ("Restricted.", AccessStatus.Restricted),
+    ("Open with advisory.", AccessStatus.OpenWithAdvisory),
+    ("Open with Advisory.", AccessStatus.OpenWithAdvisory),
+    ("Open", AccessStatus.Open),
+    ("Open access.", AccessStatus.Open),
+    ("Unrestricted / open", AccessStatus.Open),
+    ("Unrestricted (open)", AccessStatus.Open),
+    ("Closed.", AccessStatus.Closed),
+    ("Permission is required to view these item.", AccessStatus.PermissionRequired),
+    ("Permission is required to view this item.", AccessStatus.PermissionRequired),
+  )
+
+  it("matches particular strings in 506 subfield ǂa to an access status") {
+    forAll(testCases) { case (text, expectedStatus) =>
+      val accessConditions = getAccessConditions(
+        bibVarFields = List(
+          VarField(
+            marcTag = Some("506"),
+            subfields = List(
+              MarcSubfield(tag = "a", content = text)
+            )
+          )
+        )
+      )
+
+      accessConditions shouldBe List(
+        AccessCondition(
+          status = Some(expectedStatus),
+          terms = None,
+          to = None
+        )
+      )
+    }
+  }
+
+  it("exposes the terms from 506 subfield ǂa if it can't map them to an AccessStatus") {
+    val accessConditions = getAccessConditions(
+      bibVarFields = List(
+        VarField(
+          marcTag = Some("506"),
+          subfields = List(
+            MarcSubfield(tag = "a", content = "ACME Library membership required for access.")
+          )
+        )
+      )
+    )
+
+    accessConditions shouldBe List(
+      AccessCondition(
+        status = None,
+        terms = Some("ACME Library membership required for access."),
+        to = None
+      )
+    )
+  }
+
+  it("exposes the terms from 506 subfield ǂa if there's no consistent access status") {
+    val accessConditions = getAccessConditions(
+      bibVarFields = List(
+        VarField(
+          marcTag = Some("506"),
+          subfields = List(
+            MarcSubfield(tag = "a", content = "Restricted"),
+            MarcSubfield(tag = "f", content = "Open")
+          )
+        )
+      )
+    )
+
+    accessConditions shouldBe List(
+      AccessCondition(
+        status = None,
+        terms = Some("Restricted"),
+        to = None
+      )
+    )
+  }
+
+  it("strips whitespace from the access conditions") {
+    val accessConditions = getAccessConditions(
+      bibVarFields = List(
+        VarField(
+          marcTag = Some("506"),
+          subfields = List(
+            MarcSubfield("a", "Access restricted to authorized subscribers. "),
+          )
+        )
+      )
+    )
+
+    accessConditions shouldBe List(
+      AccessCondition(
+        status = None,
+        terms = Some("Access restricted to authorized subscribers."),
+        to = None
+      )
+    )
+  }
+
   private def getAccessConditions(bibVarFields: List[VarField]): List[AccessCondition] =
     SierraAccessConditions(
       bibId = createSierraBibNumber,

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraAccessConditionsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraAccessConditionsTest.scala
@@ -3,11 +3,22 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
-import uk.ac.wellcome.platform.transformer.sierra.generators.{MarcGenerators, SierraDataGenerators}
-import uk.ac.wellcome.platform.transformer.sierra.source.{MarcSubfield, VarField}
+import uk.ac.wellcome.platform.transformer.sierra.generators.{
+  MarcGenerators,
+  SierraDataGenerators
+}
+import uk.ac.wellcome.platform.transformer.sierra.source.{
+  MarcSubfield,
+  VarField
+}
 import weco.catalogue.internal_model.locations.{AccessCondition, AccessStatus}
 
-class SierraAccessConditionsTest extends AnyFunSpec with Matchers with MarcGenerators with SierraDataGenerators with TableDrivenPropertyChecks {
+class SierraAccessConditionsTest
+    extends AnyFunSpec
+    with Matchers
+    with MarcGenerators
+    with SierraDataGenerators
+    with TableDrivenPropertyChecks {
   it("drops an empty string in 506 subfield ǂa") {
     val accessConditions = getAccessConditions(
       bibVarFields = List(
@@ -36,40 +47,48 @@ class SierraAccessConditionsTest extends AnyFunSpec with Matchers with MarcGener
     ("Unrestricted / open", AccessStatus.Open),
     ("Unrestricted (open)", AccessStatus.Open),
     ("Closed.", AccessStatus.Closed),
-    ("Permission is required to view these item.", AccessStatus.PermissionRequired),
-    ("Permission is required to view this item.", AccessStatus.PermissionRequired),
+    (
+      "Permission is required to view these item.",
+      AccessStatus.PermissionRequired),
+    (
+      "Permission is required to view this item.",
+      AccessStatus.PermissionRequired),
   )
 
   it("matches particular strings in 506 subfield ǂa to an access status") {
-    forAll(testCases) { case (text, expectedStatus) =>
-      val accessConditions = getAccessConditions(
-        bibVarFields = List(
-          VarField(
-            marcTag = Some("506"),
-            subfields = List(
-              MarcSubfield(tag = "a", content = text)
+    forAll(testCases) {
+      case (text, expectedStatus) =>
+        val accessConditions = getAccessConditions(
+          bibVarFields = List(
+            VarField(
+              marcTag = Some("506"),
+              subfields = List(
+                MarcSubfield(tag = "a", content = text)
+              )
             )
           )
         )
-      )
 
-      accessConditions shouldBe List(
-        AccessCondition(
-          status = Some(expectedStatus),
-          terms = None,
-          to = None
+        accessConditions shouldBe List(
+          AccessCondition(
+            status = Some(expectedStatus),
+            terms = None,
+            to = None
+          )
         )
-      )
     }
   }
 
-  it("exposes the terms from 506 subfield ǂa if it can't map them to an AccessStatus") {
+  it(
+    "exposes the terms from 506 subfield ǂa if it can't map them to an AccessStatus") {
     val accessConditions = getAccessConditions(
       bibVarFields = List(
         VarField(
           marcTag = Some("506"),
           subfields = List(
-            MarcSubfield(tag = "a", content = "ACME Library membership required for access.")
+            MarcSubfield(
+              tag = "a",
+              content = "ACME Library membership required for access.")
           )
         )
       )
@@ -84,7 +103,8 @@ class SierraAccessConditionsTest extends AnyFunSpec with Matchers with MarcGener
     )
   }
 
-  it("exposes the terms from 506 subfield ǂa if there's no consistent access status") {
+  it(
+    "exposes the terms from 506 subfield ǂa if there's no consistent access status") {
     val accessConditions = getAccessConditions(
       bibVarFields = List(
         VarField(
@@ -112,7 +132,9 @@ class SierraAccessConditionsTest extends AnyFunSpec with Matchers with MarcGener
         VarField(
           marcTag = Some("506"),
           subfields = List(
-            MarcSubfield(tag = "a", content = "Access restricted to authorized subscribers"),
+            MarcSubfield(
+              tag = "a",
+              content = "Access restricted to authorized subscribers"),
             MarcSubfield(tag = "f", content = ".")
           )
         )
@@ -149,7 +171,8 @@ class SierraAccessConditionsTest extends AnyFunSpec with Matchers with MarcGener
     )
   }
 
-  private def getAccessConditions(bibVarFields: List[VarField]): List[AccessCondition] =
+  private def getAccessConditions(
+    bibVarFields: List[VarField]): List[AccessCondition] =
     SierraAccessConditions(
       bibId = createSierraBibNumber,
       bibData = createSierraBibDataWith(varFields = bibVarFields)

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraAccessConditionsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraAccessConditionsTest.scala
@@ -106,6 +106,28 @@ class SierraAccessConditionsTest extends AnyFunSpec with Matchers with MarcGener
     )
   }
 
+  it("ignores a single period 506 subfield ǂf") {
+    val accessConditions = getAccessConditions(
+      bibVarFields = List(
+        VarField(
+          marcTag = Some("506"),
+          subfields = List(
+            MarcSubfield(tag = "a", content = "Access restricted to authorized subscribers"),
+            MarcSubfield(tag = "f", content = ".")
+          )
+        )
+      )
+    )
+
+    accessConditions shouldBe List(
+      AccessCondition(
+        status = None,
+        terms = Some("Access restricted to authorized subscribers"),
+        to = None
+      )
+    )
+  }
+
   it("strips whitespace from the access conditions") {
     val accessConditions = getAccessConditions(
       bibVarFields = List(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocationTest.scala
@@ -280,7 +280,7 @@ class SierraLocationTest
 
       location.accessConditions.head.status shouldBe Some(
         AccessStatus.Restricted)
-      location.accessConditions.head.terms shouldBe Some("Restricted")
+      location.accessConditions.head.terms shouldBe None
     }
 
     it("does not set an AccessStatus if the contents of ǂa and ǂf disagree") {
@@ -370,26 +370,6 @@ class SierraLocationTest
           accessConditions = List()
         )
       )
-    }
-
-    it("strips whitespace from the access conditions") {
-      val bibData = createSierraBibDataWith(
-        varFields = List(
-          VarField(
-            marcTag = Some("506"),
-            subfields = List(
-              MarcSubfield("a", "Permission is required to view this item. "),
-            )
-          )
-        )
-      )
-
-      val location =
-        transformer.getPhysicalLocation(bibId, itemId, itemData, bibData).get
-      location.accessConditions should have size 1
-
-      location.accessConditions.head.terms shouldBe Some(
-        "Permission is required to view this item.")
     }
   }
 }


### PR DESCRIPTION
As part of the work on https://github.com/wellcomecollection/platform/issues/5171, I discovered that we were being a bit ambitious with our access status parser. In particular, we were trying to parse the free-text access conditions in 506 subfield ǂa, which it turns out is way harder than I originally anticipated.

In particular, how do you tell the difference between:

> This item was previously closed, and then reassessed and opened.

and

> This item was previously open, and then reassessed and closed.

So this patch dramatically scales back our attempt to read this field. If we see an exact match (e.g. the literal string `Open`), we'll move those terms to an access status and drop the terms. Anything else, we ignore the terms for the purpose of populating our AccessStatus model.

I've also moved the AccessCondition creation in the Sierra transformer onto a separate object – it's going to get even more complicated as a result of the requesting work.