### PR TITLE
bump elastic version

### DIFF
--- a/common/internal_model/docker-compose.yml
+++ b/common/internal_model/docker-compose.yml
@@ -1,5 +1,5 @@
 elasticsearch:
-  image: "docker.elastic.co/elasticsearch/elasticsearch:7.9.0"
+  image: "docker.elastic.co/elasticsearch/elasticsearch:7.12.1"
   ports:
     - "9200:9200"
     - "9300:9300"

--- a/common/pipeline_storage/docker-compose.yml
+++ b/common/pipeline_storage/docker-compose.yml
@@ -3,7 +3,7 @@ sqs:
   ports:
     - "9324:9324"
 elasticsearch:
-  image: "docker.elastic.co/elasticsearch/elasticsearch:7.9.3"
+  image: "docker.elastic.co/elasticsearch/elasticsearch:7.12.1"
   ports:
     - "9200:9200"
     - "9300:9300"

--- a/pipeline/ingestor/ingestor_images/docker-compose.yml
+++ b/pipeline/ingestor/ingestor_images/docker-compose.yml
@@ -3,7 +3,7 @@ sqs:
   ports:
     - "9324:9324"
 elasticsearch:
-  image: "docker.elastic.co/elasticsearch/elasticsearch:7.9.0"
+  image: "docker.elastic.co/elasticsearch/elasticsearch:7.12.1"
   ports:
     - "9200:9200"
     - "9300:9300"

--- a/pipeline/ingestor/ingestor_works/docker-compose.yml
+++ b/pipeline/ingestor/ingestor_works/docker-compose.yml
@@ -3,7 +3,7 @@ sqs:
   ports:
     - "9324:9324"
 elasticsearch:
-  image: "docker.elastic.co/elasticsearch/elasticsearch:7.9.0"
+  image: "docker.elastic.co/elasticsearch/elasticsearch:7.12.1"
   ports:
     - "9200:9200"
     - "9300:9300"

--- a/pipeline/matcher/docker-compose.yml
+++ b/pipeline/matcher/docker-compose.yml
@@ -7,7 +7,7 @@ dynamodb:
   ports:
     - "45678:8000"
 elasticsearch:
-  image: "docker.elastic.co/elasticsearch/elasticsearch:7.9.3"
+  image: "docker.elastic.co/elasticsearch/elasticsearch:7.12.1"
   ports:
     - "9200:9200"
     - "9300:9300"

--- a/pipeline/relation_embedder/relation_embedder/docker-compose.yml
+++ b/pipeline/relation_embedder/relation_embedder/docker-compose.yml
@@ -4,7 +4,7 @@ sqs:
    - "9324:9324"
 
 elasticsearch:
-  image: "docker.elastic.co/elasticsearch/elasticsearch:7.9.0"
+  image: "docker.elastic.co/elasticsearch/elasticsearch:7.12.1"
   ports:
     - "9200:9200"
     - "9300:9300"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object WellcomeDependencies {
 
-  val defaultVersion = "26.14.0"
+  val defaultVersion = "26.15.0"
 
   lazy val versions = new {
     val typesafe = defaultVersion

--- a/sierra_adapter/sierra_indexer/docker-compose.yml
+++ b/sierra_adapter/sierra_indexer/docker-compose.yml
@@ -3,7 +3,7 @@ sqs:
  ports:
    - "9324:9324"
 elasticsearch:
-  image: "docker.elastic.co/elasticsearch/elasticsearch:7.9.0"
+  image: "docker.elastic.co/elasticsearch/elasticsearch:7.12.1"
   ports:
     - "9200:9200"
     - "9300:9300"


### PR DESCRIPTION
[As per the scala libs](https://github.com/wellcomecollection/scala-libs/blob/main/project/Dependencies.scala#L9)

Strangely `elastic4s` is `7.12.2`, where that doesn't really exist, elastic only goes to `7.12.1` - but `elastic4s` is weird.