### PR TITLE
Actually use the new item access in the transformer

### DIFF
--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -337,7 +337,12 @@ object SierraItemAccess extends SierraQueryOps with Logging {
             s"bibStatus=$bibStatus, holdCount=$holdCount, status=$status, " +
             s"opacmsg=$opacmsg, isRequestable=$isRequestable, location=$location"
         )
-        (None, ItemStatus.Unavailable)
+        (Some(
+          createAccessCondition(
+            status = Some(AccessStatus.TemporarilyUnavailable),
+            note = Some("Please check this item on the Wellcome Library website for access information")
+          )
+        ), ItemStatus.Unavailable)
     }
   }
 

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraAccessStatusTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraAccessStatusTest.scala
@@ -89,6 +89,19 @@ class SierraAccessStatusTest
     accessStatus shouldBe None
   }
 
+  it("returns Open if the first indicator is 0") {
+    val accessStatus = getAccessStatus(
+      bibVarFields = List(
+        VarField(
+          marcTag = Some("506"),
+          indicator1 = Some("0")
+        )
+      )
+    )
+
+    accessStatus shouldBe Some(AccessStatus.Open)
+  }
+
   it("returns None if the first indicator and subfield ǂf disagree") {
     val accessStatus = getAccessStatus(
       bibVarFields = List(

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocation.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocation.scala
@@ -3,6 +3,7 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers
 import weco.catalogue.internal_model.locations._
 import weco.catalogue.source_model.sierra.rules.{
   SierraAccessStatus,
+  SierraItemAccess,
   SierraPhysicalLocationType
 }
 import weco.catalogue.source_model.sierra.{
@@ -43,14 +44,17 @@ trait SierraLocation {
         }
       }
 
+      (accessCondition, _) =
+        SierraItemAccess(
+          id = itemNumber,
+          bibStatus = SierraAccessStatus.forBib(bibNumber, bibData),
+          location = Some(locationType),
+          itemData = itemData
+        )
+
       physicalLocation = PhysicalLocation(
         locationType = locationType,
-        accessConditions = SierraAccessStatus
-          .forBib(bibNumber, bibData)
-          .map { status =>
-            AccessCondition(status)
-          }
-          .toList,
+        accessConditions = accessCondition.toList,
         label = label,
         shelfmark = SierraShelfmark(bibData, itemData)
       )

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsTest.scala
@@ -7,10 +7,18 @@ import weco.catalogue.internal_model.identifiers.{
   IdentifierType,
   SourceIdentifier
 }
-import weco.catalogue.internal_model.locations.{LocationType, PhysicalLocation}
+import weco.catalogue.internal_model.locations.{
+  AccessCondition,
+  LocationType,
+  PhysicalLocation
+}
 import weco.catalogue.internal_model.work.Item
 import weco.catalogue.source_model.generators.SierraDataGenerators
-import weco.catalogue.source_model.sierra.marc.{MarcSubfield, VarField}
+import weco.catalogue.source_model.sierra.marc.{
+  FixedField,
+  MarcSubfield,
+  VarField
+}
 import weco.catalogue.source_model.sierra.source.SierraSourceLocation
 import weco.catalogue.source_model.sierra.{
   SierraBibData,
@@ -187,7 +195,23 @@ class SierraItemsTest
       code = "sghi2",
       name = "Closed stores Hist. 2"
     )
-    val itemData = createSierraItemDataWith(location = Some(sierraLocation))
+    val itemData = createSierraItemDataWith(
+      location = Some(sierraLocation),
+      fixedFields = Map(
+        "79" -> FixedField(
+          label = "LOCATION",
+          value = "sghi2",
+          display = "Closed stores Hist. 2"),
+        "88" -> FixedField(
+          label = "STATUS",
+          value = "-",
+          display = "Available"),
+        "108" -> FixedField(
+          label = "OPACMSG",
+          value = "f",
+          display = "Online request"),
+      )
+    )
 
     val itemDataMap = Map(createSierraItemNumber -> itemData)
 
@@ -195,7 +219,8 @@ class SierraItemsTest
     item.locations shouldBe List(
       PhysicalLocation(
         locationType = LocationType.ClosedStores,
-        label = LocationType.ClosedStores.label
+        label = LocationType.ClosedStores.label,
+        accessConditions = List(AccessCondition(terms = Some("Online request")))
       )
     )
   }
@@ -210,12 +235,8 @@ class SierraItemsTest
     val itemDataMap = Map(createSierraItemNumber -> itemData)
 
     val item = getTransformedItems(itemDataMap = itemDataMap).head
-    item.locations shouldBe List(
-      PhysicalLocation(
-        locationType = LocationType.OpenShelves,
-        label = openLocation.name
-      )
-    )
+    item.locations should have size 1
+    item.locations.head.asInstanceOf[PhysicalLocation].label shouldBe openLocation.name
   }
 
   it("creates an item with a physical location and ignores digital locations") {
@@ -229,19 +250,35 @@ class SierraItemsTest
             SierraSourceLocation("digi", "Digitised Collections"),
             SierraSourceLocation("dlnk", "Digitised content"))))
 
-    val itemDataMap = Map(
-      createSierraItemNumber -> createSierraItemDataWith(
-        location = Some(sierraPhysicalLocation1))
+    val itemData = createSierraItemDataWith(
+      location = Some(sierraPhysicalLocation1),
+      fixedFields = Map(
+        "79" -> FixedField(
+          label = "LOCATION",
+          value = "sicon",
+          display = "Closed stores Iconographic"),
+        "88" -> FixedField(
+          label = "STATUS",
+          value = "-",
+          display = "Available"),
+        "108" -> FixedField(
+          label = "OPACMSG",
+          value = "f",
+          display = "Online request"),
+      )
     )
 
     val results =
-      getTransformedItems(bibData = bibData, itemDataMap = itemDataMap)
+      getTransformedItems(
+        bibData = bibData,
+        itemDataMap = Map(createSierraItemNumber -> itemData))
 
     results.head.locations should be(
       List(
         PhysicalLocation(
           locationType = LocationType.ClosedStores,
-          label = LocationType.ClosedStores.label
+          label = LocationType.ClosedStores.label,
+          accessConditions = List(AccessCondition(terms = Some("Online request")))
         )
       ))
   }
@@ -284,12 +321,11 @@ class SierraItemsTest
 
       items should have size 4
       items.foreach {
-        _.locations shouldBe List(
-          PhysicalLocation(
-            locationType = LocationType.ClosedStores,
-            label = LocationType.ClosedStores.label
-          )
-        )
+        _.locations.foreach { loc =>
+          val physicalLoc = loc.asInstanceOf[PhysicalLocation]
+          physicalLoc.locationType shouldBe LocationType.ClosedStores
+          physicalLoc.label shouldBe LocationType.ClosedStores.label
+        }
       }
     }
 
@@ -316,12 +352,11 @@ class SierraItemsTest
 
       items should have size 4
       items.foreach {
-        _.locations shouldBe List(
-          PhysicalLocation(
-            locationType = LocationType.ClosedStores,
-            label = LocationType.ClosedStores.label
-          )
-        )
+        _.locations.foreach { loc =>
+          val physicalLoc = loc.asInstanceOf[PhysicalLocation]
+          physicalLoc.locationType shouldBe LocationType.ClosedStores
+          physicalLoc.label shouldBe LocationType.ClosedStores.label
+        }
       }
     }
 

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
@@ -133,6 +133,18 @@ class SierraTransformerTest
          |  "location": {
          |    "code": "sgmed",
          |    "name": "Closed stores Med."
+         |  },
+         |  "fixedFields": {
+         |    "88": {
+         |      "label": "STATUS",
+         |      "value": "-",
+         |      "display": "Available"
+         |    },
+         |    "108": {
+         |      "label": "OPACMSG",
+         |      "value": "f",
+         |      "display": "Online request"
+         |    }
          |  }
          |}
          |""".stripMargin
@@ -175,7 +187,8 @@ class SierraTransformerTest
       locations = List(
         PhysicalLocation(
           locationType = LocationType.ClosedStores,
-          label = LocationType.ClosedStores.label
+          label = LocationType.ClosedStores.label,
+          accessConditions = List(AccessCondition(terms = Some("Online request")))
         )
       )
     )


### PR DESCRIPTION
This is a pretty critical step to getting the data on the site!

I've also added a message directing people to Encore if we can't map an access status yet, so they'll be a bit more visible and we can direct our efforts to get them cleaned up.

This might need us to bring back that link in certain circumstances, annoyingly.