### PR TITLE
Fix BuildKite publishing of source_model

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -71,21 +71,7 @@ steps:
   - label: publish internal model
     if: build.branch == "main"
     env:
-      PROJECT: internal_model
-    plugins:
-      - docker#v3.5.0:
-          image: "wellcome/sbt_wrapper"
-          mount-ssh-agent: true
-          volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
-          network: "host"
-          always-pull: true
-          propagate-environment: true
-          entrypoint: "/usr/bin/python3"
-    command: "/workdir/.buildkite/scripts/publish.py"
-  - label: publish source model
-    if: build.branch == "main"
-    env:
-      PROJECT: source_model
+      PROJECTS: internal_model source_model
     plugins:
       - docker#v3.5.0:
           image: "wellcome/sbt_wrapper"

--- a/.buildkite/scripts/publish.py
+++ b/.buildkite/scripts/publish.py
@@ -23,7 +23,7 @@ def publish(project_name):
 # when used with the buildkite docker plugin incorrectly parses
 # spaces as newlines preventing passing args to this script!
 if __name__ == "__main__":
-    project = os.environ.get("PROJECT")
+    projects = os.environ.get("PROJECTS").split()
     commit_range = None
     local_head = local_current_head()
 
@@ -40,10 +40,12 @@ if __name__ == "__main__":
 
     changed_paths = get_changed_paths(commit_range, globs=None)
 
-    # Determine whether we should build this project
+    # Determine whether we should build these projects
 
     sbt_repo = Repository(".sbt_metadata")
-    if not should_run_sbt_project(sbt_repo, project, changed_paths):
-        print(f"Nothing in this patch affects {project}, so stopping.")
+    if not any(should_run_sbt_project(sbt_repo, p, changed_paths) for p in projects):
+        print(f"Nothing in this patch affects {projects}, so stopping.")
         sys.exit(0)
-    publish(project)
+
+    for p in projects:
+        publish(p)

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessStatus.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessStatus.scala
@@ -24,10 +24,10 @@ sealed trait AccessStatus extends EnumEntry { this: AccessStatus =>
   }
 }
 
-object AccessStatus extends Enum[License] {
+object AccessStatus extends Enum[AccessStatus] {
   val values = findValues
   assert(
-    values.size == values.map { _.id }.toSet.size,
+    values.size == values.map { _.name }.toSet.size,
     "IDs for AccessStatus are not unique!"
   )
 


### PR DESCRIPTION
The previous commit to main published source_model 4268, but didn't publish any version of internal_model.

Because source_model has a dependency on internal_model, when you try to load that in the catalogue-api repo, you get an error:

> I need internal_model 4268 to go with source_model 4268, but I can't find it. 💥 

See the BuildKite failures for https://github.com/wellcomecollection/catalogue-api/pull/105. Publishing both libraries if either of them has changed will get around this for now.

This isn't an issue in scala-libs because publishing there is an all-or-nothing process – either everything gets published, or nothing does.

For https://github.com/wellcomecollection/catalogue-api/issues/103 