### PR TITLE
Only use 949 field tag c for constructing the shelfmark

### DIFF
--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraShelfmark.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraShelfmark.scala
@@ -44,10 +44,13 @@ object SierraShelfmark extends SierraQueryOps {
         //
         // We used to use the callNumber field on Sierra item records, but this
         // draws from some MARC fields that we don't want (including 999).
+        //
+        // Field tag c is for "call number" data.  In particular, we don't want
+        // to expose field tag a, which has legacy data we don't want to display.
+        // See https://wellcome.slack.com/archives/CGXDT2GSH/p1622719935015500?thread_ts=1622719185.015400&cid=CGXDT2GSH
         itemData.varFields
-          .filter { vf =>
-            vf.marcTag.contains("949")
-          }
+          .filter { _.marcTag.contains("949") }
+          .filter { _.fieldTag.contains("c") }
           .subfieldsWithTags("a")
           .headOption
           .map { _.content.trim }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocationTest.scala
@@ -145,8 +145,9 @@ class SierraLocationTest
       val itemData: SierraItemData = createSierraItemDataWith(
         location = Some(SierraSourceLocation("info", "Open shelves")),
         varFields = List(
-          createVarFieldWith(
-            marcTag = "949",
+          VarField(
+            marcTag = Some("949"),
+            fieldTag = Some("c"),
             subfields = List(
               MarcSubfield(tag = "a", content = "AX1234:Box 1")
             )

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraShelfmarkTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraShelfmarkTest.scala
@@ -24,10 +24,11 @@ class SierraShelfmarkTest
     getShelfmark(itemData = itemData) shouldBe None
   }
 
-  it("uses the contents of field 949 subfield ǂa") {
+  it("uses the contents of field 949 field tag c subfield ǂa") {
     val varFields = List(
-      createVarFieldWith(
-        marcTag = "949",
+      VarField(
+        marcTag = Some("949"),
+        fieldTag = Some("c"),
         subfields = List(
           MarcSubfield(tag = "a", content = "S7956")
         )
@@ -41,8 +42,9 @@ class SierraShelfmarkTest
 
   it("strips whitespace from shelfmarks") {
     val varFields = List(
-      createVarFieldWith(
-        marcTag = "949",
+      VarField(
+        marcTag = Some("949"),
+        fieldTag = Some("c"),
         subfields = List(
           MarcSubfield(tag = "a", content = "/LEATHER            ")
         )
@@ -56,8 +58,9 @@ class SierraShelfmarkTest
 
   it("suppresses shelfmarks for Archives & Manuscripts") {
     val varFields = List(
-      createVarFieldWith(
-        marcTag = "949",
+      VarField(
+        marcTag = Some("949"),
+        fieldTag = Some("c"),
         subfields = List(
           MarcSubfield(tag = "a", content = "PP/BOW/P.1.2.3/10:Box 123,1")
         )
@@ -77,10 +80,27 @@ class SierraShelfmarkTest
 
   it("ignores any other 949 subfields") {
     val varFields = List(
-      createVarFieldWith(
-        marcTag = "949",
+      VarField(
+        marcTag = Some("949"),
+        fieldTag = Some("c"),
         subfields = List(
           MarcSubfield(tag = "d", content = "X42461")
+        )
+      )
+    )
+
+    val itemData = createSierraItemDataWith(varFields = varFields)
+
+    getShelfmark(itemData = itemData) shouldBe None
+  }
+
+  it("ignores any instances of 949 with a different field tag") {
+    val varFields = List(
+      VarField(
+        marcTag = Some("949"),
+        fieldTag = Some("a"),
+        subfields = List(
+          MarcSubfield(tag = "a", content = "X42461")
         )
       )
     )
@@ -100,8 +120,9 @@ class SierraShelfmarkTest
       )
 
       val varFields = List(
-        createVarFieldWith(
-          marcTag = "949",
+        VarField(
+          marcTag = Some("949"),
+          fieldTag = Some("c"),
           subfields = List(
             MarcSubfield(tag = "a", content = "S7956")
           )


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/platform/issues/5188

Previously we'd pick up any instance of the 949 field for the shelfmark, but sometimes that would be field tag `a`, which has legacy data we shouldn't be exposing. Now we exclusively use field tag `c`, which is the "call number" field we're meant to be using.