### PR TITLE
Use logging cluster id from shared state

### DIFF
--- a/infrastructure/critical/locals.tf
+++ b/infrastructure/critical/locals.tf
@@ -1,14 +1,8 @@
-data "aws_ssm_parameter" "admin_cidr_ingress" {
-  name = "/infra_critical/config/prod/admin_cidr_ingress"
-}
-
-data "ec_deployment" "logging" {
-  id = "f4c9aca09347dad4c05f35cfbec04cdb"
-}
-
 locals {
   vpc_id_new          = local.catalogue_vpcs["catalogue_vpc_delta_id"]
   private_subnets_new = local.catalogue_vpcs["catalogue_vpc_delta_private_subnets"]
+
+  logging_cluster_id = data.terraform_remote_state.infra_critical.outputs.logging_cluster_id
 
   admin_cidr_ingress = data.aws_ssm_parameter.admin_cidr_ingress.value
 
@@ -17,4 +11,12 @@ locals {
     "arn:aws:iam::964279923020:role/datascience_ec2",
     "arn:aws:iam::964279923020:root",
   ]
+}
+
+data "aws_ssm_parameter" "admin_cidr_ingress" {
+  name = "/infra_critical/config/prod/admin_cidr_ingress"
+}
+
+data "ec_deployment" "logging" {
+  id = local.logging_cluster_id
 }


### PR DESCRIPTION
This change follows the good practise of using the logging cluster ID from remote state, rather than hard coding where it can get out of date.

Dependent on: https://github.com/wellcomecollection/platform-infrastructure/pull/189