### PR TITLE
Add an AccessMethod type to the access condition model

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessCondition.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessCondition.scala
@@ -1,13 +1,14 @@
 package weco.catalogue.internal_model.locations
 
 case class AccessCondition(
+  method: Option[AccessMethod] = None,
   status: Option[AccessStatus] = None,
   terms: Option[String] = None,
   to: Option[String] = None,
   note: Option[String] = None
 ) {
   def isEmpty: Boolean =
-    this == AccessCondition(None, None, None)
+    this == AccessCondition()
 
   def isAvailable: Boolean = status.exists(_.isAvailable)
 

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessMethod.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessMethod.scala
@@ -1,0 +1,19 @@
+package weco.catalogue.internal_model.locations
+
+import enumeratum.{Enum, EnumEntry}
+
+sealed trait AccessMethod extends EnumEntry { this: AccessMethod =>
+  def name: String = this.getClass.getSimpleName.stripSuffix("$")
+}
+
+object AccessMethod extends Enum[License] {
+  val values = findValues
+  assert(
+    values.size == values.map { _.id }.toSet.size,
+    "IDs for AccessMethod are not unique!"
+  )
+
+  case object OnlineRequest extends AccessMethod
+  case object ManualRequest extends AccessMethod
+  case object NotRequestable extends AccessMethod
+}

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -3,6 +3,7 @@ package weco.catalogue.source_model.sierra.rules
 import grizzled.slf4j.Logging
 import weco.catalogue.internal_model.locations.{
   AccessCondition,
+  AccessMethod,
   AccessStatus,
   ItemStatus,
   LocationType,
@@ -54,8 +55,8 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           Some(LocationType.ClosedStores))
           if bibStatus.isEmpty || bibStatus.contains(AccessStatus.Open) =>
         val ac = createAccessCondition(
+          method = Some(AccessMethod.OnlineRequest),
           status = bibStatus,
-          terms = Some("Online request"),
           note = itemData.displayNote
         )
 
@@ -86,8 +87,8 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           Requestable,
           Some(LocationType.ClosedStores)) =>
         val ac = createAccessCondition(
+          method = Some(AccessMethod.OnlineRequest),
           status = Some(AccessStatus.Open),
-          terms = Some("Online request"),
           note = itemData.displayNote
         )
 
@@ -124,6 +125,7 @@ object SierraItemAccess extends SierraQueryOps with Logging {
         (
           Some(
             createAccessCondition(
+              method = Some(AccessMethod.NotRequestable),
               terms = Some(message),
               note = itemData.displayNote)),
           ItemStatus.Unavailable)
@@ -141,7 +143,7 @@ object SierraItemAccess extends SierraQueryOps with Logging {
         (
           Some(
             createAccessCondition(
-              terms = Some("Manual request"),
+              method = Some(AccessMethod.ManualRequest),
               note = itemData.displayNote)),
           ItemStatus.Available)
 
@@ -212,8 +214,8 @@ object SierraItemAccess extends SierraQueryOps with Logging {
         (
           Some(
             createAccessCondition(
+              method = Some(AccessMethod.OnlineRequest),
               status = Some(AccessStatus.Restricted),
-              terms = Some("Online request"),
               note = itemData.displayNote)),
           ItemStatus.Available)
 
@@ -358,6 +360,7 @@ object SierraItemAccess extends SierraQueryOps with Logging {
   }
 
   private def createAccessCondition(
+    method: Option[AccessMethod] = None,
     status: Option[AccessStatus] = None,
     terms: Option[String] = None,
     note: Option[String]
@@ -374,6 +377,7 @@ object SierraItemAccess extends SierraQueryOps with Logging {
       }
 
     AccessCondition(
+      method = method,
       status = status,
       terms = accessTerms,
       note = accessNote

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -4,6 +4,7 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.catalogue.internal_model.locations.{
   AccessCondition,
+  AccessMethod,
   AccessStatus,
   ItemStatus,
   LocationType
@@ -44,7 +45,7 @@ class SierraItemAccessTest
             itemData = itemData
           )
 
-          ac shouldBe Some(AccessCondition(terms = Some("Online request")))
+          ac shouldBe Some(AccessCondition(method = Some(AccessMethod.OnlineRequest)))
           itemStatus shouldBe ItemStatus.Available
         }
 
@@ -75,8 +76,8 @@ class SierraItemAccessTest
 
           ac shouldBe Some(
             AccessCondition(
-              status = Some(AccessStatus.Open),
-              terms = Some("Online request")))
+              method = Some(AccessMethod.OnlineRequest),
+              status = Some(AccessStatus.Open)))
           itemStatus shouldBe ItemStatus.Available
         }
 
@@ -107,8 +108,8 @@ class SierraItemAccessTest
 
           ac shouldBe Some(
             AccessCondition(
-              status = Some(AccessStatus.Restricted),
-              terms = Some("Online request")))
+              method = Some(AccessMethod.OnlineRequest),
+              status = Some(AccessStatus.Restricted)))
           itemStatus shouldBe ItemStatus.Available
         }
 
@@ -139,8 +140,8 @@ class SierraItemAccessTest
 
           ac shouldBe Some(
             AccessCondition(
-              status = Some(AccessStatus.Open),
-              terms = Some("Online request")))
+              method = Some(AccessMethod.OnlineRequest),
+              status = Some(AccessStatus.Open)))
           itemStatus shouldBe ItemStatus.Available
         }
       }
@@ -175,7 +176,7 @@ class SierraItemAccessTest
             itemData = itemData
           )
 
-          ac shouldBe Some(AccessCondition(terms = Some("Manual request")))
+          ac shouldBe Some(AccessCondition(method = Some(AccessMethod.ManualRequest)))
           itemStatus shouldBe ItemStatus.Available
         }
 
@@ -205,7 +206,9 @@ class SierraItemAccessTest
           )
 
           ac shouldBe Some(
-            AccessCondition(terms = Some("Please request top item.")))
+            AccessCondition(
+              method = Some(AccessMethod.NotRequestable),
+              terms = Some("Please request top item.")))
           itemStatus shouldBe ItemStatus.Unavailable
         }
 
@@ -235,7 +238,9 @@ class SierraItemAccessTest
           )
 
           ac shouldBe Some(
-            AccessCondition(terms = Some("Please request top item.")))
+            AccessCondition(
+              method = Some(AccessMethod.NotRequestable),
+              terms = Some("Please request top item.")))
           itemStatus shouldBe ItemStatus.Unavailable
         }
 

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -45,7 +45,8 @@ class SierraItemAccessTest
             itemData = itemData
           )
 
-          ac shouldBe Some(AccessCondition(method = Some(AccessMethod.OnlineRequest)))
+          ac shouldBe Some(
+            AccessCondition(method = Some(AccessMethod.OnlineRequest)))
           itemStatus shouldBe ItemStatus.Available
         }
 
@@ -176,7 +177,8 @@ class SierraItemAccessTest
             itemData = itemData
           )
 
-          ac shouldBe Some(AccessCondition(method = Some(AccessMethod.ManualRequest)))
+          ac shouldBe Some(
+            AccessCondition(method = Some(AccessMethod.ManualRequest)))
           itemStatus shouldBe ItemStatus.Available
         }
 

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsTest.scala
@@ -9,6 +9,7 @@ import weco.catalogue.internal_model.identifiers.{
 }
 import weco.catalogue.internal_model.locations.{
   AccessCondition,
+  AccessMethod,
   LocationType,
   PhysicalLocation
 }
@@ -220,7 +221,7 @@ class SierraItemsTest
       PhysicalLocation(
         locationType = LocationType.ClosedStores,
         label = LocationType.ClosedStores.label,
-        accessConditions = List(AccessCondition(terms = Some("Online request")))
+        accessConditions = List(AccessCondition(method = Some(AccessMethod.OnlineRequest)))
       )
     )
   }
@@ -281,7 +282,7 @@ class SierraItemsTest
           locationType = LocationType.ClosedStores,
           label = LocationType.ClosedStores.label,
           accessConditions =
-            List(AccessCondition(terms = Some("Online request")))
+            List(AccessCondition(method = Some(AccessMethod.OnlineRequest)))
         )
       ))
   }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsTest.scala
@@ -221,7 +221,8 @@ class SierraItemsTest
       PhysicalLocation(
         locationType = LocationType.ClosedStores,
         label = LocationType.ClosedStores.label,
-        accessConditions = List(AccessCondition(method = Some(AccessMethod.OnlineRequest)))
+        accessConditions =
+          List(AccessCondition(method = Some(AccessMethod.OnlineRequest)))
       )
     )
   }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocationTest.scala
@@ -60,7 +60,8 @@ class SierraLocationTest
       val expectedLocation = PhysicalLocation(
         locationType = LocationType.ClosedStores,
         label = LocationType.ClosedStores.label,
-        accessConditions = List(AccessCondition(method = Some(AccessMethod.OnlineRequest)))
+        accessConditions =
+          List(AccessCondition(method = Some(AccessMethod.OnlineRequest)))
       )
 
       transformer.getPhysicalLocation(bibId, itemId, itemData, bibData) shouldBe Some(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocationTest.scala
@@ -4,6 +4,7 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.catalogue.internal_model.locations.{
   AccessCondition,
+  AccessMethod,
   AccessStatus,
   LocationType,
   PhysicalLocation
@@ -59,7 +60,7 @@ class SierraLocationTest
       val expectedLocation = PhysicalLocation(
         locationType = LocationType.ClosedStores,
         label = LocationType.ClosedStores.label,
-        accessConditions = List(AccessCondition(terms = Some("Online request")))
+        accessConditions = List(AccessCondition(method = Some(AccessMethod.OnlineRequest)))
       )
 
       transformer.getPhysicalLocation(bibId, itemId, itemData, bibData) shouldBe Some(
@@ -136,8 +137,8 @@ class SierraLocationTest
         transformer.getPhysicalLocation(bibId, itemId, itemData, bibData).get
       location.accessConditions shouldBe List(
         AccessCondition(
-          status = Some(AccessStatus.Open),
-          terms = Some("Online request"))
+          method = Some(AccessMethod.OnlineRequest),
+          status = Some(AccessStatus.Open))
       )
     }
 

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraTransformerTest.scala
@@ -189,7 +189,7 @@ class SierraTransformerTest
           locationType = LocationType.ClosedStores,
           label = LocationType.ClosedStores.label,
           accessConditions =
-            List(AccessCondition(terms = Some("Online request")))
+            List(AccessCondition(method = Some(AccessMethod.OnlineRequest)))
         )
       )
     )


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5189

Right now it's pretty sparsely populated, and I haven't added NotRequestable everywhere – in particular, if the access status makes it clear that you can't request it (e.g. if the item is closed). It's a small change that gets us a bit closer to the ideal.