### PR TITLE
Handle a bit more of the tail of access conditions

### DIFF
--- a/common/source_model/src/main/resources/logback.xml
+++ b/common/source_model/src/main/resources/logback.xml
@@ -1,0 +1,24 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender">
+    <queueSize>8192</queueSize>
+    <neverBlock>true</neverBlock>
+    <appender-ref ref="STDOUT"/>
+  </appender>
+
+  <root level="${log_level:-INFO}">
+    <appender-ref ref="ASYNC"/>
+  </root>
+
+  <!-- reduce external logging -->
+  <logger name="org.apache.http" level="ERROR"/>
+  <logger name="io.netty" level="ERROR"/>
+  <logger name="com.amazonaws" level="${log_level:-WARN}"/>
+  <logger name="software.amazon.awssdk" level="${log_level:-WARN}"/>
+  <logger name="com.sksamuel.elastic4s" level="${log_level:-WARN}"/>
+</configuration>

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -1,5 +1,6 @@
 package weco.catalogue.source_model.sierra.rules
 
+import grizzled.slf4j.Logging
 import weco.catalogue.internal_model.locations.{
   AccessCondition,
   AccessStatus,
@@ -27,7 +28,7 @@ import weco.catalogue.source_model.sierra.source.{
   *     data from Sierra.
   *
   */
-object SierraItemAccess extends SierraQueryOps {
+object SierraItemAccess extends SierraQueryOps with Logging {
   def apply(
     id: SierraItemNumber,
     bibStatus: Option[AccessStatus],
@@ -281,9 +282,12 @@ object SierraItemAccess extends SierraQueryOps {
               "Item is in use by another reader. Please ask at Enquiry Desk."))),
           ItemStatus.TemporarilyUnavailable)
 
-      case other =>
-        println(s"@@ $other @@")
-        throw new Throwable(s"Unhandled!!! $other")
+      case (bibStatus, holdCount, status, opacmsg, isRequestable, location) =>
+        warn(
+          s"Unable to assign access status for item ${id.withCheckDigit}: " +
+            s"bibStatus=$bibStatus, holdCount=$holdCount, status=$status, " +
+            s"opacmsg=$opacmsg, isRequestable=$isRequestable, location=$location"
+        )
         (None, ItemStatus.Unavailable)
     }
   }

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -205,7 +205,8 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           Some(OpacMsg.DonorPermission),
           _: NotRequestable,
           Some(LocationType.ClosedStores))
-          if bibStatus.isEmpty || bibStatus.contains(AccessStatus.PermissionRequired) =>
+          if bibStatus.isEmpty || bibStatus.contains(
+            AccessStatus.PermissionRequired) =>
         (
           Some(
             AccessCondition(
@@ -222,12 +223,12 @@ object SierraItemAccess extends SierraQueryOps with Logging {
       //
       // Example: b16621980 / i15960201
       case (
-        None,
-        Some(0),
-        Some(Status.Available),
-        Some(OpacMsg.ByAppointment),
-        _: NotRequestable,
-        Some(LocationType.ClosedStores)) =>
+          None,
+          Some(0),
+          Some(Status.Available),
+          Some(OpacMsg.ByAppointment),
+          _: NotRequestable,
+          Some(LocationType.ClosedStores)) =>
         (
           Some(
             AccessCondition(

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -213,6 +213,21 @@ object SierraItemAccess extends SierraQueryOps {
               terms = Some(message))),
           ItemStatus.Unavailable)
 
+      // A withdrawn status also overrides all other values.
+      case (
+          _,
+          _,
+          Some(Status.Withdrawn),
+          _,
+          NotRequestable.ItemWithdrawn(message),
+          _) =>
+        (
+          Some(
+            AccessCondition(
+              status = Some(AccessStatus.Unavailable),
+              terms = Some(message))),
+          ItemStatus.Unavailable)
+
       // If an item is on hold for another reader, it can't be requested -- even
       // if it would ordinarily be requestable.
       //

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -196,6 +196,20 @@ object SierraItemAccess extends SierraQueryOps {
               note = itemData.displayNote)),
           ItemStatus.Available)
 
+      case (
+          Some(AccessStatus.PermissionRequired),
+          Some(0),
+          Some(Status.PermissionRequired),
+          Some(OpacMsg.DonorPermission),
+          _: NotRequestable,
+          Some(LocationType.ClosedStores)) =>
+        (
+          Some(
+            AccessCondition(
+              status = Some(AccessStatus.PermissionRequired),
+              note = itemData.displayNote)),
+          ItemStatus.Available)
+
       // A missing status overrides all other values.
       //
       // Example: b10379198 / i10443861

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -7,7 +7,7 @@ import weco.catalogue.internal_model.locations.{
   LocationType,
   PhysicalLocationType
 }
-import weco.catalogue.source_model.sierra.SierraItemData
+import weco.catalogue.source_model.sierra.{SierraItemData, SierraItemNumber}
 import weco.catalogue.source_model.sierra.source.{
   OpacMsg,
   SierraQueryOps,
@@ -29,6 +29,7 @@ import weco.catalogue.source_model.sierra.source.{
   */
 object SierraItemAccess extends SierraQueryOps {
   def apply(
+    id: SierraItemNumber,
     bibStatus: Option[AccessStatus],
     location: Option[PhysicalLocationType],
     itemData: SierraItemData

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -197,12 +197,13 @@ object SierraItemAccess extends SierraQueryOps {
           ItemStatus.Available)
 
       case (
-          Some(AccessStatus.PermissionRequired),
+          bibStatus,
           Some(0),
           Some(Status.PermissionRequired),
           Some(OpacMsg.DonorPermission),
           _: NotRequestable,
-          Some(LocationType.ClosedStores)) =>
+          Some(LocationType.ClosedStores))
+          if bibStatus.isEmpty || bibStatus.contains(AccessStatus.PermissionRequired) =>
         (
           Some(
             AccessCondition(

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -213,6 +213,28 @@ object SierraItemAccess extends SierraQueryOps with Logging {
               note = itemData.displayNote)),
           ItemStatus.Available)
 
+      // Normally we expect the opacmsg 'By appointment' to be accompanied by the
+      // status 'permission required'.  On ~3000 items, the status is actually 'available'.
+      // We can guess what the right behaviour is, so let's map all these to 'by appointment'.
+      //
+      // TODO: Find out from the Collections team if this status/opacmsg pair is meant
+      // to exist.  If not, work with them to clean it up and then remove this branch.
+      //
+      // Example: b16621980 / i15960201
+      case (
+        None,
+        Some(0),
+        Some(Status.Available),
+        Some(OpacMsg.ByAppointment),
+        _: NotRequestable,
+        Some(LocationType.ClosedStores)) =>
+        (
+          Some(
+            AccessCondition(
+              status = Some(AccessStatus.ByAppointment),
+              note = itemData.displayNote)),
+          ItemStatus.Available)
+
       // A missing status overrides all other values.
       //
       // Example: b10379198 / i10443861

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -267,7 +267,7 @@ object SierraItemAccess extends SierraQueryOps {
 
       case other =>
         println(s"@@ $other @@")
-        throw new Throwable("Unhandled!!!")
+        throw new Throwable(s"Unhandled!!! $other")
         (None, ItemStatus.Unavailable)
     }
   }

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -282,6 +282,8 @@ object SierraItemAccess extends SierraQueryOps with Logging {
               "Item is in use by another reader. Please ask at Enquiry Desk."))),
           ItemStatus.TemporarilyUnavailable)
 
+      // If we can't work out how this item should be handled, then let's mark it
+      // as unavailable for now.
       case (bibStatus, holdCount, status, opacmsg, isRequestable, location) =>
         warn(
           s"Unable to assign access status for item ${id.withCheckDigit}: " +

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/source/Status.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/source/Status.scala
@@ -8,4 +8,5 @@ object Status {
   val Closed = "h"
   val Restricted = "6"
   val OnHoldshelf = "!"
+  val Withdrawn = "x"
 }

--- a/common/source_model/src/test/resources/logback-test.xml
+++ b/common/source_model/src/test/resources/logback-test.xml
@@ -1,0 +1,21 @@
+<configuration>
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
+  <appender name="standard" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%blue(%d{HH:mm:ss}) %magenta([%logger{0}]) %yellow(%-5level) %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="DEBUG">
+    <appender-ref ref="standard"/>
+  </root>
+
+  <!-- Edit these to change the log levels for external libraries -->
+  <logger name="org.apache.http" level="OFF"/>
+  <logger name="io.netty" level="OFF"/>
+  <logger name="com.amazonaws" level="OFF"/>
+  <logger name="software.amazon.awssdk" level="OFF"/>
+  <logger name="akka.actor" level="OFF"/>
+  <logger name="com.sksamuel.elastic4s" level="OFF"/>
+</configuration>

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -514,6 +514,36 @@ class SierraItemAccessTest
           itemStatus shouldBe ItemStatus.Available
         }
 
+        it("if the bib and item needs donor permission") {
+          val itemData = createSierraItemDataWith(
+            fixedFields = Map(
+              "79" -> FixedField(
+                label = "LOCATION",
+                value = "sicon",
+                display = "Closed stores Visual"),
+              "88" -> FixedField(
+                label = "STATUS",
+                value = "y",
+                display = "Permission required"),
+              "108" -> FixedField(
+                label = "OPACMSG",
+                value = "q",
+                display = "Donor permission"),
+            )
+          )
+
+          val (ac, itemStatus) = SierraItemAccess(
+            bibStatus = None,
+            location = Some(LocationType.ClosedStores),
+            itemData = itemData
+          )
+
+          ac shouldBe Some(
+            AccessCondition(status = AccessStatus.PermissionRequired)
+          )
+          itemStatus shouldBe ItemStatus.Available
+        }
+
         it("if the item is missing") {
           val itemData = createSierraItemDataWith(
             fixedFields = Map(

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -85,7 +85,7 @@ class SierraItemAccessTest
             .flatMap { SierraPhysicalLocationType.fromName(itemId, _) }
 
           val ac = Try {
-            SierraItemAccess(bibAccessStatus, location, itemData)
+            SierraItemAccess(itemId, bibAccessStatus, location, itemData)
           }
 
           ac match {
@@ -174,6 +174,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
+            id = itemId,
             bibStatus = None,
             location = Some(LocationType.ClosedStores),
             itemData = itemData
@@ -202,6 +203,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
+            id = itemId,
             bibStatus = Some(AccessStatus.Open),
             location = Some(LocationType.ClosedStores),
             itemData = itemData
@@ -233,6 +235,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
+            id = itemId,
             bibStatus = Some(AccessStatus.Restricted),
             location = Some(LocationType.ClosedStores),
             itemData = itemData
@@ -270,6 +273,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
+            id = itemId,
             bibStatus = None,
             location = Some(LocationType.ClosedStores),
             itemData = itemData
@@ -298,6 +302,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
+            id = itemId,
             bibStatus = None,
             location = None,
             itemData = itemData
@@ -327,6 +332,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
+            id = itemId,
             bibStatus = None,
             location = None,
             itemData = itemData
@@ -356,6 +362,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
+            id = itemId,
             bibStatus = Some(AccessStatus.Closed),
             location = Some(LocationType.ClosedStores),
             itemData = itemData
@@ -384,6 +391,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
+            id = itemId,
             bibStatus = Some(AccessStatus.Closed),
             location = None,
             itemData = itemData
@@ -412,6 +420,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
+            id = itemId,
             bibStatus = None,
             location = Some(LocationType.ClosedStores),
             itemData = itemData
@@ -440,6 +449,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
+            id = itemId,
             bibStatus = None,
             location = Some(LocationType.ClosedStores),
             itemData = itemData
@@ -473,6 +483,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
+            id = itemId,
             bibStatus = Some(AccessStatus.ByAppointment),
             location = Some(LocationType.ClosedStores),
             itemData = itemData
@@ -503,6 +514,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
+            id = itemId,
             bibStatus = Some(AccessStatus.PermissionRequired),
             location = Some(LocationType.ClosedStores),
             itemData = itemData
@@ -533,6 +545,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
+            id = itemId,
             bibStatus = None,
             location = Some(LocationType.ClosedStores),
             itemData = itemData
@@ -563,6 +576,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
+            id = itemId,
             bibStatus = None,
             location = Some(LocationType.ClosedStores),
             itemData = itemData
@@ -596,6 +610,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
+            id = itemId,
             bibStatus = None,
             location = Some(LocationType.ClosedStores),
             itemData = itemData
@@ -633,6 +648,7 @@ class SierraItemAccessTest
         )
 
         val (ac, itemStatus) = SierraItemAccess(
+          id = itemId,
           bibStatus = None,
           location = Some(LocationType.ClosedStores),
           itemData = itemData
@@ -668,6 +684,7 @@ class SierraItemAccessTest
         )
 
         val (ac, itemStatus) = SierraItemAccess(
+          id = itemId,
           bibStatus = None,
           location = Some(LocationType.ClosedStores),
           itemData = itemData
@@ -706,6 +723,7 @@ class SierraItemAccessTest
         )
 
         val (ac, itemStatus) = SierraItemAccess(
+          id = itemId,
           bibStatus = None,
           location = Some(LocationType.OpenShelves),
           itemData = itemData
@@ -741,6 +759,7 @@ class SierraItemAccessTest
         )
 
         val (ac, itemStatus) = SierraItemAccess(
+          id = itemId,
           bibStatus = None,
           location = Some(LocationType.OpenShelves),
           itemData = itemData
@@ -775,6 +794,7 @@ class SierraItemAccessTest
       )
 
       val (ac, itemStatus) = SierraItemAccess(
+        id = itemId,
         bibStatus = None,
         location = Some(LocationType.OpenShelves),
         itemData = itemData
@@ -789,4 +809,6 @@ class SierraItemAccessTest
       itemStatus shouldBe ItemStatus.Unavailable
     }
   }
+
+  val itemId: SierraItemNumber = createSierraItemNumber
 }

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -2,86 +2,20 @@ package weco.catalogue.source_model.sierra.rules
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import uk.ac.wellcome.json.JsonUtil._
 import weco.catalogue.internal_model.locations.{
   AccessCondition,
   AccessStatus,
   ItemStatus,
-  LocationType,
-  PhysicalLocationType
+  LocationType
 }
 import weco.catalogue.source_model.generators.SierraDataGenerators
-import weco.catalogue.source_model.sierra.Implicits._
+import weco.catalogue.source_model.sierra.SierraItemNumber
 import weco.catalogue.source_model.sierra.marc.{FixedField, VarField}
-import weco.catalogue.source_model.sierra.{
-  SierraBibData,
-  SierraBibNumber,
-  SierraItemData,
-  SierraItemNumber,
-  SierraTransformable
-}
-
-import java.io.{BufferedReader, FileInputStream, InputStreamReader}
 
 class SierraItemAccessTest
     extends AnyFunSpec
     with Matchers
     with SierraDataGenerators {
-  it("assigns access conditions for all Sierra items") {
-    // Note: this test is not meant to hang around long-term.  It's a test harness
-    // that runs through every SierraTransformable instance, tries to assign some
-    // access conditions, and counts how many it can't handle.
-    //
-    // Looking at the items that can't be assigned access conditions helps us
-    // find what needs fixing in the data/transformer.
-    val reader: Iterator[String] =
-      new Iterator[String] {
-        val reader =
-          new BufferedReader(
-            new InputStreamReader(new FileInputStream(
-              "/Users/alexwlchan/desktop/sierra/out_trimmed6.json")))
-
-        override def hasNext: Boolean = reader.ready
-        override def next(): String = reader.readLine()
-      }
-
-    val bibItemPairs: Iterator[
-      (SierraBibNumber, SierraBibData, SierraItemNumber, SierraItemData)] =
-      reader
-        .flatMap { json =>
-          val t = fromJson[SierraTransformable](json).get
-
-          t.maybeBibRecord match {
-            case Some(bibRecord) =>
-              val bibData = fromJson[SierraBibData](bibRecord.data).get
-              t.itemRecords.values.toList.map { itemRecord =>
-                val itemData = fromJson[SierraItemData](itemRecord.data).get
-                (bibRecord.id, bibData, itemRecord.id, itemData)
-              }
-
-            case None => List()
-          }
-        }
-
-    bibItemPairs
-      .filterNot {
-        case (_, bibData, _, itemData) =>
-          bibData.suppressed | bibData.deleted | itemData.suppressed | itemData.deleted
-      }
-      .foreach {
-        case (bibId, bibData, itemId, itemData) =>
-          // Note: When we wire up these into the items/locations code, we'll pass
-          // in these values rather than re-parse them, but this works well enough
-          // for the test harness.
-          val bibAccessStatus = SierraAccessStatus.forBib(bibId, bibData)
-          val location: Option[PhysicalLocationType] = itemData.location
-            .map { _.name }
-            .flatMap { SierraPhysicalLocationType.fromName(itemId, _) }
-
-          SierraItemAccess(itemId, bibAccessStatus, location, itemData)
-      }
-  }
-
   describe("an item in the closed stores") {
     describe("with no holds") {
       describe("can be requested online") {

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -21,14 +21,13 @@ import weco.catalogue.source_model.sierra.{
   SierraTransformable
 }
 
-import java.io.{BufferedReader, FileInputStream, InputStreamReader, PrintWriter}
-import scala.util.{Failure, Success, Try}
+import java.io.{BufferedReader, FileInputStream, InputStreamReader}
 
 class SierraItemAccessTest
     extends AnyFunSpec
     with Matchers
     with SierraDataGenerators {
-  ignore("assigns access conditions for all Sierra items") {
+  it("assigns access conditions for all Sierra items") {
     // Note: this test is not meant to hang around long-term.  It's a test harness
     // that runs through every SierraTransformable instance, tries to assign some
     // access conditions, and counts how many it can't handle.
@@ -64,11 +63,6 @@ class SierraItemAccessTest
           }
         }
 
-    var handled = 0
-    var unhandled = 0
-
-    val log = new PrintWriter("/users/alexwlchan/desktop/sierra_item_access_out.txt")
-
     bibItemPairs
       .filterNot {
         case (_, bibData, _, itemData) =>
@@ -84,72 +78,8 @@ class SierraItemAccessTest
             .map { _.name }
             .flatMap { SierraPhysicalLocationType.fromName(itemId, _) }
 
-          val ac = Try {
-            SierraItemAccess(itemId, bibAccessStatus, location, itemData)
-          }
-
-          ac match {
-            case Success(_) => handled += 1
-            case Failure(err) =>
-              log.write(s"${bibId.withCheckDigit} / ${itemId.withCheckDigit}\n")
-              log.write(s"${bibData.varFields.filter(_.marcTag.contains("506"))}\n")
-              log.write(s"location = ${itemData.location}, holdCount = ${itemData.holdCount}\n")
-
-              val interestingFixedFields = itemData.fixedFields.filterNot {
-                case (code, _) =>
-                  Set(
-                    "68",
-                    "63",
-                    "71",
-                    "72",
-                    "80",
-                    "67",
-                    "66",
-                    "69",
-                    "78",
-                    "109",
-                    "162",
-                    "264",
-                    "161",
-                    "306",
-                    "70",
-                    "86",
-                    "64",
-                    "81",
-                    "59",
-                    "64",
-                    "76",
-                    "98",
-                    "93",
-                    "84",
-                    "265",
-                    "62",
-                    "83",
-                    "77",
-                    "110",
-                    "60",
-                    "94",
-                    "127",
-                    "57",
-                    "58",
-                    "74",
-                    "85"
-                  ).contains(code)
-              }
-              log.write(s"interesting fixed fields: $interestingFixedFields\n")
-
-              val noteFields = itemData.varFields.filter(_.fieldTag.contains("n"))
-              log.write(s"notes = $noteFields\n")
-
-              log.write(s"err = $err\n\n- - -\n\n")
-
-              unhandled += 1
-          }
+          SierraItemAccess(itemId, bibAccessStatus, location, itemData)
       }
-
-    log.flush()
-
-    println(s"$handled handled, $unhandled unhandled")
   }
 
   describe("an item in the closed stores") {

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -484,6 +484,36 @@ class SierraItemAccessTest
           itemStatus shouldBe ItemStatus.Available
         }
 
+        it("if the bib and item need donor permission") {
+          val itemData = createSierraItemDataWith(
+            fixedFields = Map(
+              "79" -> FixedField(
+                label = "LOCATION",
+                value = "sc#ac",
+                display = "Unrequestable Arch. & MSS"),
+              "88" -> FixedField(
+                label = "STATUS",
+                value = "y",
+                display = "Permission required"),
+              "108" -> FixedField(
+                label = "OPACMSG",
+                value = "q",
+                display = "Donor permission"),
+            )
+          )
+
+          val (ac, itemStatus) = SierraItemAccess(
+            bibStatus = Some(AccessStatus.PermissionRequired),
+            location = Some(LocationType.ClosedStores),
+            itemData = itemData
+          )
+
+          ac shouldBe Some(
+            AccessCondition(status = AccessStatus.PermissionRequired)
+          )
+          itemStatus shouldBe ItemStatus.Available
+        }
+
         it("if the item is missing") {
           val itemData = createSierraItemDataWith(
             fixedFields = Map(

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -421,6 +421,41 @@ class SierraItemAccessTest
           itemStatus shouldBe ItemStatus.Available
         }
 
+        it("if the item is by appointment, even if the status is wrong") {
+          val itemData = createSierraItemDataWith(
+            fixedFields = Map(
+              "61" -> FixedField(
+                label = "I TYPE",
+                value = "17",
+                display = "film"),
+              "79" -> FixedField(
+                label = "LOCATION",
+                value = "mfohc",
+                display = "Closed stores Moving image and sound collections"),
+              "88" -> FixedField(
+                label = "STATUS",
+                value = "-",
+                display = "Available"),
+              "108" -> FixedField(
+                label = "OPACMSG",
+                value = "a",
+                display = "By appointment"),
+            )
+          )
+
+          val (ac, itemStatus) = SierraItemAccess(
+            id = itemId,
+            bibStatus = None,
+            location = Some(LocationType.ClosedStores),
+            itemData = itemData
+          )
+
+          ac shouldBe Some(
+            AccessCondition(status = AccessStatus.ByAppointment)
+          )
+          itemStatus shouldBe ItemStatus.Available
+        }
+
         it("if the item is missing") {
           val itemData = createSierraItemDataWith(
             fixedFields = Map(

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -511,6 +511,39 @@ class SierraItemAccessTest
           )
           itemStatus shouldBe ItemStatus.Unavailable
         }
+
+        it("if the item is withdrawn") {
+          val itemData = createSierraItemDataWith(
+            fixedFields = Map(
+              "79" -> FixedField(
+                label = "LOCATION",
+                value = "sghx2",
+                display = "Closed stores Hist. O/S 2"),
+              "88" -> FixedField(
+                label = "STATUS",
+                value = "x",
+                display = "Withdrawn"),
+              "108" -> FixedField(
+                label = "OPACMSG",
+                value = "u",
+                display = "Unavailable"),
+            )
+          )
+
+          val (ac, itemStatus) = SierraItemAccess(
+            bibStatus = None,
+            location = Some(LocationType.ClosedStores),
+            itemData = itemData
+          )
+
+          ac shouldBe Some(
+            AccessCondition(
+              status = Some(AccessStatus.Unavailable),
+              terms = Some("This item is withdrawn.")
+            )
+          )
+          itemStatus shouldBe ItemStatus.Unavailable
+        }
       }
     }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -99,6 +99,8 @@ object ExternalDependencies {
     val enumeratum = "1.6.1"
     val enumeratumScalacheck = "1.6.1"
     val jsoup = "1.13.1"
+    val logback = "1.1.8"
+
     val scalaJHttp = "2.3.0"
   }
 
@@ -175,6 +177,12 @@ object ExternalDependencies {
   val scalaJDependencies = Seq(
     "org.scalaj" %% "scalaj-http" % versions.scalaJHttp
   )
+
+  val logbackDependencies = Seq(
+    "ch.qos.logback" % "logback-classic" % versions.logback,
+    "ch.qos.logback" % "logback-core" % versions.logback,
+    "ch.qos.logback" % "logback-access" % versions.logback
+  )
 }
 
 object CatalogueDependencies {
@@ -196,7 +204,8 @@ object CatalogueDependencies {
   val sourceModelDependencies: Seq[sbt.ModuleID] =
     WellcomeDependencies.storageLibrary ++
       WellcomeDependencies.fixturesLibrary ++
-      ExternalDependencies.scalatestDependencies
+      ExternalDependencies.scalatestDependencies ++
+      ExternalDependencies.logbackDependencies
 
   val sourceModelTypesafeDependencies: Seq[ModuleID] =
     WellcomeDependencies.storageTypesafeLibrary ++


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/platform/issues/5171 as "good enough for now".

This extends the tail of items for which we can create access statuses – to 99.1% of items. This means there are ~7k items (of 787k) we don't know how to map – so we default them to Unavailable until we can get more input. I've reached out to the Collections team who are also working on cleaning up the data – either they'll give me some guidance on how to map the long tail, or change the data in Sierra to fix it. Either way, 99.1% feels plenty good enough to an initial implementation.

Once this is merged, I think we're in a suitable position to run a reindex with this new model, and get this data into the API where it can be picked up on the works pages.

