### PR TITLE
Update the handling of 5XX notes fields in Sierra

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Note.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Note.scala
@@ -57,3 +57,5 @@ case class ArrangementNote(content: String) extends Note
 case class LetteringNote(content: String) extends Note
 
 case class LanguageNote(content: String) extends Note
+
+case class ReferencesNote(content: String) extends Note

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraNotes.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraNotes.scala
@@ -44,6 +44,14 @@ object SierraNotes extends SierraDataTransformer with SierraQueryOps {
   def apply(bibData: SierraBibData): List[Note] =
     bibData.varFields
       .map {
+        // For the 561 "Ownership and Custodial History" field, we only want
+        // to expose the note when the 1st indicator is 1 ("public note").
+        // We don't want to expose the field otherwise.
+        //
+        // See https://www.loc.gov/marc/bibliographic/bd561.html
+        case vf @ VarField(_, Some("561"), _, Some("1"), _, _) =>
+          Some((vf, Some(createNoteFromContents(OwnershipNote))))
+
         case vf @ VarField(_, Some(marcTag), _, _, _, _) =>
           Some((vf, notesFields.get(marcTag)))
         case _ => None

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraNotes.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraNotes.scala
@@ -18,7 +18,7 @@ object SierraNotes extends SierraDataTransformer with SierraQueryOps {
     "505" -> createNoteFromContents(ContentsNote),
     "506" -> createNoteFromContents(TermsOfUse),
     "508" -> createNoteFromContents(CreditsNote),
-    "510" -> createNoteFromContents(PublicationsNote),
+    "510" -> createNoteFromContents(ReferencesNote),
     "511" -> createNoteFromContents(CreditsNote),
     "514" -> createNoteFromContents(LetteringNote),
     "518" -> createNoteFromContents(TimeAndPlaceNote),

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraNotesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraNotesTest.scala
@@ -3,12 +3,9 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.catalogue.internal_model.work._
-import weco.catalogue.source_model.generators.{
-  MarcGenerators,
-  SierraDataGenerators
-}
+import weco.catalogue.source_model.generators.{MarcGenerators, SierraDataGenerators}
 import weco.catalogue.source_model.sierra.SierraBibData
-import weco.catalogue.source_model.sierra.marc.MarcSubfield
+import weco.catalogue.source_model.sierra.marc.{MarcSubfield, VarField}
 
 class SierraNotesTest
     extends AnyFunSpec
@@ -118,6 +115,37 @@ class SierraNotesTest
     SierraNotes(bibData) shouldBe List(
       LocationOfOriginalNote("The originals are in Oman"),
       LocationOfDuplicatesNote("The duplicates are in Denmark")
+    )
+  }
+
+  it("only gets an ownership note if 561 1st indicator is 1") {
+    val bibData = createSierraBibDataWith(
+      varFields = List(
+        VarField(
+          marcTag = Some("561"),
+          indicator1 = Some("1"),
+          subfields = List(
+            MarcSubfield(tag = "a", content = "Provenance: one plate in the set of plates"),
+          )
+        ),
+        VarField(
+          marcTag = Some("561"),
+          indicator1 = Some("0"),
+          subfields = List(
+            MarcSubfield(tag = "a", content = "Purchased from John Smith on 01/01/2001"),
+          )
+        ),
+        VarField(
+          marcTag = Some("561"),
+          indicator1 = None,
+          subfields = List(
+            MarcSubfield(tag = "a", content = "Private contact details for John Smith"),
+          )
+        )
+      )
+    )
+    SierraNotes(bibData) shouldBe List(
+      OwnershipNote("Provenance: one plate in the set of plates")
     )
   }
 

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraNotesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraNotesTest.scala
@@ -25,7 +25,7 @@ class SierraNotesTest
       "505" -> ContentsNote("contents note"),
       "506" -> TermsOfUse("typical terms of use"),
       "508" -> CreditsNote("credits note a"),
-      "510" -> PublicationsNote("publications a"),
+      "510" -> ReferencesNote("references a"),
       "511" -> CreditsNote("credits note b"),
       "514" -> LetteringNote("Completeness:"),
       "518" -> TimeAndPlaceNote("time and place note"),

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraNotesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraNotesTest.scala
@@ -3,7 +3,10 @@ package uk.ac.wellcome.platform.transformer.sierra.transformers
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.catalogue.internal_model.work._
-import weco.catalogue.source_model.generators.{MarcGenerators, SierraDataGenerators}
+import weco.catalogue.source_model.generators.{
+  MarcGenerators,
+  SierraDataGenerators
+}
 import weco.catalogue.source_model.sierra.SierraBibData
 import weco.catalogue.source_model.sierra.marc.{MarcSubfield, VarField}
 
@@ -125,21 +128,27 @@ class SierraNotesTest
           marcTag = Some("561"),
           indicator1 = Some("1"),
           subfields = List(
-            MarcSubfield(tag = "a", content = "Provenance: one plate in the set of plates"),
+            MarcSubfield(
+              tag = "a",
+              content = "Provenance: one plate in the set of plates"),
           )
         ),
         VarField(
           marcTag = Some("561"),
           indicator1 = Some("0"),
           subfields = List(
-            MarcSubfield(tag = "a", content = "Purchased from John Smith on 01/01/2001"),
+            MarcSubfield(
+              tag = "a",
+              content = "Purchased from John Smith on 01/01/2001"),
           )
         ),
         VarField(
           marcTag = Some("561"),
           indicator1 = None,
           subfields = List(
-            MarcSubfield(tag = "a", content = "Private contact details for John Smith"),
+            MarcSubfield(
+              tag = "a",
+              content = "Private contact details for John Smith"),
           )
         )
       )


### PR DESCRIPTION
* Map the 510 notes field to a ReferencesNote (https://github.com/wellcomecollection/platform/issues/5198)
* Create an ownership note from 561 if ind1 = '1' (https://github.com/wellcomecollection/platform/issues/5199)

These changes won't appear in the API immediately – we need to sort out the CCR issues, and the new `ReferencesNote` will need an internal_model bump in the API.