### PR TITLE
Don't add Availability.InLibrary if the location is offsite

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Availability.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Availability.scala
@@ -64,7 +64,8 @@ object Availabilities {
         // can actually see, so we don't include items that have been ordered
         // but aren't available to view yet.
         case physicalLoc: PhysicalLocation
-          if physicalLoc.locationType == LocationType.OnOrder => false
+            if physicalLoc.locationType == LocationType.OnOrder =>
+          false
 
         // Don't include items if they have a physical location but are actually
         // held in another institution.
@@ -75,7 +76,10 @@ object Availabilities {
         //
         // See https://github.com/wellcomecollection/platform/issues/5190
         case physicalLoc: PhysicalLocation
-          if physicalLoc.accessConditions.exists { _.termsAreOtherInstitution } => false
+            if physicalLoc.accessConditions.exists {
+              _.termsAreOtherInstitution
+            } =>
+          false
 
         case _: PhysicalLocation => true
 
@@ -93,13 +97,18 @@ object Availabilities {
     def termsAreOtherInstitution: Boolean =
       ac.terms match {
         case Some(t) if t.toLowerCase.contains("available at") => true
-        case Some(t) if t.toLowerCase.contains("available by appointment at") => true
+        case Some(t) if t.toLowerCase.contains("available by appointment at") =>
+          true
 
         case Some(t) if t.contains("Churchill Archives Centre") => true
-        case Some(t) if t.contains("UCL Special Collections and Archives") => true
+        case Some(t) if t.contains("UCL Special Collections and Archives") =>
+          true
         case Some(t) if t.contains("at King's College London") => true
-        case Some(t) if t.contains("at the Army Medical Services Museum") => true
-        case Some(t) if t.contains("currently remains with the Martin Leake family") => true
+        case Some(t) if t.contains("at the Army Medical Services Museum") =>
+          true
+        case Some(t)
+            if t.contains("currently remains with the Martin Leake family") =>
+          true
 
         case _ => false
       }

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/AvailabilityTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/AvailabilityTest.scala
@@ -3,7 +3,11 @@ package weco.catalogue.internal_model.work
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.models.work.generators.{ItemsGenerators, WorkGenerators}
-import weco.catalogue.internal_model.locations.{AccessStatus, LocationType}
+import weco.catalogue.internal_model.locations.{
+  AccessCondition,
+  AccessStatus,
+  LocationType
+}
 
 class AvailabilityTest
     extends AnyFunSpec
@@ -44,6 +48,27 @@ class AvailabilityTest
               locations = List(
                 createPhysicalLocationWith(
                   locationType = LocationType.OnOrder
+                )
+              ))
+          )
+        )
+      val workAvailabilities = Availabilities.forWorkData(work.data)
+
+      workAvailabilities shouldBe empty
+    }
+
+    it("does not add Availability.InLibrary if the location is offsite") {
+      val work = denormalisedWork()
+        .items(
+          List(
+            createIdentifiedItemWith(
+              locations = List(
+                createPhysicalLocationWith(
+                  accessConditions = List(
+                    AccessCondition(
+                      terms = Some("Available at Churchill Archives Centre")
+                    )
+                  )
                 )
               ))
           )


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5190

This isn't perfect, but it takes us in the right direction and removes a bunch of items from the "In the library" filter that are actually in somebody else's library.