### PR TITLE
Some refactoring to add access conditions on items

### DIFF
--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/RulesForRequestingResult.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/RulesForRequestingResult.scala
@@ -4,10 +4,31 @@ sealed trait RulesForRequestingResult
 
 case object Requestable extends RulesForRequestingResult
 
-case class NotRequestable(message: Option[String] = None)
-  extends RulesForRequestingResult
+sealed trait NotRequestable extends RulesForRequestingResult
 
-case object NotRequestable {
-  def apply(message: String): NotRequestable =
-    NotRequestable(message = Some(message))
+object NotRequestable {
+  case class NeedsManualRequest(message: String) extends NotRequestable
+
+  case class ItemClosed(message: String) extends NotRequestable
+  case class ItemMissing(message: String) extends NotRequestable
+  case class ItemOnSearch(message: String) extends NotRequestable
+  case class ItemUnavailable(message: String) extends NotRequestable
+  case class ItemWithdrawn(message: String) extends NotRequestable
+
+  case class ContactUs(message: String) extends NotRequestable
+
+  case class OnHold(message: String) extends NotRequestable
+
+  case class OnOpenShelves(message: String) extends NotRequestable
+  case class OnExhibition(message: String) extends NotRequestable
+  case class OnNewBooksDisplay(message: String) extends NotRequestable
+
+  case class AtDigitisation(message: String) extends NotRequestable
+  case class AtConservation(message: String) extends NotRequestable
+
+  case class RequestTopItem(message: String) extends NotRequestable
+
+  case class BelongsInStrongroom(message: String) extends NotRequestable
+
+  case object NoReason extends NotRequestable
 }

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/RulesForRequestingResult.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/RulesForRequestingResult.scala
@@ -1,0 +1,13 @@
+package weco.catalogue.source_model.sierra.rules
+
+sealed trait RulesForRequestingResult
+
+case object Requestable extends RulesForRequestingResult
+
+case class NotRequestable(message: Option[String] = None)
+  extends RulesForRequestingResult
+
+case object NotRequestable {
+  def apply(message: String): NotRequestable =
+    NotRequestable(message = Some(message))
+}

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala
@@ -43,7 +43,7 @@ object SierraRulesForRequesting {
       //    q|i||97||=|x||This item belongs in the Strongroom
       //
       // This rule means "if fixed field 97 on the item has the value 'x'".
-      case i if i.imessage.contains("x") =>
+      case i if i.fixedField("97").contains("x") =>
         NotRequestable.BelongsInStrongroom("This item belongs in the Strongroom")
 
       // These cases cover the lines:
@@ -58,18 +58,18 @@ object SierraRulesForRequesting {
       //
       // These rules mean "if fixed field 88 on the item has a given value,
       // show this message".
-      case i if i.status.contains("m") =>
+      case i if i.fixedField("88").contains("m") =>
         NotRequestable.ItemMissing("This item is missing.")
-      case i if i.status.contains("s") =>
+      case i if i.fixedField("88").contains("s") =>
         NotRequestable.ItemOnSearch("This item is on search.")
-      case i if i.status.contains("x") =>
+      case i if i.fixedField("88").contains("x") =>
         NotRequestable.ItemWithdrawn("This item is withdrawn.")
-      case i if i.status.contains("r") =>
+      case i if i.fixedField("88").contains("r") =>
         NotRequestable.ItemUnavailable("This item is unavailable.")
-      case i if i.status.contains("z") => NotRequestable.NoReason
-      case i if i.status.contains("v") =>
+      case i if i.fixedField("88").contains("z") => NotRequestable.NoReason
+      case i if i.fixedField("88").contains("v") =>
         NotRequestable.AtConservation("This item is with conservation.")
-      case i if i.status.contains("h") =>
+      case i if i.fixedField("88").contains("h") =>
         NotRequestable.ItemClosed("This item is closed.")
 
       // These cases cover the lines:
@@ -79,7 +79,7 @@ object SierraRulesForRequesting {
       //
       // These are similar to the rules above; the difference is that the 'v' means
       // "if this line or the next line matches".  The 'q' means 'end of rule'.
-      case i if i.status.contains("b") || i.status.contains("c") =>
+      case i if i.fixedField("88").contains("b") || i.fixedField("88").contains("c") =>
         NotRequestable.RequestTopItem("Please request top item.")
 
       // These cases cover the lines:
@@ -89,11 +89,11 @@ object SierraRulesForRequesting {
       //    q|i||88||=|y||
       //
       // These are the same as the checks above.
-      case i if i.status.contains("d") =>
+      case i if i.fixedField("88").contains("d") =>
         NotRequestable.OnNewBooksDisplay("On new books display.")
-      case i if i.status.contains("e") =>
+      case i if i.fixedField("88").contains("e") =>
         NotRequestable.OnExhibition("On exhibition. Please ask at Enquiry Desk.")
-      case i if i.status.contains("y") =>
+      case i if i.fixedField("88").contains("y") =>
         NotRequestable.NoReason
 
       // These cases cover the lines:
@@ -115,7 +115,7 @@ object SierraRulesForRequesting {
       //    - I haven't found an example of an item with tag 8, so I'm skipping that rule
       //      for now.  TODO: Find an example of this.
       //
-      case i if i.loanRule.getOrElse("0") != "0" || i.status.contains("!") =>
+      case i if i.fixedField("87").getOrElse("0") != "0" || i.fixedField("88").contains("!") =>
         NotRequestable.OnHold(
           "Item is in use by another reader. Please ask at Enquiry Desk.")
 
@@ -128,7 +128,7 @@ object SierraRulesForRequesting {
       //    q|i||79||=|mfulc||Item cannot be requested online. Please contact Medical Film & Audio Library.   Email: mfac@wellcome.ac.uk. Telephone: +44 (0)20 76118596/97.
       //
       case i
-          if i.locationCode.containsAnyOf(
+          if i.fixedField("79").containsAnyOf(
             "mfgmc",
             "mfinc",
             "mfwcm",
@@ -156,7 +156,7 @@ object SierraRulesForRequesting {
       //    q|i||79||=|ofvds||This item cannot be requested online. Please place a manual request.
       //
       case i
-          if i.locationCode.containsAnyOf(
+          if i.fixedField("79").containsAnyOf(
             "dbiaa",
             "dcoaa",
             "dinad",
@@ -180,7 +180,7 @@ object SierraRulesForRequesting {
       //    v|i||79||=|isvid||
       //    q|i||79||=|iscdr||Item cannot be requested online. Please ask at Information Service desk, email: infoserv@wellcome.ac.uk or telephone +44 (0)20 7611 8722.
       //
-      case i if i.locationCode.containsAnyOf("isvid", "iscdr") =>
+      case i if i.fixedField("79").containsAnyOf("isvid", "iscdr") =>
         NotRequestable.ContactUs(
           "Item cannot be requested online. Please ask at Information Service desk, email: infoserv@wellcome.ac.uk or telephone +44 (0)20 7611 8722.")
 
@@ -217,7 +217,7 @@ object SierraRulesForRequesting {
       //    q|i||79||=|wsrex||Item is on open shelves.  Check Location and Shelfmark for location details.
       //
       case i
-          if i.locationCode.containsAnyOf(
+          if i.fixedField("79").containsAnyOf(
             "isope",
             "isref",
             "gblip",
@@ -272,15 +272,15 @@ object SierraRulesForRequesting {
       //    v|i||79||=|sompr||
       //    q|i||79||=|somsy||Please complete a manual request slip.  This item cannot be requested online.
       //
-      case i if i.itemType.contains("22") =>
+      case i if i.fixedField("61").contains("22") =>
         NotRequestable.OnExhibition(
           "Item is on Exhibition Reserve. Please ask at the Enquiry Desk")
 
-      case i if i.itemType.containsAnyOf("17", "18", "15") =>
+      case i if i.fixedField("61").containsAnyOf("17", "18", "15") =>
         NotRequestable.NoReason
 
       case i
-          if i.itemType.containsAnyOf("4", "14") || i.locationCode
+          if i.fixedField("61").containsAnyOf("4", "14") || i.fixedField("79")
             .containsAnyOf(
               "ofvn1",
               "scmwc",
@@ -300,7 +300,7 @@ object SierraRulesForRequesting {
       //
       //    q|i||79||=|sepep||
       //
-      case i if i.locationCode.contains("sepep") =>
+      case i if i.fixedField("79").contains("sepep") =>
         NotRequestable.NoReason
 
       // This case covers the lines:
@@ -320,7 +320,7 @@ object SierraRulesForRequesting {
       //    q|i||79||=|swm#7||Item not available due to provisions of Data Protection Act. Return to Archives catalogue to see when this file will be opened.
       //
       case i
-          if i.locationCode.containsAnyOf(
+          if i.fixedField("79").containsAnyOf(
             "sc#ac",
             "sc#ra",
             "sc#wa",
@@ -354,7 +354,7 @@ object SierraRulesForRequesting {
       //    q|i||79||=|temp6||At digitisation and temporarily unavailable.
       //
       case i
-          if i.locationCode.containsAnyOf(
+          if i.fixedField("79").containsAnyOf(
             "temp1",
             "temp2",
             "temp3",
@@ -368,34 +368,22 @@ object SierraRulesForRequesting {
       //    v|i||79||=|rm001||
       //    q|i||79||=|rmdda||
       //
-      case i if i.locationCode.containsAnyOf("rm001", "rmdda") =>
+      case i if i.fixedField("79").containsAnyOf("rm001", "rmdda") =>
         NotRequestable.NoReason
 
       // This case covers the line:
       //
       //    q|i||97||=|j||
       //
-      case i if i.imessage.contains("j") =>
+      case i if i.fixedField("97").contains("j") =>
         NotRequestable.NoReason
 
       case _ => Requestable
     }
 
   private implicit class ItemDataOps(itemData: SierraItemData) {
-    def imessage: Option[String] =
-      itemData.fixedFields.get("97").map { _.value.trim }
-
-    def status: Option[String] =
-      itemData.fixedFields.get("88").map { _.value.trim }
-
-    def loanRule: Option[String] =
-      itemData.fixedFields.get("87").map { _.value.trim }
-
-    def locationCode: Option[String] =
-      itemData.fixedFields.get("79").map { _.value.trim }
-
-    def itemType: Option[String] =
-      itemData.fixedFields.get("61").map { _.value.trim }
+    def fixedField(code: String): Option[String] =
+      itemData.fixedFields.get(code).map { _.value.trim }
   }
 
   private implicit class OptionalStringOps(s: Option[String]) {

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala
@@ -22,14 +22,24 @@ case object Requestable extends RulesForRequestingResult
   * The original rules are included for reference and to help apply updates,
   * along with explanations of the syntax.
   *
+  * If you disagree with one of these rules, you have two options:
+  *
+  *   1)  Discuss the change with Library Systems Support and get it changed
+  *       in Sierra proper, then update this object to match
+  *   2)  Work around it elsewhere in our applications
+  *
+  * But don't modify these rules without updating the canonical set in Sierra --
+  * this is meant to be a 1:1 reflection of those rules, not a mix of Sierra rules
+  * and platform logic.
+  *
   * Relevant Sierra docs:
   *
-  *   - Rules for Requesting syntax
-  *     https://documentation.iii.com/sierrahelp/Content/sgasaa/sgasaa_requestrl.html
-  *   - Fixed fields on items
-  *     https://documentation.iii.com/sierrahelp/Content/sril/sril_records_fixed_field_types_item.html
-  *   - Variable length fields on items
-  *     https://documentation.iii.com/sierrahelp/Content/sril/sril_records_varfld_types_item.html
+  *   -   Rules for Requesting syntax
+  *       https://documentation.iii.com/sierrahelp/Content/sgasaa/sgasaa_requestrl.html
+  *   -   Fixed fields on items
+  *       https://documentation.iii.com/sierrahelp/Content/sril/sril_records_fixed_field_types_item.html
+  *   -   Variable length fields on items
+  *       https://documentation.iii.com/sierrahelp/Content/sril/sril_records_varfld_types_item.html
   *
   */
 object SierraRulesForRequesting {

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala
@@ -2,18 +2,6 @@ package weco.catalogue.source_model.sierra.rules
 
 import weco.catalogue.source_model.sierra.SierraItemData
 
-sealed trait RulesForRequestingResult
-
-case class NotRequestable(message: Option[String] = None)
-    extends RulesForRequestingResult
-
-case object NotRequestable {
-  def apply(message: String): NotRequestable =
-    NotRequestable(message = Some(message))
-}
-
-case object Requestable extends RulesForRequestingResult
-
 /** The Rules for Requesting are a set of rules in Sierra that can block an item
   * from being requested, and if so, optionally explain to the user why an item
   * can't be requested.

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala
@@ -1,4 +1,6 @@
-package weco.catalogue.source_model.sierra
+package weco.catalogue.source_model.sierra.rules
+
+import weco.catalogue.source_model.sierra.SierraItemData
 
 sealed trait RulesForRequestingResult
 

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala
@@ -44,7 +44,8 @@ object SierraRulesForRequesting {
       //
       // This rule means "if fixed field 97 on the item has the value 'x'".
       case i if i.fixedField("97").contains("x") =>
-        NotRequestable.BelongsInStrongroom("This item belongs in the Strongroom")
+        NotRequestable.BelongsInStrongroom(
+          "This item belongs in the Strongroom")
 
       // These cases cover the lines:
       //
@@ -79,7 +80,10 @@ object SierraRulesForRequesting {
       //
       // These are similar to the rules above; the difference is that the 'v' means
       // "if this line or the next line matches".  The 'q' means 'end of rule'.
-      case i if i.fixedField("88").contains("b") || i.fixedField("88").contains("c") =>
+      case i
+          if i
+            .fixedField("88")
+            .contains("b") || i.fixedField("88").contains("c") =>
         NotRequestable.RequestTopItem("Please request top item.")
 
       // These cases cover the lines:
@@ -92,7 +96,8 @@ object SierraRulesForRequesting {
       case i if i.fixedField("88").contains("d") =>
         NotRequestable.OnNewBooksDisplay("On new books display.")
       case i if i.fixedField("88").contains("e") =>
-        NotRequestable.OnExhibition("On exhibition. Please ask at Enquiry Desk.")
+        NotRequestable.OnExhibition(
+          "On exhibition. Please ask at Enquiry Desk.")
       case i if i.fixedField("88").contains("y") =>
         NotRequestable.NoReason
 
@@ -115,7 +120,10 @@ object SierraRulesForRequesting {
       //    - I haven't found an example of an item with tag 8, so I'm skipping that rule
       //      for now.  TODO: Find an example of this.
       //
-      case i if i.fixedField("87").getOrElse("0") != "0" || i.fixedField("88").contains("!") =>
+      case i
+          if i.fixedField("87").getOrElse("0") != "0" || i
+            .fixedField("88")
+            .contains("!") =>
         NotRequestable.OnHold(
           "Item is in use by another reader. Please ask at Enquiry Desk.")
 
@@ -128,12 +136,9 @@ object SierraRulesForRequesting {
       //    q|i||79||=|mfulc||Item cannot be requested online. Please contact Medical Film & Audio Library.   Email: mfac@wellcome.ac.uk. Telephone: +44 (0)20 76118596/97.
       //
       case i
-          if i.fixedField("79").containsAnyOf(
-            "mfgmc",
-            "mfinc",
-            "mfwcm",
-            "hmfac",
-            "mfulc") =>
+          if i
+            .fixedField("79")
+            .containsAnyOf("mfgmc", "mfinc", "mfwcm", "hmfac", "mfulc") =>
         NotRequestable.ContactUs(
           "Item cannot be requested online. Please contact Medical Film & Audio Library.   Email: mfac@wellcome.ac.uk. Telephone: +44 (0)20 76118596/97.")
 
@@ -156,22 +161,24 @@ object SierraRulesForRequesting {
       //    q|i||79||=|ofvds||This item cannot be requested online. Please place a manual request.
       //
       case i
-          if i.fixedField("79").containsAnyOf(
-            "dbiaa",
-            "dcoaa",
-            "dinad",
-            "dinop",
-            "dinsd",
-            "dints",
-            "dpoaa",
-            "dimgs",
-            "dhuaa",
-            "dimgs",
-            "dingo",
-            "dpleg",
-            "dpuih",
-            "gblip",
-            "ofvds") =>
+          if i
+            .fixedField("79")
+            .containsAnyOf(
+              "dbiaa",
+              "dcoaa",
+              "dinad",
+              "dinop",
+              "dinsd",
+              "dints",
+              "dpoaa",
+              "dimgs",
+              "dhuaa",
+              "dimgs",
+              "dingo",
+              "dpleg",
+              "dpuih",
+              "gblip",
+              "ofvds") =>
         NotRequestable.NeedsManualRequest(
           "This item cannot be requested online. Please place a manual request.")
 
@@ -217,37 +224,39 @@ object SierraRulesForRequesting {
       //    q|i||79||=|wsrex||Item is on open shelves.  Check Location and Shelfmark for location details.
       //
       case i
-          if i.fixedField("79").containsAnyOf(
-            "isope",
-            "isref",
-            "gblip",
-            "wghib",
-            "wghig",
-            "wghip",
-            "wghir",
-            "wghxb",
-            "wghxg",
-            "wghxp",
-            "wghxr",
-            "wgmem",
-            "wgmxm",
-            "wgpvm",
-            "wgsee",
-            "wgsem",
-            "wgser",
-            "wqrfc",
-            "wqrfd",
-            "wqrfe",
-            "wqrfp",
-            "wqrfr",
-            "wslob",
-            "wslom",
-            "wslor",
-            "wslox",
-            "wsref",
-            "hgslr",
-            "wsrex"
-          ) =>
+          if i
+            .fixedField("79")
+            .containsAnyOf(
+              "isope",
+              "isref",
+              "gblip",
+              "wghib",
+              "wghig",
+              "wghip",
+              "wghir",
+              "wghxb",
+              "wghxg",
+              "wghxp",
+              "wghxr",
+              "wgmem",
+              "wgmxm",
+              "wgpvm",
+              "wgsee",
+              "wgsem",
+              "wgser",
+              "wqrfc",
+              "wqrfd",
+              "wqrfe",
+              "wqrfp",
+              "wqrfr",
+              "wslob",
+              "wslom",
+              "wslor",
+              "wslox",
+              "wsref",
+              "hgslr",
+              "wsrex"
+            ) =>
         NotRequestable.OnOpenShelves(
           "Item is on open shelves.  Check Location and Shelfmark for location details.")
 
@@ -280,7 +289,8 @@ object SierraRulesForRequesting {
         NotRequestable.NoReason
 
       case i
-          if i.fixedField("61").containsAnyOf("4", "14") || i.fixedField("79")
+          if i.fixedField("61").containsAnyOf("4", "14") || i
+            .fixedField("79")
             .containsAnyOf(
               "ofvn1",
               "scmwc",
@@ -320,20 +330,22 @@ object SierraRulesForRequesting {
       //    q|i||79||=|swm#7||Item not available due to provisions of Data Protection Act. Return to Archives catalogue to see when this file will be opened.
       //
       case i
-          if i.fixedField("79").containsAnyOf(
-            "sc#ac",
-            "sc#ra",
-            "sc#wa",
-            "sc#wf",
-            "swm#m",
-            "swm#o",
-            "swm#1",
-            "swm#2",
-            "swm#3",
-            "swm#4",
-            "swm#5",
-            "swm#6",
-            "swm#7") =>
+          if i
+            .fixedField("79")
+            .containsAnyOf(
+              "sc#ac",
+              "sc#ra",
+              "sc#wa",
+              "sc#wf",
+              "swm#m",
+              "swm#o",
+              "swm#1",
+              "swm#2",
+              "swm#3",
+              "swm#4",
+              "swm#5",
+              "swm#6",
+              "swm#7") =>
         NotRequestable.ItemUnavailable(
           "Item not available due to provisions of Data Protection Act. Return to Archives catalogue to see when this file will be opened.")
 
@@ -354,14 +366,17 @@ object SierraRulesForRequesting {
       //    q|i||79||=|temp6||At digitisation and temporarily unavailable.
       //
       case i
-          if i.fixedField("79").containsAnyOf(
-            "temp1",
-            "temp2",
-            "temp3",
-            "temp4",
-            "temp5",
-            "temp6") =>
-        NotRequestable.AtDigitisation("At digitisation and temporarily unavailable.")
+          if i
+            .fixedField("79")
+            .containsAnyOf(
+              "temp1",
+              "temp2",
+              "temp3",
+              "temp4",
+              "temp5",
+              "temp6") =>
+        NotRequestable.AtDigitisation(
+          "At digitisation and temporarily unavailable.")
 
       // This case covers the lines:
       //

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/source/SierraQueryOps.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/source/SierraQueryOps.scala
@@ -1,8 +1,8 @@
-package uk.ac.wellcome.platform.transformer.sierra.source
+package weco.catalogue.source_model.sierra.source
 
 import grizzled.slf4j.Logging
-import weco.catalogue.source_model.sierra.marc.{MarcSubfield, VarField}
 import weco.catalogue.source_model.sierra.SierraBibData
+import weco.catalogue.source_model.sierra.marc.{MarcSubfield, VarField}
 
 trait SierraQueryOps extends Logging {
 
@@ -87,7 +87,8 @@ trait SierraQueryOps extends Logging {
           Some(
             MarcSubfield(
               tag = tag,
-              content = multiple.map { _.content }.mkString(" "))
+              content = multiple.map { _.content }.mkString(" ")
+            )
           )
       }
 

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/source/SierraQueryOps.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/source/SierraQueryOps.scala
@@ -1,7 +1,7 @@
 package weco.catalogue.source_model.sierra.source
 
 import grizzled.slf4j.Logging
-import weco.catalogue.source_model.sierra.SierraBibData
+import weco.catalogue.source_model.sierra.{SierraBibData, SierraItemData}
 import weco.catalogue.source_model.sierra.marc.{MarcSubfield, VarField}
 
 trait SierraQueryOps extends Logging {
@@ -47,6 +47,28 @@ trait SierraQueryOps extends Logging {
 
     def subfieldsWithTag(tag: (String, String)): List[MarcSubfield] =
       subfieldsWithTags(tag)
+  }
+
+  implicit class ItemDataOps(itemData: SierraItemData) {
+    def displayNote: Option[String] = {
+      val varfields = itemData.varFields
+        .filter { _.fieldTag.contains("n") }
+        .collect {
+          case VarField(Some(content), _, _, _, _, Nil) =>
+            content
+
+          case VarField(None, _, _, _, _, subfields) =>
+            subfields.map { _.content }.mkString(" ")
+        }
+        .filterNot(_.isEmpty)
+        .distinct
+
+      if (varfields.isEmpty) {
+        None
+      } else {
+        Some(varfields.mkString("\n\n"))
+      }
+    }
   }
 
   implicit class VarFieldsOps(varfields: List[VarField]) {

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequestingTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequestingTest.scala
@@ -42,7 +42,10 @@ class SierraRulesForRequestingTest
       ("b", NotRequestable.RequestTopItem("Please request top item.")),
       ("c", NotRequestable.RequestTopItem("Please request top item.")),
       ("d", NotRequestable.OnNewBooksDisplay("On new books display.")),
-      ("e", NotRequestable.OnExhibition("On exhibition. Please ask at Enquiry Desk.")),
+      (
+        "e",
+        NotRequestable.OnExhibition(
+          "On exhibition. Please ask at Enquiry Desk.")),
       ("y", NotRequestable.NoReason),
     )
 
@@ -91,9 +94,8 @@ class SierraRulesForRequestingTest
       forAll(testCases) {
         assertBlockedWith(
           _,
-          expectedResult =
-            NotRequestable.ContactUs(
-              "Item cannot be requested online. Please contact Medical Film & Audio Library.   Email: mfac@wellcome.ac.uk. Telephone: +44 (0)20 76118596/97.")
+          expectedResult = NotRequestable.ContactUs(
+            "Item cannot be requested online. Please contact Medical Film & Audio Library.   Email: mfac@wellcome.ac.uk. Telephone: +44 (0)20 76118596/97.")
         )
       }
     }
@@ -120,8 +122,7 @@ class SierraRulesForRequestingTest
       forAll(testCases) {
         assertBlockedWith(
           _,
-          expectedResult =
-            NotRequestable.NeedsManualRequest(
+          expectedResult = NotRequestable.NeedsManualRequest(
             "This item cannot be requested online. Please place a manual request."))
       }
     }
@@ -132,9 +133,8 @@ class SierraRulesForRequestingTest
       forAll(testCases) {
         assertBlockedWith(
           _,
-          expectedResult =
-            NotRequestable.ContactUs(
-              "Item cannot be requested online. Please ask at Information Service desk, email: infoserv@wellcome.ac.uk or telephone +44 (0)20 7611 8722.")
+          expectedResult = NotRequestable.ContactUs(
+            "Item cannot be requested online. Please ask at Information Service desk, email: infoserv@wellcome.ac.uk or telephone +44 (0)20 7611 8722.")
         )
       }
     }
@@ -178,9 +178,8 @@ class SierraRulesForRequestingTest
       forAll(testCases) {
         assertBlockedWith(
           _,
-          expectedResult =
-            NotRequestable.OnOpenShelves(
-              "Item is on open shelves.  Check Location and Shelfmark for location details."))
+          expectedResult = NotRequestable.OnOpenShelves(
+            "Item is on open shelves.  Check Location and Shelfmark for location details."))
       }
     }
 
@@ -202,9 +201,8 @@ class SierraRulesForRequestingTest
       forAll(testCases) {
         assertBlockedWith(
           _,
-          expectedResult =
-            NotRequestable.NeedsManualRequest(
-              "Please complete a manual request slip.  This item cannot be requested online."))
+          expectedResult = NotRequestable.NeedsManualRequest(
+            "Please complete a manual request slip.  This item cannot be requested online."))
       }
     }
 
@@ -236,9 +234,9 @@ class SierraRulesForRequestingTest
       forAll(testCases) {
         assertBlockedWith(
           _,
-          expectedResult =
-            NotRequestable.ItemUnavailable(
-              "Item not available due to provisions of Data Protection Act. Return to Archives catalogue to see when this file will be opened."))
+          expectedResult = NotRequestable.ItemUnavailable(
+            "Item not available due to provisions of Data Protection Act. Return to Archives catalogue to see when this file will be opened.")
+        )
       }
     }
 
@@ -260,8 +258,9 @@ class SierraRulesForRequestingTest
       }
     }
 
-    def assertBlockedWith(locationCode: String,
-                          expectedResult: RulesForRequestingResult): Assertion = {
+    def assertBlockedWith(
+      locationCode: String,
+      expectedResult: RulesForRequestingResult): Assertion = {
       val item = createSierraItemDataWith(
         fixedFields =
           Map("79" -> FixedField(label = "LOCATION", value = locationCode))

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequestingTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequestingTest.scala
@@ -1,11 +1,10 @@
-package weco.catalogue.source_model.sierra
+package weco.catalogue.source_model.sierra.rules
 
 import org.scalatest.Assertion
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
 import weco.catalogue.source_model.generators.SierraDataGenerators
-import weco.catalogue.source_model.sierra
 import weco.catalogue.source_model.sierra.marc.FixedField
 
 class SierraRulesForRequestingTest
@@ -27,7 +26,7 @@ class SierraRulesForRequestingTest
       fixedFields = Map("97" -> FixedField(label = "IMESSAGE", value = "j"))
     )
 
-    sierra.SierraRulesForRequesting(item) shouldBe NotRequestable()
+    SierraRulesForRequesting(item) shouldBe NotRequestable()
   }
 
   it("blocks an item based on the status") {
@@ -54,7 +53,7 @@ class SierraRulesForRequestingTest
             Map("88" -> FixedField(label = "STATUS", value = status))
         )
 
-        sierra.SierraRulesForRequesting(item) shouldBe NotRequestable(
+        SierraRulesForRequesting(item) shouldBe NotRequestable(
           expectedMessage)
     }
   }
@@ -64,7 +63,7 @@ class SierraRulesForRequestingTest
       fixedFields = Map("87" -> FixedField(label = "LOANRULE", value = "1"))
     )
 
-    sierra.SierraRulesForRequesting(item) shouldBe NotRequestable(
+    SierraRulesForRequesting(item) shouldBe NotRequestable(
       "Item is in use by another reader. Please ask at Enquiry Desk.")
   }
 
@@ -73,7 +72,7 @@ class SierraRulesForRequestingTest
       fixedFields = Map("88" -> FixedField(label = "STATUS", value = "!"))
     )
 
-    sierra.SierraRulesForRequesting(item) shouldBe NotRequestable(
+    SierraRulesForRequesting(item) shouldBe NotRequestable(
       "Item is in use by another reader. Please ask at Enquiry Desk.")
   }
 
@@ -82,7 +81,7 @@ class SierraRulesForRequestingTest
       fixedFields = Map("87" -> FixedField(label = "LOANRULE", value = "0"))
     )
 
-    sierra.SierraRulesForRequesting(item) shouldBe Requestable
+    SierraRulesForRequesting(item) shouldBe Requestable
   }
 
   describe("blocks an item based on fixed field 79 (location)") {
@@ -214,7 +213,7 @@ class SierraRulesForRequestingTest
             Map("79" -> FixedField(label = "LOCATION", value = locationCode))
         )
 
-        sierra.SierraRulesForRequesting(item) shouldBe NotRequestable()
+        SierraRulesForRequesting(item) shouldBe NotRequestable()
       }
     }
 
@@ -267,7 +266,7 @@ class SierraRulesForRequestingTest
           Map("79" -> FixedField(label = "LOCATION", value = locationCode))
       )
 
-      sierra.SierraRulesForRequesting(item) shouldBe NotRequestable(
+      SierraRulesForRequesting(item) shouldBe NotRequestable(
         expectedMessage)
     }
   }
@@ -298,7 +297,7 @@ class SierraRulesForRequestingTest
             Map("61" -> FixedField(label = "I TYPE", value = itemType))
         )
 
-        sierra.SierraRulesForRequesting(item) shouldBe NotRequestable(
+        SierraRulesForRequesting(item) shouldBe NotRequestable(
           expectedMessage)
     }
   }
@@ -325,7 +324,7 @@ class SierraRulesForRequestingTest
     )
 
     forAll(testCases) {
-      sierra.SierraRulesForRequesting(_) shouldBe Requestable
+      SierraRulesForRequesting(_) shouldBe Requestable
     }
   }
 }

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/source/SierraQueryOpsTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/source/SierraQueryOpsTest.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.transformer.sierra.source
+package weco.catalogue.source_model.sierra.source
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/source/SierraQueryOpsTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/source/SierraQueryOpsTest.scala
@@ -2,11 +2,8 @@ package weco.catalogue.source_model.sierra.source
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import weco.catalogue.source_model.generators.{
-  MarcGenerators,
-  SierraDataGenerators
-}
-import weco.catalogue.source_model.sierra.marc.MarcSubfield
+import weco.catalogue.source_model.generators.{MarcGenerators, SierraDataGenerators}
+import weco.catalogue.source_model.sierra.marc.{MarcSubfield, VarField}
 
 class SierraQueryOpsTest
     extends AnyFunSpec
@@ -14,6 +11,39 @@ class SierraQueryOpsTest
     with MarcGenerators
     with SierraDataGenerators
     with SierraQueryOps {
+
+  describe("ItemDataOps") {
+    describe("displayNote") {
+      it("returns None if there are no varfields with field tag n") {
+        val item = createSierraItemData
+
+        item.displayNote shouldBe None
+      }
+
+      it("finds the content from a single field tag n") {
+        val item = createSierraItemDataWith(
+          varFields = List(
+            VarField(fieldTag = Some("n"), content = Some("Offsite"))
+          )
+        )
+
+        item.displayNote shouldBe Some("Offsite")
+      }
+
+      it("finds the content from the subfields on field tag n") {
+        val item = createSierraItemDataWith(
+          varFields = List(
+            VarField(fieldTag = Some("n"), subfields = List(
+              MarcSubfield(tag = "a", content = "Part of:"),
+              MarcSubfield(tag = "c", content = "a special collection"),
+            ))
+          )
+        )
+
+        item.displayNote shouldBe Some("Part of: a special collection")
+      }
+    }
+  }
 
   it("finds the varfields with given tags") {
     val varFields = List(

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/source/SierraQueryOpsTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/source/SierraQueryOpsTest.scala
@@ -2,7 +2,10 @@ package weco.catalogue.source_model.sierra.source
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import weco.catalogue.source_model.generators.{MarcGenerators, SierraDataGenerators}
+import weco.catalogue.source_model.generators.{
+  MarcGenerators,
+  SierraDataGenerators
+}
 import weco.catalogue.source_model.sierra.marc.{MarcSubfield, VarField}
 
 class SierraQueryOpsTest
@@ -33,10 +36,12 @@ class SierraQueryOpsTest
       it("finds the content from the subfields on field tag n") {
         val item = createSierraItemDataWith(
           varFields = List(
-            VarField(fieldTag = Some("n"), subfields = List(
-              MarcSubfield(tag = "a", content = "Part of:"),
-              MarcSubfield(tag = "c", content = "a special collection"),
-            ))
+            VarField(
+              fieldTag = Some("n"),
+              subfields = List(
+                MarcSubfield(tag = "a", content = "Part of:"),
+                MarcSubfield(tag = "c", content = "a special collection"),
+              ))
           )
         )
 

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraAccessStatus.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraAccessStatus.scala
@@ -1,8 +1,8 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
-import uk.ac.wellcome.platform.transformer.sierra.source.SierraQueryOps
 import weco.catalogue.internal_model.locations.AccessStatus
 import weco.catalogue.source_model.sierra.marc.VarField
+import weco.catalogue.source_model.sierra.source.SierraQueryOps
 import weco.catalogue.source_model.sierra.{SierraBibData, SierraBibNumber}
 
 object SierraAccessStatus extends SierraQueryOps {

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraAgents.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraAgents.scala
@@ -1,6 +1,5 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
-import uk.ac.wellcome.platform.transformer.sierra.source.SierraQueryOps
 import weco.catalogue.internal_model.identifiers.{
   IdState,
   IdentifierType,
@@ -8,6 +7,7 @@ import weco.catalogue.internal_model.identifiers.{
 }
 import weco.catalogue.internal_model.work.{Meeting, Organisation, Person}
 import weco.catalogue.source_model.sierra.marc.MarcSubfield
+import weco.catalogue.source_model.sierra.source.SierraQueryOps
 
 trait SierraAgents extends SierraQueryOps {
   // This is used to construct a Person from MARc tags 100, 700 and 600.

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraAlternativeTitles.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraAlternativeTitles.scala
@@ -1,8 +1,8 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
-import uk.ac.wellcome.platform.transformer.sierra.source.SierraQueryOps
 import weco.catalogue.source_model.sierra.SierraBibData
 import weco.catalogue.source_model.sierra.marc.MarcSubfield
+import weco.catalogue.source_model.sierra.source.SierraQueryOps
 
 // Populate work:alternativeTitles
 //

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraConcepts.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraConcepts.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
 import weco.catalogue.internal_model.text.TextNormalisation._
-import uk.ac.wellcome.platform.transformer.sierra.source.SierraQueryOps
 import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.work.{
   AbstractConcept,
@@ -10,6 +9,7 @@ import weco.catalogue.internal_model.work.{
   Place
 }
 import weco.catalogue.source_model.sierra.marc.{MarcSubfield, VarField}
+import weco.catalogue.source_model.sierra.source.SierraQueryOps
 
 trait SierraConcepts extends SierraQueryOps {
 

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraContributors.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraContributors.scala
@@ -1,10 +1,10 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
-import uk.ac.wellcome.platform.transformer.sierra.source.SierraQueryOps
 import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.work._
 import weco.catalogue.source_model.sierra.SierraBibData
 import weco.catalogue.source_model.sierra.marc.MarcSubfield
+import weco.catalogue.source_model.sierra.source.SierraQueryOps
 
 /* Populate wwork:contributors. Rules:
  *

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraDescription.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraDescription.scala
@@ -3,8 +3,8 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers
 import grizzled.slf4j.Logging
 
 import java.net.URL
-import uk.ac.wellcome.platform.transformer.sierra.source.SierraQueryOps
 import weco.catalogue.source_model.sierra.marc.{MarcSubfield, VarField}
+import weco.catalogue.source_model.sierra.source.SierraQueryOps
 import weco.catalogue.source_model.sierra.{SierraBibData, SierraBibNumber}
 
 import scala.util.Try

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraDuration.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraDuration.scala
@@ -2,8 +2,8 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers
 
 import scala.util.Try
 import scala.concurrent.duration._
-import uk.ac.wellcome.platform.transformer.sierra.source.SierraQueryOps
 import weco.catalogue.source_model.sierra.SierraBibData
+import weco.catalogue.source_model.sierra.source.SierraQueryOps
 
 object SierraDuration extends SierraDataTransformer with SierraQueryOps {
 

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraEdition.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraEdition.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
-import uk.ac.wellcome.platform.transformer.sierra.source.SierraQueryOps
 import weco.catalogue.source_model.sierra.SierraBibData
+import weco.catalogue.source_model.sierra.source.SierraQueryOps
 
 // Populate work:edition
 //

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraElectronicResources.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraElectronicResources.scala
@@ -3,7 +3,6 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers
 import grizzled.slf4j.Logging
 import weco.catalogue.internal_model.locations.AccessStatus.LicensedResources
 import weco.catalogue.internal_model.locations.LocationType.OnlineResource
-import uk.ac.wellcome.platform.transformer.sierra.source.SierraQueryOps
 import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.locations.{
   AccessCondition,
@@ -12,6 +11,7 @@ import weco.catalogue.internal_model.locations.{
 import weco.catalogue.internal_model.work.Item
 import weco.catalogue.source_model.sierra.marc.{MarcSubfield, VarField}
 import weco.catalogue.source_model.sierra.TypedSierraRecordNumber
+import weco.catalogue.source_model.sierra.source.SierraQueryOps
 
 import java.net.URL
 import scala.util.Try

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraGenres.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraGenres.scala
@@ -1,10 +1,10 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
-import uk.ac.wellcome.platform.transformer.sierra.source.SierraQueryOps
 import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.work.{Concept, Genre}
 import weco.catalogue.source_model.sierra.marc.{MarcSubfield, VarField}
 import weco.catalogue.source_model.sierra.SierraBibData
+import weco.catalogue.source_model.sierra.source.SierraQueryOps
 
 // Populate wwork:genres
 //

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldings.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldings.scala
@@ -2,10 +2,10 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers
 
 import com.github.tototoshi.csv.CSVReader
 import weco.catalogue.internal_model.locations.LocationType.ClosedStores
-import uk.ac.wellcome.platform.transformer.sierra.source.SierraQueryOps
 import weco.catalogue.internal_model.locations.PhysicalLocation
 import weco.catalogue.internal_model.work.{Holdings, Item}
 import weco.catalogue.source_model.sierra.marc.FixedField
+import weco.catalogue.source_model.sierra.source.SierraQueryOps
 import weco.catalogue.source_model.sierra.{
   SierraBibNumber,
   SierraHoldingsData,

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
@@ -1,9 +1,9 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
 import grizzled.slf4j.Logging
-import uk.ac.wellcome.platform.transformer.sierra.source.SierraQueryOps
 import weco.catalogue.source_model.sierra.marc.{MarcSubfield, VarField}
 import weco.catalogue.source_model.sierra.TypedSierraRecordNumber
+import weco.catalogue.source_model.sierra.source.SierraQueryOps
 
 import scala.util.{Failure, Success, Try}
 

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIconographicNumber.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIconographicNumber.scala
@@ -1,8 +1,10 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
-import uk.ac.wellcome.platform.transformer.sierra.source.SierraQueryOps
 import weco.catalogue.source_model.sierra.SierraBibData
-import weco.catalogue.source_model.sierra.source.SierraMaterialType
+import weco.catalogue.source_model.sierra.source.{
+  SierraMaterialType,
+  SierraQueryOps
+}
 
 object SierraIconographicNumber
     extends SierraDataTransformer

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiers.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraIdentifiers.scala
@@ -1,10 +1,10 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
-import uk.ac.wellcome.platform.transformer.sierra.source.SierraQueryOps
 import weco.catalogue.internal_model.identifiers.{
   IdentifierType,
   SourceIdentifier
 }
+import weco.catalogue.source_model.sierra.source.SierraQueryOps
 import weco.catalogue.source_model.sierra.{SierraBibData, SierraBibNumber}
 
 // Populate wwork:identifiers.

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItems.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItems.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
 import grizzled.slf4j.Logging
-import uk.ac.wellcome.platform.transformer.sierra.source.SierraQueryOps
 import weco.catalogue.internal_model.identifiers.{
   IdState,
   IdentifierType,
@@ -12,6 +11,7 @@ import weco.catalogue.internal_model.locations.{
   PhysicalLocationType
 }
 import weco.catalogue.internal_model.work.Item
+import weco.catalogue.source_model.sierra.source.SierraQueryOps
 import weco.catalogue.source_model.sierra.{
   SierraBibData,
   SierraBibNumber,

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLanguages.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLanguages.scala
@@ -1,9 +1,11 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
 import grizzled.slf4j.Logging
-import uk.ac.wellcome.platform.transformer.sierra.source.SierraQueryOps
 import weco.catalogue.internal_model.languages.{Language, MarcLanguageCodeList}
-import weco.catalogue.source_model.sierra.source.SierraSourceLanguage
+import weco.catalogue.source_model.sierra.source.{
+  SierraQueryOps,
+  SierraSourceLanguage
+}
 import weco.catalogue.source_model.sierra.{SierraBibData, SierraBibNumber}
 
 object SierraLanguages

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLettering.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLettering.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
-import uk.ac.wellcome.platform.transformer.sierra.source.SierraQueryOps
 import weco.catalogue.source_model.sierra.SierraBibData
+import weco.catalogue.source_model.sierra.source.SierraQueryOps
 
 // Populate wwork:lettering.
 //

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraMergeCandidates.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraMergeCandidates.scala
@@ -3,7 +3,6 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers
 import grizzled.slf4j.Logging
 
 import java.util.UUID
-import uk.ac.wellcome.platform.transformer.sierra.source.SierraQueryOps
 import uk.ac.wellcome.platform.transformer.sierra.transformers.parsers.MiroIdParsing
 import weco.catalogue.internal_model.identifiers.{
   IdState,
@@ -11,6 +10,7 @@ import weco.catalogue.internal_model.identifiers.{
   SourceIdentifier
 }
 import weco.catalogue.internal_model.work.MergeCandidate
+import weco.catalogue.source_model.sierra.source.SierraQueryOps
 import weco.catalogue.source_model.sierra.{SierraBibData, SierraBibNumber}
 
 import scala.util.Try

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraNotes.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraNotes.scala
@@ -1,9 +1,9 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
-import uk.ac.wellcome.platform.transformer.sierra.source.SierraQueryOps
 import weco.catalogue.internal_model.work._
 import weco.catalogue.source_model.sierra.SierraBibData
 import weco.catalogue.source_model.sierra.marc.VarField
+import weco.catalogue.source_model.sierra.source.SierraQueryOps
 
 object SierraNotes extends SierraDataTransformer with SierraQueryOps {
 

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraPhysicalDescription.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraPhysicalDescription.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
-import uk.ac.wellcome.platform.transformer.sierra.source.SierraQueryOps
 import weco.catalogue.source_model.sierra.SierraBibData
+import weco.catalogue.source_model.sierra.source.SierraQueryOps
 
 // Populate wwork:physicalDescription.
 //

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraProduction.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraProduction.scala
@@ -1,11 +1,11 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
 import uk.ac.wellcome.platform.transformer.sierra.exceptions.CataloguingException
-import uk.ac.wellcome.platform.transformer.sierra.source._
 import uk.ac.wellcome.platform.transformer.sierra.transformers.parsers.Marc008Parser
 import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.work._
 import weco.catalogue.source_model.sierra.marc.{MarcSubfield, VarField}
+import weco.catalogue.source_model.sierra.source.SierraQueryOps
 import weco.catalogue.source_model.sierra.{SierraBibData, SierraBibNumber}
 
 object SierraProduction

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraShelfmark.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraShelfmark.scala
@@ -1,7 +1,9 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
-import uk.ac.wellcome.platform.transformer.sierra.source.SierraQueryOps
-import weco.catalogue.source_model.sierra.source.SierraMaterialType
+import weco.catalogue.source_model.sierra.source.{
+  SierraMaterialType,
+  SierraQueryOps
+}
 import weco.catalogue.source_model.sierra.{SierraBibData, SierraItemData}
 
 object SierraShelfmark extends SierraQueryOps {

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTitle.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTitle.scala
@@ -1,8 +1,8 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
 import uk.ac.wellcome.platform.transformer.sierra.exceptions.ShouldNotTransformException
-import uk.ac.wellcome.platform.transformer.sierra.source.SierraQueryOps
 import weco.catalogue.source_model.sierra.SierraBibData
+import weco.catalogue.source_model.sierra.source.SierraQueryOps
 
 object SierraTitle extends SierraDataTransformer with SierraQueryOps {
 

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraSubjectsTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/subjects/SierraSubjectsTransformer.scala
@@ -1,11 +1,11 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers.subjects
 
 import uk.ac.wellcome.platform.transformer.sierra.transformers.SierraIdentifiedDataTransformer
-import uk.ac.wellcome.platform.transformer.sierra.source.SierraQueryOps
 import weco.catalogue.internal_model.text.TextNormalisation._
 import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.work.Subject
 import weco.catalogue.source_model.sierra.marc.VarField
+import weco.catalogue.source_model.sierra.source.SierraQueryOps
 import weco.catalogue.source_model.sierra.{SierraBibData, SierraBibNumber}
 
 trait SierraSubjectsTransformer


### PR DESCRIPTION
This patch contains some pieces spun out of https://github.com/wellcomecollection/catalogue-pipeline/pull/1631 to be a bit more reviewable, with some refactoring to make it easier to add access conditions in a subsequent patch.

Specifically, this patch:

* Adds a type hierarchy to Rules for Requesting, so we can pattern match on them without looking at the exact strings
* Makes the correspondence between the original rules and our code a bit clearer
* Adds a method for finding the display note on an item, which is one of the fields we use for access conditions