### PR TITLE
Add a constructor for VarField with fieldTag + content

### DIFF
--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/marc/VarField.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/marc/VarField.scala
@@ -34,3 +34,11 @@ case class VarField(
   @JsonKey("ind2") indicator2: Option[String] = None,
   subfields: List[MarcSubfield] = Nil
 )
+
+case object VarField {
+  def apply(fieldTag: String, content: String): VarField =
+    VarField(
+      fieldTag = Some(fieldTag),
+      content = Some(content)
+    )
+}

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/marc/MarcFieldTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/marc/MarcFieldTest.scala
@@ -52,8 +52,8 @@ class MarcFieldTest extends AnyFunSpec with Matchers with JsonAssertions {
     }"""
 
     val expectedVarField = VarField(
-      fieldTag = Some("c"),
-      content = Some("Enjoying an event with enormous eagles")
+      fieldTag = "c",
+      content = "Enjoying an event with enormous eagles"
     )
 
     fromJson[VarField](jsonString).get shouldBe expectedVarField

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -379,9 +379,9 @@ class SierraItemAccessTest
             ),
             varFields = List(
               VarField(
-                fieldTag = Some("n"),
-                content = Some(
-                  "<p>This item is being digitised and is currently unavailable.")
+                fieldTag = "n",
+                content =
+                  "<p>This item is being digitised and is currently unavailable."
               )
             )
           )
@@ -690,9 +690,9 @@ class SierraItemAccessTest
           ),
           varFields = List(
             VarField(
-              fieldTag = Some("n"),
-              content = Some(
-                "Shelved at the end of the Quick Ref. section with the oversize Quick Ref. books.")
+              fieldTag = "n",
+              content =
+                "Shelved at the end of the Quick Ref. section with the oversize Quick Ref. books."
             )
           )
         )
@@ -772,9 +772,9 @@ class SierraItemAccessTest
       ),
       varFields = List(
         VarField(
-          fieldTag = Some("n"),
-          content = Some(
-            "Email library@wellcomecollection.org to tell us why you need the physical copy. We'll reply within a week.")
+          fieldTag = "n",
+          content =
+            "Email library@wellcomecollection.org to tell us why you need the physical copy. We'll reply within a week."
         )
       )
     )

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/source/SierraQueryOpsTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/source/SierraQueryOpsTest.scala
@@ -26,7 +26,7 @@ class SierraQueryOpsTest
       it("finds the content from a single field tag n") {
         val item = createSierraItemDataWith(
           varFields = List(
-            VarField(fieldTag = Some("n"), content = Some("Offsite"))
+            VarField(fieldTag = "n", content = "Offsite")
           )
         )
 
@@ -52,8 +52,8 @@ class SierraQueryOpsTest
         val item = createSierraItemDataWith(
           varFields = List(
             VarField(
-              fieldTag = Some("n"),
-              content = Some(" Conserved (2016)")
+              fieldTag = "n",
+              content = " Conserved (2016)"
             )
           )
         )
@@ -65,9 +65,9 @@ class SierraQueryOpsTest
         val item = createSierraItemDataWith(
           varFields = List(
             VarField(
-              fieldTag = Some("n"),
-              content = Some(
-                "<p>This item is being digitised and is currently unavailable.")
+              fieldTag = "n",
+              content =
+                "<p>This item is being digitised and is currently unavailable."
             )
           )
         )

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsTest.scala
@@ -39,12 +39,12 @@ class SierraHoldingsTest
       // This example is based on b1017055 / h1068096
       val varFields = List(
         VarField(
-          content = Some("00000ny   22000003n 4500"),
-          fieldTag = Some("_")
+          content = "00000ny   22000003n 4500",
+          fieldTag = "_"
         ),
         VarField(
-          content = Some("HighWire - Free Full Text"),
-          fieldTag = Some("p")
+          content = "HighWire - Free Full Text",
+          fieldTag = "p"
         )
       )
 

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsTest.scala
@@ -81,8 +81,8 @@ class SierraItemsTest
     it("uses the contents of the varfield with field tag v") {
       val itemData = createSierraItemDataWith(
         varFields = List(
-          VarField(fieldTag = Some("b"), content = Some("S11.1L")),
-          VarField(fieldTag = Some("v"), content = Some("Envelope")),
+          VarField(fieldTag = "b", content = "S11.1L"),
+          VarField(fieldTag = "v", content = "Envelope"),
         )
       )
 
@@ -92,9 +92,9 @@ class SierraItemsTest
     it("skips instances of field tag that are empty") {
       val itemData = createSierraItemDataWith(
         varFields = List(
-          VarField(fieldTag = Some("b"), content = Some("S11.1L")),
-          VarField(fieldTag = Some("v"), content = Some("")),
-          VarField(fieldTag = Some("v"), content = Some("Envelope")),
+          VarField(fieldTag = "b", content = "S11.1L"),
+          VarField(fieldTag = "v", content = ""),
+          VarField(fieldTag = "v", content = "Envelope"),
         )
       )
 
@@ -105,7 +105,7 @@ class SierraItemsTest
       "uses the contents of subfield ǂa if field tag ǂv doesn't have a contents field") {
       val itemData = createSierraItemDataWith(
         varFields = List(
-          VarField(fieldTag = Some("b"), content = Some("S11.1L")),
+          VarField(fieldTag = "b", content = "S11.1L"),
           VarField(
             fieldTag = Some("v"),
             subfields = List(
@@ -120,8 +120,8 @@ class SierraItemsTest
     it("picks the first suitable varfield if there are multiple options") {
       val itemData = createSierraItemDataWith(
         varFields = List(
-          VarField(fieldTag = Some("b"), content = Some("S11.1L")),
-          VarField(fieldTag = Some("v"), content = Some("Volumes 1–5")),
+          VarField(fieldTag = "b", content = "S11.1L"),
+          VarField(fieldTag = "v", content = "Volumes 1–5"),
           VarField(
             fieldTag = Some("v"),
             subfields = List(


### PR DESCRIPTION
This is a regular pattern, and a custom apply() means we don't have to write Some() everywhere.

A tiny improvement we spotted while writing #1655.