### PR TITLE
Use a strict mapping for varfields and fixed fields in the Sierra indexer

### DIFF
--- a/sierra_adapter/sierra_indexer/src/main/scala/weco/catalogue/sierra_indexer/index/SierraIndexerIndexConfig.scala
+++ b/sierra_adapter/sierra_indexer/src/main/scala/weco/catalogue/sierra_indexer/index/SierraIndexerIndexConfig.scala
@@ -2,7 +2,11 @@ package weco.catalogue.sierra_indexer.index
 
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.analysis.Analysis
-import com.sksamuel.elastic4s.requests.mappings.{FieldDefinition, MappingDefinition, ObjectField}
+import com.sksamuel.elastic4s.requests.mappings.{
+  FieldDefinition,
+  MappingDefinition,
+  ObjectField
+}
 import com.sksamuel.elastic4s.requests.mappings.dynamictemplate.DynamicMapping
 import uk.ac.wellcome.elasticsearch.IndexConfig
 import uk.ac.wellcome.models.index.IndexConfigFields

--- a/sierra_adapter/sierra_indexer/src/main/scala/weco/catalogue/sierra_indexer/index/SierraIndexerIndexConfig.scala
+++ b/sierra_adapter/sierra_indexer/src/main/scala/weco/catalogue/sierra_indexer/index/SierraIndexerIndexConfig.scala
@@ -1,0 +1,38 @@
+package weco.catalogue.sierra_indexer.index
+
+import com.sksamuel.elastic4s.ElasticDsl._
+import com.sksamuel.elastic4s.analysis.Analysis
+import com.sksamuel.elastic4s.requests.mappings.MappingDefinition
+import com.sksamuel.elastic4s.requests.mappings.dynamictemplate.DynamicMapping
+import uk.ac.wellcome.elasticsearch.IndexConfig
+import uk.ac.wellcome.models.index.IndexConfigFields
+
+trait SierraIndexerIndexConfig extends IndexConfig with IndexConfigFields {
+  override def analysis: Analysis =
+    Analysis(analyzers = List())
+}
+
+object VarfieldIndexConfig extends SierraIndexerIndexConfig {
+  val fields = Seq(
+    objectField("parent").fields(
+      keywordField("id"),
+      keywordField("idWithCheckDigit"),
+      keywordField("recordType")
+    ),
+    intField("position"),
+    objectField("varField").fields(
+      keywordField("fieldTag"),
+      keywordField("ind1"),
+      keywordField("ind2"),
+      keywordField("marcTag"),
+      objectField("subfields").fields(
+        keywordField("tag"),
+        englishTextKeywordField("content")
+      ),
+      englishTextKeywordField("content")
+    )
+  )
+
+  override def mapping: MappingDefinition =
+    properties(fields).dynamic(DynamicMapping.Strict)
+}

--- a/sierra_adapter/sierra_indexer/src/main/scala/weco/catalogue/sierra_indexer/index/SierraIndexerIndexConfig.scala
+++ b/sierra_adapter/sierra_indexer/src/main/scala/weco/catalogue/sierra_indexer/index/SierraIndexerIndexConfig.scala
@@ -2,7 +2,7 @@ package weco.catalogue.sierra_indexer.index
 
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.analysis.Analysis
-import com.sksamuel.elastic4s.requests.mappings.MappingDefinition
+import com.sksamuel.elastic4s.requests.mappings.{FieldDefinition, MappingDefinition, ObjectField}
 import com.sksamuel.elastic4s.requests.mappings.dynamictemplate.DynamicMapping
 import uk.ac.wellcome.elasticsearch.IndexConfig
 import uk.ac.wellcome.models.index.IndexConfigFields
@@ -10,15 +10,22 @@ import uk.ac.wellcome.models.index.IndexConfigFields
 trait SierraIndexerIndexConfig extends IndexConfig with IndexConfigFields {
   override def analysis: Analysis =
     Analysis(analyzers = List())
+
+  def fields: Seq[FieldDefinition]
+
+  val parent: ObjectField = objectField("parent").fields(
+    keywordField("id"),
+    keywordField("idWithCheckDigit"),
+    keywordField("recordType")
+  )
+
+  override def mapping: MappingDefinition =
+    properties(fields).dynamic(DynamicMapping.Strict)
 }
 
 object VarfieldIndexConfig extends SierraIndexerIndexConfig {
-  val fields = Seq(
-    objectField("parent").fields(
-      keywordField("id"),
-      keywordField("idWithCheckDigit"),
-      keywordField("recordType")
-    ),
+  val fields: Seq[FieldDefinition] = Seq(
+    parent,
     intField("position"),
     objectField("varField").fields(
       keywordField("fieldTag"),
@@ -32,7 +39,16 @@ object VarfieldIndexConfig extends SierraIndexerIndexConfig {
       englishTextKeywordField("content")
     )
   )
+}
 
-  override def mapping: MappingDefinition =
-    properties(fields).dynamic(DynamicMapping.Strict)
+object FixedFieldIndexConfig extends SierraIndexerIndexConfig {
+  val fields: Seq[FieldDefinition] = Seq(
+    parent,
+    keywordField("code"),
+    objectField("fixedField").fields(
+      keywordField("label"),
+      englishTextKeywordField("display"),
+      englishTextKeywordField("value")
+    )
+  )
 }

--- a/sierra_adapter/sierra_indexer/src/main/scala/weco/catalogue/sierra_indexer/services/Splitter.scala
+++ b/sierra_adapter/sierra_indexer/src/main/scala/weco/catalogue/sierra_indexer/services/Splitter.scala
@@ -24,12 +24,10 @@ class Splitter(indexPrefix: String)(
     val varFields = IndexerRequest.varFields(indexPrefix, apiData)
     val fixedFields = IndexerRequest.fixedFields(indexPrefix, apiData)
 
-    val varFieldDeletions = IndexerRequest.varFieldDeletions(
-      indexPrefix,
-      apiData)
-    val fixedFieldDeletions = IndexerRequest.fixedFieldDeletions(
-      indexPrefix,
-      apiData)
+    val varFieldDeletions =
+      IndexerRequest.varFieldDeletions(indexPrefix, apiData)
+    val fixedFieldDeletions =
+      IndexerRequest.fixedFieldDeletions(indexPrefix, apiData)
 
     (
       mainRecords ++ varFields ++ fixedFields,
@@ -37,8 +35,7 @@ class Splitter(indexPrefix: String)(
     )
   }
 
-  private def getSierraApiData(
-    t: SierraTransformable): Seq[(Parent, Json)] = {
+  private def getSierraApiData(t: SierraTransformable): Seq[(Parent, Json)] = {
     val itemIds = t.itemRecords.keys.map { _.withoutCheckDigit }.toList.sorted
     val holdingsIds =
       t.holdingsRecords.keys.map { _.withoutCheckDigit }.toList.sorted

--- a/sierra_adapter/sierra_indexer/src/main/scala/weco/catalogue/sierra_indexer/services/Splitter.scala
+++ b/sierra_adapter/sierra_indexer/src/main/scala/weco/catalogue/sierra_indexer/services/Splitter.scala
@@ -1,9 +1,6 @@
 package weco.catalogue.sierra_indexer.services
 
-import com.sksamuel.elastic4s.{ElasticClient, Index}
-import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.requests.delete.DeleteByQueryRequest
-import com.sksamuel.elastic4s.requests.get.GetResponse
 import com.sksamuel.elastic4s.requests.indexes.IndexRequest
 import grizzled.slf4j.Logging
 import io.circe.parser._
@@ -17,88 +14,31 @@ import scala.concurrent.{ExecutionContext, Future}
 // that can be sent to Elasticsearch.
 class Splitter(indexPrefix: String)(
   implicit
-  client: ElasticClient,
   ec: ExecutionContext
 ) extends Logging {
-  import weco.catalogue.sierra_indexer.services.SierraJsonOps._
-
   def split(t: SierraTransformable)
-    : Future[(Seq[IndexRequest], Seq[DeleteByQueryRequest])] = {
-    for {
-      apiData <- getSierraApiData(t)
+    : Future[(Seq[IndexRequest], Seq[DeleteByQueryRequest])] = Future {
+    val apiData = getSierraApiData(t)
 
-      // This is an attempt to reduce the pressure on the Elasticsearch cluster.
-      //
-      // We look at the main record for this bib/item/holdings, and compare it to what's
-      // already stored.  Note that these records include the modifiedDate/deletedDate, e.g
-      //
-      //    {"id": "1234567", "modifiedDate": "2001-01-01T01:01:01Z", …}
-      //
-      // and we assume that this value will change when the record is modified.
-      // Because the modified/deletedDate is part of the JSON, it is sufficient to compare
-      // the JSON strings without extracting the dates directly.
-      //
-      // If you wanted to go one step further, you could diff individual
-      // varFields/fixedFields, but that adds more complexity.
-      //
-      // I'm hoping this is a quick fix that makes the indexer performance "good enough"
-      // without us having to pour money into the reporting cluster.
-      stored <- getStored(apiData)
-      modifiedApiData = stored
-        .filter {
-          case ((parent, json), getResponse)
-              if jsonStringsMatch(
-                json.withId(parent.id).remainder,
-                getResponse.sourceAsString) =>
-            debug(
-              s"Not indexing ${parent.id.withCheckDigit}; it is already indexed")
-            false
+    val mainRecords = IndexerRequest.mainRecords(indexPrefix, apiData)
+    val varFields = IndexerRequest.varFields(indexPrefix, apiData)
+    val fixedFields = IndexerRequest.fixedFields(indexPrefix, apiData)
 
-          case ((parent, _), _) =>
-            debug(s"Indexing ${parent.id.withCheckDigit}")
-            true
-        }
-        .map { case ((parent, json), _) => (parent, json) }
+    val varFieldDeletions = IndexerRequest.varFieldDeletions(
+      indexPrefix,
+      apiData)
+    val fixedFieldDeletions = IndexerRequest.fixedFieldDeletions(
+      indexPrefix,
+      apiData)
 
-      mainRecords = IndexerRequest.mainRecords(indexPrefix, modifiedApiData)
-      varFields = IndexerRequest.varFields(indexPrefix, modifiedApiData)
-      fixedFields = IndexerRequest.fixedFields(indexPrefix, modifiedApiData)
-
-      varFieldDeletions = IndexerRequest.varFieldDeletions(
-        indexPrefix,
-        modifiedApiData)
-      fixedFieldDeletions = IndexerRequest.fixedFieldDeletions(
-        indexPrefix,
-        modifiedApiData)
-    } yield
-      (
-        mainRecords ++ varFields ++ fixedFields,
-        varFieldDeletions ++ fixedFieldDeletions
-      )
-  }
-
-  private def jsonStringsMatch(j1: Json, j2: String): Boolean =
-    parse(j2) match {
-      case Right(value) => value == j1
-      case _            => false
-    }
-
-  private def getStored(apiData: Seq[(Parent, Json)])
-    : Future[Seq[((Parent, Json), GetResponse)]] = {
-    val gets = apiData.map {
-      case (parent, _) =>
-        get(
-          Index(s"${indexPrefix}_${parent.recordType}"),
-          id = parent.id.withoutCheckDigit)
-    }
-
-    client.execute(multiget(gets)).map { resp =>
-      apiData.zip(resp.result.items)
-    }
+    (
+      mainRecords ++ varFields ++ fixedFields,
+      varFieldDeletions ++ fixedFieldDeletions
+    )
   }
 
   private def getSierraApiData(
-    t: SierraTransformable): Future[Seq[(Parent, Json)]] = {
+    t: SierraTransformable): Seq[(Parent, Json)] = {
     val itemIds = t.itemRecords.keys.map { _.withoutCheckDigit }.toList.sorted
     val holdingsIds =
       t.holdingsRecords.keys.map { _.withoutCheckDigit }.toList.sorted
@@ -150,9 +90,9 @@ class Splitter(indexPrefix: String)(
     val failures = data.collect { case (parent, Left(err)) => (parent, err) }
 
     if (failures.isEmpty) {
-      Future.successful(successes)
+      successes
     } else {
-      Future.failed(new Throwable(s"Could not parse all records: $failures"))
+      throw new Throwable(s"Could not parse all records: $failures")
     }
   }
 }

--- a/sierra_adapter/sierra_indexer/src/main/scala/weco/catalogue/sierra_indexer/services/Worker.scala
+++ b/sierra_adapter/sierra_indexer/src/main/scala/weco/catalogue/sierra_indexer/services/Worker.scala
@@ -13,7 +13,7 @@ import uk.ac.wellcome.storage.Identified
 import uk.ac.wellcome.storage.s3.S3ObjectLocation
 import uk.ac.wellcome.storage.store.Readable
 import uk.ac.wellcome.typesafe.Runnable
-import weco.catalogue.sierra_indexer.index.VarfieldIndexConfig
+import weco.catalogue.sierra_indexer.index.{FixedFieldIndexConfig, VarfieldIndexConfig}
 import weco.catalogue.source_model.SierraSourcePayload
 import weco.catalogue.source_model.sierra.SierraTransformable
 
@@ -37,6 +37,12 @@ class Worker(
         elasticClient,
         index = Index(s"${indexPrefix}_varfields"),
         config = VarfieldIndexConfig
+      ).create
+
+      _ <- new ElasticsearchIndexCreator(
+        elasticClient,
+        index = Index(s"${indexPrefix}_fixedfields"),
+        config = FixedFieldIndexConfig
       ).create
 
       _ <- sqsStream.foreach("Sierra indexer", processMessage)

--- a/sierra_adapter/sierra_indexer/src/main/scala/weco/catalogue/sierra_indexer/services/Worker.scala
+++ b/sierra_adapter/sierra_indexer/src/main/scala/weco/catalogue/sierra_indexer/services/Worker.scala
@@ -13,7 +13,10 @@ import uk.ac.wellcome.storage.Identified
 import uk.ac.wellcome.storage.s3.S3ObjectLocation
 import uk.ac.wellcome.storage.store.Readable
 import uk.ac.wellcome.typesafe.Runnable
-import weco.catalogue.sierra_indexer.index.{FixedFieldIndexConfig, VarfieldIndexConfig}
+import weco.catalogue.sierra_indexer.index.{
+  FixedFieldIndexConfig,
+  VarfieldIndexConfig
+}
 import weco.catalogue.source_model.SierraSourcePayload
 import weco.catalogue.source_model.sierra.SierraTransformable
 

--- a/sierra_adapter/sierra_indexer/src/test/resources/logback-test.xml
+++ b/sierra_adapter/sierra_indexer/src/test/resources/logback-test.xml
@@ -1,0 +1,25 @@
+<configuration>
+
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
+  <appender name="standard" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="silent" class="ch.qos.logback.core.NOPAppender"/>
+
+  <root level="DEBUG">
+    <!-- Use the CATALOGUE_TEST_LOGGING env var to set which logger to use -->
+    <appender-ref ref="${CATALOGUE_TEST_LOGGING:-silent}"/>
+  </root>
+
+  <!-- Edit these to change the log levels for external libraries -->
+  <logger name="org.apache.http" level="OFF"/>
+  <logger name="io.netty" level="OFF"/>
+  <logger name="com.amazonaws" level="OFF"/>
+  <logger name="software.amazon.awssdk" level="OFF"/>
+  <logger name="akka.actor" level="OFF"/>
+  <logger name="com.sksamuel.elastic4s" level="OFF"/>
+</configuration>

--- a/sierra_adapter/sierra_indexer/src/test/scala/weco/catalogue/sierra_indexer/SierraIndexerFeatureTest.scala
+++ b/sierra_adapter/sierra_indexer/src/test/scala/weco/catalogue/sierra_indexer/SierraIndexerFeatureTest.scala
@@ -1106,7 +1106,7 @@ class SierraIndexerFeatureTest
       ).await
 
       withLocalSqsQueuePair() { case QueuePair(queue, dlq) =>
-        withWorker(queue, store, indexPrefix) { worker =>
+        withWorker(queue, store, indexPrefix) { _ =>
           sendNotificationToSQS(
             queue,
             SierraSourcePayload(
@@ -1118,7 +1118,7 @@ class SierraIndexerFeatureTest
 
           eventually {
             assertQueueEmpty(queue)
-            assertQueueHasSize(queue, size = 1)
+            assertQueueHasSize(dlq, size = 1)
           }
         }
       }

--- a/sierra_adapter/sierra_indexer/src/test/scala/weco/catalogue/sierra_indexer/fixtures/IndexerFixtures.scala
+++ b/sierra_adapter/sierra_indexer/src/test/scala/weco/catalogue/sierra_indexer/fixtures/IndexerFixtures.scala
@@ -26,7 +26,7 @@ trait IndexerFixtures
     with Akka
     with SQS { this: Suite =>
   def withWorker[R](
-    queue: Queue,
+    queue: Queue = Queue("test://q", "arn::test:q", visibilityTimeout = 1),
     typedStore: MemoryTypedStore[S3ObjectLocation, SierraTransformable],
     indexPrefix: String)(
     testWith: TestWith[Worker, R]

--- a/sierra_adapter/sierra_indexer/src/test/scala/weco/catalogue/sierra_indexer/services/WorkerTest.scala
+++ b/sierra_adapter/sierra_indexer/src/test/scala/weco/catalogue/sierra_indexer/services/WorkerTest.scala
@@ -1,0 +1,95 @@
+package weco.catalogue.sierra_indexer.services
+
+import com.sksamuel.elastic4s.ElasticDsl._
+import com.sksamuel.elastic4s.Indexes
+import org.scalatest.funspec.AnyFunSpec
+import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
+import uk.ac.wellcome.storage.generators.S3ObjectLocationGenerators
+import uk.ac.wellcome.storage.s3.S3ObjectLocation
+import uk.ac.wellcome.storage.store.memory.MemoryTypedStore
+import weco.catalogue.sierra_indexer.fixtures.IndexerFixtures
+import weco.catalogue.source_model.SierraSourcePayload
+import weco.catalogue.source_model.generators.SierraGenerators
+import weco.catalogue.source_model.sierra.Implicits._
+import weco.catalogue.source_model.sierra.SierraTransformable
+
+class WorkerTest extends AnyFunSpec with IndexerFixtures with S3ObjectLocationGenerators with SierraGenerators {
+  it("returns an error if one of the bulk requests fails") {
+    withIndices { indexPrefix =>
+      val location = createS3ObjectLocation
+
+      val bibId = createSierraBibNumber
+
+      val transformable = createSierraTransformableWith(
+        maybeBibRecord = Some(
+          createSierraBibRecordWith(
+            id = bibId,
+            data =
+              s"""
+                 |{
+                 |  "id" : "$bibId",
+                 |  "updatedDate" : "2013-12-12T13:56:07Z",
+                 |  "deleted" : false,
+                 |  "varFields" : [
+                 |    {
+                 |      "fieldTag" : "b",
+                 |      "content" : "22501328220"
+                 |    },
+                 |    {
+                 |      "fieldTag" : "c",
+                 |      "marcTag" : "949",
+                 |      "ind1" : " ",
+                 |      "ind2" : " ",
+                 |      "subfields" : [
+                 |        {
+                 |          "tag" : "a",
+                 |          "content" : "/RHO"
+                 |        }
+                 |      ]
+                 |    }
+                 |  ]
+                 |}
+                 |""".stripMargin
+          )
+        )
+      )
+
+      val store = MemoryTypedStore[S3ObjectLocation, SierraTransformable](
+        initialEntries = Map(location -> transformable)
+      )
+
+      // Make the varfields index read-only, so any attempt to index data into
+      // this index should fail.
+      elasticClient.execute(
+        updateSettings(
+          Indexes(s"${indexPrefix}_varfields"), settings = Map("blocks.read_only" -> "true")
+        )
+      ).await
+
+      withLocalSqsQueuePair() { case QueuePair(queue, dlq) =>
+        withWorker(queue, store, indexPrefix) { worker =>
+          val future = worker.processMessage(
+            createNotificationMessageWith(
+              SierraSourcePayload(
+                id = bibId.withoutCheckDigit,
+                location = location,
+                version = 1
+              )
+            )
+          )
+
+          eventually {
+            assertQueueEmpty(queue)
+            assertQueueHasSize(queue, size = 1)
+          }
+
+          whenReady(future.failed) { err =>
+            err shouldBe a[RuntimeException]
+            err.getMessage should startWith("Errors in the bulk response")
+          }
+        }
+      }
+    }
+  }
+}

--- a/sierra_adapter/sierra_indexer/src/test/scala/weco/catalogue/sierra_indexer/services/WorkerTest.scala
+++ b/sierra_adapter/sierra_indexer/src/test/scala/weco/catalogue/sierra_indexer/services/WorkerTest.scala
@@ -79,11 +79,6 @@ class WorkerTest extends AnyFunSpec with IndexerFixtures with S3ObjectLocationGe
             )
           )
 
-          eventually {
-            assertQueueEmpty(queue)
-            assertQueueHasSize(queue, size = 1)
-          }
-
           whenReady(future.failed) { err =>
             err shouldBe a[RuntimeException]
             err.getMessage should startWith("Errors in the bulk response")


### PR DESCRIPTION
This is a tentative fix for https://github.com/wellcomecollection/platform/issues/5073

This patch addresses two issues in the Sierra indexer:

- **There was no explicit mapping.** I wrote the original implementation in a hurry, and I didn't bother to define a mapping – what's the worst that could happen?

   Turns out, the first value the Elasticsearch dynamic mapper saw in the `fixedField.value` field was a date – so it assumed that would be the case for all subsequent values. This blocks indexing any fixed field which has non-date or non-numeric value.

   This patch adds a strict mapping for the fixed field/varfield indexes. I haven't added an index for bibs/items/holdings/orders because that data tends to have more consistent types, but the exact set of fields changes more over time.

   This should allow all fixed fields to be indexed, and as a bonus reduce the indexing load on the cluster – I can tell it to treat certain fields as keywords, rather than having it analyse them as text.

- **Errors would fail silently.** This was another case of laziness in the initial implementation – I didn't expect the bulk indexing responses from Elasticsearch, so errors vanished into the aether.

    This patch updates the indexer to check the results, and fail if any of the documents don't index correctly. This would have helped us identify this issue much sooner.

Once this patch is reviewed and merged, I'll deploy it and kick off a reindex into a fresh set of indices, then rearrange everything so existing dashboards/scripts continue to work.