### PR TITLE
add search properties to index config

### DIFF
--- a/.sbt_metadata/tei_github.json
+++ b/.sbt_metadata/tei_github.json
@@ -1,0 +1,6 @@
+{
+  "id" : "tei_github",
+  "folder" : "tei_adapter/tei_github",
+  "dependencyIds" : [
+  ]
+}

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/index/WorksIndexConfig.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/index/WorksIndexConfig.scala
@@ -95,7 +95,7 @@ object IndexedWorkIndexConfig extends WorksIndexConfig {
       englishTextKeywordField("physicalDescription"),
       multilingualField("lettering"),
       objectField("contributors").fields(
-        objectField("agent").fields(label).copyTo(titlesAndContributorsPath)
+        objectField("agent").fields(label.copyTo(titlesAndContributorsPath))
       ),
       objectField("subjects").fields(
         label,

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/index/WorksIndexConfig.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/index/WorksIndexConfig.scala
@@ -176,9 +176,15 @@ object IndexedWorkIndexConfig extends WorksIndexConfig {
         .dynamic("false")
     )
 
+  val search = objectField("search").fields(
+    textField("relations").analyzer("with_slashes_text_analyzer"),
+    multilingualField("titlesAndContributors")
+  )
+
   val fields =
     Seq(
       state,
+      search,
       keywordField("type"),
       data.dynamic("false"),
       objectField("invisibilityReasons")

--- a/common/internal_model/src/main/scala/uk/ac/wellcome/models/index/WorksIndexConfig.scala
+++ b/common/internal_model/src/main/scala/uk/ac/wellcome/models/index/WorksIndexConfig.scala
@@ -77,6 +77,9 @@ object IndexedWorkIndexConfig extends WorksIndexConfig {
   // we do not need to map every field and can save CPU.
   override val dynamicMapping: DynamicMapping = DynamicMapping.Strict
 
+  val relationsPath = List("search.relations")
+  val titlesAndContributorsPath = List("search.titlesAndContributors")
+
   // Indexing lots of individual fields on Elasticsearch can be very CPU
   // intensive, so here only include fields that are needed for querying in the
   // API.
@@ -84,13 +87,15 @@ object IndexedWorkIndexConfig extends WorksIndexConfig {
     objectField("data").fields(
       objectField("otherIdentifiers").fields(lowercaseKeyword("value")),
       objectField("format").fields(keywordField("id")),
-      multilingualFieldWithKeyword("title"),
-      multilingualFieldWithKeyword("alternativeTitles"),
+      multilingualFieldWithKeyword("title")
+        .copyTo(relationsPath ++ titlesAndContributorsPath),
+      multilingualFieldWithKeyword("alternativeTitles")
+        .copyTo(relationsPath ++ titlesAndContributorsPath),
       englishTextField("description"),
       englishTextKeywordField("physicalDescription"),
       multilingualField("lettering"),
       objectField("contributors").fields(
-        objectField("agent").fields(label)
+        objectField("agent").fields(label).copyTo(titlesAndContributorsPath)
       ),
       objectField("subjects").fields(
         label,
@@ -129,21 +134,21 @@ object IndexedWorkIndexConfig extends WorksIndexConfig {
       textField("edition"),
       objectField("notes").fields(englishTextField("content")),
       intField("duration"),
-      collectionPath(copyDepthTo = Some("data.collectionPath.depth")),
+      collectionPath(copyPathTo = Some("data.collectionPath.depth")),
       objectField("imageData").fields(
         objectField("id").fields(canonicalId, sourceIdentifier)
       ),
       keywordField("workType")
     )
 
-  def collectionPath(copyDepthTo: Option[String]) = {
+  def collectionPath(copyPathTo: Option[String]) = {
     val path = textField("path")
       .analyzer(pathAnalyzer.name)
       .fields(keywordField("keyword"))
-      .copyTo(copyDepthTo.toList)
+      .copyTo(copyPathTo.toList ++ relationsPath)
 
     objectField("collectionPath").fields(
-      label,
+      label.copyTo(relationsPath),
       path,
       tokenCountField("depth").analyzer("standard")
     )
@@ -164,8 +169,8 @@ object IndexedWorkIndexConfig extends WorksIndexConfig {
             intField("depth"),
             intField("numChildren"),
             intField("numDescendents"),
-            multilingualFieldWithKeyword("title"),
-            collectionPath(copyDepthTo = None)
+            multilingualFieldWithKeyword("title").copyTo(relationsPath),
+            collectionPath(copyPathTo = None)
           )
         )
         .dynamic("false"),

--- a/common/internal_model/src/test/resources/ImagesIndexConfig.json
+++ b/common/internal_model/src/test/resources/ImagesIndexConfig.json
@@ -36,6 +36,17 @@
           "type" : "custom",
           "tokenizer" : "whitespace"
         },
+        "with_slashes_text_analyzer": {
+          "type": "custom",
+          "tokenizer" : "standard",
+          "char_filter": [
+            "with_slashes_char_filter"
+          ],
+          "filter": [
+            "lowercase",
+            "asciifolding_token_filter"
+          ]
+        },
         "arabic_analyzer" : {
           "type" : "custom",
           "tokenizer" : "standard",
@@ -141,6 +152,12 @@
         "italian_token_filter" : {
           "type" : "stemmer",
           "name" : "italian"
+        }
+      },
+      "char_filter": {
+        "with_slashes_char_filter" : {
+          "type" : "mapping",
+          "mappings" : ["/=> __"]
         }
       }
     }

--- a/common/internal_model/src/test/resources/WorksIndexConfig.json
+++ b/common/internal_model/src/test/resources/WorksIndexConfig.json
@@ -36,15 +36,15 @@
           "type" : "custom",
           "tokenizer" : "whitespace"
         },
-        "with_slashes_text_analyzer": {
-          "type": "custom",
+        "with_slashes_text_analyzer" : {
+          "type" : "custom",
           "tokenizer" : "standard",
-          "char_filter": [
-            "with_slashes_char_filter"
-          ],
-          "filter": [
+          "filter" : [
             "lowercase",
             "asciifolding_token_filter"
+          ],
+          "char_filter" : [
+            "with_slashes_char_filter"
           ]
         },
         "arabic_analyzer" : {
@@ -111,6 +111,14 @@
           "replacement" : "/"
         }
       },
+      "char_filter" : {
+        "with_slashes_char_filter" : {
+          "type" : "mapping",
+          "mappings" : [
+            "/=> __"
+          ]
+        }
+      },
       "filter" : {
         "asciifolding_token_filter" : {
           "type" : "asciifolding",
@@ -153,64 +161,12 @@
           "type" : "stemmer",
           "name" : "italian"
         }
-      },
-      "char_filter": {
-        "with_slashes_char_filter" : {
-          "type" : "mapping",
-          "mappings" : ["/=> __"]
-        }
       }
     }
   },
   "mappings" : {
     "dynamic" : "strict",
     "properties" : {
-      "search": {
-        "type": "object",
-        "properties": {
-          "relations": {
-            "type": "text",
-            "analyzer": "with_slashes_text_analyzer"
-          },
-          "titlesAndContributors": {
-            "type": "text",
-            "fields": {
-              "arabic" : {
-                "type" : "text",
-                "analyzer" : "arabic_analyzer"
-              },
-              "bengali" : {
-                "type" : "text",
-                "analyzer" : "bengali_analyzer"
-              },
-              "english": {
-                "analyzer": "english_analyzer",
-                "type": "text"
-              },
-              "french" : {
-                "type" : "text",
-                "analyzer" : "french_analyzer"
-              },
-              "german" : {
-                "type" : "text",
-                "analyzer" : "german_analyzer"
-              },
-              "hindi" : {
-                "type" : "text",
-                "analyzer" : "hindi_analyzer"
-              },
-              "italian" : {
-                "type" : "text",
-                "analyzer" : "italian_analyzer"
-              },
-              "shingles" : {
-                "type" : "text",
-                "analyzer" : "shingle_asciifolding_analyzer"
-              }
-            }
-          }
-        }
-      },
       "state" : {
         "type" : "object",
         "properties" : {
@@ -266,6 +222,9 @@
                   },
                   "title" : {
                     "type" : "text",
+                    "copy_to" : [
+                      "search.relations"
+                    ],
                     "fields" : {
                       "keyword" : {
                         "type" : "keyword",
@@ -311,6 +270,9 @@
                       "label" : {
                         "type" : "text",
                         "analyzer" : "asciifolding_analyzer",
+                        "copy_to" : [
+                          "search.relations"
+                        ],
                         "fields" : {
                           "keyword" : {
                             "type" : "keyword"
@@ -324,6 +286,9 @@
                       "path" : {
                         "type" : "text",
                         "analyzer" : "path_hierarchy_analyzer",
+                        "copy_to" : [
+                          "search.relations"
+                        ],
                         "fields" : {
                           "keyword" : {
                             "type" : "keyword"
@@ -352,6 +317,52 @@
           }
         }
       },
+      "search" : {
+        "type" : "object",
+        "properties" : {
+          "relations" : {
+            "type" : "text",
+            "analyzer" : "with_slashes_text_analyzer"
+          },
+          "titlesAndContributors" : {
+            "type" : "text",
+            "fields" : {
+              "english" : {
+                "type" : "text",
+                "analyzer" : "english_analyzer"
+              },
+              "shingles" : {
+                "type" : "text",
+                "analyzer" : "shingle_asciifolding_analyzer"
+              },
+              "arabic" : {
+                "type" : "text",
+                "analyzer" : "arabic_analyzer"
+              },
+              "bengali" : {
+                "type" : "text",
+                "analyzer" : "bengali_analyzer"
+              },
+              "french" : {
+                "type" : "text",
+                "analyzer" : "french_analyzer"
+              },
+              "german" : {
+                "type" : "text",
+                "analyzer" : "german_analyzer"
+              },
+              "hindi" : {
+                "type" : "text",
+                "analyzer" : "hindi_analyzer"
+              },
+              "italian" : {
+                "type" : "text",
+                "analyzer" : "italian_analyzer"
+              }
+            }
+          }
+        }
+      },
       "type" : {
         "type" : "keyword"
       },
@@ -377,6 +388,10 @@
           },
           "title" : {
             "type" : "text",
+            "copy_to" : [
+              "search.relations",
+              "search.titlesAndContributors"
+            ],
             "fields" : {
               "keyword" : {
                 "type" : "keyword",
@@ -418,6 +433,10 @@
           },
           "alternativeTitles" : {
             "type" : "text",
+            "copy_to" : [
+              "search.relations",
+              "search.titlesAndContributors"
+            ],
             "fields" : {
               "keyword" : {
                 "type" : "keyword",
@@ -520,6 +539,9 @@
             "properties" : {
               "agent" : {
                 "type" : "object",
+                "copy_to" : [
+                  "search.titlesAndContributors"
+                ],
                 "properties" : {
                   "label" : {
                     "type" : "text",
@@ -825,6 +847,9 @@
               "label" : {
                 "type" : "text",
                 "analyzer" : "asciifolding_analyzer",
+                "copy_to" : [
+                  "search.relations"
+                ],
                 "fields" : {
                   "keyword" : {
                     "type" : "keyword"
@@ -839,7 +864,8 @@
                 "type" : "text",
                 "analyzer" : "path_hierarchy_analyzer",
                 "copy_to" : [
-                  "data.collectionPath.depth"
+                  "data.collectionPath.depth",
+                  "search.relations"
                 ],
                 "fields" : {
                   "keyword" : {

--- a/common/internal_model/src/test/resources/WorksIndexConfig.json
+++ b/common/internal_model/src/test/resources/WorksIndexConfig.json
@@ -539,11 +539,11 @@
             "properties" : {
               "agent" : {
                 "type" : "object",
-                "copy_to" : [
-                  "search.titlesAndContributors"
-                ],
                 "properties" : {
                   "label" : {
+                    "copy_to" : [
+                      "search.titlesAndContributors"
+                    ],
                     "type" : "text",
                     "analyzer" : "asciifolding_analyzer",
                     "fields" : {

--- a/common/internal_model/src/test/resources/WorksIndexConfig.json
+++ b/common/internal_model/src/test/resources/WorksIndexConfig.json
@@ -36,6 +36,17 @@
           "type" : "custom",
           "tokenizer" : "whitespace"
         },
+        "with_slashes_text_analyzer": {
+          "type": "custom",
+          "tokenizer" : "standard",
+          "char_filter": [
+            "with_slashes_char_filter"
+          ],
+          "filter": [
+            "lowercase",
+            "asciifolding_token_filter"
+          ]
+        },
         "arabic_analyzer" : {
           "type" : "custom",
           "tokenizer" : "standard",
@@ -142,12 +153,64 @@
           "type" : "stemmer",
           "name" : "italian"
         }
+      },
+      "char_filter": {
+        "with_slashes_char_filter" : {
+          "type" : "mapping",
+          "mappings" : ["/=> __"]
+        }
       }
     }
   },
   "mappings" : {
     "dynamic" : "strict",
     "properties" : {
+      "search": {
+        "type": "object",
+        "properties": {
+          "relations": {
+            "type": "text",
+            "analyzer": "with_slashes_text_analyzer"
+          },
+          "titlesAndContributors": {
+            "type": "text",
+            "fields": {
+              "arabic" : {
+                "type" : "text",
+                "analyzer" : "arabic_analyzer"
+              },
+              "bengali" : {
+                "type" : "text",
+                "analyzer" : "bengali_analyzer"
+              },
+              "english": {
+                "analyzer": "english_analyzer",
+                "type": "text"
+              },
+              "french" : {
+                "type" : "text",
+                "analyzer" : "french_analyzer"
+              },
+              "german" : {
+                "type" : "text",
+                "analyzer" : "german_analyzer"
+              },
+              "hindi" : {
+                "type" : "text",
+                "analyzer" : "hindi_analyzer"
+              },
+              "italian" : {
+                "type" : "text",
+                "analyzer" : "italian_analyzer"
+              },
+              "shingles" : {
+                "type" : "text",
+                "analyzer" : "shingle_asciifolding_analyzer"
+              }
+            }
+          }
+        }
+      },
       "state" : {
         "type" : "object",
         "properties" : {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -110,7 +110,8 @@ object ExternalDependencies {
   )
 
   val scribeJavaDependencies = Seq(
-    "com.github.dakatsuka" %% "akka-http-oauth2-client" % "0.2.0")
+    "com.github.dakatsuka" %% "akka-http-oauth2-client" % "0.2.0"
+  )
 
   val akkaHttpDependencies = Seq(
     "com.typesafe.akka" %% "akka-testkit" % versions.akka % "test",
@@ -133,7 +134,8 @@ object ExternalDependencies {
 
   val mockitoDependencies: Seq[ModuleID] = Seq(
     "org.mockito" % "mockito-core" % versions.mockito % "test",
-    "org.scalatestplus" %% versions.scalatestplusMockitoArtifactId % versions.scalatestplus % "test")
+    "org.scalatestplus" %% versions.scalatestplusMockitoArtifactId % versions.scalatestplus % "test"
+  )
 
   val wireMockDependencies = Seq(
     "com.github.tomakehurst" % "wiremock" % "2.25.1" % Test


### PR DESCRIPTION
This work is to give us some fields that we can search in ways to address collections search and the fuzziness issues.

In short we have:
`search.relations`: This stores the titles, refnos and altrefnos of collections, and all ancestor relations so that we can search for the IDs and titles collectively e.g. `wa/hmm durham`. Slashes are preserved (they are noramlly stripped with the standard analyzer) by mapping `/ => __`.

`search.titlesAndContributors`: This stores the titles and contributor labels. The reason for this is so we can search across fields, but also apply fuzziness, [which you cannot do with a `multi_match` `cross_fields` query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html#crossfields-fuzziness).

[You can see the new mappings and query here](https://rank.wellcomecollection.org/search?rankId=works-with-search-fields)