### PR TITLE
Correctly merge digitised archive material

### DIFF
--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/TargetPrecedence.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/TargetPrecedence.scala
@@ -1,0 +1,36 @@
+package uk.ac.wellcome.platform.merger.rules
+
+import weco.catalogue.internal_model.work.Work
+import weco.catalogue.internal_model.work.WorkState.Identified
+
+object TargetPrecedence {
+  import WorkPredicates._
+
+  // This is the canonical list of the order in which we try to select target works
+  private val targetPrecedence = Seq(
+    singlePhysicalItemCalmWork,
+    sierraElectronicVideo,
+    physicalSierra,
+    sierraWork
+  )
+
+  def targetSatisfying(
+    additionalPredicate: WorkPredicate
+  )(works: Seq[Work[Identified]]): Option[Work.Visible[Identified]] =
+    targetPrecedence.view
+      .flatMap(
+        pred => works.find(work => pred(work) && additionalPredicate(work))
+      )
+      .headOption
+      .collect(visibleWork)
+
+  def getTarget(
+    works: Seq[Work[Identified]]
+  ): Option[Work.Visible[Identified]] =
+    targetSatisfying(anyWork)(works)
+
+  def visibleWork
+    : PartialFunction[Work[Identified], Work.Visible[Identified]] = {
+    case work: Work.Visible[Identified] => work
+  }
+}

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/WorkPredicates.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/rules/WorkPredicates.scala
@@ -12,22 +12,30 @@ import weco.catalogue.internal_model.locations.{
 }
 import weco.catalogue.internal_model.work.{Format, Item, Work}
 
+import scala.Function.const
+
 object WorkPredicates {
   type WorkPredicate = Work[Identified] => Boolean
 
   private val sierraIdentified: WorkPredicate = identifierTypeId(
-    IdentifierType.SierraSystemNumber)
+    IdentifierType.SierraSystemNumber
+  )
   private val metsIdentified: WorkPredicate = identifierTypeId(
-    IdentifierType.METS)
+    IdentifierType.METS
+  )
   private val calmIdentified: WorkPredicate = identifierTypeId(
-    IdentifierType.CalmRecordIdentifier)
+    IdentifierType.CalmRecordIdentifier
+  )
   private val miroIdentified: WorkPredicate = identifierTypeId(
-    IdentifierType.MiroImageNumber)
+    IdentifierType.MiroImageNumber
+  )
 
   val sierraWork: WorkPredicate = sierraIdentified
   val zeroItem: WorkPredicate = work => work.data.items.isEmpty
   val singleItem: WorkPredicate = work => work.data.items.size == 1
   val multiItem: WorkPredicate = work => work.data.items.size > 1
+
+  val anyWork: WorkPredicate = const(true)
 
   val zeroIdentifiedItems: WorkPredicate =
     work =>
@@ -133,8 +141,9 @@ object WorkPredicates {
       .find(_.identifierType == IdentifierType.WellcomeDigcode)
       .exists(_.value == digcode)
 
-  private def identifierTypeId(id: IdentifierType)(
-    work: Work[Identified]): Boolean =
+  private def identifierTypeId(
+    id: IdentifierType
+  )(work: Work[Identified]): Boolean =
     work.sourceIdentifier.identifierType == id
 
   private def format(format: Format)(work: Work[Identified]): Boolean =
@@ -147,7 +156,8 @@ object WorkPredicates {
     }
 
   private def satisfiesAll(predicates: (Work[Identified] => Boolean)*)(
-    work: Work[Identified]): Boolean = predicates.forall(_(work))
+    work: Work[Identified]
+  ): Boolean = predicates.forall(_(work))
 
   implicit class WorkPredicateOps(val predA: WorkPredicate) {
     def or(predB: WorkPredicate): WorkPredicate =

--- a/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
+++ b/pipeline/merger/src/main/scala/uk/ac/wellcome/platform/merger/services/Merger.scala
@@ -31,11 +31,13 @@ trait Merger extends MergerLogging {
   type MergeState = Map[Work[Identified], Boolean]
 
   protected def findTarget(
-    works: Seq[Work[Identified]]): Option[Work.Visible[Identified]]
+    works: Seq[Work[Identified]]
+  ): Option[Work.Visible[Identified]]
 
   protected def createMergeResult(
     target: Work.Visible[Identified],
-    sources: Seq[Work[Identified]]): State[MergeState, MergeResult]
+    sources: Seq[Work[Identified]]
+  ): State[MergeState, MergeResult]
 
   private case class CategorisedWorks(
     target: Work.Visible[Identified],
@@ -47,7 +49,8 @@ trait Merger extends MergerLogging {
   }
 
   private def categoriseWorks(
-    works: Seq[Work[Identified]]): Option[CategorisedWorks] =
+    works: Seq[Work[Identified]]
+  ): Option[CategorisedWorks] =
     works match {
       case List(unmatchedWork: Work.Visible[Identified]) =>
         Some(CategorisedWorks(target = unmatchedWork))
@@ -60,7 +63,7 @@ trait Merger extends MergerLogging {
               .filterNot { _.sourceIdentifier == target.sourceIdentifier },
             deleted = matchedWorks.collect {
               case w: Work.Deleted[Identified] => w
-            },
+            }
           )
         }
     }
@@ -119,20 +122,24 @@ trait Merger extends MergerLogging {
       }
       .getOrElse(MergerOutcome.passThrough(works))
 
-  private def redirectSourceToTarget(target: Work.Visible[Identified])(
-    source: Work[Identified]): Work.Redirected[Identified] =
+  private def redirectSourceToTarget(
+    target: Work.Visible[Identified]
+  )(source: Work[Identified]): Work.Redirected[Identified] =
     Work.Redirected[Identified](
       version = source.version,
       state = Identified(
         source.sourceIdentifier,
         source.state.canonicalId,
-        source.state.sourceModifiedTime),
+        source.state.sourceModifiedTime
+      ),
       redirectTarget =
         IdState.Identified(target.state.canonicalId, target.sourceIdentifier)
     )
 
-  private def logIntentions(target: Work.Visible[Identified],
-                            sources: Seq[Work[Identified]]): Unit =
+  private def logIntentions(
+    target: Work.Visible[Identified],
+    sources: Seq[Work[Identified]]
+  ): Unit =
     sources match {
       case Nil =>
         info(s"Processing ${describeWork(target)}")
@@ -140,12 +147,15 @@ trait Merger extends MergerLogging {
         info(s"Attempting to merge ${describeMergeSet(target, sources)}")
     }
 
-  private def logResult(result: MergeResult,
-                        redirects: Seq[Work[_]],
-                        remaining: Seq[Work[_]]): Unit = {
+  private def logResult(
+    result: MergeResult,
+    redirects: Seq[Work[_]],
+    remaining: Seq[Work[_]]
+  ): Unit = {
     if (redirects.nonEmpty) {
       info(
-        s"Merged ${describeMergeOutcome(result.mergedTarget, redirects, remaining)}")
+        s"Merged ${describeMergeOutcome(result.mergedTarget, redirects, remaining)}"
+      )
     }
     if (result.imageDataWithSources.nonEmpty) {
       info(s"Created images ${describeImages(result.imageDataWithSources)}")
@@ -156,7 +166,8 @@ trait Merger extends MergerLogging {
 object Merger {
   // Parameter can't be `State` as that shadows the Cats type
   implicit class WorkMergingOps[StateT <: WorkState](
-    work: Work.Visible[StateT]) {
+    work: Work.Visible[StateT]
+  ) {
     def mapData(
       f: WorkData[StateT#WorkDataState] => WorkData[StateT#WorkDataState]
     ): Work.Visible[StateT] =
@@ -169,19 +180,14 @@ object PlatformMerger extends Merger {
   import Merger.WorkMergingOps
 
   override def findTarget(
-    works: Seq[Work[Identified]]): Option[Work.Visible[Identified]] =
-    works
-      .find(WorkPredicates.singlePhysicalItemCalmWork)
-      .orElse(works.find(WorkPredicates.sierraElectronicVideo))
-      .orElse(works.find(WorkPredicates.physicalSierra))
-      .orElse(works.find(WorkPredicates.sierraWork)) match {
-      case Some(target: Work.Visible[Identified]) => Some(target)
-      case _                                      => None
-    }
+    works: Seq[Work[Identified]]
+  ): Option[Work.Visible[Identified]] =
+    TargetPrecedence.getTarget(works)
 
   override def createMergeResult(
     target: Work.Visible[Identified],
-    sources: Seq[Work[Identified]]): State[MergeState, MergeResult] =
+    sources: Seq[Work[Identified]]
+  ): State[MergeState, MergeResult] =
     if (sources.isEmpty)
       State.pure(
         MergeResult(
@@ -211,24 +217,24 @@ object PlatformMerger extends Merger {
             imageData = sourceImageData
           )
         }
-      } yield
-        MergeResult(
-          mergedTarget = work,
-          imageDataWithSources = sourceImageData.map { imageData =>
-            ImageDataWithSource(
-              imageData = imageData,
-              source = image.ParentWorks(
-                canonicalWork = work.toParentWork,
-                redirectedWork = sources
-                  .find { _.data.imageData.contains(imageData) }
-                  .map(_.toParentWork)
-              )
+      } yield MergeResult(
+        mergedTarget = work,
+        imageDataWithSources = sourceImageData.map { imageData =>
+          ImageDataWithSource(
+            imageData = imageData,
+            source = image.ParentWorks(
+              canonicalWork = work.toParentWork,
+              redirectedWork = sources
+                .find { _.data.imageData.contains(imageData) }
+                .map(_.toParentWork)
             )
-          }
-        )
+          )
+        }
+      )
 
   private def standaloneImages(
-    target: Work.Visible[Identified]): List[ImageData[IdState.Identified]] =
+    target: Work.Visible[Identified]
+  ): List[ImageData[IdState.Identified]] =
     if (WorkPredicates.singleDigitalItemMiroWork(target)) target.data.imageData
     else Nil
 }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerScenarioTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/MergerScenarioTest.scala
@@ -196,6 +196,52 @@ class MergerScenarioTest
       calmItem.id shouldBe sierra.data.items.head.id
     }
 
+    Scenario("A Calm work, a Sierra work, and a Miro work are matched") {
+      Given("A Calm work, a Sierra work and a Miro work")
+      val sierra = sierraPhysicalIdentifiedWork()
+      val calm = calmIdentifiedWork()
+      val miro = miroIdentifiedWork()
+
+      When("the works are merged")
+      val outcome = merger.merge(Seq(sierra, calm, miro))
+
+      Then("the Sierra work is redirected to the Calm work")
+      outcome.getMerged(sierra) should beRedirectedTo(calm)
+
+      And("the Miro work is redirected to the Calm work")
+      outcome.getMerged(miro) should beRedirectedTo(calm)
+
+      And("the Calm work contains the Miro location")
+      outcome.getMerged(calm).data.items.flatMap(_.locations) should
+        contain(miro.data.items.head.locations.head)
+      And("the Calm work contains the Miro image")
+      outcome.getMerged(calm).data.imageData should contain(miro.singleImage)
+    }
+
+    Scenario("A Calm work, a Sierra picture work, and a METS work are matched") {
+      Given("A Calm work, a Sierra picture work and a METS work")
+      val sierraPicture = sierraIdentifiedWork()
+        .items(List(createIdentifiedPhysicalItem))
+        .format(Format.Pictures)
+      val calm = calmIdentifiedWork()
+      val mets = metsIdentifiedWork()
+
+      When("the works are merged")
+      val outcome = merger.merge(Seq(sierraPicture, calm, mets))
+
+      Then("the Sierra work is redirected to the Calm work")
+      outcome.getMerged(sierraPicture) should beRedirectedTo(calm)
+
+      And("the METS work is redirected to the Calm work")
+      outcome.getMerged(mets) should beRedirectedTo(calm)
+
+      And("the Calm work contains the METS location")
+      outcome.getMerged(calm).data.items.flatMap(_.locations) should
+        contain(mets.data.items.head.locations.head)
+      And("the Calm work contains the METS image")
+      outcome.getMerged(calm).data.imageData should contain(mets.singleImage)
+    }
+
     Scenario("A digitised video with Sierra physical records and e-bibs") {
       // This test case is based on a real example of four related works that
       // were being merged incorrectly.  In particular, the METS work (and associated

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/TargetPrecedenceTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/TargetPrecedenceTest.scala
@@ -42,7 +42,7 @@ class TargetPrecedenceTest
         )
         .value shouldBe multiItemPhysicalSierra
     }
-    it("finally, chooses any remaining sierra work") {
+    it("finally, chooses any remaining Sierra work") {
       TargetPrecedence
         .getTarget(
           Seq(digitalSierra, miro)
@@ -56,10 +56,12 @@ class TargetPrecedenceTest
   }
 
   it("can apply an additional predicate for target selection") {
-    TargetPrecedence
-      .targetSatisfying(WorkPredicates.singleItemSierra)(
-        Seq(multiItemPhysicalSierra, digitalSierra, miro)
-      )
-      .value shouldBe digitalSierra
+    val works = Seq(multiItemPhysicalSierra, digitalSierra, miro)
+    val nonPredicated = TargetPrecedence.getTarget(works)
+    val singleItemPredicated =
+      TargetPrecedence.targetSatisfying(WorkPredicates.singleItemSierra)(works)
+
+    nonPredicated.value shouldBe multiItemPhysicalSierra
+    singleItemPredicated.value shouldBe digitalSierra
   }
 }

--- a/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/TargetPrecedenceTest.scala
+++ b/pipeline/merger/src/test/scala/uk/ac/wellcome/platform/merger/rules/TargetPrecedenceTest.scala
@@ -1,0 +1,65 @@
+package uk.ac.wellcome.platform.merger.rules
+
+import org.scalatest.OptionValues
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.models.work.generators.SourceWorkGenerators
+import weco.catalogue.internal_model.work.Format
+
+class TargetPrecedenceTest
+    extends AnyFunSpec
+    with Matchers
+    with SourceWorkGenerators
+    with OptionValues {
+
+  val calm = calmIdentifiedWork()
+  val videoSierra = sierraDigitalIdentifiedWork().format(Format.Videos)
+  val multiItemPhysicalSierra = sierraIdentifiedWork().items(
+    List(createIdentifiedPhysicalItem, createIdentifiedPhysicalItem)
+  )
+  val digitalSierra = sierraDigitalIdentifiedWork()
+  val miro = miroIdentifiedWork()
+
+  describe("target precedence is respected") {
+    it("first, chooses a Calm work") {
+      TargetPrecedence
+        .getTarget(
+          Seq(calm, videoSierra, multiItemPhysicalSierra, digitalSierra, miro)
+        )
+        .value shouldBe calm
+    }
+    it("second, chooses a Sierra e-video") {
+      TargetPrecedence
+        .getTarget(
+          Seq(videoSierra, multiItemPhysicalSierra, digitalSierra, miro)
+        )
+        .value shouldBe videoSierra
+    }
+    it("third, chooses a physical Sierra work") {
+      TargetPrecedence
+        .getTarget(
+          Seq(multiItemPhysicalSierra, digitalSierra, miro)
+        )
+        .value shouldBe multiItemPhysicalSierra
+    }
+    it("finally, chooses any remaining sierra work") {
+      TargetPrecedence
+        .getTarget(
+          Seq(digitalSierra, miro)
+        )
+        .value shouldBe digitalSierra
+    }
+  }
+
+  it("returns None if no valid targets are present") {
+    TargetPrecedence.getTarget(Seq(miro)) shouldBe empty
+  }
+
+  it("can apply an additional predicate for target selection") {
+    TargetPrecedence
+      .targetSatisfying(WorkPredicates.singleItemSierra)(
+        Seq(multiItemPhysicalSierra, digitalSierra, miro)
+      )
+      .value shouldBe digitalSierra
+  }
+}


### PR DESCRIPTION
I have been claiming that METS/Miro works linked to a Sierra work that is linked to a Calm record get merged correctly based on the rules that we have for merging to "plain" Sierra works - turns out that wasn't true!

This PR resolves that issue by merging METS and Miro items, and by changing the `ImageDataRule` so that it always uses a Sierra target in the graph, even if the "principal" target as identified by the top-level merger is a Calm work.