### PR TITLE
Improve how we handle the displayNote field from Sierra

### DIFF
--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -196,7 +196,7 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           NotRequestable.ItemUnavailable(_),
           _) =>
         val terms = itemData.displayNote match {
-          case Some(note) => Some(note.replace("<p>", ""))
+          case Some(note) => Some(note)
           case None =>
             Some("This item is being digitised and is currently unavailable.")
         }

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -193,7 +193,8 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           Some(
             createAccessCondition(
               status = Some(AccessStatus.TemporarilyUnavailable),
-              terms = Some("This item is being digitised and is currently unavailable."),
+              terms = Some(
+                "This item is being digitised and is currently unavailable."),
               note = itemData.displayNote)),
           ItemStatus.TemporarilyUnavailable)
 
@@ -355,7 +356,8 @@ object SierraItemAccess extends SierraQueryOps with Logging {
   ): AccessCondition = {
     val (accessTerms, accessNote) =
       (terms, note) match {
-        case (None, Some(note)) if note.containsAccessTerms => (Some(note), None)
+        case (None, Some(note)) if note.containsAccessTerms =>
+          (Some(note), None)
 
         case (Some(terms), Some(note)) if terms == note =>
           (Some(terms), None)

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/source/SierraQueryOps.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/source/SierraQueryOps.scala
@@ -66,7 +66,7 @@ trait SierraQueryOps extends Logging {
       if (varfields.isEmpty) {
         None
       } else {
-        Some(varfields.mkString("\n\n"))
+        Some(varfields.mkString("\n\n").trim)
       }
     }
   }

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/source/SierraQueryOps.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/source/SierraQueryOps.scala
@@ -66,7 +66,7 @@ trait SierraQueryOps extends Logging {
       if (varfields.isEmpty) {
         None
       } else {
-        Some(varfields.mkString("\n\n").trim)
+        Some(varfields.mkString("\n\n").trim.replace("<p>", ""))
       }
     }
   }

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -773,7 +773,8 @@ class SierraItemAccessTest
       varFields = List(
         VarField(
           fieldTag = Some("n"),
-          content = Some("Email library@wellcomecollection.org to tell us why you need the physical copy. We'll reply within a week.")
+          content = Some(
+            "Email library@wellcomecollection.org to tell us why you need the physical copy. We'll reply within a week.")
         )
       )
     )
@@ -786,7 +787,8 @@ class SierraItemAccessTest
     )
 
     ac.get.note shouldBe None
-    ac.get.terms shouldBe Some("Email library@wellcomecollection.org to tell us why you need the physical copy. We'll reply within a week.")
+    ac.get.terms shouldBe Some(
+      "Email library@wellcomecollection.org to tell us why you need the physical copy. We'll reply within a week.")
   }
 
   val itemId: SierraItemNumber = createSierraItemNumber

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -749,5 +749,45 @@ class SierraItemAccessTest
     }
   }
 
+  it("moves the display note to the terms if it's access related") {
+    val itemData = createSierraItemDataWith(
+      fixedFields = Map(
+        "61" -> FixedField(
+          label = "I TYPE",
+          value = "4",
+          display = "serial"
+        ),
+        "79" -> FixedField(
+          label = "LOCATION",
+          value = "hgser",
+          display = "Offsite"),
+        "88" -> FixedField(
+          label = "STATUS",
+          value = "y",
+          display = "Permission required"),
+        "108" -> FixedField(
+          label = "OPACMSG",
+          value = "a",
+          display = "By appointment"),
+      ),
+      varFields = List(
+        VarField(
+          fieldTag = Some("n"),
+          content = Some("Email library@wellcomecollection.org to tell us why you need the physical copy. We'll reply within a week.")
+        )
+      )
+    )
+
+    val (ac, _) = SierraItemAccess(
+      id = itemId,
+      bibStatus = None,
+      location = Some(LocationType.ClosedStores),
+      itemData = itemData
+    )
+
+    ac.get.note shouldBe None
+    ac.get.terms shouldBe Some("Email library@wellcomecollection.org to tell us why you need the physical copy. We'll reply within a week.")
+  }
+
   val itemId: SierraItemNumber = createSierraItemNumber
 }

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/source/SierraQueryOpsTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/source/SierraQueryOpsTest.scala
@@ -60,6 +60,19 @@ class SierraQueryOpsTest
 
         item.displayNote shouldBe Some("Conserved (2016)")
       }
+
+      it("removes a leading <p> tag") {
+        val item = createSierraItemDataWith(
+          varFields = List(
+            VarField(
+              fieldTag = Some("n"),
+              content = Some("<p>This item is being digitised and is currently unavailable.")
+            )
+          )
+        )
+
+        item.displayNote shouldBe Some("This item is being digitised and is currently unavailable.")
+      }
     }
   }
 

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/source/SierraQueryOpsTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/source/SierraQueryOpsTest.scala
@@ -66,12 +66,14 @@ class SierraQueryOpsTest
           varFields = List(
             VarField(
               fieldTag = Some("n"),
-              content = Some("<p>This item is being digitised and is currently unavailable.")
+              content = Some(
+                "<p>This item is being digitised and is currently unavailable.")
             )
           )
         )
 
-        item.displayNote shouldBe Some("This item is being digitised and is currently unavailable.")
+        item.displayNote shouldBe Some(
+          "This item is being digitised and is currently unavailable.")
       }
     }
   }

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/source/SierraQueryOpsTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/source/SierraQueryOpsTest.scala
@@ -47,6 +47,19 @@ class SierraQueryOpsTest
 
         item.displayNote shouldBe Some("Part of: a special collection")
       }
+
+      it("removes any whitespace") {
+        val item = createSierraItemDataWith(
+          varFields = List(
+            VarField(
+              fieldTag = Some("n"),
+              content = Some(" Conserved (2016)")
+            )
+          )
+        )
+
+        item.displayNote shouldBe Some("Conserved (2016)")
+      }
     }
   }
 


### PR DESCRIPTION
Follows https://github.com/wellcomecollection/catalogue-pipeline/pull/1644

The display note field in Sierra has two main use cases:

1. Distinguishing between different copies of an item, so people know which item to request, e.g. "impression lacking lettering"
2. Recording information about how to access the item, e.g. "please email us"

Previously we'd always put this in the "note" field on our AccessCondition model, but that doesn't seem appropriate for case (2). This patch adds some simple heuristics for improving how we map this field, in particular:

* Remove extra whitespace and `<p>` tags
* If the notes and the term are the same, we don't need both
* If the note looks like something access-related and we don't have any explicit terms, put the note in the terms field instead