### PR TITLE
Link to wellcomelibrary.org directly from the access terms

### DIFF
--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -9,7 +9,11 @@ import weco.catalogue.internal_model.locations.{
   LocationType,
   PhysicalLocationType
 }
-import weco.catalogue.source_model.sierra.{SierraItemData, SierraItemNumber}
+import weco.catalogue.source_model.sierra.{
+  SierraBibNumber,
+  SierraItemData,
+  SierraItemNumber
+}
 import weco.catalogue.source_model.sierra.source.{
   OpacMsg,
   SierraQueryOps,
@@ -31,6 +35,7 @@ import weco.catalogue.source_model.sierra.source.{
   */
 object SierraItemAccess extends SierraQueryOps with Logging {
   def apply(
+    bibId: SierraBibNumber,
     itemId: SierraItemNumber,
     bibStatus: Option[AccessStatus],
     location: Option[PhysicalLocationType],
@@ -333,6 +338,13 @@ object SierraItemAccess extends SierraQueryOps with Logging {
 
       // If we can't work out how this item should be handled, then let's mark it
       // as unavailable for now.
+      //
+      // TODO: We should work with the Collections team to better handle any records
+      // that are hitting this branch.  Sending readers to Encore isn't a long-term
+      // solution.  Remove this link when Encore goes away.
+      //
+      // Note: once you remove the link, you can also remove the bibId passed into
+      // this apply() method.
       case (bibStatus, holdCount, status, opacmsg, isRequestable, location) =>
         warn(
           s"Unable to assign access status for item ${itemId.withCheckDigit}: " +
@@ -344,7 +356,7 @@ object SierraItemAccess extends SierraQueryOps with Logging {
             createAccessCondition(
               status = Some(AccessStatus.TemporarilyUnavailable),
               note = Some(
-                "Please check this item on the Wellcome Library website for access information")
+                s"""Please check this item <a href="https://search.wellcomelibrary.org/iii/encore/record/C__Rb${bibId.withoutCheckDigit}?lang=eng">on the Wellcome Library website</a> for access information""")
             )
           ),
           ItemStatus.Unavailable)

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -31,7 +31,7 @@ import weco.catalogue.source_model.sierra.source.{
   */
 object SierraItemAccess extends SierraQueryOps with Logging {
   def apply(
-    id: SierraItemNumber,
+    itemId: SierraItemNumber,
     bibStatus: Option[AccessStatus],
     location: Option[PhysicalLocationType],
     itemData: SierraItemData
@@ -335,7 +335,7 @@ object SierraItemAccess extends SierraQueryOps with Logging {
       // as unavailable for now.
       case (bibStatus, holdCount, status, opacmsg, isRequestable, location) =>
         warn(
-          s"Unable to assign access status for item ${id.withCheckDigit}: " +
+          s"Unable to assign access status for item ${itemId.withCheckDigit}: " +
             s"bibStatus=$bibStatus, holdCount=$holdCount, status=$status, " +
             s"opacmsg=$opacmsg, isRequestable=$isRequestable, location=$location"
         )

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -39,7 +39,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
-            id = itemId,
+            itemId = itemId,
             bibStatus = None,
             location = Some(LocationType.ClosedStores),
             itemData = itemData
@@ -69,7 +69,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
-            id = itemId,
+            itemId = itemId,
             bibStatus = Some(AccessStatus.Open),
             location = Some(LocationType.ClosedStores),
             itemData = itemData
@@ -101,7 +101,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
-            id = itemId,
+            itemId = itemId,
             bibStatus = Some(AccessStatus.Restricted),
             location = Some(LocationType.ClosedStores),
             itemData = itemData
@@ -133,7 +133,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
-            id = itemId,
+            itemId = itemId,
             bibStatus = Some(AccessStatus.Restricted),
             location = Some(LocationType.ClosedStores),
             itemData = itemData
@@ -171,7 +171,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
-            id = itemId,
+            itemId = itemId,
             bibStatus = None,
             location = Some(LocationType.ClosedStores),
             itemData = itemData
@@ -201,7 +201,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
-            id = itemId,
+            itemId = itemId,
             bibStatus = None,
             location = None,
             itemData = itemData
@@ -233,7 +233,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
-            id = itemId,
+            itemId = itemId,
             bibStatus = None,
             location = None,
             itemData = itemData
@@ -265,7 +265,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
-            id = itemId,
+            itemId = itemId,
             bibStatus = Some(AccessStatus.Closed),
             location = Some(LocationType.ClosedStores),
             itemData = itemData
@@ -294,7 +294,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
-            id = itemId,
+            itemId = itemId,
             bibStatus = Some(AccessStatus.Closed),
             location = None,
             itemData = itemData
@@ -323,7 +323,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
-            id = itemId,
+            itemId = itemId,
             bibStatus = None,
             location = Some(LocationType.ClosedStores),
             itemData = itemData
@@ -352,7 +352,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
-            id = itemId,
+            itemId = itemId,
             bibStatus = None,
             location = Some(LocationType.ClosedStores),
             itemData = itemData
@@ -394,7 +394,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
-            id = itemId,
+            itemId = itemId,
             bibStatus = None,
             location = Some(LocationType.ClosedStores),
             itemData = itemData
@@ -429,7 +429,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
-            id = itemId,
+            itemId = itemId,
             bibStatus = Some(AccessStatus.ByAppointment),
             location = Some(LocationType.ClosedStores),
             itemData = itemData
@@ -460,7 +460,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
-            id = itemId,
+            itemId = itemId,
             bibStatus = Some(AccessStatus.PermissionRequired),
             location = Some(LocationType.ClosedStores),
             itemData = itemData
@@ -491,7 +491,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
-            id = itemId,
+            itemId = itemId,
             bibStatus = None,
             location = Some(LocationType.ClosedStores),
             itemData = itemData
@@ -522,7 +522,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
-            id = itemId,
+            itemId = itemId,
             bibStatus = None,
             location = Some(LocationType.ClosedStores),
             itemData = itemData
@@ -556,7 +556,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
-            id = itemId,
+            itemId = itemId,
             bibStatus = None,
             location = Some(LocationType.ClosedStores),
             itemData = itemData
@@ -594,7 +594,7 @@ class SierraItemAccessTest
         )
 
         val (ac, itemStatus) = SierraItemAccess(
-          id = itemId,
+          itemId = itemId,
           bibStatus = None,
           location = Some(LocationType.ClosedStores),
           itemData = itemData
@@ -630,7 +630,7 @@ class SierraItemAccessTest
         )
 
         val (ac, itemStatus) = SierraItemAccess(
-          id = itemId,
+          itemId = itemId,
           bibStatus = None,
           location = Some(LocationType.ClosedStores),
           itemData = itemData
@@ -669,7 +669,7 @@ class SierraItemAccessTest
         )
 
         val (ac, itemStatus) = SierraItemAccess(
-          id = itemId,
+          itemId = itemId,
           bibStatus = None,
           location = Some(LocationType.OpenShelves),
           itemData = itemData
@@ -705,7 +705,7 @@ class SierraItemAccessTest
         )
 
         val (ac, itemStatus) = SierraItemAccess(
-          id = itemId,
+          itemId = itemId,
           bibStatus = None,
           location = Some(LocationType.OpenShelves),
           itemData = itemData
@@ -740,7 +740,7 @@ class SierraItemAccessTest
       )
 
       val (ac, itemStatus) = SierraItemAccess(
-        id = itemId,
+        itemId = itemId,
         bibStatus = None,
         location = Some(LocationType.OpenShelves),
         itemData = itemData
@@ -787,7 +787,7 @@ class SierraItemAccessTest
     )
 
     val (ac, _) = SierraItemAccess(
-      id = itemId,
+      itemId = itemId,
       bibStatus = None,
       location = Some(LocationType.ClosedStores),
       itemData = itemData

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -10,7 +10,7 @@ import weco.catalogue.internal_model.locations.{
   LocationType
 }
 import weco.catalogue.source_model.generators.SierraDataGenerators
-import weco.catalogue.source_model.sierra.SierraItemNumber
+import weco.catalogue.source_model.sierra.{SierraBibNumber, SierraItemNumber}
 import weco.catalogue.source_model.sierra.marc.{FixedField, VarField}
 
 class SierraItemAccessTest
@@ -39,6 +39,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
+            bibId = bibId,
             itemId = itemId,
             bibStatus = None,
             location = Some(LocationType.ClosedStores),
@@ -69,6 +70,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
+            bibId = bibId,
             itemId = itemId,
             bibStatus = Some(AccessStatus.Open),
             location = Some(LocationType.ClosedStores),
@@ -101,6 +103,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
+            bibId = bibId,
             itemId = itemId,
             bibStatus = Some(AccessStatus.Restricted),
             location = Some(LocationType.ClosedStores),
@@ -133,6 +136,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
+            bibId = bibId,
             itemId = itemId,
             bibStatus = Some(AccessStatus.Restricted),
             location = Some(LocationType.ClosedStores),
@@ -171,6 +175,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
+            bibId = bibId,
             itemId = itemId,
             bibStatus = None,
             location = Some(LocationType.ClosedStores),
@@ -201,6 +206,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
+            bibId = bibId,
             itemId = itemId,
             bibStatus = None,
             location = None,
@@ -233,6 +239,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
+            bibId = bibId,
             itemId = itemId,
             bibStatus = None,
             location = None,
@@ -265,6 +272,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
+            bibId = bibId,
             itemId = itemId,
             bibStatus = Some(AccessStatus.Closed),
             location = Some(LocationType.ClosedStores),
@@ -294,6 +302,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
+            bibId = bibId,
             itemId = itemId,
             bibStatus = Some(AccessStatus.Closed),
             location = None,
@@ -323,6 +332,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
+            bibId = bibId,
             itemId = itemId,
             bibStatus = None,
             location = Some(LocationType.ClosedStores),
@@ -352,6 +362,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
+            bibId = bibId,
             itemId = itemId,
             bibStatus = None,
             location = Some(LocationType.ClosedStores),
@@ -394,6 +405,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
+            bibId = bibId,
             itemId = itemId,
             bibStatus = None,
             location = Some(LocationType.ClosedStores),
@@ -429,6 +441,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
+            bibId = bibId,
             itemId = itemId,
             bibStatus = Some(AccessStatus.ByAppointment),
             location = Some(LocationType.ClosedStores),
@@ -460,6 +473,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
+            bibId = bibId,
             itemId = itemId,
             bibStatus = Some(AccessStatus.PermissionRequired),
             location = Some(LocationType.ClosedStores),
@@ -491,6 +505,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
+            bibId = bibId,
             itemId = itemId,
             bibStatus = None,
             location = Some(LocationType.ClosedStores),
@@ -522,6 +537,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
+            bibId = bibId,
             itemId = itemId,
             bibStatus = None,
             location = Some(LocationType.ClosedStores),
@@ -556,6 +572,7 @@ class SierraItemAccessTest
           )
 
           val (ac, itemStatus) = SierraItemAccess(
+            bibId = bibId,
             itemId = itemId,
             bibStatus = None,
             location = Some(LocationType.ClosedStores),
@@ -594,6 +611,7 @@ class SierraItemAccessTest
         )
 
         val (ac, itemStatus) = SierraItemAccess(
+          bibId = bibId,
           itemId = itemId,
           bibStatus = None,
           location = Some(LocationType.ClosedStores),
@@ -630,6 +648,7 @@ class SierraItemAccessTest
         )
 
         val (ac, itemStatus) = SierraItemAccess(
+          bibId = bibId,
           itemId = itemId,
           bibStatus = None,
           location = Some(LocationType.ClosedStores),
@@ -669,6 +688,7 @@ class SierraItemAccessTest
         )
 
         val (ac, itemStatus) = SierraItemAccess(
+          bibId = bibId,
           itemId = itemId,
           bibStatus = None,
           location = Some(LocationType.OpenShelves),
@@ -705,6 +725,7 @@ class SierraItemAccessTest
         )
 
         val (ac, itemStatus) = SierraItemAccess(
+          bibId = bibId,
           itemId = itemId,
           bibStatus = None,
           location = Some(LocationType.OpenShelves),
@@ -740,6 +761,7 @@ class SierraItemAccessTest
       )
 
       val (ac, itemStatus) = SierraItemAccess(
+        bibId = bibId,
         itemId = itemId,
         bibStatus = None,
         location = Some(LocationType.OpenShelves),
@@ -787,6 +809,7 @@ class SierraItemAccessTest
     )
 
     val (ac, _) = SierraItemAccess(
+      bibId = bibId,
       itemId = itemId,
       bibStatus = None,
       location = Some(LocationType.ClosedStores),
@@ -798,5 +821,6 @@ class SierraItemAccessTest
       "Email library@wellcomecollection.org to tell us why you need the physical copy. We'll reply within a week.")
   }
 
+  val bibId: SierraBibNumber = createSierraBibNumber
   val itemId: SierraItemNumber = createSierraItemNumber
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocation.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocation.scala
@@ -45,7 +45,7 @@ trait SierraLocation {
       }
 
       (accessCondition, _) = SierraItemAccess(
-        id = itemNumber,
+        itemId = itemNumber,
         bibStatus = SierraAccessStatus.forBib(bibNumber, bibData),
         location = Some(locationType),
         itemData = itemData

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocation.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocation.scala
@@ -45,6 +45,7 @@ trait SierraLocation {
       }
 
       (accessCondition, _) = SierraItemAccess(
+        bibId = bibNumber,
         itemId = itemNumber,
         bibStatus = SierraAccessStatus.forBib(bibNumber, bibData),
         location = Some(locationType),

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraLocationTest.scala
@@ -244,7 +244,7 @@ class SierraLocationTest
         AccessCondition(
           status = Some(AccessStatus.TemporarilyUnavailable),
           terms = Some(
-            "Please check this item on the Wellcome Library website for access information")
+            s"""Please check this item <a href="https://search.wellcomelibrary.org/iii/encore/record/C__Rb${bibId.withoutCheckDigit}?lang=eng">on the Wellcome Library website</a> for access information""")
         )
       )
     }


### PR DESCRIPTION
There are access terms that contain HTML that we'll need to render on /works (e.g. links to the Access Policy).

This patch modifies the message _"Please check this item on the Wellcome Library website for access information"_ (which gets added when we can't yet determine the access status) to include a hyperlink to the page in Encore. This lets us keep all the logic for including this link in a single place, rather than having data quality issues leak into the front-end code.