### PR TITLE
Search index config JSON tests

### DIFF
--- a/common/internal_model/src/test/resources/ImagesIndexConfig.json
+++ b/common/internal_model/src/test/resources/ImagesIndexConfig.json
@@ -1,0 +1,1154 @@
+{
+  "settings" : {
+    "analysis" : {
+      "analyzer" : {
+        "path_hierarchy_analyzer" : {
+          "type" : "custom",
+          "tokenizer" : "path_hierarchy_tokenizer"
+        },
+        "asciifolding_analyzer" : {
+          "type" : "custom",
+          "tokenizer" : "standard",
+          "filter" : [
+            "lowercase",
+            "asciifolding_token_filter"
+          ]
+        },
+        "shingle_asciifolding_analyzer" : {
+          "type" : "custom",
+          "tokenizer" : "standard",
+          "filter" : [
+            "lowercase",
+            "shingle_token_filter",
+            "asciifolding_token_filter"
+          ]
+        },
+        "english_analyzer" : {
+          "type" : "custom",
+          "tokenizer" : "standard",
+          "filter" : [
+            "lowercase",
+            "english_token_filter",
+            "english_possessive_token_filter"
+          ]
+        },
+        "whitespace_analyzer" : {
+          "type" : "custom",
+          "tokenizer" : "whitespace"
+        },
+        "arabic_analyzer" : {
+          "type" : "custom",
+          "tokenizer" : "standard",
+          "filter" : [
+            "lowercase",
+            "arabic_token_filter"
+          ]
+        },
+        "bengali_analyzer" : {
+          "type" : "custom",
+          "tokenizer" : "standard",
+          "filter" : [
+            "lowercase",
+            "bengali_token_filter"
+          ]
+        },
+        "french_analyzer" : {
+          "type" : "custom",
+          "tokenizer" : "standard",
+          "filter" : [
+            "lowercase",
+            "french_token_filter"
+          ]
+        },
+        "german_analyzer" : {
+          "type" : "custom",
+          "tokenizer" : "standard",
+          "filter" : [
+            "lowercase",
+            "german_token_filter"
+          ]
+        },
+        "hindi_analyzer" : {
+          "type" : "custom",
+          "tokenizer" : "standard",
+          "filter" : [
+            "lowercase",
+            "hindi_token_filter"
+          ]
+        },
+        "italian_analyzer" : {
+          "type" : "custom",
+          "tokenizer" : "standard",
+          "filter" : [
+            "lowercase",
+            "italian_token_filter"
+          ]
+        }
+      },
+      "normalizer" : {
+        "lowercase_normalizer" : {
+          "type" : "custom",
+          "filter" : [
+            "lowercase"
+          ]
+        }
+      },
+      "tokenizer" : {
+        "path_hierarchy_tokenizer" : {
+          "type" : "path_hierarchy",
+          "delimiter" : "/",
+          "replacement" : "/"
+        }
+      },
+      "filter" : {
+        "asciifolding_token_filter" : {
+          "type" : "asciifolding",
+          "preserve_original" : true
+        },
+        "shingle_token_filter" : {
+          "type" : "shingle",
+          "max_shingle_size" : 4,
+          "min_shingle_size" : 2
+        },
+        "english_token_filter" : {
+          "type" : "stemmer",
+          "name" : "english"
+        },
+        "english_possessive_token_filter" : {
+          "type" : "stemmer",
+          "name" : "possessive_english"
+        },
+        "arabic_token_filter" : {
+          "type" : "stemmer",
+          "name" : "arabic"
+        },
+        "bengali_token_filter" : {
+          "type" : "stemmer",
+          "name" : "bengali"
+        },
+        "french_token_filter" : {
+          "type" : "stemmer",
+          "name" : "french"
+        },
+        "german_token_filter" : {
+          "type" : "stemmer",
+          "name" : "german"
+        },
+        "hindi_token_filter" : {
+          "type" : "stemmer",
+          "name" : "hindi"
+        },
+        "italian_token_filter" : {
+          "type" : "stemmer",
+          "name" : "italian"
+        }
+      }
+    }
+  },
+  "mappings" : {
+    "dynamic" : "strict",
+    "properties" : {
+      "version" : {
+        "type" : "integer"
+      },
+      "modifiedTime" : {
+        "type" : "date"
+      },
+      "source" : {
+        "type" : "object",
+        "properties" : {
+          "canonicalWork" : {
+            "type" : "object",
+            "properties" : {
+              "id" : {
+                "type" : "object",
+                "properties" : {
+                  "canonicalId" : {
+                    "type" : "keyword",
+                    "normalizer" : "lowercase_normalizer"
+                  },
+                  "sourceIdentifier" : {
+                    "type" : "object",
+                    "properties" : {
+                      "value" : {
+                        "type" : "keyword",
+                        "normalizer" : "lowercase_normalizer"
+                      }
+                    },
+                    "dynamic" : "false"
+                  }
+                }
+              },
+              "data" : {
+                "type" : "object",
+                "properties" : {
+                  "otherIdentifiers" : {
+                    "type" : "object",
+                    "properties" : {
+                      "value" : {
+                        "type" : "keyword",
+                        "normalizer" : "lowercase_normalizer"
+                      }
+                    }
+                  },
+                  "title" : {
+                    "type" : "text",
+                    "fields" : {
+                      "keyword" : {
+                        "type" : "keyword",
+                        "normalizer" : "lowercase_normalizer"
+                      },
+                      "english" : {
+                        "type" : "text",
+                        "analyzer" : "english_analyzer"
+                      },
+                      "shingles" : {
+                        "type" : "text",
+                        "analyzer" : "shingle_asciifolding_analyzer"
+                      },
+                      "arabic" : {
+                        "type" : "text",
+                        "analyzer" : "arabic_analyzer"
+                      },
+                      "bengali" : {
+                        "type" : "text",
+                        "analyzer" : "bengali_analyzer"
+                      },
+                      "french" : {
+                        "type" : "text",
+                        "analyzer" : "french_analyzer"
+                      },
+                      "german" : {
+                        "type" : "text",
+                        "analyzer" : "german_analyzer"
+                      },
+                      "hindi" : {
+                        "type" : "text",
+                        "analyzer" : "hindi_analyzer"
+                      },
+                      "italian" : {
+                        "type" : "text",
+                        "analyzer" : "italian_analyzer"
+                      }
+                    }
+                  },
+                  "alternativeTitles" : {
+                    "type" : "text",
+                    "fields" : {
+                      "keyword" : {
+                        "type" : "keyword",
+                        "normalizer" : "lowercase_normalizer"
+                      },
+                      "english" : {
+                        "type" : "text",
+                        "analyzer" : "english_analyzer"
+                      },
+                      "shingles" : {
+                        "type" : "text",
+                        "analyzer" : "shingle_asciifolding_analyzer"
+                      },
+                      "arabic" : {
+                        "type" : "text",
+                        "analyzer" : "arabic_analyzer"
+                      },
+                      "bengali" : {
+                        "type" : "text",
+                        "analyzer" : "bengali_analyzer"
+                      },
+                      "french" : {
+                        "type" : "text",
+                        "analyzer" : "french_analyzer"
+                      },
+                      "german" : {
+                        "type" : "text",
+                        "analyzer" : "german_analyzer"
+                      },
+                      "hindi" : {
+                        "type" : "text",
+                        "analyzer" : "hindi_analyzer"
+                      },
+                      "italian" : {
+                        "type" : "text",
+                        "analyzer" : "italian_analyzer"
+                      }
+                    }
+                  },
+                  "description" : {
+                    "type" : "text",
+                    "fields" : {
+                      "english" : {
+                        "type" : "text",
+                        "analyzer" : "english_analyzer"
+                      },
+                      "shingles" : {
+                        "type" : "text",
+                        "analyzer" : "shingle_asciifolding_analyzer"
+                      },
+                      "arabic" : {
+                        "type" : "text",
+                        "analyzer" : "arabic_analyzer"
+                      },
+                      "bengali" : {
+                        "type" : "text",
+                        "analyzer" : "bengali_analyzer"
+                      },
+                      "french" : {
+                        "type" : "text",
+                        "analyzer" : "french_analyzer"
+                      },
+                      "german" : {
+                        "type" : "text",
+                        "analyzer" : "german_analyzer"
+                      },
+                      "hindi" : {
+                        "type" : "text",
+                        "analyzer" : "hindi_analyzer"
+                      },
+                      "italian" : {
+                        "type" : "text",
+                        "analyzer" : "italian_analyzer"
+                      }
+                    }
+                  },
+                  "physicalDescription" : {
+                    "type" : "text",
+                    "fields" : {
+                      "keyword" : {
+                        "type" : "keyword"
+                      },
+                      "english" : {
+                        "type" : "text",
+                        "analyzer" : "english"
+                      }
+                    }
+                  },
+                  "lettering" : {
+                    "type" : "text",
+                    "fields" : {
+                      "english" : {
+                        "type" : "text",
+                        "analyzer" : "english_analyzer"
+                      },
+                      "shingles" : {
+                        "type" : "text",
+                        "analyzer" : "shingle_asciifolding_analyzer"
+                      },
+                      "arabic" : {
+                        "type" : "text",
+                        "analyzer" : "arabic_analyzer"
+                      },
+                      "bengali" : {
+                        "type" : "text",
+                        "analyzer" : "bengali_analyzer"
+                      },
+                      "french" : {
+                        "type" : "text",
+                        "analyzer" : "french_analyzer"
+                      },
+                      "german" : {
+                        "type" : "text",
+                        "analyzer" : "german_analyzer"
+                      },
+                      "hindi" : {
+                        "type" : "text",
+                        "analyzer" : "hindi_analyzer"
+                      },
+                      "italian" : {
+                        "type" : "text",
+                        "analyzer" : "italian_analyzer"
+                      }
+                    }
+                  },
+                  "contributors" : {
+                    "type" : "object",
+                    "properties" : {
+                      "agent" : {
+                        "type" : "object",
+                        "properties" : {
+                          "label" : {
+                            "type" : "text",
+                            "analyzer" : "asciifolding_analyzer",
+                            "fields" : {
+                              "keyword" : {
+                                "type" : "keyword"
+                              },
+                              "lowercaseKeyword" : {
+                                "type" : "keyword",
+                                "normalizer" : "lowercase_normalizer"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "subjects" : {
+                    "type" : "object",
+                    "properties" : {
+                      "concepts" : {
+                        "type" : "object",
+                        "properties" : {
+                          "label" : {
+                            "type" : "text",
+                            "analyzer" : "asciifolding_analyzer",
+                            "fields" : {
+                              "keyword" : {
+                                "type" : "keyword"
+                              },
+                              "lowercaseKeyword" : {
+                                "type" : "keyword",
+                                "normalizer" : "lowercase_normalizer"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "genres" : {
+                    "type" : "object",
+                    "properties" : {
+                      "label" : {
+                        "type" : "text",
+                        "analyzer" : "asciifolding_analyzer",
+                        "fields" : {
+                          "keyword" : {
+                            "type" : "keyword"
+                          },
+                          "lowercaseKeyword" : {
+                            "type" : "keyword",
+                            "normalizer" : "lowercase_normalizer"
+                          }
+                        }
+                      },
+                      "concepts" : {
+                        "type" : "object",
+                        "properties" : {
+                          "label" : {
+                            "type" : "text",
+                            "analyzer" : "asciifolding_analyzer",
+                            "fields" : {
+                              "keyword" : {
+                                "type" : "keyword"
+                              },
+                              "lowercaseKeyword" : {
+                                "type" : "keyword",
+                                "normalizer" : "lowercase_normalizer"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "production" : {
+                    "type" : "object",
+                    "properties" : {
+                      "places" : {
+                        "type" : "object",
+                        "properties" : {
+                          "label" : {
+                            "type" : "text",
+                            "analyzer" : "asciifolding_analyzer",
+                            "fields" : {
+                              "keyword" : {
+                                "type" : "keyword"
+                              },
+                              "lowercaseKeyword" : {
+                                "type" : "keyword",
+                                "normalizer" : "lowercase_normalizer"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "agents" : {
+                        "type" : "object",
+                        "properties" : {
+                          "label" : {
+                            "type" : "text",
+                            "analyzer" : "asciifolding_analyzer",
+                            "fields" : {
+                              "keyword" : {
+                                "type" : "keyword"
+                              },
+                              "lowercaseKeyword" : {
+                                "type" : "keyword",
+                                "normalizer" : "lowercase_normalizer"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "dates" : {
+                        "type" : "object",
+                        "properties" : {
+                          "label" : {
+                            "type" : "text",
+                            "analyzer" : "asciifolding_analyzer",
+                            "fields" : {
+                              "keyword" : {
+                                "type" : "keyword"
+                              },
+                              "lowercaseKeyword" : {
+                                "type" : "keyword",
+                                "normalizer" : "lowercase_normalizer"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "function" : {
+                        "type" : "object",
+                        "properties" : {
+                          "label" : {
+                            "type" : "text",
+                            "analyzer" : "asciifolding_analyzer",
+                            "fields" : {
+                              "keyword" : {
+                                "type" : "keyword"
+                              },
+                              "lowercaseKeyword" : {
+                                "type" : "keyword",
+                                "normalizer" : "lowercase_normalizer"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "languages" : {
+                    "type" : "object",
+                    "properties" : {
+                      "label" : {
+                        "type" : "text",
+                        "analyzer" : "asciifolding_analyzer",
+                        "fields" : {
+                          "keyword" : {
+                            "type" : "keyword"
+                          },
+                          "lowercaseKeyword" : {
+                            "type" : "keyword",
+                            "normalizer" : "lowercase_normalizer"
+                          }
+                        }
+                      },
+                      "id" : {
+                        "type" : "keyword"
+                      }
+                    }
+                  },
+                  "edition" : {
+                    "type" : "text"
+                  },
+                  "notes" : {
+                    "type" : "object",
+                    "properties" : {
+                      "content" : {
+                        "type" : "text",
+                        "fields" : {
+                          "english" : {
+                            "type" : "text",
+                            "analyzer" : "english_analyzer"
+                          },
+                          "shingles" : {
+                            "type" : "text",
+                            "analyzer" : "shingle_asciifolding_analyzer"
+                          },
+                          "arabic" : {
+                            "type" : "text",
+                            "analyzer" : "arabic_analyzer"
+                          },
+                          "bengali" : {
+                            "type" : "text",
+                            "analyzer" : "bengali_analyzer"
+                          },
+                          "french" : {
+                            "type" : "text",
+                            "analyzer" : "french_analyzer"
+                          },
+                          "german" : {
+                            "type" : "text",
+                            "analyzer" : "german_analyzer"
+                          },
+                          "hindi" : {
+                            "type" : "text",
+                            "analyzer" : "hindi_analyzer"
+                          },
+                          "italian" : {
+                            "type" : "text",
+                            "analyzer" : "italian_analyzer"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "collectionPath" : {
+                    "type" : "object",
+                    "properties" : {
+                      "label" : {
+                        "type" : "text",
+                        "analyzer" : "asciifolding_analyzer",
+                        "fields" : {
+                          "keyword" : {
+                            "type" : "keyword"
+                          },
+                          "lowercaseKeyword" : {
+                            "type" : "keyword",
+                            "normalizer" : "lowercase_normalizer"
+                          }
+                        }
+                      },
+                      "path" : {
+                        "type" : "text"
+                      }
+                    }
+                  }
+                }
+              },
+              "type" : {
+                "type" : "keyword"
+              }
+            },
+            "dynamic" : "false"
+          },
+          "redirectedWork" : {
+            "type" : "object",
+            "properties" : {
+              "id" : {
+                "type" : "object",
+                "properties" : {
+                  "canonicalId" : {
+                    "type" : "keyword",
+                    "normalizer" : "lowercase_normalizer"
+                  },
+                  "sourceIdentifier" : {
+                    "type" : "object",
+                    "properties" : {
+                      "value" : {
+                        "type" : "keyword",
+                        "normalizer" : "lowercase_normalizer"
+                      }
+                    },
+                    "dynamic" : "false"
+                  }
+                }
+              },
+              "data" : {
+                "type" : "object",
+                "properties" : {
+                  "otherIdentifiers" : {
+                    "type" : "object",
+                    "properties" : {
+                      "value" : {
+                        "type" : "keyword",
+                        "normalizer" : "lowercase_normalizer"
+                      }
+                    }
+                  },
+                  "title" : {
+                    "type" : "text",
+                    "fields" : {
+                      "keyword" : {
+                        "type" : "keyword",
+                        "normalizer" : "lowercase_normalizer"
+                      },
+                      "english" : {
+                        "type" : "text",
+                        "analyzer" : "english_analyzer"
+                      },
+                      "shingles" : {
+                        "type" : "text",
+                        "analyzer" : "shingle_asciifolding_analyzer"
+                      },
+                      "arabic" : {
+                        "type" : "text",
+                        "analyzer" : "arabic_analyzer"
+                      },
+                      "bengali" : {
+                        "type" : "text",
+                        "analyzer" : "bengali_analyzer"
+                      },
+                      "french" : {
+                        "type" : "text",
+                        "analyzer" : "french_analyzer"
+                      },
+                      "german" : {
+                        "type" : "text",
+                        "analyzer" : "german_analyzer"
+                      },
+                      "hindi" : {
+                        "type" : "text",
+                        "analyzer" : "hindi_analyzer"
+                      },
+                      "italian" : {
+                        "type" : "text",
+                        "analyzer" : "italian_analyzer"
+                      }
+                    }
+                  },
+                  "alternativeTitles" : {
+                    "type" : "text",
+                    "fields" : {
+                      "keyword" : {
+                        "type" : "keyword",
+                        "normalizer" : "lowercase_normalizer"
+                      },
+                      "english" : {
+                        "type" : "text",
+                        "analyzer" : "english_analyzer"
+                      },
+                      "shingles" : {
+                        "type" : "text",
+                        "analyzer" : "shingle_asciifolding_analyzer"
+                      },
+                      "arabic" : {
+                        "type" : "text",
+                        "analyzer" : "arabic_analyzer"
+                      },
+                      "bengali" : {
+                        "type" : "text",
+                        "analyzer" : "bengali_analyzer"
+                      },
+                      "french" : {
+                        "type" : "text",
+                        "analyzer" : "french_analyzer"
+                      },
+                      "german" : {
+                        "type" : "text",
+                        "analyzer" : "german_analyzer"
+                      },
+                      "hindi" : {
+                        "type" : "text",
+                        "analyzer" : "hindi_analyzer"
+                      },
+                      "italian" : {
+                        "type" : "text",
+                        "analyzer" : "italian_analyzer"
+                      }
+                    }
+                  },
+                  "description" : {
+                    "type" : "text",
+                    "fields" : {
+                      "english" : {
+                        "type" : "text",
+                        "analyzer" : "english_analyzer"
+                      },
+                      "shingles" : {
+                        "type" : "text",
+                        "analyzer" : "shingle_asciifolding_analyzer"
+                      },
+                      "arabic" : {
+                        "type" : "text",
+                        "analyzer" : "arabic_analyzer"
+                      },
+                      "bengali" : {
+                        "type" : "text",
+                        "analyzer" : "bengali_analyzer"
+                      },
+                      "french" : {
+                        "type" : "text",
+                        "analyzer" : "french_analyzer"
+                      },
+                      "german" : {
+                        "type" : "text",
+                        "analyzer" : "german_analyzer"
+                      },
+                      "hindi" : {
+                        "type" : "text",
+                        "analyzer" : "hindi_analyzer"
+                      },
+                      "italian" : {
+                        "type" : "text",
+                        "analyzer" : "italian_analyzer"
+                      }
+                    }
+                  },
+                  "physicalDescription" : {
+                    "type" : "text",
+                    "fields" : {
+                      "keyword" : {
+                        "type" : "keyword"
+                      },
+                      "english" : {
+                        "type" : "text",
+                        "analyzer" : "english"
+                      }
+                    }
+                  },
+                  "lettering" : {
+                    "type" : "text",
+                    "fields" : {
+                      "english" : {
+                        "type" : "text",
+                        "analyzer" : "english_analyzer"
+                      },
+                      "shingles" : {
+                        "type" : "text",
+                        "analyzer" : "shingle_asciifolding_analyzer"
+                      },
+                      "arabic" : {
+                        "type" : "text",
+                        "analyzer" : "arabic_analyzer"
+                      },
+                      "bengali" : {
+                        "type" : "text",
+                        "analyzer" : "bengali_analyzer"
+                      },
+                      "french" : {
+                        "type" : "text",
+                        "analyzer" : "french_analyzer"
+                      },
+                      "german" : {
+                        "type" : "text",
+                        "analyzer" : "german_analyzer"
+                      },
+                      "hindi" : {
+                        "type" : "text",
+                        "analyzer" : "hindi_analyzer"
+                      },
+                      "italian" : {
+                        "type" : "text",
+                        "analyzer" : "italian_analyzer"
+                      }
+                    }
+                  },
+                  "contributors" : {
+                    "type" : "object",
+                    "properties" : {
+                      "agent" : {
+                        "type" : "object",
+                        "properties" : {
+                          "label" : {
+                            "type" : "text",
+                            "analyzer" : "asciifolding_analyzer",
+                            "fields" : {
+                              "keyword" : {
+                                "type" : "keyword"
+                              },
+                              "lowercaseKeyword" : {
+                                "type" : "keyword",
+                                "normalizer" : "lowercase_normalizer"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "subjects" : {
+                    "type" : "object",
+                    "properties" : {
+                      "concepts" : {
+                        "type" : "object",
+                        "properties" : {
+                          "label" : {
+                            "type" : "text",
+                            "analyzer" : "asciifolding_analyzer",
+                            "fields" : {
+                              "keyword" : {
+                                "type" : "keyword"
+                              },
+                              "lowercaseKeyword" : {
+                                "type" : "keyword",
+                                "normalizer" : "lowercase_normalizer"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "genres" : {
+                    "type" : "object",
+                    "properties" : {
+                      "label" : {
+                        "type" : "text",
+                        "analyzer" : "asciifolding_analyzer",
+                        "fields" : {
+                          "keyword" : {
+                            "type" : "keyword"
+                          },
+                          "lowercaseKeyword" : {
+                            "type" : "keyword",
+                            "normalizer" : "lowercase_normalizer"
+                          }
+                        }
+                      },
+                      "concepts" : {
+                        "type" : "object",
+                        "properties" : {
+                          "label" : {
+                            "type" : "text",
+                            "analyzer" : "asciifolding_analyzer",
+                            "fields" : {
+                              "keyword" : {
+                                "type" : "keyword"
+                              },
+                              "lowercaseKeyword" : {
+                                "type" : "keyword",
+                                "normalizer" : "lowercase_normalizer"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "production" : {
+                    "type" : "object",
+                    "properties" : {
+                      "places" : {
+                        "type" : "object",
+                        "properties" : {
+                          "label" : {
+                            "type" : "text",
+                            "analyzer" : "asciifolding_analyzer",
+                            "fields" : {
+                              "keyword" : {
+                                "type" : "keyword"
+                              },
+                              "lowercaseKeyword" : {
+                                "type" : "keyword",
+                                "normalizer" : "lowercase_normalizer"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "agents" : {
+                        "type" : "object",
+                        "properties" : {
+                          "label" : {
+                            "type" : "text",
+                            "analyzer" : "asciifolding_analyzer",
+                            "fields" : {
+                              "keyword" : {
+                                "type" : "keyword"
+                              },
+                              "lowercaseKeyword" : {
+                                "type" : "keyword",
+                                "normalizer" : "lowercase_normalizer"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "dates" : {
+                        "type" : "object",
+                        "properties" : {
+                          "label" : {
+                            "type" : "text",
+                            "analyzer" : "asciifolding_analyzer",
+                            "fields" : {
+                              "keyword" : {
+                                "type" : "keyword"
+                              },
+                              "lowercaseKeyword" : {
+                                "type" : "keyword",
+                                "normalizer" : "lowercase_normalizer"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "function" : {
+                        "type" : "object",
+                        "properties" : {
+                          "label" : {
+                            "type" : "text",
+                            "analyzer" : "asciifolding_analyzer",
+                            "fields" : {
+                              "keyword" : {
+                                "type" : "keyword"
+                              },
+                              "lowercaseKeyword" : {
+                                "type" : "keyword",
+                                "normalizer" : "lowercase_normalizer"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "languages" : {
+                    "type" : "object",
+                    "properties" : {
+                      "label" : {
+                        "type" : "text",
+                        "analyzer" : "asciifolding_analyzer",
+                        "fields" : {
+                          "keyword" : {
+                            "type" : "keyword"
+                          },
+                          "lowercaseKeyword" : {
+                            "type" : "keyword",
+                            "normalizer" : "lowercase_normalizer"
+                          }
+                        }
+                      },
+                      "id" : {
+                        "type" : "keyword"
+                      }
+                    }
+                  },
+                  "edition" : {
+                    "type" : "text"
+                  },
+                  "notes" : {
+                    "type" : "object",
+                    "properties" : {
+                      "content" : {
+                        "type" : "text",
+                        "fields" : {
+                          "english" : {
+                            "type" : "text",
+                            "analyzer" : "english_analyzer"
+                          },
+                          "shingles" : {
+                            "type" : "text",
+                            "analyzer" : "shingle_asciifolding_analyzer"
+                          },
+                          "arabic" : {
+                            "type" : "text",
+                            "analyzer" : "arabic_analyzer"
+                          },
+                          "bengali" : {
+                            "type" : "text",
+                            "analyzer" : "bengali_analyzer"
+                          },
+                          "french" : {
+                            "type" : "text",
+                            "analyzer" : "french_analyzer"
+                          },
+                          "german" : {
+                            "type" : "text",
+                            "analyzer" : "german_analyzer"
+                          },
+                          "hindi" : {
+                            "type" : "text",
+                            "analyzer" : "hindi_analyzer"
+                          },
+                          "italian" : {
+                            "type" : "text",
+                            "analyzer" : "italian_analyzer"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "collectionPath" : {
+                    "type" : "object",
+                    "properties" : {
+                      "label" : {
+                        "type" : "text",
+                        "analyzer" : "asciifolding_analyzer",
+                        "fields" : {
+                          "keyword" : {
+                            "type" : "keyword"
+                          },
+                          "lowercaseKeyword" : {
+                            "type" : "keyword",
+                            "normalizer" : "lowercase_normalizer"
+                          }
+                        }
+                      },
+                      "path" : {
+                        "type" : "text"
+                      }
+                    }
+                  }
+                }
+              },
+              "type" : {
+                "type" : "keyword"
+              }
+            },
+            "dynamic" : "false"
+          },
+          "type" : {
+            "type" : "keyword"
+          }
+        }
+      },
+      "state" : {
+        "type" : "object",
+        "properties" : {
+          "canonicalId" : {
+            "type" : "keyword",
+            "normalizer" : "lowercase_normalizer"
+          },
+          "sourceIdentifier" : {
+            "type" : "object",
+            "properties" : {
+              "value" : {
+                "type" : "keyword",
+                "normalizer" : "lowercase_normalizer"
+              }
+            },
+            "dynamic" : "false"
+          },
+          "inferredData" : {
+            "type" : "object",
+            "properties" : {
+              "features1" : {
+                "type" : "dense_vector",
+                "dims" : 2048
+              },
+              "features2" : {
+                "type" : "dense_vector",
+                "dims" : 2048
+              },
+              "lshEncodedFeatures" : {
+                "type" : "keyword"
+              },
+              "palette" : {
+                "type" : "keyword"
+              },
+              "binSizes" : {
+                "type" : "integer",
+                "index" : "false"
+              },
+              "binMinima" : {
+                "type" : "float",
+                "index" : "false"
+              },
+              "aspectRatio" : {
+                "type" : "float"
+              }
+            }
+          },
+          "derivedData" : {
+            "type" : "object",
+            "properties" : {
+              "sourceContributorAgents" : {
+                "type" : "keyword"
+              }
+            },
+            "dynamic" : "false"
+          }
+        }
+      },
+      "locations" : {
+        "type" : "object",
+        "properties" : {
+          "license" : {
+            "type" : "object",
+            "properties" : {
+              "id" : {
+                "type" : "keyword"
+              }
+            }
+          }
+        },
+        "dynamic" : "false"
+      }
+    },
+    "_meta" : {
+      "model.versions.0" : "b60a01f8d3d8e30a301952463e3922f2e02b8914"
+    }
+  }
+}

--- a/common/internal_model/src/test/resources/ImagesIndexConfig.json
+++ b/common/internal_model/src/test/resources/ImagesIndexConfig.json
@@ -1146,9 +1146,6 @@
         },
         "dynamic" : "false"
       }
-    },
-    "_meta" : {
-      "model.versions.0" : "b60a01f8d3d8e30a301952463e3922f2e02b8914"
     }
   }
 }

--- a/common/internal_model/src/test/resources/WorksIndexConfig.json
+++ b/common/internal_model/src/test/resources/WorksIndexConfig.json
@@ -1,0 +1,857 @@
+{
+  "settings" : {
+    "analysis" : {
+      "analyzer" : {
+        "path_hierarchy_analyzer" : {
+          "type" : "custom",
+          "tokenizer" : "path_hierarchy_tokenizer"
+        },
+        "asciifolding_analyzer" : {
+          "type" : "custom",
+          "tokenizer" : "standard",
+          "filter" : [
+            "lowercase",
+            "asciifolding_token_filter"
+          ]
+        },
+        "shingle_asciifolding_analyzer" : {
+          "type" : "custom",
+          "tokenizer" : "standard",
+          "filter" : [
+            "lowercase",
+            "shingle_token_filter",
+            "asciifolding_token_filter"
+          ]
+        },
+        "english_analyzer" : {
+          "type" : "custom",
+          "tokenizer" : "standard",
+          "filter" : [
+            "lowercase",
+            "english_token_filter",
+            "english_possessive_token_filter"
+          ]
+        },
+        "whitespace_analyzer" : {
+          "type" : "custom",
+          "tokenizer" : "whitespace"
+        },
+        "arabic_analyzer" : {
+          "type" : "custom",
+          "tokenizer" : "standard",
+          "filter" : [
+            "lowercase",
+            "arabic_token_filter"
+          ]
+        },
+        "bengali_analyzer" : {
+          "type" : "custom",
+          "tokenizer" : "standard",
+          "filter" : [
+            "lowercase",
+            "bengali_token_filter"
+          ]
+        },
+        "french_analyzer" : {
+          "type" : "custom",
+          "tokenizer" : "standard",
+          "filter" : [
+            "lowercase",
+            "french_token_filter"
+          ]
+        },
+        "german_analyzer" : {
+          "type" : "custom",
+          "tokenizer" : "standard",
+          "filter" : [
+            "lowercase",
+            "german_token_filter"
+          ]
+        },
+        "hindi_analyzer" : {
+          "type" : "custom",
+          "tokenizer" : "standard",
+          "filter" : [
+            "lowercase",
+            "hindi_token_filter"
+          ]
+        },
+        "italian_analyzer" : {
+          "type" : "custom",
+          "tokenizer" : "standard",
+          "filter" : [
+            "lowercase",
+            "italian_token_filter"
+          ]
+        }
+      },
+      "normalizer" : {
+        "lowercase_normalizer" : {
+          "type" : "custom",
+          "filter" : [
+            "lowercase"
+          ]
+        }
+      },
+      "tokenizer" : {
+        "path_hierarchy_tokenizer" : {
+          "type" : "path_hierarchy",
+          "delimiter" : "/",
+          "replacement" : "/"
+        }
+      },
+      "filter" : {
+        "asciifolding_token_filter" : {
+          "type" : "asciifolding",
+          "preserve_original" : true
+        },
+        "shingle_token_filter" : {
+          "type" : "shingle",
+          "max_shingle_size" : 4,
+          "min_shingle_size" : 2
+        },
+        "english_token_filter" : {
+          "type" : "stemmer",
+          "name" : "english"
+        },
+        "english_possessive_token_filter" : {
+          "type" : "stemmer",
+          "name" : "possessive_english"
+        },
+        "arabic_token_filter" : {
+          "type" : "stemmer",
+          "name" : "arabic"
+        },
+        "bengali_token_filter" : {
+          "type" : "stemmer",
+          "name" : "bengali"
+        },
+        "french_token_filter" : {
+          "type" : "stemmer",
+          "name" : "french"
+        },
+        "german_token_filter" : {
+          "type" : "stemmer",
+          "name" : "german"
+        },
+        "hindi_token_filter" : {
+          "type" : "stemmer",
+          "name" : "hindi"
+        },
+        "italian_token_filter" : {
+          "type" : "stemmer",
+          "name" : "italian"
+        }
+      }
+    }
+  },
+  "mappings" : {
+    "dynamic" : "strict",
+    "properties" : {
+      "state" : {
+        "type" : "object",
+        "properties" : {
+          "canonicalId" : {
+            "type" : "keyword",
+            "normalizer" : "lowercase_normalizer"
+          },
+          "sourceIdentifier" : {
+            "type" : "object",
+            "properties" : {
+              "value" : {
+                "type" : "keyword",
+                "normalizer" : "lowercase_normalizer"
+              }
+            },
+            "dynamic" : "false"
+          },
+          "sourceModifiedTime" : {
+            "type" : "date"
+          },
+          "mergedTime" : {
+            "type" : "date"
+          },
+          "indexedTime" : {
+            "type" : "date"
+          },
+          "availabilities" : {
+            "type" : "object",
+            "properties" : {
+              "id" : {
+                "type" : "keyword"
+              }
+            }
+          },
+          "relations" : {
+            "type" : "object",
+            "properties" : {
+              "ancestors" : {
+                "type" : "object",
+                "properties" : {
+                  "id" : {
+                    "type" : "keyword",
+                    "normalizer" : "lowercase_normalizer"
+                  },
+                  "depth" : {
+                    "type" : "integer"
+                  },
+                  "numChildren" : {
+                    "type" : "integer"
+                  },
+                  "numDescendents" : {
+                    "type" : "integer"
+                  },
+                  "title" : {
+                    "type" : "text",
+                    "fields" : {
+                      "keyword" : {
+                        "type" : "keyword",
+                        "normalizer" : "lowercase_normalizer"
+                      },
+                      "english" : {
+                        "type" : "text",
+                        "analyzer" : "english_analyzer"
+                      },
+                      "shingles" : {
+                        "type" : "text",
+                        "analyzer" : "shingle_asciifolding_analyzer"
+                      },
+                      "arabic" : {
+                        "type" : "text",
+                        "analyzer" : "arabic_analyzer"
+                      },
+                      "bengali" : {
+                        "type" : "text",
+                        "analyzer" : "bengali_analyzer"
+                      },
+                      "french" : {
+                        "type" : "text",
+                        "analyzer" : "french_analyzer"
+                      },
+                      "german" : {
+                        "type" : "text",
+                        "analyzer" : "german_analyzer"
+                      },
+                      "hindi" : {
+                        "type" : "text",
+                        "analyzer" : "hindi_analyzer"
+                      },
+                      "italian" : {
+                        "type" : "text",
+                        "analyzer" : "italian_analyzer"
+                      }
+                    }
+                  },
+                  "collectionPath" : {
+                    "type" : "object",
+                    "properties" : {
+                      "label" : {
+                        "type" : "text",
+                        "analyzer" : "asciifolding_analyzer",
+                        "fields" : {
+                          "keyword" : {
+                            "type" : "keyword"
+                          },
+                          "lowercaseKeyword" : {
+                            "type" : "keyword",
+                            "normalizer" : "lowercase_normalizer"
+                          }
+                        }
+                      },
+                      "path" : {
+                        "type" : "text",
+                        "analyzer" : "path_hierarchy_analyzer",
+                        "fields" : {
+                          "keyword" : {
+                            "type" : "keyword"
+                          }
+                        }
+                      },
+                      "depth" : {
+                        "type" : "token_count",
+                        "analyzer" : "standard"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "dynamic" : "false"
+          },
+          "derivedData" : {
+            "type" : "object",
+            "properties" : {
+              "contributorAgents" : {
+                "type" : "keyword"
+              }
+            },
+            "dynamic" : "false"
+          }
+        }
+      },
+      "type" : {
+        "type" : "keyword"
+      },
+      "data" : {
+        "type" : "object",
+        "properties" : {
+          "otherIdentifiers" : {
+            "type" : "object",
+            "properties" : {
+              "value" : {
+                "type" : "keyword",
+                "normalizer" : "lowercase_normalizer"
+              }
+            }
+          },
+          "format" : {
+            "type" : "object",
+            "properties" : {
+              "id" : {
+                "type" : "keyword"
+              }
+            }
+          },
+          "title" : {
+            "type" : "text",
+            "fields" : {
+              "keyword" : {
+                "type" : "keyword",
+                "normalizer" : "lowercase_normalizer"
+              },
+              "english" : {
+                "type" : "text",
+                "analyzer" : "english_analyzer"
+              },
+              "shingles" : {
+                "type" : "text",
+                "analyzer" : "shingle_asciifolding_analyzer"
+              },
+              "arabic" : {
+                "type" : "text",
+                "analyzer" : "arabic_analyzer"
+              },
+              "bengali" : {
+                "type" : "text",
+                "analyzer" : "bengali_analyzer"
+              },
+              "french" : {
+                "type" : "text",
+                "analyzer" : "french_analyzer"
+              },
+              "german" : {
+                "type" : "text",
+                "analyzer" : "german_analyzer"
+              },
+              "hindi" : {
+                "type" : "text",
+                "analyzer" : "hindi_analyzer"
+              },
+              "italian" : {
+                "type" : "text",
+                "analyzer" : "italian_analyzer"
+              }
+            }
+          },
+          "alternativeTitles" : {
+            "type" : "text",
+            "fields" : {
+              "keyword" : {
+                "type" : "keyword",
+                "normalizer" : "lowercase_normalizer"
+              },
+              "english" : {
+                "type" : "text",
+                "analyzer" : "english_analyzer"
+              },
+              "shingles" : {
+                "type" : "text",
+                "analyzer" : "shingle_asciifolding_analyzer"
+              },
+              "arabic" : {
+                "type" : "text",
+                "analyzer" : "arabic_analyzer"
+              },
+              "bengali" : {
+                "type" : "text",
+                "analyzer" : "bengali_analyzer"
+              },
+              "french" : {
+                "type" : "text",
+                "analyzer" : "french_analyzer"
+              },
+              "german" : {
+                "type" : "text",
+                "analyzer" : "german_analyzer"
+              },
+              "hindi" : {
+                "type" : "text",
+                "analyzer" : "hindi_analyzer"
+              },
+              "italian" : {
+                "type" : "text",
+                "analyzer" : "italian_analyzer"
+              }
+            }
+          },
+          "description" : {
+            "type" : "text",
+            "fields" : {
+              "english" : {
+                "type" : "text",
+                "analyzer" : "english"
+              }
+            }
+          },
+          "physicalDescription" : {
+            "type" : "text",
+            "fields" : {
+              "keyword" : {
+                "type" : "keyword"
+              },
+              "english" : {
+                "type" : "text",
+                "analyzer" : "english"
+              }
+            }
+          },
+          "lettering" : {
+            "type" : "text",
+            "fields" : {
+              "english" : {
+                "type" : "text",
+                "analyzer" : "english_analyzer"
+              },
+              "shingles" : {
+                "type" : "text",
+                "analyzer" : "shingle_asciifolding_analyzer"
+              },
+              "arabic" : {
+                "type" : "text",
+                "analyzer" : "arabic_analyzer"
+              },
+              "bengali" : {
+                "type" : "text",
+                "analyzer" : "bengali_analyzer"
+              },
+              "french" : {
+                "type" : "text",
+                "analyzer" : "french_analyzer"
+              },
+              "german" : {
+                "type" : "text",
+                "analyzer" : "german_analyzer"
+              },
+              "hindi" : {
+                "type" : "text",
+                "analyzer" : "hindi_analyzer"
+              },
+              "italian" : {
+                "type" : "text",
+                "analyzer" : "italian_analyzer"
+              }
+            }
+          },
+          "contributors" : {
+            "type" : "object",
+            "properties" : {
+              "agent" : {
+                "type" : "object",
+                "properties" : {
+                  "label" : {
+                    "type" : "text",
+                    "analyzer" : "asciifolding_analyzer",
+                    "fields" : {
+                      "keyword" : {
+                        "type" : "keyword"
+                      },
+                      "lowercaseKeyword" : {
+                        "type" : "keyword",
+                        "normalizer" : "lowercase_normalizer"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "subjects" : {
+            "type" : "object",
+            "properties" : {
+              "label" : {
+                "type" : "text",
+                "analyzer" : "asciifolding_analyzer",
+                "fields" : {
+                  "keyword" : {
+                    "type" : "keyword"
+                  },
+                  "lowercaseKeyword" : {
+                    "type" : "keyword",
+                    "normalizer" : "lowercase_normalizer"
+                  }
+                }
+              },
+              "concepts" : {
+                "type" : "object",
+                "properties" : {
+                  "label" : {
+                    "type" : "text",
+                    "analyzer" : "asciifolding_analyzer",
+                    "fields" : {
+                      "keyword" : {
+                        "type" : "keyword"
+                      },
+                      "lowercaseKeyword" : {
+                        "type" : "keyword",
+                        "normalizer" : "lowercase_normalizer"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "genres" : {
+            "type" : "object",
+            "properties" : {
+              "label" : {
+                "type" : "text",
+                "analyzer" : "asciifolding_analyzer",
+                "fields" : {
+                  "keyword" : {
+                    "type" : "keyword"
+                  },
+                  "lowercaseKeyword" : {
+                    "type" : "keyword",
+                    "normalizer" : "lowercase_normalizer"
+                  }
+                }
+              },
+              "concepts" : {
+                "type" : "object",
+                "properties" : {
+                  "label" : {
+                    "type" : "text",
+                    "analyzer" : "asciifolding_analyzer",
+                    "fields" : {
+                      "keyword" : {
+                        "type" : "keyword"
+                      },
+                      "lowercaseKeyword" : {
+                        "type" : "keyword",
+                        "normalizer" : "lowercase_normalizer"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "items" : {
+            "type" : "object",
+            "properties" : {
+              "locations" : {
+                "type" : "object",
+                "properties" : {
+                  "type" : {
+                    "type" : "keyword"
+                  },
+                  "locationType" : {
+                    "type" : "object",
+                    "properties" : {
+                      "id" : {
+                        "type" : "keyword"
+                      }
+                    }
+                  },
+                  "license" : {
+                    "type" : "object",
+                    "properties" : {
+                      "id" : {
+                        "type" : "keyword"
+                      }
+                    }
+                  },
+                  "accessConditions" : {
+                    "type" : "object",
+                    "properties" : {
+                      "status" : {
+                        "type" : "object",
+                        "properties" : {
+                          "type" : {
+                            "type" : "keyword"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "id" : {
+                "type" : "object",
+                "properties" : {
+                  "canonicalId" : {
+                    "type" : "keyword",
+                    "normalizer" : "lowercase_normalizer"
+                  },
+                  "sourceIdentifier" : {
+                    "type" : "object",
+                    "properties" : {
+                      "value" : {
+                        "type" : "keyword",
+                        "normalizer" : "lowercase_normalizer"
+                      }
+                    },
+                    "dynamic" : "false"
+                  },
+                  "otherIdentifiers" : {
+                    "type" : "object",
+                    "properties" : {
+                      "value" : {
+                        "type" : "keyword",
+                        "normalizer" : "lowercase_normalizer"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "production" : {
+            "type" : "object",
+            "properties" : {
+              "label" : {
+                "type" : "text",
+                "analyzer" : "asciifolding_analyzer",
+                "fields" : {
+                  "keyword" : {
+                    "type" : "keyword"
+                  },
+                  "lowercaseKeyword" : {
+                    "type" : "keyword",
+                    "normalizer" : "lowercase_normalizer"
+                  }
+                }
+              },
+              "places" : {
+                "type" : "object",
+                "properties" : {
+                  "label" : {
+                    "type" : "text",
+                    "analyzer" : "asciifolding_analyzer",
+                    "fields" : {
+                      "keyword" : {
+                        "type" : "keyword"
+                      },
+                      "lowercaseKeyword" : {
+                        "type" : "keyword",
+                        "normalizer" : "lowercase_normalizer"
+                      }
+                    }
+                  }
+                }
+              },
+              "agents" : {
+                "type" : "object",
+                "properties" : {
+                  "label" : {
+                    "type" : "text",
+                    "analyzer" : "asciifolding_analyzer",
+                    "fields" : {
+                      "keyword" : {
+                        "type" : "keyword"
+                      },
+                      "lowercaseKeyword" : {
+                        "type" : "keyword",
+                        "normalizer" : "lowercase_normalizer"
+                      }
+                    }
+                  }
+                }
+              },
+              "dates" : {
+                "type" : "object",
+                "properties" : {
+                  "label" : {
+                    "type" : "text",
+                    "analyzer" : "asciifolding_analyzer",
+                    "fields" : {
+                      "keyword" : {
+                        "type" : "keyword"
+                      },
+                      "lowercaseKeyword" : {
+                        "type" : "keyword",
+                        "normalizer" : "lowercase_normalizer"
+                      }
+                    }
+                  },
+                  "range" : {
+                    "type" : "object",
+                    "properties" : {
+                      "from" : {
+                        "type" : "date"
+                      }
+                    }
+                  }
+                }
+              },
+              "function" : {
+                "type" : "object",
+                "properties" : {
+                  "label" : {
+                    "type" : "text",
+                    "analyzer" : "asciifolding_analyzer",
+                    "fields" : {
+                      "keyword" : {
+                        "type" : "keyword"
+                      },
+                      "lowercaseKeyword" : {
+                        "type" : "keyword",
+                        "normalizer" : "lowercase_normalizer"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "languages" : {
+            "type" : "object",
+            "properties" : {
+              "label" : {
+                "type" : "text",
+                "analyzer" : "asciifolding_analyzer",
+                "fields" : {
+                  "keyword" : {
+                    "type" : "keyword"
+                  },
+                  "lowercaseKeyword" : {
+                    "type" : "keyword",
+                    "normalizer" : "lowercase_normalizer"
+                  }
+                }
+              },
+              "id" : {
+                "type" : "keyword"
+              }
+            }
+          },
+          "edition" : {
+            "type" : "text"
+          },
+          "notes" : {
+            "type" : "object",
+            "properties" : {
+              "content" : {
+                "type" : "text",
+                "fields" : {
+                  "english" : {
+                    "type" : "text",
+                    "analyzer" : "english"
+                  }
+                }
+              }
+            }
+          },
+          "duration" : {
+            "type" : "integer"
+          },
+          "collectionPath" : {
+            "type" : "object",
+            "properties" : {
+              "label" : {
+                "type" : "text",
+                "analyzer" : "asciifolding_analyzer",
+                "fields" : {
+                  "keyword" : {
+                    "type" : "keyword"
+                  },
+                  "lowercaseKeyword" : {
+                    "type" : "keyword",
+                    "normalizer" : "lowercase_normalizer"
+                  }
+                }
+              },
+              "path" : {
+                "type" : "text",
+                "analyzer" : "path_hierarchy_analyzer",
+                "copy_to" : [
+                  "data.collectionPath.depth"
+                ],
+                "fields" : {
+                  "keyword" : {
+                    "type" : "keyword"
+                  }
+                }
+              },
+              "depth" : {
+                "type" : "token_count",
+                "analyzer" : "standard"
+              }
+            }
+          },
+          "imageData" : {
+            "type" : "object",
+            "properties" : {
+              "id" : {
+                "type" : "object",
+                "properties" : {
+                  "canonicalId" : {
+                    "type" : "keyword",
+                    "normalizer" : "lowercase_normalizer"
+                  },
+                  "sourceIdentifier" : {
+                    "type" : "object",
+                    "properties" : {
+                      "value" : {
+                        "type" : "keyword",
+                        "normalizer" : "lowercase_normalizer"
+                      }
+                    },
+                    "dynamic" : "false"
+                  }
+                }
+              }
+            }
+          },
+          "workType" : {
+            "type" : "keyword"
+          }
+        },
+        "dynamic" : "false"
+      },
+      "invisibilityReasons" : {
+        "type" : "object",
+        "properties" : {
+          "type" : {
+            "type" : "keyword"
+          }
+        },
+        "dynamic" : "false"
+      },
+      "deletedReason" : {
+        "type" : "object",
+        "properties" : {
+          "type" : {
+            "type" : "keyword"
+          }
+        },
+        "dynamic" : "false"
+      },
+      "redirectTarget" : {
+        "type" : "object",
+        "dynamic" : "false"
+      },
+      "redirectSources" : {
+        "type" : "object",
+        "dynamic" : "false"
+      },
+      "version" : {
+        "type" : "integer"
+      }
+    },
+    "_meta" : {
+      "model.versions.0" : "b60a01f8d3d8e30a301952463e3922f2e02b8914"
+    }
+  }
+}

--- a/common/internal_model/src/test/resources/WorksIndexConfig.json
+++ b/common/internal_model/src/test/resources/WorksIndexConfig.json
@@ -849,9 +849,6 @@
       "version" : {
         "type" : "integer"
       }
-    },
-    "_meta" : {
-      "model.versions.0" : "b60a01f8d3d8e30a301952463e3922f2e02b8914"
     }
   }
 }

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/index/SearchIndexConfigJsonTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/index/SearchIndexConfigJsonTest.scala
@@ -38,7 +38,7 @@ class SearchIndexConfigJsonTest
       CreateIndexRequest(
         "works",
         analysis = Some(IndexedWorkIndexConfig.analysis),
-        mapping = Some(IndexedWorkIndexConfig.mapping)
+        mapping = Some(IndexedWorkIndexConfig.mapping.meta(Map()))
       )
     ).string()
     assertJsonStringsAreEqual(fileJson, indexJson)
@@ -55,7 +55,7 @@ class SearchIndexConfigJsonTest
       CreateIndexRequest(
         "images",
         analysis = Some(IndexedImageIndexConfig.analysis),
-        mapping = Some(IndexedImageIndexConfig.mapping)
+        mapping = Some(IndexedImageIndexConfig.mapping.meta(Map()))
       )
     ).string()
     assertJsonStringsAreEqual(fileJson, indexJson)

--- a/common/internal_model/src/test/scala/uk/ac/wellcome/models/index/SearchIndexConfigJsonTest.scala
+++ b/common/internal_model/src/test/scala/uk/ac/wellcome/models/index/SearchIndexConfigJsonTest.scala
@@ -1,0 +1,63 @@
+package uk.ac.wellcome.models.index
+
+import com.sksamuel.elastic4s.requests.indexes.{
+  CreateIndexContentBuilder,
+  CreateIndexRequest
+}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.io.Source
+import uk.ac.wellcome.json.utils.JsonAssertions
+
+/**
+  * These tests are to allow us to confirm that the JSON
+  * from the Scala index config matches the work we do
+  * in the rank app for search.
+  *
+  * The reason being is that the scala4s can _sometimes_
+  * be hard to ensure it\s creating the right JSON,
+  * which in and of itself is easy to understand.
+  *
+  * In essence the flow is test in rank,
+  * get the JSON, paste it here and create the Scala.
+  */
+class SearchIndexConfigJsonTest
+    extends AnyFunSpec
+    with Matchers
+    with JsonAssertions {
+
+  it("generates the correct works index config") {
+    val fileJson =
+      Source
+        .fromResource("WorksIndexConfig.json")
+        .getLines
+        .mkString
+
+    val indexJson = CreateIndexContentBuilder(
+      CreateIndexRequest(
+        "works",
+        analysis = Some(IndexedWorkIndexConfig.analysis),
+        mapping = Some(IndexedWorkIndexConfig.mapping)
+      )
+    ).string()
+    assertJsonStringsAreEqual(fileJson, indexJson)
+  }
+
+  it("generates the correct images index config") {
+    val fileJson =
+      Source
+        .fromResource("ImagesIndexConfig.json")
+        .getLines
+        .mkString
+
+    val indexJson = CreateIndexContentBuilder(
+      CreateIndexRequest(
+        "images",
+        analysis = Some(IndexedImageIndexConfig.analysis),
+        mapping = Some(IndexedImageIndexConfig.mapping)
+      )
+    ).string()
+    assertJsonStringsAreEqual(fileJson, indexJson)
+  }
+}


### PR DESCRIPTION
Adds tests similar to the tests in the catalogue pipeline.

Helps with the workflow, and adds a little confidence that the work we're doing in rank is being implemented correctly.

Now rank is in the repo, we'll be able to slowly integrate the two., but this will allow me to move onto implementing the less fuzzy and collection search more confidently.