### PR TITLE
Parse access conditions for 98.7% of Sierra items

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessCondition.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessCondition.scala
@@ -3,7 +3,8 @@ package weco.catalogue.internal_model.locations
 case class AccessCondition(
   status: Option[AccessStatus] = None,
   terms: Option[String] = None,
-  to: Option[String] = None
+  to: Option[String] = None,
+  note: Option[String] = None
 ) {
   def isEmpty: Boolean =
     this == AccessCondition(None, None, None)

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/ItemStatus.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/ItemStatus.scala
@@ -1,0 +1,9 @@
+package weco.catalogue.internal_model.locations
+
+sealed trait ItemStatus
+
+object ItemStatus {
+  case object Available extends ItemStatus
+  case object TemporarilyUnavailable extends ItemStatus
+  case object Unavailable extends ItemStatus
+}

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraItemData.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraItemData.scala
@@ -6,7 +6,12 @@ import weco.catalogue.source_model.sierra.source.SierraSourceLocation
 case class SierraItemData(
   deleted: Boolean = false,
   suppressed: Boolean = false,
+  holdCount: Option[Int] = Some(0),
   location: Option[SierraSourceLocation] = None,
   fixedFields: Map[String, FixedField] = Map(),
   varFields: List[VarField] = List()
-)
+) {
+  require(
+    holdCount.getOrElse(0) >= 0,
+    s"Item has a negative hold count, how? $holdCount")
+}

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/marc/FixedField.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/marc/FixedField.scala
@@ -13,5 +13,11 @@ package weco.catalogue.source_model.sierra.marc
 //
 case class FixedField(
   label: String,
-  value: String
+  value: String,
+  display: Option[String] = None
 )
+
+case object FixedField {
+  def apply(label: String, value: String, display: String): FixedField =
+    FixedField(label = label, value = value, display = Some(display))
+}

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraAccessStatus.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraAccessStatus.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.transformer.sierra.transformers
+package weco.catalogue.source_model.sierra.rules
 
 import weco.catalogue.internal_model.locations.AccessStatus
 import weco.catalogue.source_model.sierra.marc.VarField

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -146,6 +146,25 @@ object SierraItemAccess extends SierraQueryOps {
               note = itemData.displayNote)),
           ItemStatus.TemporarilyUnavailable)
 
+      // An item which is restricted can be requested online -- the user will have to fill in
+      // any paperwork when they actually visit the library.
+      //
+      // Example: b29459126 / i19023340
+      case (
+        Some(AccessStatus.Restricted),
+        Some(0),
+        Some(Status.Restricted),
+        Some(OpacMsg.OnlineRequest),
+        Requestable,
+        Some(LocationType.ClosedStores)) =>
+        (
+          Some(
+            AccessCondition(
+              status = Some(AccessStatus.Restricted),
+              terms = Some("Online request"),
+              note = itemData.displayNote)),
+          ItemStatus.Available)
+
       case other =>
         println(s"@@ $other @@")
         throw new Throwable("Unhandled!!!")

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -43,8 +43,10 @@ object SierraItemAccess extends SierraQueryOps {
       // Items on the closed stores that are requestable get the "Online request" condition.
       //
       // Example: b18799966 / i17571170
-      case (None, Some(0), Some(Status.Available), Some(OpacMsg.OnlineRequest), Requestable, Some(LocationType.ClosedStores)) =>
+      case (bibStatus, Some(0), Some(Status.Available), Some(OpacMsg.OnlineRequest), Requestable, Some(LocationType.ClosedStores))
+        if bibStatus.isEmpty || bibStatus.contains(AccessStatus.Open) =>
         val ac = AccessCondition(
+          status = bibStatus,
           terms = Some("Online request"),
           note = itemData.displayNote
         )
@@ -108,7 +110,7 @@ object SierraItemAccess extends SierraQueryOps {
         Some(Status.Closed),
         Some(OpacMsg.Unavailable),
         NotRequestable.ItemClosed(_),
-        Some(LocationType.ClosedStores)) =>
+        locationType) if locationType.isEmpty || locationType.contains(LocationType.ClosedStores) =>
         (
           Some(
             AccessCondition(

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -73,6 +73,12 @@ object SierraItemAccess extends SierraQueryOps {
         val ac = itemData.displayNote.map { note => AccessCondition(note = Some(note)) }
         (ac, ItemStatus.Available)
 
+      // There are some items that are labelled "bound in above" or "contained in above".
+      //
+      // These items aren't requestable on their own; you have to request the "primary" item.
+      case (None, _, _, _, NotRequestable.RequestTopItem(message), _) =>
+        (Some(AccessCondition(terms = Some(message))), ItemStatus.Unavailable)
+
       case other =>
         println(s"@@ $other @@")
         throw new Throwable("Unhandled!!!")

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -79,6 +79,23 @@ object SierraItemAccess extends SierraQueryOps {
       case (None, _, _, _, NotRequestable.RequestTopItem(message), _) =>
         (Some(AccessCondition(terms = Some(message))), ItemStatus.Unavailable)
 
+      // Handle any cases that require a manual request.
+      //
+      // Example: b32214832 / i19389383
+      case (
+        None,
+        Some(0),
+        Some(Status.Available),
+        Some(OpacMsg.ManualRequest),
+        NotRequestable.NeedsManualRequest(_),
+        Some(LocationType.ClosedStores)) =>
+        (
+          Some(
+            AccessCondition(
+              terms = Some("Manual request"),
+              note = itemData.displayNote)),
+          ItemStatus.Available)
+
       case other =>
         println(s"@@ $other @@")
         throw new Throwable("Unhandled!!!")

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -116,6 +116,36 @@ object SierraItemAccess extends SierraQueryOps {
               note = itemData.displayNote)),
           ItemStatus.Unavailable)
 
+      // Handle any cases where the item is explicitly unavailable.
+      case (
+        None,
+        _,
+        Some(Status.Unavailable),
+        Some(OpacMsg.Unavailable),
+        NotRequestable.ItemUnavailable(_),
+        _) =>
+        (
+          Some(
+            AccessCondition(
+              status = Some(AccessStatus.Unavailable),
+              note = itemData.displayNote)),
+          ItemStatus.Unavailable)
+
+      case (
+        None,
+        _,
+        Some(Status.Unavailable),
+        Some(OpacMsg.AtDigitisation),
+        NotRequestable.ItemUnavailable(_),
+        _) =>
+        (
+          Some(
+            AccessCondition(
+              status = Some(AccessStatus.TemporarilyUnavailable),
+              terms = Some("At digitisation and temporarily unavailable"),
+              note = itemData.displayNote)),
+          ItemStatus.TemporarilyUnavailable)
+
       case other =>
         println(s"@@ $other @@")
         throw new Throwable("Unhandled!!!")

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -165,6 +165,25 @@ object SierraItemAccess extends SierraQueryOps {
               note = itemData.displayNote)),
           ItemStatus.Available)
 
+      // The status "by appointment" takes precedence over "permission required".
+      //
+      // Examples: b32214832 / i19389383, b16576111 / 15862409
+      case (
+        bibStatus,
+        Some(0),
+        Some(Status.PermissionRequired),
+        Some(OpacMsg.ByAppointment),
+        NotRequestable.NoReason,
+        Some(LocationType.ClosedStores))
+        if bibStatus.isEmpty || bibStatus.contains(AccessStatus.ByAppointment) || bibStatus
+          .contains(AccessStatus.PermissionRequired) =>
+        (
+          Some(
+            AccessCondition(
+              status = Some(AccessStatus.ByAppointment),
+              note = itemData.displayNote)),
+          ItemStatus.Available)
+
       case other =>
         println(s"@@ $other @@")
         throw new Throwable("Unhandled!!!")

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -51,6 +51,28 @@ object SierraItemAccess extends SierraQueryOps {
 
         (Some(ac), ItemStatus.Available)
 
+      // Items on the open shelves don't have any access conditions.
+      //
+      // We could add an access status of "Open" here, but it feels dubious to be
+      // synthesising access information that doesn't come from the source records.
+      //
+      // Note: We create an AccessCondition here so we can carry information from the
+      // display note.  This is used sparingly, but occasionally contains useful information
+      // for readers, e.g.
+      //
+      //      Shelved at the end of the Quick Ref. section with the oversize Quick Ref. books.
+      //
+      // Example: b1659504x / i15894897
+      case (
+        None,
+        Some(0),
+        Some(Status.Available),
+        Some(OpacMsg.OpenShelves),
+        NotRequestable.OnOpenShelves(_),
+        Some(LocationType.OpenShelves)) =>
+        val ac = itemData.displayNote.map { note => AccessCondition(note = Some(note)) }
+        (ac, ItemStatus.Available)
+
       case other =>
         println(s"@@ $other @@")
         throw new Throwable("Unhandled!!!")

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -43,8 +43,14 @@ object SierraItemAccess extends SierraQueryOps {
       // Items on the closed stores that are requestable get the "Online request" condition.
       //
       // Example: b18799966 / i17571170
-      case (bibStatus, Some(0), Some(Status.Available), Some(OpacMsg.OnlineRequest), Requestable, Some(LocationType.ClosedStores))
-        if bibStatus.isEmpty || bibStatus.contains(AccessStatus.Open) =>
+      case (
+          bibStatus,
+          Some(0),
+          Some(Status.Available),
+          Some(OpacMsg.OnlineRequest),
+          Requestable,
+          Some(LocationType.ClosedStores))
+          if bibStatus.isEmpty || bibStatus.contains(AccessStatus.Open) =>
         val ac = AccessCondition(
           status = bibStatus,
           terms = Some("Online request"),
@@ -66,13 +72,15 @@ object SierraItemAccess extends SierraQueryOps {
       //
       // Example: b1659504x / i15894897
       case (
-        None,
-        Some(0),
-        Some(Status.Available),
-        Some(OpacMsg.OpenShelves),
-        NotRequestable.OnOpenShelves(_),
-        Some(LocationType.OpenShelves)) =>
-        val ac = itemData.displayNote.map { note => AccessCondition(note = Some(note)) }
+          None,
+          Some(0),
+          Some(Status.Available),
+          Some(OpacMsg.OpenShelves),
+          NotRequestable.OnOpenShelves(_),
+          Some(LocationType.OpenShelves)) =>
+        val ac = itemData.displayNote.map { note =>
+          AccessCondition(note = Some(note))
+        }
         (ac, ItemStatus.Available)
 
       // There are some items that are labelled "bound in above" or "contained in above".
@@ -85,12 +93,12 @@ object SierraItemAccess extends SierraQueryOps {
       //
       // Example: b32214832 / i19389383
       case (
-        None,
-        Some(0),
-        Some(Status.Available),
-        Some(OpacMsg.ManualRequest),
-        NotRequestable.NeedsManualRequest(_),
-        Some(LocationType.ClosedStores)) =>
+          None,
+          Some(0),
+          Some(Status.Available),
+          Some(OpacMsg.ManualRequest),
+          NotRequestable.NeedsManualRequest(_),
+          Some(LocationType.ClosedStores)) =>
         (
           Some(
             AccessCondition(
@@ -105,12 +113,14 @@ object SierraItemAccess extends SierraQueryOps {
       //
       // Examples: b20657365 / i18576503, b1899457x / i17720734
       case (
-        Some(AccessStatus.Closed),
-        _,
-        Some(Status.Closed),
-        Some(OpacMsg.Unavailable),
-        NotRequestable.ItemClosed(_),
-        locationType) if locationType.isEmpty || locationType.contains(LocationType.ClosedStores) =>
+          Some(AccessStatus.Closed),
+          _,
+          Some(Status.Closed),
+          Some(OpacMsg.Unavailable),
+          NotRequestable.ItemClosed(_),
+          locationType)
+          if locationType.isEmpty || locationType.contains(
+            LocationType.ClosedStores) =>
         (
           Some(
             AccessCondition(
@@ -120,12 +130,12 @@ object SierraItemAccess extends SierraQueryOps {
 
       // Handle any cases where the item is explicitly unavailable.
       case (
-        None,
-        _,
-        Some(Status.Unavailable),
-        Some(OpacMsg.Unavailable),
-        NotRequestable.ItemUnavailable(_),
-        _) =>
+          None,
+          _,
+          Some(Status.Unavailable),
+          Some(OpacMsg.Unavailable),
+          NotRequestable.ItemUnavailable(_),
+          _) =>
         (
           Some(
             AccessCondition(
@@ -134,12 +144,12 @@ object SierraItemAccess extends SierraQueryOps {
           ItemStatus.Unavailable)
 
       case (
-        None,
-        _,
-        Some(Status.Unavailable),
-        Some(OpacMsg.AtDigitisation),
-        NotRequestable.ItemUnavailable(_),
-        _) =>
+          None,
+          _,
+          Some(Status.Unavailable),
+          Some(OpacMsg.AtDigitisation),
+          NotRequestable.ItemUnavailable(_),
+          _) =>
         (
           Some(
             AccessCondition(
@@ -153,12 +163,12 @@ object SierraItemAccess extends SierraQueryOps {
       //
       // Example: b29459126 / i19023340
       case (
-        Some(AccessStatus.Restricted),
-        Some(0),
-        Some(Status.Restricted),
-        Some(OpacMsg.OnlineRequest),
-        Requestable,
-        Some(LocationType.ClosedStores)) =>
+          Some(AccessStatus.Restricted),
+          Some(0),
+          Some(Status.Restricted),
+          Some(OpacMsg.OnlineRequest),
+          Requestable,
+          Some(LocationType.ClosedStores)) =>
         (
           Some(
             AccessCondition(
@@ -171,14 +181,14 @@ object SierraItemAccess extends SierraQueryOps {
       //
       // Examples: b32214832 / i19389383, b16576111 / 15862409
       case (
-        bibStatus,
-        Some(0),
-        Some(Status.PermissionRequired),
-        Some(OpacMsg.ByAppointment),
-        NotRequestable.NoReason,
-        Some(LocationType.ClosedStores))
-        if bibStatus.isEmpty || bibStatus.contains(AccessStatus.ByAppointment) || bibStatus
-          .contains(AccessStatus.PermissionRequired) =>
+          bibStatus,
+          Some(0),
+          Some(Status.PermissionRequired),
+          Some(OpacMsg.ByAppointment),
+          NotRequestable.NoReason,
+          Some(LocationType.ClosedStores))
+          if bibStatus.isEmpty || bibStatus.contains(AccessStatus.ByAppointment) || bibStatus
+            .contains(AccessStatus.PermissionRequired) =>
         (
           Some(
             AccessCondition(
@@ -190,12 +200,12 @@ object SierraItemAccess extends SierraQueryOps {
       //
       // Example: b10379198 / i10443861
       case (
-        _,
-        _,
-        Some(Status.Missing),
-        _,
-        NotRequestable.ItemMissing(message),
-        _) =>
+          _,
+          _,
+          Some(Status.Missing),
+          _,
+          NotRequestable.ItemMissing(message),
+          _) =>
         (
           Some(
             AccessCondition(
@@ -213,12 +223,12 @@ object SierraItemAccess extends SierraQueryOps {
       //     Then the status becomes "!" (On holdshelf)
       //
       case (
-        None,
-        Some(holdCount),
-        _,
-        _,
-        Requestable,
-        Some(LocationType.ClosedStores)) if holdCount > 0 =>
+          None,
+          Some(holdCount),
+          _,
+          _,
+          Requestable,
+          Some(LocationType.ClosedStores)) if holdCount > 0 =>
         (
           Some(AccessCondition(
             status = Some(AccessStatus.TemporarilyUnavailable),
@@ -227,12 +237,12 @@ object SierraItemAccess extends SierraQueryOps {
           ItemStatus.TemporarilyUnavailable)
 
       case (
-        None,
-        _,
-        _,
-        _,
-        NotRequestable.OnHold(_),
-        Some(LocationType.ClosedStores)) =>
+          None,
+          _,
+          _,
+          _,
+          NotRequestable.OnHold(_),
+          Some(LocationType.ClosedStores)) =>
         (
           Some(AccessCondition(
             status = Some(AccessStatus.TemporarilyUnavailable),

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -1,0 +1,26 @@
+package weco.catalogue.source_model.sierra.rules
+
+import weco.catalogue.internal_model.locations.{AccessCondition, AccessStatus, ItemStatus, PhysicalLocationType}
+import weco.catalogue.source_model.sierra.SierraItemData
+
+/** There are multiple sources of truth for item information in Sierra, and whether
+  * a given item can be requested online.
+  *
+  * This object tries to create a single, consistent view of this data.
+  * It returns two values:
+  *
+  *   - An access condition that can be added to a location on an Item.
+  *     This would be set in the Catalogue API.
+  *   - An ItemStatus that returns a simpler "is this available right now".
+  *     This would be returned from the items API with the most up-to-date
+  *     data from Sierra.
+  *
+  */
+object SierraItemAccess {
+  def apply(
+    bibStatus: Option[AccessStatus],
+    location: Option[PhysicalLocationType],
+    itemData: SierraItemData
+  ): (Option[AccessCondition], ItemStatus) =
+    ???
+}

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -184,6 +184,23 @@ object SierraItemAccess extends SierraQueryOps {
               note = itemData.displayNote)),
           ItemStatus.Available)
 
+      // A missing status overrides all other values.
+      //
+      // Example: b10379198 / i10443861
+      case (
+        _,
+        _,
+        Some(Status.Missing),
+        _,
+        NotRequestable.ItemMissing(message),
+        _) =>
+        (
+          Some(
+            AccessCondition(
+              status = Some(AccessStatus.Unavailable),
+              terms = Some(message))),
+          ItemStatus.Unavailable)
+
       case other =>
         println(s"@@ $other @@")
         throw new Throwable("Unhandled!!!")

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -96,6 +96,26 @@ object SierraItemAccess extends SierraQueryOps {
               note = itemData.displayNote)),
           ItemStatus.Available)
 
+      // Handle any cases where the item is closed.
+      //
+      // We don't show the text from rules for requesting -- it's not saying anything
+      // that you can't work out from the AccessStatus.
+      //
+      // Examples: b20657365 / i18576503, b1899457x / i17720734
+      case (
+        Some(AccessStatus.Closed),
+        _,
+        Some(Status.Closed),
+        Some(OpacMsg.Unavailable),
+        NotRequestable.ItemClosed(_),
+        Some(LocationType.ClosedStores)) =>
+        (
+          Some(
+            AccessCondition(
+              status = Some(AccessStatus.Closed),
+              note = itemData.displayNote)),
+          ItemStatus.Unavailable)
+
       case other =>
         println(s"@@ $other @@")
         throw new Throwable("Unhandled!!!")

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraPhysicalLocationType.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraPhysicalLocationType.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.transformer.sierra.transformers
+package weco.catalogue.source_model.sierra.rules
 
 import grizzled.slf4j.Logging
 import weco.catalogue.internal_model.locations.{
@@ -8,8 +8,10 @@ import weco.catalogue.internal_model.locations.{
 import weco.catalogue.source_model.sierra.TypedSierraRecordNumber
 
 object SierraPhysicalLocationType extends Logging {
-  def fromName(id: TypedSierraRecordNumber,
-               name: String): Option[PhysicalLocationType] =
+  def fromName(
+    id: TypedSierraRecordNumber,
+    name: String
+  ): Option[PhysicalLocationType] =
     name.toLowerCase match {
       case lowerCaseName
           if lowerCaseName.hasSubstring(
@@ -52,7 +54,8 @@ object SierraPhysicalLocationType extends Logging {
 
       case _ =>
         warn(
-          s"${id.withCheckDigit}: Unable to map Sierra location name to LocationType: $name")
+          s"${id.withCheckDigit}: Unable to map Sierra location name to LocationType: $name"
+        )
         None
     }
 

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/source/OpacMsg.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/source/OpacMsg.scala
@@ -1,0 +1,13 @@
+package weco.catalogue.source_model.sierra.source
+
+object OpacMsg {
+  val OnlineRequest = "f"
+  val ManualRequest = "n"
+  val OpenShelves = "o"
+  val ByAppointment = "a"
+  val AtDigitisation = "b"
+  val DonorPermission = "q"
+  val Unavailable = "u"
+  val StaffUseOnly = "s"
+  val AskAtDesk = "i"
+}

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/source/Status.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/source/Status.scala
@@ -1,0 +1,11 @@
+package weco.catalogue.source_model.sierra.source
+
+object Status {
+  val Available = "-"
+  val PermissionRequired = "y"
+  val Missing = "m"
+  val Unavailable = "r"
+  val Closed = "h"
+  val Restricted = "6"
+  val OnHoldshelf = "!"
+}

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/generators/SierraDataGenerators.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/generators/SierraDataGenerators.scala
@@ -32,11 +32,13 @@ trait SierraDataGenerators extends IdentifiersGenerators with SierraGenerators {
 
   def createSierraItemDataWith(
     location: Option[SierraSourceLocation] = None,
+    holdCount: Option[Int] = Some(0),
     fixedFields: Map[String, FixedField] = Map(),
     varFields: List[VarField] = Nil
   ): SierraItemData =
     SierraItemData(
       location = location,
+      holdCount = holdCount,
       fixedFields = fixedFields,
       varFields = varFields
     )

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraAccessStatusTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraAccessStatusTest.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.transformer.sierra.transformers
+package weco.catalogue.source_model.sierra.rules
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -163,6 +163,44 @@ class SierraItemAccessTest extends AnyFunSpec with Matchers with SierraDataGener
         itemStatus shouldBe ItemStatus.Available
       }
     }
+
+    it("cannot be requested if it's bound in the top item") {
+      val itemData = createSierraItemDataWith(
+        fixedFields = Map(
+          "79" -> FixedField(label = "LOCATION", value = "bwith", display = "bound in above"),
+          "88" -> FixedField(label = "STATUS", value = "b", display = "As above"),
+          "108" -> FixedField(label = "OPACMSG", value = "-", display = "-"),
+        )
+      )
+
+      val (ac, itemStatus) = SierraItemAccess(
+        bibStatus = None,
+        location = None,
+        itemData = itemData
+      )
+
+      ac shouldBe Some(AccessCondition(terms = Some("Please request top item.")))
+      itemStatus shouldBe ItemStatus.Unavailable
+    }
+
+    it("cannot be requested if it's contained the top item") {
+      val itemData = createSierraItemDataWith(
+        fixedFields = Map(
+          "79" -> FixedField(label = "LOCATION", value = "cwith", display = "contained in above"),
+          "88" -> FixedField(label = "STATUS", value = "c", display = "As above"),
+          "108" -> FixedField(label = "OPACMSG", value = "-", display = "-"),
+        )
+      )
+
+      val (ac, itemStatus) = SierraItemAccess(
+        bibStatus = None,
+        location = None,
+        itemData = itemData
+      )
+
+      ac shouldBe Some(AccessCondition(terms = Some("Please request top item.")))
+      itemStatus shouldBe ItemStatus.Unavailable
+    }
   }
 
   describe("an item on the open shelves") {

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -306,6 +306,27 @@ class SierraItemAccessTest extends AnyFunSpec with Matchers with SierraDataGener
         )
         itemStatus shouldBe ItemStatus.TemporarilyUnavailable
       }
+
+      it("if the bib and item are by appointment") {
+        val itemData = createSierraItemDataWith(
+          fixedFields = Map(
+            "79" -> FixedField(label = "LOCATION", value = "scmac", display = "Closed stores Arch. & MSS"),
+            "88" -> FixedField(label = "STATUS", value = "y", display = "Permission required"),
+            "108" -> FixedField(label = "OPACMSG", value = "a", display = "By appointment"),
+          )
+        )
+
+        val (ac, itemStatus) = SierraItemAccess(
+          bibStatus = Some(AccessStatus.ByAppointment),
+          location = Some(LocationType.ClosedStores),
+          itemData = itemData
+        )
+
+        ac shouldBe Some(
+          AccessCondition(status = AccessStatus.ByAppointment)
+        )
+        itemStatus shouldBe ItemStatus.Available
+      }
     }
   }
 

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -327,6 +327,30 @@ class SierraItemAccessTest extends AnyFunSpec with Matchers with SierraDataGener
         )
         itemStatus shouldBe ItemStatus.Available
       }
+
+      it("if the item is missing") {
+        val itemData = createSierraItemDataWith(
+          fixedFields = Map(
+            "79" -> FixedField(label = "LOCATION", value = "sghi2", display = "Closed stores Hist. 2"),
+            "88" -> FixedField(label = "STATUS", value = "m", display = "Missing"),
+            "108" -> FixedField(label = "OPACMSG", value = "f", display = "Online request"),
+          )
+        )
+
+        val (ac, itemStatus) = SierraItemAccess(
+          bibStatus = None,
+          location = Some(LocationType.ClosedStores),
+          itemData = itemData
+        )
+
+        ac shouldBe Some(
+          AccessCondition(
+            status = Some(AccessStatus.Unavailable),
+            terms = Some("This item is missing.")
+          )
+        )
+        itemStatus shouldBe ItemStatus.Unavailable
+      }
     }
   }
 
@@ -379,6 +403,30 @@ class SierraItemAccessTest extends AnyFunSpec with Matchers with SierraDataGener
         )
         itemStatus shouldBe ItemStatus.Available
       }
+    }
+
+    it("is not available if it is missing") {
+      val itemData = createSierraItemDataWith(
+        fixedFields = Map(
+          "79" -> FixedField(label = "LOCATION", value = "wgmem", display = "Medical Collection"),
+          "88" -> FixedField(label = "STATUS", value = "m", display = "Missing"),
+          "108" -> FixedField(label = "OPACMSG", value = "o", display = "Open shelves"),
+        )
+      )
+
+      val (ac, itemStatus) = SierraItemAccess(
+        bibStatus = None,
+        location = Some(LocationType.OpenShelves),
+        itemData = itemData
+      )
+
+      ac shouldBe Some(
+        AccessCondition(
+          status = Some(AccessStatus.Unavailable),
+          terms = Some("This item is missing.")
+        )
+      )
+      itemStatus shouldBe ItemStatus.Unavailable
     }
   }
 }

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -24,7 +24,10 @@ import weco.catalogue.source_model.sierra.{
 import java.io.{BufferedReader, FileInputStream, InputStreamReader}
 import scala.util.{Failure, Success, Try}
 
-class SierraItemAccessTest extends AnyFunSpec with Matchers with SierraDataGenerators {
+class SierraItemAccessTest
+    extends AnyFunSpec
+    with Matchers
+    with SierraDataGenerators {
   ignore("assigns access conditions for all Sierra items") {
     // Note: this test is not meant to hang around long-term.  It's a test harness
     // that runs through every SierraTransformable instance, tries to assign some
@@ -36,14 +39,15 @@ class SierraItemAccessTest extends AnyFunSpec with Matchers with SierraDataGener
       new Iterator[String] {
         val reader =
           new BufferedReader(
-            new InputStreamReader(
-              new FileInputStream("/Users/alexwlchan/desktop/sierra/out_trimmed6.json")))
+            new InputStreamReader(new FileInputStream(
+              "/Users/alexwlchan/desktop/sierra/out_trimmed6.json")))
 
         override def hasNext: Boolean = reader.ready
         override def next(): String = reader.readLine()
       }
 
-    val bibItemPairs: Iterator[(SierraBibNumber, SierraBibData, SierraItemNumber, SierraItemData)] =
+    val bibItemPairs: Iterator[
+      (SierraBibNumber, SierraBibData, SierraItemNumber, SierraItemData)] =
       reader
         .flatMap { json =>
           val t = fromJson[SierraTransformable](json).get
@@ -149,9 +153,18 @@ class SierraItemAccessTest extends AnyFunSpec with Matchers with SierraDataGener
         it("if it has no restrictions") {
           val itemData = createSierraItemDataWith(
             fixedFields = Map(
-              "79" -> FixedField(label = "LOCATION", value = "scmac", display = "Closed stores Arch. & MSS"),
-              "88" -> FixedField(label = "STATUS", value = "-", display = "Available"),
-              "108" -> FixedField(label = "OPACMSG", value = "f", display = "Online request"),
+              "79" -> FixedField(
+                label = "LOCATION",
+                value = "scmac",
+                display = "Closed stores Arch. & MSS"),
+              "88" -> FixedField(
+                label = "STATUS",
+                value = "-",
+                display = "Available"),
+              "108" -> FixedField(
+                label = "OPACMSG",
+                value = "f",
+                display = "Online request"),
             )
           )
 
@@ -168,9 +181,18 @@ class SierraItemAccessTest extends AnyFunSpec with Matchers with SierraDataGener
         it("if it has no restrictions and the bib is open") {
           val itemData = createSierraItemDataWith(
             fixedFields = Map(
-              "79" -> FixedField(label = "LOCATION", value = "scmwf", display = "Closed stores A&MSS Well.Found."),
-              "88" -> FixedField(label = "STATUS", value = "-", display = "Available"),
-              "108" -> FixedField(label = "OPACMSG", value = "f", display = "Online request"),
+              "79" -> FixedField(
+                label = "LOCATION",
+                value = "scmwf",
+                display = "Closed stores A&MSS Well.Found."),
+              "88" -> FixedField(
+                label = "STATUS",
+                value = "-",
+                display = "Available"),
+              "108" -> FixedField(
+                label = "OPACMSG",
+                value = "f",
+                display = "Online request"),
             )
           )
 
@@ -180,16 +202,28 @@ class SierraItemAccessTest extends AnyFunSpec with Matchers with SierraDataGener
             itemData = itemData
           )
 
-          ac shouldBe Some(AccessCondition(status = Some(AccessStatus.Open), terms = Some("Online request")))
+          ac shouldBe Some(
+            AccessCondition(
+              status = Some(AccessStatus.Open),
+              terms = Some("Online request")))
           itemStatus shouldBe ItemStatus.Available
         }
 
         it("if it's restricted") {
           val itemData = createSierraItemDataWith(
             fixedFields = Map(
-              "79" -> FixedField(label = "LOCATION", value = "scmac", display = "Closed stores Arch. & MSS"),
-              "88" -> FixedField(label = "STATUS", value = "6", display = "Restricted"),
-              "108" -> FixedField(label = "OPACMSG", value = "f", display = "Online request"),
+              "79" -> FixedField(
+                label = "LOCATION",
+                value = "scmac",
+                display = "Closed stores Arch. & MSS"),
+              "88" -> FixedField(
+                label = "STATUS",
+                value = "6",
+                display = "Restricted"),
+              "108" -> FixedField(
+                label = "OPACMSG",
+                value = "f",
+                display = "Online request"),
             )
           )
 
@@ -199,7 +233,10 @@ class SierraItemAccessTest extends AnyFunSpec with Matchers with SierraDataGener
             itemData = itemData
           )
 
-          ac shouldBe Some(AccessCondition(status = Some(AccessStatus.Restricted), terms = Some("Online request")))
+          ac shouldBe Some(
+            AccessCondition(
+              status = Some(AccessStatus.Restricted),
+              terms = Some("Online request")))
           itemStatus shouldBe ItemStatus.Available
         }
       }
@@ -208,10 +245,22 @@ class SierraItemAccessTest extends AnyFunSpec with Matchers with SierraDataGener
         it("if it needs a manual request") {
           val itemData = createSierraItemDataWith(
             fixedFields = Map(
-              "61" -> FixedField(label = "I TYPE", value = "4", display = "serial"),
-              "79" -> FixedField(label = "LOCATION", value = "sgser", display = "Closed stores journals"),
-              "88" -> FixedField(label = "STATUS", value = "-", display = "Available"),
-              "108" -> FixedField(label = "OPACMSG", value = "n", display = "Manual request"),
+              "61" -> FixedField(
+                label = "I TYPE",
+                value = "4",
+                display = "serial"),
+              "79" -> FixedField(
+                label = "LOCATION",
+                value = "sgser",
+                display = "Closed stores journals"),
+              "88" -> FixedField(
+                label = "STATUS",
+                value = "-",
+                display = "Available"),
+              "108" -> FixedField(
+                label = "OPACMSG",
+                value = "n",
+                display = "Manual request"),
             )
           )
 
@@ -228,9 +277,18 @@ class SierraItemAccessTest extends AnyFunSpec with Matchers with SierraDataGener
         it("if it's bound in the top item") {
           val itemData = createSierraItemDataWith(
             fixedFields = Map(
-              "79" -> FixedField(label = "LOCATION", value = "bwith", display = "bound in above"),
-              "88" -> FixedField(label = "STATUS", value = "b", display = "As above"),
-              "108" -> FixedField(label = "OPACMSG", value = "-", display = "-"),
+              "79" -> FixedField(
+                label = "LOCATION",
+                value = "bwith",
+                display = "bound in above"),
+              "88" -> FixedField(
+                label = "STATUS",
+                value = "b",
+                display = "As above"),
+              "108" -> FixedField(
+                label = "OPACMSG",
+                value = "-",
+                display = "-"),
             )
           )
 
@@ -240,16 +298,26 @@ class SierraItemAccessTest extends AnyFunSpec with Matchers with SierraDataGener
             itemData = itemData
           )
 
-          ac shouldBe Some(AccessCondition(terms = Some("Please request top item.")))
+          ac shouldBe Some(
+            AccessCondition(terms = Some("Please request top item.")))
           itemStatus shouldBe ItemStatus.Unavailable
         }
 
         it("if it's contained the top item") {
           val itemData = createSierraItemDataWith(
             fixedFields = Map(
-              "79" -> FixedField(label = "LOCATION", value = "cwith", display = "contained in above"),
-              "88" -> FixedField(label = "STATUS", value = "c", display = "As above"),
-              "108" -> FixedField(label = "OPACMSG", value = "-", display = "-"),
+              "79" -> FixedField(
+                label = "LOCATION",
+                value = "cwith",
+                display = "contained in above"),
+              "88" -> FixedField(
+                label = "STATUS",
+                value = "c",
+                display = "As above"),
+              "108" -> FixedField(
+                label = "OPACMSG",
+                value = "-",
+                display = "-"),
             )
           )
 
@@ -259,16 +327,26 @@ class SierraItemAccessTest extends AnyFunSpec with Matchers with SierraDataGener
             itemData = itemData
           )
 
-          ac shouldBe Some(AccessCondition(terms = Some("Please request top item.")))
+          ac shouldBe Some(
+            AccessCondition(terms = Some("Please request top item.")))
           itemStatus shouldBe ItemStatus.Unavailable
         }
 
         it("if the bib and the item are closed") {
           val itemData = createSierraItemDataWith(
             fixedFields = Map(
-              "79" -> FixedField(label = "LOCATION", value = "sc#ac", display = "Unrequestable Arch. & MSS"),
-              "88" -> FixedField(label = "STATUS", value = "h", display = "Closed"),
-              "108" -> FixedField(label = "OPACMSG", value = "u", display = "Unavailable"),
+              "79" -> FixedField(
+                label = "LOCATION",
+                value = "sc#ac",
+                display = "Unrequestable Arch. & MSS"),
+              "88" -> FixedField(
+                label = "STATUS",
+                value = "h",
+                display = "Closed"),
+              "108" -> FixedField(
+                label = "OPACMSG",
+                value = "u",
+                display = "Unavailable"),
             )
           )
 
@@ -285,9 +363,18 @@ class SierraItemAccessTest extends AnyFunSpec with Matchers with SierraDataGener
         it("if the bib and the item are closed, and there's no location") {
           val itemData = createSierraItemDataWith(
             fixedFields = Map(
-              "79" -> FixedField(label = "LOCATION", value = "sc#ac", display = "Unrequestable Arch. & MSS"),
-              "88" -> FixedField(label = "STATUS", value = "h", display = "Closed"),
-              "108" -> FixedField(label = "OPACMSG", value = "u", display = "Unavailable"),
+              "79" -> FixedField(
+                label = "LOCATION",
+                value = "sc#ac",
+                display = "Unrequestable Arch. & MSS"),
+              "88" -> FixedField(
+                label = "STATUS",
+                value = "h",
+                display = "Closed"),
+              "108" -> FixedField(
+                label = "OPACMSG",
+                value = "u",
+                display = "Unavailable"),
             )
           )
 
@@ -304,9 +391,18 @@ class SierraItemAccessTest extends AnyFunSpec with Matchers with SierraDataGener
         it("if the item is unavailable") {
           val itemData = createSierraItemDataWith(
             fixedFields = Map(
-              "79" -> FixedField(label = "LOCATION", value = "sgser", display = "Closed stores journals"),
-              "88" -> FixedField(label = "STATUS", value = "r", display = "Unavailable"),
-              "108" -> FixedField(label = "OPACMSG", value = "u", display = "Unavailable"),
+              "79" -> FixedField(
+                label = "LOCATION",
+                value = "sgser",
+                display = "Closed stores journals"),
+              "88" -> FixedField(
+                label = "STATUS",
+                value = "r",
+                display = "Unavailable"),
+              "108" -> FixedField(
+                label = "OPACMSG",
+                value = "u",
+                display = "Unavailable"),
             )
           )
 
@@ -323,9 +419,18 @@ class SierraItemAccessTest extends AnyFunSpec with Matchers with SierraDataGener
         it("if the item is at digitisation") {
           val itemData = createSierraItemDataWith(
             fixedFields = Map(
-              "79" -> FixedField(label = "LOCATION", value = "sgser", display = "Closed stores journals"),
-              "88" -> FixedField(label = "STATUS", value = "r", display = "Unavailable"),
-              "108" -> FixedField(label = "OPACMSG", value = "b", display = "@ digitisation"),
+              "79" -> FixedField(
+                label = "LOCATION",
+                value = "sgser",
+                display = "Closed stores journals"),
+              "88" -> FixedField(
+                label = "STATUS",
+                value = "r",
+                display = "Unavailable"),
+              "108" -> FixedField(
+                label = "OPACMSG",
+                value = "b",
+                display = "@ digitisation"),
             )
           )
 
@@ -347,9 +452,18 @@ class SierraItemAccessTest extends AnyFunSpec with Matchers with SierraDataGener
         it("if the bib and item are by appointment") {
           val itemData = createSierraItemDataWith(
             fixedFields = Map(
-              "79" -> FixedField(label = "LOCATION", value = "scmac", display = "Closed stores Arch. & MSS"),
-              "88" -> FixedField(label = "STATUS", value = "y", display = "Permission required"),
-              "108" -> FixedField(label = "OPACMSG", value = "a", display = "By appointment"),
+              "79" -> FixedField(
+                label = "LOCATION",
+                value = "scmac",
+                display = "Closed stores Arch. & MSS"),
+              "88" -> FixedField(
+                label = "STATUS",
+                value = "y",
+                display = "Permission required"),
+              "108" -> FixedField(
+                label = "OPACMSG",
+                value = "a",
+                display = "By appointment"),
             )
           )
 
@@ -368,9 +482,18 @@ class SierraItemAccessTest extends AnyFunSpec with Matchers with SierraDataGener
         it("if the item is missing") {
           val itemData = createSierraItemDataWith(
             fixedFields = Map(
-              "79" -> FixedField(label = "LOCATION", value = "sghi2", display = "Closed stores Hist. 2"),
-              "88" -> FixedField(label = "STATUS", value = "m", display = "Missing"),
-              "108" -> FixedField(label = "OPACMSG", value = "f", display = "Online request"),
+              "79" -> FixedField(
+                label = "LOCATION",
+                value = "sghi2",
+                display = "Closed stores Hist. 2"),
+              "88" -> FixedField(
+                label = "STATUS",
+                value = "m",
+                display = "Missing"),
+              "108" -> FixedField(
+                label = "OPACMSG",
+                value = "f",
+                display = "Online request"),
             )
           )
 
@@ -396,9 +519,18 @@ class SierraItemAccessTest extends AnyFunSpec with Matchers with SierraDataGener
         val itemData = createSierraItemDataWith(
           holdCount = Some(1),
           fixedFields = Map(
-            "79" -> FixedField(label = "LOCATION", value = "sgeph", display = "Closed stores ephemera"),
-            "88" -> FixedField(label = "STATUS", value = "-", display = "Available"),
-            "108" -> FixedField(label = "OPACMSG", value = "f", display = "Online request"),
+            "79" -> FixedField(
+              label = "LOCATION",
+              value = "sgeph",
+              display = "Closed stores ephemera"),
+            "88" -> FixedField(
+              label = "STATUS",
+              value = "-",
+              display = "Available"),
+            "108" -> FixedField(
+              label = "OPACMSG",
+              value = "f",
+              display = "Online request"),
           )
         )
 
@@ -411,7 +543,8 @@ class SierraItemAccessTest extends AnyFunSpec with Matchers with SierraDataGener
         ac shouldBe Some(
           AccessCondition(
             status = Some(AccessStatus.TemporarilyUnavailable),
-            terms = Some("Item is in use by another reader. Please ask at Enquiry Desk.")
+            terms = Some(
+              "Item is in use by another reader. Please ask at Enquiry Desk.")
           )
         )
         itemStatus shouldBe ItemStatus.TemporarilyUnavailable
@@ -421,9 +554,18 @@ class SierraItemAccessTest extends AnyFunSpec with Matchers with SierraDataGener
         val itemData = createSierraItemDataWith(
           holdCount = Some(1),
           fixedFields = Map(
-            "79" -> FixedField(label = "LOCATION", value = "swms4", display = "Closed stores WMS 4"),
-            "88" -> FixedField(label = "STATUS", value = "!", display = "On holdshelf"),
-            "108" -> FixedField(label = "OPACMSG", value = "f", display = "Online request"),
+            "79" -> FixedField(
+              label = "LOCATION",
+              value = "swms4",
+              display = "Closed stores WMS 4"),
+            "88" -> FixedField(
+              label = "STATUS",
+              value = "!",
+              display = "On holdshelf"),
+            "108" -> FixedField(
+              label = "OPACMSG",
+              value = "f",
+              display = "Online request"),
           )
         )
 
@@ -436,7 +578,8 @@ class SierraItemAccessTest extends AnyFunSpec with Matchers with SierraDataGener
         ac shouldBe Some(
           AccessCondition(
             status = Some(AccessStatus.TemporarilyUnavailable),
-            terms = Some("Item is in use by another reader. Please ask at Enquiry Desk.")
+            terms = Some(
+              "Item is in use by another reader. Please ask at Enquiry Desk.")
           )
         )
         itemStatus shouldBe ItemStatus.TemporarilyUnavailable
@@ -449,9 +592,18 @@ class SierraItemAccessTest extends AnyFunSpec with Matchers with SierraDataGener
       it("cannot be requested online") {
         val itemData = createSierraItemDataWith(
           fixedFields = Map(
-            "79" -> FixedField(label = "LOCATION", value = "wgmem", display = "Medical Collection"),
-            "88" -> FixedField(label = "STATUS", value = "-", display = "Available"),
-            "108" -> FixedField(label = "OPACMSG", value = "o", display = "Open shelves"),
+            "79" -> FixedField(
+              label = "LOCATION",
+              value = "wgmem",
+              display = "Medical Collection"),
+            "88" -> FixedField(
+              label = "STATUS",
+              value = "-",
+              display = "Available"),
+            "108" -> FixedField(
+              label = "OPACMSG",
+              value = "o",
+              display = "Open shelves"),
           )
         )
 
@@ -468,14 +620,24 @@ class SierraItemAccessTest extends AnyFunSpec with Matchers with SierraDataGener
       it("gets a display note") {
         val itemData = createSierraItemDataWith(
           fixedFields = Map(
-            "79" -> FixedField(label = "LOCATION", value = "wgpvm", display = "History of Medicine"),
-            "88" -> FixedField(label = "STATUS", value = "-", display = "Available"),
-            "108" -> FixedField(label = "OPACMSG", value = "o", display = "Open shelves"),
+            "79" -> FixedField(
+              label = "LOCATION",
+              value = "wgpvm",
+              display = "History of Medicine"),
+            "88" -> FixedField(
+              label = "STATUS",
+              value = "-",
+              display = "Available"),
+            "108" -> FixedField(
+              label = "OPACMSG",
+              value = "o",
+              display = "Open shelves"),
           ),
           varFields = List(
             VarField(
               fieldTag = Some("n"),
-              content = Some("Shelved at the end of the Quick Ref. section with the oversize Quick Ref. books.")
+              content = Some(
+                "Shelved at the end of the Quick Ref. section with the oversize Quick Ref. books.")
             )
           )
         )
@@ -488,7 +650,8 @@ class SierraItemAccessTest extends AnyFunSpec with Matchers with SierraDataGener
 
         ac shouldBe Some(
           AccessCondition(
-            note = Some("Shelved at the end of the Quick Ref. section with the oversize Quick Ref. books.")
+            note = Some(
+              "Shelved at the end of the Quick Ref. section with the oversize Quick Ref. books.")
           )
         )
         itemStatus shouldBe ItemStatus.Available
@@ -498,9 +661,18 @@ class SierraItemAccessTest extends AnyFunSpec with Matchers with SierraDataGener
     it("is not available if it is missing") {
       val itemData = createSierraItemDataWith(
         fixedFields = Map(
-          "79" -> FixedField(label = "LOCATION", value = "wgmem", display = "Medical Collection"),
-          "88" -> FixedField(label = "STATUS", value = "m", display = "Missing"),
-          "108" -> FixedField(label = "OPACMSG", value = "o", display = "Open shelves"),
+          "79" -> FixedField(
+            label = "LOCATION",
+            value = "wgmem",
+            display = "Medical Collection"),
+          "88" -> FixedField(
+            label = "STATUS",
+            value = "m",
+            display = "Missing"),
+          "108" -> FixedField(
+            label = "OPACMSG",
+            value = "o",
+            display = "Open shelves"),
         )
       )
 

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -165,6 +165,25 @@ class SierraItemAccessTest extends AnyFunSpec with Matchers with SierraDataGener
           itemStatus shouldBe ItemStatus.Available
         }
 
+        it("if it has no restrictions and the bib is open") {
+          val itemData = createSierraItemDataWith(
+            fixedFields = Map(
+              "79" -> FixedField(label = "LOCATION", value = "scmwf", display = "Closed stores A&MSS Well.Found."),
+              "88" -> FixedField(label = "STATUS", value = "-", display = "Available"),
+              "108" -> FixedField(label = "OPACMSG", value = "f", display = "Online request"),
+            )
+          )
+
+          val (ac, itemStatus) = SierraItemAccess(
+            bibStatus = Some(AccessStatus.Open),
+            location = Some(LocationType.ClosedStores),
+            itemData = itemData
+          )
+
+          ac shouldBe Some(AccessCondition(status = Some(AccessStatus.Open), terms = Some("Online request")))
+          itemStatus shouldBe ItemStatus.Available
+        }
+
         it("if it's restricted") {
           val itemData = createSierraItemDataWith(
             fixedFields = Map(
@@ -256,6 +275,25 @@ class SierraItemAccessTest extends AnyFunSpec with Matchers with SierraDataGener
           val (ac, itemStatus) = SierraItemAccess(
             bibStatus = Some(AccessStatus.Closed),
             location = Some(LocationType.ClosedStores),
+            itemData = itemData
+          )
+
+          ac shouldBe Some(AccessCondition(status = AccessStatus.Closed))
+          itemStatus shouldBe ItemStatus.Unavailable
+        }
+
+        it("if the bib and the item are closed, and there's no location") {
+          val itemData = createSierraItemDataWith(
+            fixedFields = Map(
+              "79" -> FixedField(label = "LOCATION", value = "sc#ac", display = "Unrequestable Arch. & MSS"),
+              "88" -> FixedField(label = "STATUS", value = "h", display = "Closed"),
+              "108" -> FixedField(label = "OPACMSG", value = "u", display = "Unavailable"),
+            )
+          )
+
+          val (ac, itemStatus) = SierraItemAccess(
+            bibStatus = Some(AccessStatus.Closed),
+            location = None,
             itemData = itemData
           )
 

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -25,7 +25,7 @@ import java.io.{BufferedReader, FileInputStream, InputStreamReader}
 import scala.util.{Failure, Success, Try}
 
 class SierraItemAccessTest extends AnyFunSpec with Matchers with SierraDataGenerators {
-  it("assigns access conditions for all Sierra items") {
+  ignore("assigns access conditions for all Sierra items") {
     // Note: this test is not meant to hang around long-term.  It's a test harness
     // that runs through every SierraTransformable instance, tries to assign some
     // access conditions, and counts how many it can't handle.

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -1,0 +1,130 @@
+package weco.catalogue.source_model.sierra.rules
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.json.JsonUtil._
+import weco.catalogue.internal_model.locations.PhysicalLocationType
+import weco.catalogue.source_model.sierra.Implicits._
+import weco.catalogue.source_model.sierra.{SierraBibData, SierraBibNumber, SierraItemData, SierraItemNumber, SierraTransformable}
+
+import java.io.{BufferedReader, FileInputStream, InputStreamReader}
+import scala.util.{Failure, Success, Try}
+
+class SierraItemAccessTest extends AnyFunSpec with Matchers {
+  it("assigns access conditions for all Sierra items") {
+    // Note: this test is not meant to hang around long-term.  It's a test harness
+    // that runs through every SierraTransformable instance, tries to assign some
+    // access conditions, and counts how many it can't handle.
+    //
+    // Looking at the items that can't be assigned access conditions helps us
+    // find what needs fixing in the data/transformer.
+    val reader: Iterator[String] =
+      new Iterator[String] {
+        val reader =
+          new BufferedReader(
+            new InputStreamReader(
+              new FileInputStream("/Users/alexwlchan/desktop/sierra/out.json")))
+
+        override def hasNext: Boolean = reader.ready
+        override def next(): String = reader.readLine()
+      }
+
+    val bibItemPairs: Iterator[(SierraBibNumber, SierraBibData, SierraItemNumber, SierraItemData)] =
+      reader
+        .flatMap { json =>
+          val t = fromJson[SierraTransformable](json).get
+
+          t.maybeBibRecord match {
+            case Some(bibRecord) =>
+              val bibData = fromJson[SierraBibData](bibRecord.data).get
+              t.itemRecords.values.toList.map { itemRecord =>
+                val itemData = fromJson[SierraItemData](itemRecord.data).get
+                (bibRecord.id, bibData, itemRecord.id, itemData)
+              }
+
+            case None => List()
+          }
+        }
+
+    var handled = 0
+    var unhandled = 0
+
+    bibItemPairs
+      .filterNot {
+        case (_, bibData, _, itemData) =>
+          bibData.suppressed | bibData.deleted | itemData.suppressed | itemData.deleted
+      }
+      .foreach {
+        case (bibId, bibData, itemId, itemData) =>
+          // Note: When we wire up these into the items/locations code, we'll pass
+          // in these values rather than re-parse them, but this works well enough
+          // for the test harness.
+          val bibAccessStatus = SierraAccessStatus.forBib(bibId, bibData)
+          val location: Option[PhysicalLocationType] = itemData.location
+            .map { _.name }
+            .flatMap { SierraPhysicalLocationType.fromName(itemId, _) }
+
+          val ac = Try {
+            SierraItemAccess(bibAccessStatus, location, itemData)
+          }
+
+          // Print the bib/item data for the first 100 failures
+          if (unhandled < 100) {
+            println(bibId.withCheckDigit)
+            println(bibData.varFields.filter(_.marcTag.contains("506")))
+            println(itemId.withCheckDigit)
+            println(itemData.location)
+            println(itemData.fixedFields.filterNot {
+              case (code, _) =>
+                Set(
+                  "68",
+                  "63",
+                  "71",
+                  "72",
+                  "80",
+                  "67",
+                  "66",
+                  "69",
+                  "78",
+                  "109",
+                  "162",
+                  "264",
+                  "161",
+                  "306",
+                  "70",
+                  "86",
+                  "64",
+                  "81",
+                  "59",
+                  "64",
+                  "76",
+                  "98",
+                  "93",
+                  "84",
+                  "265",
+                  "62",
+                  "83",
+                  "77",
+                  "110",
+                  "60",
+                  "94",
+                  "127",
+                  "57",
+                  "58",
+                  "74",
+                  "85"
+                ).contains(code)
+            })
+            println(itemData.varFields.filter(_.fieldTag.contains("n")))
+            println("")
+          }
+
+          ac match {
+            case Success(_) => handled += 1
+            case Failure(_) => unhandled += 1
+          }
+      }
+
+    println(s"$handled handled, $unhandled unhandled")
+  }
+}

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -242,6 +242,49 @@ class SierraItemAccessTest extends AnyFunSpec with Matchers with SierraDataGener
         ac shouldBe Some(AccessCondition(status = AccessStatus.Closed))
         itemStatus shouldBe ItemStatus.Unavailable
       }
+
+      it("if the item is unavailable") {
+        val itemData = createSierraItemDataWith(
+          fixedFields = Map(
+            "79" -> FixedField(label = "LOCATION", value = "sgser", display = "Closed stores journals"),
+            "88" -> FixedField(label = "STATUS", value = "r", display = "Unavailable"),
+            "108" -> FixedField(label = "OPACMSG", value = "u", display = "Unavailable"),
+          )
+        )
+
+        val (ac, itemStatus) = SierraItemAccess(
+          bibStatus = None,
+          location = Some(LocationType.ClosedStores),
+          itemData = itemData
+        )
+
+        ac shouldBe Some(AccessCondition(status = AccessStatus.Unavailable))
+        itemStatus shouldBe ItemStatus.Unavailable
+      }
+
+      it("if the item is at digitisation") {
+        val itemData = createSierraItemDataWith(
+          fixedFields = Map(
+            "79" -> FixedField(label = "LOCATION", value = "sgser", display = "Closed stores journals"),
+            "88" -> FixedField(label = "STATUS", value = "r", display = "Unavailable"),
+            "108" -> FixedField(label = "OPACMSG", value = "b", display = "@ digitisation"),
+          )
+        )
+
+        val (ac, itemStatus) = SierraItemAccess(
+          bibStatus = None,
+          location = Some(LocationType.ClosedStores),
+          itemData = itemData
+        )
+
+        ac shouldBe Some(
+          AccessCondition(
+            status = Some(AccessStatus.TemporarilyUnavailable),
+            terms = Some("At digitisation and temporarily unavailable")
+          )
+        )
+        itemStatus shouldBe ItemStatus.TemporarilyUnavailable
+      }
     }
   }
 

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -205,151 +205,151 @@ class SierraItemAccessTest extends AnyFunSpec with Matchers with SierraDataGener
           ac shouldBe Some(AccessCondition(terms = Some("Manual request")))
           itemStatus shouldBe ItemStatus.Available
         }
-      }
 
-      it("if it's bound in the top item") {
-        val itemData = createSierraItemDataWith(
-          fixedFields = Map(
-            "79" -> FixedField(label = "LOCATION", value = "bwith", display = "bound in above"),
-            "88" -> FixedField(label = "STATUS", value = "b", display = "As above"),
-            "108" -> FixedField(label = "OPACMSG", value = "-", display = "-"),
+        it("if it's bound in the top item") {
+          val itemData = createSierraItemDataWith(
+            fixedFields = Map(
+              "79" -> FixedField(label = "LOCATION", value = "bwith", display = "bound in above"),
+              "88" -> FixedField(label = "STATUS", value = "b", display = "As above"),
+              "108" -> FixedField(label = "OPACMSG", value = "-", display = "-"),
+            )
           )
-        )
 
-        val (ac, itemStatus) = SierraItemAccess(
-          bibStatus = None,
-          location = None,
-          itemData = itemData
-        )
-
-        ac shouldBe Some(AccessCondition(terms = Some("Please request top item.")))
-        itemStatus shouldBe ItemStatus.Unavailable
-      }
-
-      it("if it's contained the top item") {
-        val itemData = createSierraItemDataWith(
-          fixedFields = Map(
-            "79" -> FixedField(label = "LOCATION", value = "cwith", display = "contained in above"),
-            "88" -> FixedField(label = "STATUS", value = "c", display = "As above"),
-            "108" -> FixedField(label = "OPACMSG", value = "-", display = "-"),
+          val (ac, itemStatus) = SierraItemAccess(
+            bibStatus = None,
+            location = None,
+            itemData = itemData
           )
-        )
 
-        val (ac, itemStatus) = SierraItemAccess(
-          bibStatus = None,
-          location = None,
-          itemData = itemData
-        )
+          ac shouldBe Some(AccessCondition(terms = Some("Please request top item.")))
+          itemStatus shouldBe ItemStatus.Unavailable
+        }
 
-        ac shouldBe Some(AccessCondition(terms = Some("Please request top item.")))
-        itemStatus shouldBe ItemStatus.Unavailable
-      }
-
-      it("if the bib and the item are closed") {
-        val itemData = createSierraItemDataWith(
-          fixedFields = Map(
-            "79" -> FixedField(label = "LOCATION", value = "sc#ac", display = "Unrequestable Arch. & MSS"),
-            "88" -> FixedField(label = "STATUS", value = "h", display = "Closed"),
-            "108" -> FixedField(label = "OPACMSG", value = "u", display = "Unavailable"),
+        it("if it's contained the top item") {
+          val itemData = createSierraItemDataWith(
+            fixedFields = Map(
+              "79" -> FixedField(label = "LOCATION", value = "cwith", display = "contained in above"),
+              "88" -> FixedField(label = "STATUS", value = "c", display = "As above"),
+              "108" -> FixedField(label = "OPACMSG", value = "-", display = "-"),
+            )
           )
-        )
 
-        val (ac, itemStatus) = SierraItemAccess(
-          bibStatus = Some(AccessStatus.Closed),
-          location = Some(LocationType.ClosedStores),
-          itemData = itemData
-        )
-
-        ac shouldBe Some(AccessCondition(status = AccessStatus.Closed))
-        itemStatus shouldBe ItemStatus.Unavailable
-      }
-
-      it("if the item is unavailable") {
-        val itemData = createSierraItemDataWith(
-          fixedFields = Map(
-            "79" -> FixedField(label = "LOCATION", value = "sgser", display = "Closed stores journals"),
-            "88" -> FixedField(label = "STATUS", value = "r", display = "Unavailable"),
-            "108" -> FixedField(label = "OPACMSG", value = "u", display = "Unavailable"),
+          val (ac, itemStatus) = SierraItemAccess(
+            bibStatus = None,
+            location = None,
+            itemData = itemData
           )
-        )
 
-        val (ac, itemStatus) = SierraItemAccess(
-          bibStatus = None,
-          location = Some(LocationType.ClosedStores),
-          itemData = itemData
-        )
+          ac shouldBe Some(AccessCondition(terms = Some("Please request top item.")))
+          itemStatus shouldBe ItemStatus.Unavailable
+        }
 
-        ac shouldBe Some(AccessCondition(status = AccessStatus.Unavailable))
-        itemStatus shouldBe ItemStatus.Unavailable
-      }
-
-      it("if the item is at digitisation") {
-        val itemData = createSierraItemDataWith(
-          fixedFields = Map(
-            "79" -> FixedField(label = "LOCATION", value = "sgser", display = "Closed stores journals"),
-            "88" -> FixedField(label = "STATUS", value = "r", display = "Unavailable"),
-            "108" -> FixedField(label = "OPACMSG", value = "b", display = "@ digitisation"),
+        it("if the bib and the item are closed") {
+          val itemData = createSierraItemDataWith(
+            fixedFields = Map(
+              "79" -> FixedField(label = "LOCATION", value = "sc#ac", display = "Unrequestable Arch. & MSS"),
+              "88" -> FixedField(label = "STATUS", value = "h", display = "Closed"),
+              "108" -> FixedField(label = "OPACMSG", value = "u", display = "Unavailable"),
+            )
           )
-        )
 
-        val (ac, itemStatus) = SierraItemAccess(
-          bibStatus = None,
-          location = Some(LocationType.ClosedStores),
-          itemData = itemData
-        )
-
-        ac shouldBe Some(
-          AccessCondition(
-            status = Some(AccessStatus.TemporarilyUnavailable),
-            terms = Some("At digitisation and temporarily unavailable")
+          val (ac, itemStatus) = SierraItemAccess(
+            bibStatus = Some(AccessStatus.Closed),
+            location = Some(LocationType.ClosedStores),
+            itemData = itemData
           )
-        )
-        itemStatus shouldBe ItemStatus.TemporarilyUnavailable
-      }
 
-      it("if the bib and item are by appointment") {
-        val itemData = createSierraItemDataWith(
-          fixedFields = Map(
-            "79" -> FixedField(label = "LOCATION", value = "scmac", display = "Closed stores Arch. & MSS"),
-            "88" -> FixedField(label = "STATUS", value = "y", display = "Permission required"),
-            "108" -> FixedField(label = "OPACMSG", value = "a", display = "By appointment"),
+          ac shouldBe Some(AccessCondition(status = AccessStatus.Closed))
+          itemStatus shouldBe ItemStatus.Unavailable
+        }
+
+        it("if the item is unavailable") {
+          val itemData = createSierraItemDataWith(
+            fixedFields = Map(
+              "79" -> FixedField(label = "LOCATION", value = "sgser", display = "Closed stores journals"),
+              "88" -> FixedField(label = "STATUS", value = "r", display = "Unavailable"),
+              "108" -> FixedField(label = "OPACMSG", value = "u", display = "Unavailable"),
+            )
           )
-        )
 
-        val (ac, itemStatus) = SierraItemAccess(
-          bibStatus = Some(AccessStatus.ByAppointment),
-          location = Some(LocationType.ClosedStores),
-          itemData = itemData
-        )
-
-        ac shouldBe Some(
-          AccessCondition(status = AccessStatus.ByAppointment)
-        )
-        itemStatus shouldBe ItemStatus.Available
-      }
-
-      it("if the item is missing") {
-        val itemData = createSierraItemDataWith(
-          fixedFields = Map(
-            "79" -> FixedField(label = "LOCATION", value = "sghi2", display = "Closed stores Hist. 2"),
-            "88" -> FixedField(label = "STATUS", value = "m", display = "Missing"),
-            "108" -> FixedField(label = "OPACMSG", value = "f", display = "Online request"),
+          val (ac, itemStatus) = SierraItemAccess(
+            bibStatus = None,
+            location = Some(LocationType.ClosedStores),
+            itemData = itemData
           )
-        )
 
-        val (ac, itemStatus) = SierraItemAccess(
-          bibStatus = None,
-          location = Some(LocationType.ClosedStores),
-          itemData = itemData
-        )
+          ac shouldBe Some(AccessCondition(status = AccessStatus.Unavailable))
+          itemStatus shouldBe ItemStatus.Unavailable
+        }
 
-        ac shouldBe Some(
-          AccessCondition(
-            status = Some(AccessStatus.Unavailable),
-            terms = Some("This item is missing.")
+        it("if the item is at digitisation") {
+          val itemData = createSierraItemDataWith(
+            fixedFields = Map(
+              "79" -> FixedField(label = "LOCATION", value = "sgser", display = "Closed stores journals"),
+              "88" -> FixedField(label = "STATUS", value = "r", display = "Unavailable"),
+              "108" -> FixedField(label = "OPACMSG", value = "b", display = "@ digitisation"),
+            )
           )
-        )
-        itemStatus shouldBe ItemStatus.Unavailable
+
+          val (ac, itemStatus) = SierraItemAccess(
+            bibStatus = None,
+            location = Some(LocationType.ClosedStores),
+            itemData = itemData
+          )
+
+          ac shouldBe Some(
+            AccessCondition(
+              status = Some(AccessStatus.TemporarilyUnavailable),
+              terms = Some("At digitisation and temporarily unavailable")
+            )
+          )
+          itemStatus shouldBe ItemStatus.TemporarilyUnavailable
+        }
+
+        it("if the bib and item are by appointment") {
+          val itemData = createSierraItemDataWith(
+            fixedFields = Map(
+              "79" -> FixedField(label = "LOCATION", value = "scmac", display = "Closed stores Arch. & MSS"),
+              "88" -> FixedField(label = "STATUS", value = "y", display = "Permission required"),
+              "108" -> FixedField(label = "OPACMSG", value = "a", display = "By appointment"),
+            )
+          )
+
+          val (ac, itemStatus) = SierraItemAccess(
+            bibStatus = Some(AccessStatus.ByAppointment),
+            location = Some(LocationType.ClosedStores),
+            itemData = itemData
+          )
+
+          ac shouldBe Some(
+            AccessCondition(status = AccessStatus.ByAppointment)
+          )
+          itemStatus shouldBe ItemStatus.Available
+        }
+
+        it("if the item is missing") {
+          val itemData = createSierraItemDataWith(
+            fixedFields = Map(
+              "79" -> FixedField(label = "LOCATION", value = "sghi2", display = "Closed stores Hist. 2"),
+              "88" -> FixedField(label = "STATUS", value = "m", display = "Missing"),
+              "108" -> FixedField(label = "OPACMSG", value = "f", display = "Online request"),
+            )
+          )
+
+          val (ac, itemStatus) = SierraItemAccess(
+            bibStatus = None,
+            location = Some(LocationType.ClosedStores),
+            itemData = itemData
+          )
+
+          ac shouldBe Some(
+            AccessCondition(
+              status = Some(AccessStatus.Unavailable),
+              terms = Some("This item is missing.")
+            )
+          )
+          itemStatus shouldBe ItemStatus.Unavailable
+        }
       }
     }
 

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -162,6 +162,26 @@ class SierraItemAccessTest extends AnyFunSpec with Matchers with SierraDataGener
         ac shouldBe Some(AccessCondition(terms = Some("Online request")))
         itemStatus shouldBe ItemStatus.Available
       }
+
+      it("cannot be requested online if it needs a manual request") {
+        val itemData = createSierraItemDataWith(
+          fixedFields = Map(
+            "61" -> FixedField(label = "I TYPE", value = "4", display = "serial"),
+            "79" -> FixedField(label = "LOCATION", value = "sgser", display = "Closed stores journals"),
+            "88" -> FixedField(label = "STATUS", value = "-", display = "Available"),
+            "108" -> FixedField(label = "OPACMSG", value = "n", display = "Manual request"),
+          )
+        )
+
+        val (ac, itemStatus) = SierraItemAccess(
+          bibStatus = None,
+          location = Some(LocationType.ClosedStores),
+          itemData = itemData
+        )
+
+        ac shouldBe Some(AccessCondition(terms = Some("Manual request")))
+        itemStatus shouldBe ItemStatus.Available
+      }
     }
 
     it("cannot be requested if it's bound in the top item") {

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -145,23 +145,44 @@ class SierraItemAccessTest extends AnyFunSpec with Matchers with SierraDataGener
 
   describe("an item in the closed stores") {
     describe("with no holds") {
-      it("can be requested online if it has no restrictions") {
-        val itemData = createSierraItemDataWith(
-          fixedFields = Map(
-            "79" -> FixedField(label = "LOCATION", value = "scmac", display = "Closed stores Arch. & MSS"),
-            "88" -> FixedField(label = "STATUS", value = "-", display = "Available"),
-            "108" -> FixedField(label = "OPACMSG", value = "f", display = "Online request"),
+      describe("can be requested online") {
+        it("if it has no restrictions") {
+          val itemData = createSierraItemDataWith(
+            fixedFields = Map(
+              "79" -> FixedField(label = "LOCATION", value = "scmac", display = "Closed stores Arch. & MSS"),
+              "88" -> FixedField(label = "STATUS", value = "-", display = "Available"),
+              "108" -> FixedField(label = "OPACMSG", value = "f", display = "Online request"),
+            )
           )
-        )
 
-        val (ac, itemStatus) = SierraItemAccess(
-          bibStatus = None,
-          location = Some(LocationType.ClosedStores),
-          itemData = itemData
-        )
+          val (ac, itemStatus) = SierraItemAccess(
+            bibStatus = None,
+            location = Some(LocationType.ClosedStores),
+            itemData = itemData
+          )
 
-        ac shouldBe Some(AccessCondition(terms = Some("Online request")))
-        itemStatus shouldBe ItemStatus.Available
+          ac shouldBe Some(AccessCondition(terms = Some("Online request")))
+          itemStatus shouldBe ItemStatus.Available
+        }
+
+        it("if it's restricted") {
+          val itemData = createSierraItemDataWith(
+            fixedFields = Map(
+              "79" -> FixedField(label = "LOCATION", value = "scmac", display = "Closed stores Arch. & MSS"),
+              "88" -> FixedField(label = "STATUS", value = "6", display = "Restricted"),
+              "108" -> FixedField(label = "OPACMSG", value = "f", display = "Online request"),
+            )
+          )
+
+          val (ac, itemStatus) = SierraItemAccess(
+            bibStatus = Some(AccessStatus.Restricted),
+            location = Some(LocationType.ClosedStores),
+            itemData = itemData
+          )
+
+          ac shouldBe Some(AccessCondition(status = Some(AccessStatus.Restricted), terms = Some("Online request")))
+          itemStatus shouldBe ItemStatus.Available
+        }
       }
 
       describe("cannot be requested") {

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraPhysicalLocationTypeTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraPhysicalLocationTypeTest.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.transformer.sierra.transformers
+package weco.catalogue.source_model.sierra.rules
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldings.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldings.scala
@@ -5,6 +5,7 @@ import weco.catalogue.internal_model.locations.LocationType.ClosedStores
 import weco.catalogue.internal_model.locations.PhysicalLocation
 import weco.catalogue.internal_model.work.{Holdings, Item}
 import weco.catalogue.source_model.sierra.marc.FixedField
+import weco.catalogue.source_model.sierra.rules.SierraPhysicalLocationType
 import weco.catalogue.source_model.sierra.source.SierraQueryOps
 import weco.catalogue.source_model.sierra.{
   SierraBibNumber,

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldings.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldings.scala
@@ -36,8 +36,8 @@ object SierraHoldings extends SierraQueryOps {
         .partition {
           case (_, holdingsData) =>
             holdingsData.fixedFields.get("40") match {
-              case Some(FixedField(_, value)) if value.trim == "elro" => true
-              case _                                                  => false
+              case Some(FixedField(_, value, _)) if value.trim == "elro" => true
+              case _                                                     => false
             }
         }
 

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItems.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItems.scala
@@ -11,6 +11,7 @@ import weco.catalogue.internal_model.locations.{
   PhysicalLocationType
 }
 import weco.catalogue.internal_model.work.Item
+import weco.catalogue.source_model.sierra.rules.SierraPhysicalLocationType
 import weco.catalogue.source_model.sierra.source.SierraQueryOps
 import weco.catalogue.source_model.sierra.{
   SierraBibData,

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItems.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItems.scala
@@ -66,7 +66,7 @@ object SierraItems extends Logging with SierraLocation with SierraQueryOps {
     val otherLocations =
       sierraItemDataMap
         .collect {
-          case (id, SierraItemData(_, _, Some(location), _, _)) =>
+          case (id, SierraItemData(_, _, _, Some(location), _, _)) =>
             id -> location
         }
         .filterNot {

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocation.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocation.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
 import weco.catalogue.internal_model.locations._
+import weco.catalogue.source_model.sierra.rules.SierraPhysicalLocationType
 import weco.catalogue.source_model.sierra.{
   SierraBibData,
   SierraBibNumber,

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocation.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocation.scala
@@ -1,7 +1,10 @@
 package uk.ac.wellcome.platform.transformer.sierra.transformers
 
 import weco.catalogue.internal_model.locations._
-import weco.catalogue.source_model.sierra.rules.SierraPhysicalLocationType
+import weco.catalogue.source_model.sierra.rules.{
+  SierraAccessStatus,
+  SierraPhysicalLocationType
+}
 import weco.catalogue.source_model.sierra.{
   SierraBibData,
   SierraBibNumber,


### PR DESCRIPTION
It's not quite 99.5%, but I'm close!

This PR adds a new object `SierraItemAccess`, which creates an access condition for a Sierra item to use in the catalogue pipeline. It also creates an ItemStatus to use in the items API (Available/Unavailable/TemporarilyUnavailable). Although these are different services, the logic is similar enough that it's worth developing them in parallel.

There are ~10k items left that this code can't handle – either I need to add more test cases, or I need to get the data fixed in Sierra. I haven't wired this code in anywhere, because I want to do a bit more analysis before I put it on the critical path.

I'd like to get this much reviewed and merged as-is, and come back to add extra cases later. I think this is 80% complete, but it'll take another 80% of the time (and code!) to get the remaining 20%, so to speak. 