### PR TITLE
Deduplicate some of the holdings data

### DIFF
--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
@@ -97,6 +97,7 @@ object SierraHoldingsEnumeration extends SierraQueryOps with Logging {
           createString(id, label, value) + " " + publicNote
       }
       .map { _.trim }
+      .distinct
   }
 
   private def createString(id: TypedSierraRecordNumber,

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
@@ -349,13 +349,13 @@ object SierraHoldingsEnumeration extends SierraQueryOps with Logging {
           case Success(Seq(link, sequence)) => Some(Value(link, sequence, vf))
           case _ =>
             warn(
-              s"${id.withCheckDigit}: an instance of $labelTag subfield ǂ8 could not be parsed as a link/sequence: $content")
+              s"${id.withCheckDigit}: an instance of $valueTag subfield ǂ8 could not be parsed as a link/sequence: $content")
             None
         }
 
       case None =>
         warn(
-          s"${id.withCheckDigit}: an instance of $labelTag is missing subfield ǂ8")
+          s"${id.withCheckDigit}: an instance of $valueTag is missing subfield ǂ8")
         None
     }
 

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
@@ -106,6 +106,42 @@ class SierraHoldingsEnumerationTest
     getEnumerations(varFields) shouldBe List("vol.1 (2001)")
   }
 
+  it("deduplicates based on the rendered values") {
+    // This is based on holdings record c11058213, which is linked
+    // to bib b29248164
+    val varFields = List(
+      createVarFieldWith(
+        marcTag = "863",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "1.1"),
+          MarcSubfield(tag = "i", content = "2004-"),
+          MarcSubfield(tag = "j", content = "01-"),
+          MarcSubfield(tag = "k", content = "01-"),
+        )
+      ),
+      createVarFieldWith(
+        marcTag = "863",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "1.2"),
+          MarcSubfield(tag = "i", content = "2004-"),
+          MarcSubfield(tag = "j", content = "01-"),
+          MarcSubfield(tag = "k", content = "01-"),
+        )
+      ),
+      createVarFieldWith(
+        marcTag = "853",
+        subfields = List(
+          MarcSubfield(tag = "8", content = "1"),
+          MarcSubfield(tag = "i", content = "(year)"),
+          MarcSubfield(tag = "j", content = "(month)"),
+          MarcSubfield(tag = "k", content = "(day)"),
+        )
+      )
+    )
+
+    getEnumerations(varFields) shouldBe List("1 Jan. 2004 -")
+  }
+
   it("skips empty values in field 863") {
     // This is based on b13108608
     val varFields = List(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraHoldingsTest.scala
@@ -11,6 +11,7 @@ import weco.catalogue.internal_model.locations.{
   AccessCondition,
   AccessStatus,
   DigitalLocation,
+  LocationType,
   PhysicalLocation
 }
 import weco.catalogue.internal_model.work.Holdings
@@ -238,6 +239,98 @@ class SierraHoldingsTest
             )
           ),
           enumeration = List()
+        )
+      )
+    }
+
+    it("combines holdings if they have the same URL but distinct data") {
+      // This test is based on holdings c10885389 and c11142145, which
+      // are both linked to bib b25314166
+      val holdingsData1 = SierraHoldingsData(
+        fixedFields = Map(
+          "40" -> FixedField(label = "LOCATION", value = "elro ")
+        ),
+        varFields = List(
+          VarField(
+            marcTag = Some("863"),
+            subfields = List(
+              MarcSubfield(tag = "8", content = "1.1"),
+              MarcSubfield(tag = "i", content = "1787-1789"),
+              MarcSubfield(tag = "j", content = "01-12"),
+              MarcSubfield(tag = "k", content = "01-31")
+            )
+          ),
+          VarField(
+            marcTag = Some("853"),
+            subfields = List(
+              MarcSubfield(tag = "8", content = "1"),
+              MarcSubfield(tag = "i", content = "(year)"),
+              MarcSubfield(tag = "j", content = "(month)"),
+              MarcSubfield(tag = "k", content = "(day)")
+            )
+          ),
+          VarField(
+            marcTag = Some("856"),
+            subfields = List(
+              MarcSubfield(tag = "u", content = "http://example.org/journal"),
+              MarcSubfield(tag = "z", content = "Connect to 17th-18th Century Burney Collection newspapers")
+            )
+          )
+        )
+      )
+
+      val holdingsData2 = SierraHoldingsData(
+        fixedFields = Map(
+          "40" -> FixedField(label = "LOCATION", value = "elro ")
+        ),
+        varFields = List(
+          VarField(
+            marcTag = Some("863"),
+            subfields = List(
+              MarcSubfield(tag = "8", content = "1.1"),
+              MarcSubfield(tag = "i", content = "1787-1789"),
+              MarcSubfield(tag = "j", content = "01-12"),
+              MarcSubfield(tag = "k", content = "01-31")
+            )
+          ),
+          VarField(
+            marcTag = Some("853"),
+            subfields = List(
+              MarcSubfield(tag = "8", content = "1"),
+              MarcSubfield(tag = "i", content = "(year)"),
+              MarcSubfield(tag = "j", content = "(month)"),
+              MarcSubfield(tag = "k", content = "(day)")
+            )
+          ),
+          VarField(
+            marcTag = Some("856"),
+            subfields = List(
+              MarcSubfield(tag = "u", content = "http://example.org/journal"),
+              MarcSubfield(tag = "z", content = "Universal London Price Current -- Seventeenth and Eighteenth Century Burney Newspapers Collection")
+            )
+          )
+        )
+      )
+
+      val holdings = getHoldings(
+        Map(
+          createSierraHoldingsNumber -> holdingsData1,
+          createSierraHoldingsNumber -> holdingsData2
+        )
+      )
+
+      holdings shouldBe List(
+        Holdings(
+          note = Some("Universal London Price Current -- Seventeenth and Eighteenth Century Burney Newspapers Collection"),
+          enumeration = List("1 Jan. 1787 - 31 Dec. 1789"),
+          location = Some(
+            DigitalLocation(
+              url = "http://example.org/journal",
+              linkText = Some("Connect to 17th-18th Century Burney Collection newspapers"),
+              locationType = LocationType.OnlineResource,
+              accessConditions = List(AccessCondition(status = AccessStatus.LicensedResources))
+            )
+          )
         )
       )
     }


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5134

A lot of the holdings data is a mess, and various values have been duplicated. Because of how the holdings data arrives in Sierra, it's not necessarily easy to fix – and there are other source data fixes I'd rather prioritise.

This patch cleans up the most common forms of duplicate data, in particular:

- De-duplicating within the enumeration (this is the list of available issues, e.g. `1 Jan. 2004 - 31 Dec. 2004`)
- Merging holdings with the same URL. If the same URL appears in two holdings records, but they populate different fields (e.g. note and linkText), we combine them into a single record rather than showing the URL twice.