### PR TITLE
Retain the unidentified item from the 856 web link when merging

### DIFF
--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/ItemsRuleTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/ItemsRuleTest.scala
@@ -6,8 +6,19 @@ import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.models.work.generators.SourceWorkGenerators
 import uk.ac.wellcome.platform.merger.models.FieldMergeResult
 import weco.catalogue.internal_model.identifiers.IdState
-import weco.catalogue.internal_model.locations.{AccessCondition, AccessStatus, DigitalLocation, LocationType}
-import weco.catalogue.internal_model.work.{Format, Item, MergeCandidate, Work, WorkState}
+import weco.catalogue.internal_model.locations.{
+  AccessCondition,
+  AccessStatus,
+  DigitalLocation,
+  LocationType
+}
+import weco.catalogue.internal_model.work.{
+  Format,
+  Item,
+  MergeCandidate,
+  Work,
+  WorkState
+}
 
 class ItemsRuleTest
     extends AnyFunSpec

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/ItemsRuleTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/ItemsRuleTest.scala
@@ -5,7 +5,9 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.models.work.generators.SourceWorkGenerators
 import uk.ac.wellcome.platform.merger.models.FieldMergeResult
-import weco.catalogue.internal_model.work.{Format, Work, WorkState}
+import weco.catalogue.internal_model.identifiers.IdState
+import weco.catalogue.internal_model.locations.{AccessCondition, AccessStatus, DigitalLocation, LocationType}
+import weco.catalogue.internal_model.work.{Format, Item, MergeCandidate, Work, WorkState}
 
 class ItemsRuleTest
     extends AnyFunSpec
@@ -68,6 +70,44 @@ class ItemsRuleTest
         items should have size 1
         items.head shouldBe metsWork.data.items.head
         mergedSources should be(Seq(metsWork))
+    }
+  }
+
+  it("merges an 856 item from a digitised Sierra work into a physical work") {
+    val item = Item(
+      id = IdState.Unidentifiable,
+      locations = List(
+        DigitalLocation(
+          url = "https://example.org/b12345678",
+          locationType = LocationType.OnlineResource,
+          accessConditions = List(
+            AccessCondition(status = AccessStatus.LicensedResources)
+          )
+        )
+      )
+    )
+
+    val digitisedWork = sierraIdentifiedWork().items(List(item))
+
+    val physicalWork =
+      sierraIdentifiedWork()
+        .mergeCandidates(
+          List(
+            MergeCandidate(
+              id = IdState.Identified(
+                canonicalId = digitisedWork.state.canonicalId,
+                sourceIdentifier = digitisedWork.state.sourceIdentifier
+              ),
+              reason = Some("Physical/digitised Sierra work")
+            )
+          )
+        )
+        .items(List(createIdentifiedPhysicalItem))
+
+    inside(ItemsRule.merge(physicalWork, List(digitisedWork))) {
+      case FieldMergeResult(items, mergedSources) =>
+        items should contain(item)
+        mergedSources should be(Seq(digitisedWork))
     }
   }
 

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
@@ -9,7 +9,13 @@ import weco.catalogue.internal_model.image.ParentWork._
 import uk.ac.wellcome.models.work.generators.SourceWorkGenerators
 import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.image.ParentWorks
-import weco.catalogue.internal_model.locations.{AccessCondition, AccessStatus, DigitalLocation, License, LocationType}
+import weco.catalogue.internal_model.locations.{
+  AccessCondition,
+  AccessStatus,
+  DigitalLocation,
+  License,
+  LocationType
+}
 import weco.catalogue.internal_model.work.{Format, Item, MergeCandidate, Work}
 
 class PlatformMergerTest

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/services/PlatformMergerTest.scala
@@ -9,13 +9,7 @@ import weco.catalogue.internal_model.image.ParentWork._
 import uk.ac.wellcome.models.work.generators.SourceWorkGenerators
 import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.image.ParentWorks
-import weco.catalogue.internal_model.locations.{
-  AccessCondition,
-  AccessStatus,
-  DigitalLocation,
-  License,
-  LocationType
-}
+import weco.catalogue.internal_model.locations.{AccessCondition, AccessStatus, DigitalLocation, License, LocationType}
 import weco.catalogue.internal_model.work.{Format, Item, MergeCandidate, Work}
 
 class PlatformMergerTest
@@ -885,5 +879,60 @@ class PlatformMergerTest
       w.state.canonicalId -> w.redirectTarget.canonicalId
     }.toMap shouldBe Map(
       metsWork.state.canonicalId -> eVideoWork.state.canonicalId)
+  }
+
+  it("retains the 856 web link item when merging physical/digitised bibs") {
+    // This test case is based on a real example, in which the links to digitised
+    // journals in the Internet Archive were being added to the 856 link in the
+    // digitised records.
+    //
+    // We don't expect digitised records to have any identified items, but if we
+    // created an item from the 856 field, then we should preserve it when merging.
+    //
+    // See https://wellcome.slack.com/archives/C8X9YKM5X/p1621866017004000
+
+    val item = Item(
+      id = IdState.Unidentifiable,
+      locations = List(
+        DigitalLocation(
+          url = "https://example.org/b12345678",
+          locationType = LocationType.OnlineResource,
+          accessConditions = List(
+            AccessCondition(status = AccessStatus.LicensedResources)
+          )
+        )
+      )
+    )
+
+    val digitisedWork = sierraIdentifiedWork().items(List(item))
+
+    val physicalWork =
+      sierraIdentifiedWork()
+        .mergeCandidates(
+          List(
+            MergeCandidate(
+              id = IdState.Identified(
+                canonicalId = digitisedWork.state.canonicalId,
+                sourceIdentifier = digitisedWork.state.sourceIdentifier
+              ),
+              reason = Some("Physical/digitised Sierra work")
+            )
+          )
+        )
+        .items(List(createIdentifiedPhysicalItem))
+
+    val result = merger
+      .merge(works = Seq(digitisedWork, physicalWork))
+      .mergedWorksWithTime(now)
+
+    val redirectedWorks = result.collect {
+      case w: Work.Redirected[Merged] => w
+    }
+    val visibleWorks = result.collect { case w: Work.Visible[Merged] => w }
+
+    redirectedWorks should have size 1
+    visibleWorks should have size 1
+
+    visibleWorks.head.data.items should contain(item)
   }
 }


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5182

Quick reminder: bibs can have an 856 field for web links, which we use to create an unidentified item. We didn't have a rule set up to copy these items when we merge, so they were being dropped – even though the 856 on digitised bibs can have useful information.

These items have their own location type (OnlineResources), so this patch modifies the merger to copy across any such items when merging physical/digitised Sierra works.

I don't think there are any untoward consequences of this change, but I'd appreciate a quick check from the resident merging expert that I haven't done something daft.