### PR TITLE
Redirect digaids Miro images even when their items aren't merged

### DIFF
--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ImageDataRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ImageDataRule.scala
@@ -18,11 +18,9 @@ object ImageDataRule extends FieldMergeRule {
   ): FieldMergeResult[FieldData] =
     FieldMergeResult(
       data = getMetsPictureAndEphemeraImages(target, sources).getOrElse(Nil) ++
-        getMiroPictureAndEphemeraImages(target, sources).getOrElse(Nil) ++
         getPairedMiroImages(target, sources).getOrElse(Nil),
       sources = List(
         getMetsPictureAndEphemeraImages,
-        getMiroPictureAndEphemeraImages,
         getPairedMiroImages
       ).flatMap(_.mergedSources(target, sources))
     )
@@ -34,15 +32,9 @@ object ImageDataRule extends FieldMergeRule {
 
   // In future we may change `digaids` to `digmiro` for all works
   // where we know that the Miro and METS images are identical
-  private lazy val getMiroPictureAndEphemeraImages = new FlatImageMergeRule {
-    val isDefinedForTarget: WorkPredicate =
-      sierraPictureOrEphemera and not(sierraDigaids)
-    val isDefinedForSource: WorkPredicate = singleDigitalItemMiroWork
-  }
-
   private lazy val getPairedMiroImages = new FlatImageMergeRule {
     val isDefinedForTarget: WorkPredicate =
-      sierraWork and not(sierraPictureOrEphemera) and not(sierraDigaids)
+      sierraWork and not(sierraDigaids)
     val isDefinedForSource: WorkPredicate = singleDigitalItemMiroWork
   }
 

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ItemsRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ItemsRule.scala
@@ -42,6 +42,7 @@ object ItemsRule extends FieldMergeRule with MergerLogging {
       ).flatMap { rule =>
         rule.mergedSources(target, sources)
       } ++ findFirstLinkedDigitisedSierraWorkFor(target, sources)
+        ++ knownDuplicateSources(target, sources)
     ).distinct
 
     FieldMergeResult(

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ItemsRule.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/ItemsRule.scala
@@ -24,12 +24,14 @@ object ItemsRule extends FieldMergeRule with MergerLogging {
 
   override def merge(
     target: Work.Visible[Identified],
-    sources: Seq[Work[Identified]]): FieldMergeResult[FieldData] = {
+    sources: Seq[Work[Identified]]
+  ): FieldMergeResult[FieldData] = {
     val items =
       mergeIntoCalmTarget(target, sources)
         .orElse(mergeMetsIntoSierraTarget(target, sources))
         .orElse(
-          mergeSingleMiroIntoSingleOrZeroItemSierraTarget(target, sources))
+          mergeSingleMiroIntoSingleOrZeroItemSierraTarget(target, sources)
+        )
         .getOrElse(target.data.items)
 
     val mergedSources = (
@@ -58,8 +60,10 @@ object ItemsRule extends FieldMergeRule with MergerLogging {
     val isDefinedForTarget: WorkPredicate = sierraWork
     val isDefinedForSource: WorkPredicate = singleDigitalItemMetsWork
 
-    def rule(target: Work.Visible[Identified],
-             sources: NonEmptyList[Work[Identified]]): FieldData =
+    def rule(
+      target: Work.Visible[Identified],
+      sources: NonEmptyList[Work[Identified]]
+    ): FieldData =
       target.data.items match {
         case List(sierraItem) =>
           List(
@@ -94,8 +98,10 @@ object ItemsRule extends FieldMergeRule with MergerLogging {
       override val isDefinedForSourceList: Seq[Work[Identified]] => Boolean =
         _.count(singleDigitalItemMiroWork) == 1
 
-      def rule(target: Work.Visible[Identified],
-               sources: NonEmptyList[Work[Identified]]): FieldData =
+      def rule(
+        target: Work.Visible[Identified],
+        sources: NonEmptyList[Work[Identified]]
+      ): FieldData =
         target.data.items match {
           case List(sierraItem) =>
             List(
@@ -107,6 +113,22 @@ object ItemsRule extends FieldMergeRule with MergerLogging {
             )
           case _ => sources.toList.flatMap(_.data.items)
         }
+    }
+
+  // While we can't merge a Miro item into a Sierra work with multiple items (as described above),
+  // we know that in some cases the duplication is such that we can treat the Miro source as having
+  // been entirely subsumed into the target despite not having used any of its data.
+  //
+  // At the moment, the only case of this is when we have a digaids work: we know that
+  // the Miro item is identical to the METS item.
+  def knownDuplicateSources(
+    target: Work.Visible[Identified],
+    sources: Seq[Work[Identified]]
+  ): Seq[Work[Identified]] =
+    if (sierraDigaids(target) && sources.exists(singleDigitalItemMetsWork)) {
+      sources.filter(singleDigitalItemMiroWork)
+    } else {
+      Nil
     }
 
   /**
@@ -121,8 +143,10 @@ object ItemsRule extends FieldMergeRule with MergerLogging {
     val isDefinedForSource
       : WorkPredicate = singleDigitalItemMetsWork or sierraWork
 
-    def rule(target: Work.Visible[Identified],
-             sources: NonEmptyList[Work[Identified]]): FieldData = {
+    def rule(
+      target: Work.Visible[Identified],
+      sources: NonEmptyList[Work[Identified]]
+    ): FieldData = {
 
       // The calm Work predicate ensures this is safe
       val calmItem = target.data.items.head
@@ -139,7 +163,8 @@ object ItemsRule extends FieldMergeRule with MergerLogging {
         calmItem.copy(
           locations = calmItem.locations ++ metsDigitalLocations,
           id = sierraItemId.getOrElse(IdState.Unidentifiable)
-        ))
+        )
+      )
     }
   }
 }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerScenarioTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerScenarioTest.scala
@@ -109,9 +109,10 @@ class MergerScenarioTest
 
     Scenario("An AIDS poster Sierra picture, a METS and a Miro are matched") {
       Given(
-        "a Sierra picture with digcode `digaids`, a METS work and a Miro work")
+        "a Sierra picture with digcode `digaids`, a METS work and a Miro work"
+      )
       val sierraDigaidsPicture = sierraIdentifiedWork()
-        .items(List(createIdentifiedPhysicalItem))
+        .items(List(createIdentifiedPhysicalItem, createIdentifiedPhysicalItem))
         .format(Format.Pictures)
         .otherIdentifiers(List(createDigcodeIdentifier("digaids")))
       val mets = metsIdentifiedWork()
@@ -159,7 +160,8 @@ class MergerScenarioTest
               MergeCandidate(
                 id = IdState.Identified(
                   sourceIdentifier = digitisedVideo.sourceIdentifier,
-                  canonicalId = digitisedVideo.state.canonicalId),
+                  canonicalId = digitisedVideo.state.canonicalId
+                ),
                 reason = Some("Physical/digitised Sierra work")
               )
             )
@@ -171,7 +173,8 @@ class MergerScenarioTest
       Then("both original works are preserved")
       outcome.resultWorks should contain theSameElementsAs Seq(
         physicalVideo,
-        digitisedVideo)
+        digitisedVideo
+      )
     }
 
     Scenario("A Calm work and a Sierra work are matched") {

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerScenarioTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerScenarioTest.scala
@@ -112,6 +112,9 @@ class MergerScenarioTest
         "a Sierra picture with digcode `digaids`, a METS work and a Miro work"
       )
       val sierraDigaidsPicture = sierraIdentifiedWork()
+      // Multiple physical items would prevent a Miro redirect in any other case,
+      // but we still expect to see it for the digaids works as the Miro item is
+      // a known duplicate of the METS item.
         .items(List(createIdentifiedPhysicalItem, createIdentifiedPhysicalItem))
         .format(Format.Pictures)
         .otherIdentifiers(List(createDigcodeIdentifier("digaids")))

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/ItemsRuleTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/ItemsRuleTest.scala
@@ -36,12 +36,14 @@ class ItemsRuleTest
   val calmWork: Work.Visible[WorkState.Identified] = calmIdentifiedWork()
 
   it(
-    "leaves items unchanged and returns a digitised version of a Sierra work as a merged source") {
+    "leaves items unchanged and returns a digitised version of a Sierra work as a merged source"
+  ) {
     val (digitisedWork, physicalWork) = sierraIdentifiedWorkPair()
 
     inside(
       ItemsRule
-        .merge(physicalWork, List(digitisedWork))) {
+        .merge(physicalWork, List(digitisedWork))
+    ) {
       case FieldMergeResult(items, mergedSources) =>
         items should have size 1
         items shouldBe physicalWork.data.items
@@ -96,7 +98,8 @@ class ItemsRuleTest
   it("does not merge any Miro sources when there are several of them") {
     inside(
       ItemsRule
-        .merge(physicalPictureSierra, List(miroWork, miroIdentifiedWork()))) {
+        .merge(physicalPictureSierra, List(miroWork, miroIdentifiedWork()))
+    ) {
       case FieldMergeResult(items, mergedSources) =>
         items shouldEqual physicalPictureSierra.data.items
         mergedSources shouldBe empty
@@ -104,7 +107,8 @@ class ItemsRuleTest
   }
 
   it(
-    "does not merge a Miro source into a Sierra work with format != picture/digital image/3D object") {
+    "does not merge a Miro source into a Sierra work with format != picture/digital image/3D object"
+  ) {
     inside(ItemsRule.merge(physicalMapsSierra, List(miroWork))) {
       case FieldMergeResult(items, mergedSources) =>
         items shouldEqual physicalMapsSierra.data.items
@@ -113,7 +117,8 @@ class ItemsRuleTest
   }
 
   it(
-    "override Miro merging with METS merging into single-item physical Sierra works items") {
+    "override Miro merging with METS merging into single-item physical Sierra works items"
+  ) {
     inside(ItemsRule.merge(physicalPictureSierra, List(miroWork, metsWork))) {
       case FieldMergeResult(items, mergedSources) =>
         items should have size 1
@@ -140,6 +145,24 @@ class ItemsRuleTest
         items should contain theSameElementsAs
           multiItemPhysicalSierra.data.items ++ metsWork.data.items
         mergedSources should be(Seq(metsWork))
+    }
+  }
+
+  it(
+    "doesn't merge Miro works into multi-item Sierra digaids works alongside METS items, but does treat them as mergedSources"
+  ) {
+    inside(
+      ItemsRule.merge(
+        multiItemPhysicalSierra
+          .otherIdentifiers(List(createDigcodeIdentifier("digaids"))),
+        List(miroWork, metsWork)
+      )
+    ) {
+      case FieldMergeResult(items, mergedSources) =>
+        items should be(
+          multiItemPhysicalSierra.data.items ++ metsWork.data.items
+        )
+        mergedSources should contain theSameElementsAs Seq(miroWork, metsWork)
     }
   }
 
@@ -173,7 +196,8 @@ class ItemsRuleTest
 
         mergedSources should contain theSameElementsAs Seq(
           metsWork,
-          physicalPictureSierra)
+          physicalPictureSierra
+        )
     }
   }
 }


### PR DESCRIPTION
See discussion following https://wellcome.slack.com/archives/C8X9YKM5X/p1621598033034300?thread_ts=1620662731.355000&cid=C8X9YKM5X for some context; comments should cover the reasoning for the chosen implementation. Scalafmt did some weird stuff with this PR for some reason.