### PR TITLE
Add functions for creating a TermsOfUse note from Calm data

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessStatus.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessStatus.scala
@@ -5,7 +5,10 @@ import enumeratum.{Enum, EnumEntry}
 class UnknownAccessStatus(status: String) extends Exception(status)
 
 sealed trait AccessStatus extends EnumEntry { this: AccessStatus =>
-  def name: String = this.getClass.getSimpleName.stripSuffix("$")
+  val id: String
+  val label: String
+
+  def name: String = id
 
   def isAvailable: Boolean = this match {
     case AccessStatus.Open              => true
@@ -37,23 +40,50 @@ object AccessStatus extends Enum[AccessStatus] {
   //
   // This is based on §12 Research access, as retrieved 8 February 2021
   //
-  case object Open extends AccessStatus
+  case object Open extends AccessStatus {
+    override val id: String = "open"
+    override val label: String = "Open"
+  }
 
-  case object OpenWithAdvisory extends AccessStatus
+  case object OpenWithAdvisory extends AccessStatus {
+    override val id: String = "open-with-advisory"
+    override val label: String = "Open with advisory"
+  }
 
-  case object Restricted extends AccessStatus
+  case object Restricted extends AccessStatus {
+    override val id: String = "restricted"
+    override val label: String = "Restricted"
+  }
 
-  case object ByAppointment extends AccessStatus
+  case object ByAppointment extends AccessStatus {
+    override val id: String = "by-appointment"
+    override val label: String = "By appointment"
+  }
 
-  case object TemporarilyUnavailable extends AccessStatus
+  case object TemporarilyUnavailable extends AccessStatus {
+    override val id: String = "temporarily-unavailable"
+    override val label: String = "Temporarily unavailable"
+  }
 
-  case object Unavailable extends AccessStatus
+  case object Unavailable extends AccessStatus {
+    override val id: String = "unavailable"
+    override val label: String = "Unavailable"
+  }
 
-  case object Closed extends AccessStatus
+  case object Closed extends AccessStatus {
+    override val id: String = "closed"
+    override val label: String = "Closed"
+  }
 
-  case object LicensedResources extends AccessStatus
+  case object LicensedResources extends AccessStatus {
+    override val id: String = "licensed-resources"
+    override val label: String = "Licensed resources"
+  }
 
-  case object PermissionRequired extends AccessStatus
+  case object PermissionRequired extends AccessStatus {
+    override val id: String = "permission-required"
+    override val label: String = "Permission required"
+  }
 
   def apply(status: String): Either[Exception, AccessStatus] = {
     val normalisedStatus = status.trim.stripSuffix(".").trim.toLowerCase()

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessStatus.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessStatus.scala
@@ -5,10 +5,10 @@ import enumeratum.{Enum, EnumEntry}
 class UnknownAccessStatus(status: String) extends Exception(status)
 
 sealed trait AccessStatus extends EnumEntry { this: AccessStatus =>
+  def name: String = this.getClass.getSimpleName.stripSuffix("$")
+
   val id: String
   val label: String
-
-  def name: String = id
 
   def isAvailable: Boolean = this match {
     case AccessStatus.Open              => true

--- a/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/models/CalmRecordOps.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/models/CalmRecordOps.scala
@@ -7,7 +7,7 @@ trait CalmRecordOps {
   implicit class CalmRecordOps(record: CalmRecord) {
 
     def get(key: String): Option[String] =
-      getList(key).headOption
+      getList(key).distinct.headOption
 
     def getList(key: String): List[String] =
       record.data

--- a/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/transformers/CalmTermsOfUse.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/transformers/CalmTermsOfUse.scala
@@ -1,0 +1,9 @@
+package uk.ac.wellcome.platform.transformer.calm.transformers
+
+import weco.catalogue.internal_model.work.TermsOfUse
+import weco.catalogue.source_model.calm.CalmRecord
+
+object CalmTermsOfUse {
+  def apply(record: CalmRecord): Option[TermsOfUse] =
+    throw new NotImplementedError(s"record = $record")
+}

--- a/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/transformers/CalmTermsOfUse.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/transformers/CalmTermsOfUse.scala
@@ -1,9 +1,36 @@
 package uk.ac.wellcome.platform.transformer.calm.transformers
 
+import uk.ac.wellcome.platform.transformer.calm.CalmRecordOps
+import weco.catalogue.internal_model.locations.AccessStatus
 import weco.catalogue.internal_model.work.TermsOfUse
 import weco.catalogue.source_model.calm.CalmRecord
 
-object CalmTermsOfUse {
-  def apply(record: CalmRecord): Option[TermsOfUse] =
-    throw new NotImplementedError(s"record = $record")
+object CalmTermsOfUse extends CalmRecordOps {
+  def apply(record: CalmRecord): Option[TermsOfUse] = {
+    val accessConditions = record.getJoined("AccessConditions")
+
+    val accessStatus = getAccessStatus(record)
+
+    val closedUntil = record.get("ClosedUntil")
+    val restrictedUntil = record.get("RestrictedUntil")
+
+    val terms =
+      (accessConditions, accessStatus, closedUntil, restrictedUntil) match {
+        // If there are conditions and no dates, we
+        case (Some(conditions), Some(status), None, None) =>
+          Some(s"$conditions ${status.label}.")
+
+        case _ => throw new NotImplementedError(s"record = $record")
+      }
+
+    terms.map(TermsOfUse)
+  }
+
+  private def getAccessStatus(record: CalmRecord): Option[AccessStatus] =
+    record.get("AccessStatus") match {
+      case Some("Open")       => Some(AccessStatus.Open)
+      case Some("Closed")     => Some(AccessStatus.Closed)
+      case Some("Restricted") => Some(AccessStatus.Restricted)
+      case _                  => None
+    }
 }

--- a/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/transformers/CalmTermsOfUse.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/uk/ac/wellcome/platform/transformer/calm/transformers/CalmTermsOfUse.scala
@@ -5,20 +5,40 @@ import weco.catalogue.internal_model.locations.AccessStatus
 import weco.catalogue.internal_model.work.TermsOfUse
 import weco.catalogue.source_model.calm.CalmRecord
 
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
 object CalmTermsOfUse extends CalmRecordOps {
   def apply(record: CalmRecord): Option[TermsOfUse] = {
     val accessConditions = record.getJoined("AccessConditions")
 
     val accessStatus = getAccessStatus(record)
 
-    val closedUntil = record.get("ClosedUntil")
+    val closedUntil = record.get("ClosedUntil").map(parseAsDate)
     val restrictedUntil = record.get("RestrictedUntil")
 
     val terms =
       (accessConditions, accessStatus, closedUntil, restrictedUntil) match {
-        // If there are conditions and no dates, we
+
+        // If there are conditions and no dates, we just create a sentence and
+        // append the access status.  We don't repeat the access status if it's
+        // already stated in the conditions.
+        //
+        // Examples:
+        //
+        //      The papers are available subject to the usual conditions of access
+        //      to Archives and Manuscripts material. Open.
+        //
+        //      Closed on depositor agreement.
+        //
+        case (Some(conditions), Some(status), None, None) if conditions.startsWith(status.label) =>
+          Some(conditions)
         case (Some(conditions), Some(status), None, None) =>
           Some(s"$conditions ${status.label}.")
+
+        // If the item is closed, we include the closure date.
+        case (Some(conditions), Some(AccessStatus.Closed), Some(closedUntil), _) =>
+          Some(createClosedMessage(conditions, closedUntil))
 
         case _ => throw new NotImplementedError(s"record = $record")
       }
@@ -26,11 +46,48 @@ object CalmTermsOfUse extends CalmRecordOps {
     terms.map(TermsOfUse)
   }
 
+  // e.g. 1 January 2021
+  private val displayFormat = DateTimeFormatter.ofPattern("d MMMM yyyy")
+
+  private def createClosedMessage(conditions: String, closedUntil: LocalDate): String =
+    (conditions, closedUntil) match {
+      case (conditions, closedUntil) if conditions.isSingleSentence & conditions.toLowerCase.contains("closed") & conditions.containsDate(closedUntil) =>
+        conditions
+
+      case (conditions, closedUntil) =>
+        s"$conditions Closed until ${closedUntil.format(displayFormat)}."
+    }
+
   private def getAccessStatus(record: CalmRecord): Option[AccessStatus] =
     record.get("AccessStatus") match {
       case Some("Open")       => Some(AccessStatus.Open)
       case Some("Closed")     => Some(AccessStatus.Closed)
-      case Some("Restricted") => Some(AccessStatus.Restricted)
+      case Some("Restricted") | Some("Certain restrictions apply") => Some(AccessStatus.Restricted)
+      case Some("By Appointment") => Some(AccessStatus.ByAppointment)
       case _                  => None
     }
+
+  // e.g. parsing dates "01/01/2039"
+  private def parseAsDate(s: String): LocalDate =
+    LocalDate.parse(s, DateTimeFormatter.ofPattern("d/M/yyyy"))
+
+  implicit class StringOps(s: String) {
+    def isSingleSentence: Boolean =
+      s.count(_ == '.') == 1
+
+    def containsDate(d: LocalDate): Boolean = {
+      // Remove any ordinals, e.g. "1st", "2nd"
+      val normalisedS = s
+        .replace("1st", "1")
+        .replace("2nd", "2")
+        .replace("3rd", "3")
+        .replace("th", "")
+
+      Seq("d MMMM yyyy").exists {
+        fmt =>
+          val dateString = d.format(DateTimeFormatter.ofPattern(fmt))
+          normalisedS.contains(s"until $dateString")
+      }
+    }
+  }
 }

--- a/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/transformers/CalmTermsOfUseTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/transformers/CalmTermsOfUseTest.scala
@@ -2,44 +2,10 @@ package uk.ac.wellcome.platform.transformer.calm.transformers
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import uk.ac.wellcome.json.JsonUtil._
 import weco.catalogue.internal_model.work.TermsOfUse
-import weco.catalogue.source_model.calm.CalmRecord
 import weco.catalogue.source_model.generators.CalmRecordGenerators
 
-import java.io.{BufferedReader, FileReader}
-import java.time.Instant
-import scala.collection.JavaConverters._
-import scala.util.{Failure, Success, Try}
-
 class CalmTermsOfUseTest extends AnyFunSpec with Matchers with CalmRecordGenerators {
-  it("covers all cases") {
-    val source = new BufferedReader(new FileReader("/users/alexwlchan/desktop/items.json"))
-
-    var handled = 0
-    var unhandled = 0
-
-    source.lines()
-      .iterator().asScala
-      .map { line => CalmRecord(
-        id = "123",
-        retrievedAt = Instant.now,
-        data = fromJson[Map[String, List[String]]](line).get
-      ) }
-      .foreach { record =>
-        Try { CalmTermsOfUse(record) } match {
-          case Success(_) => handled += 1
-          case Failure(err) =>
-            println(record)
-            println(err)
-            println("")
-            unhandled += 1
-        }
-      }
-
-    println(s"handled = $handled, unhandled = $unhandled")
-  }
-
   it("handles an item which is open") {
     val record = createCalmRecordWith(
       ("AccessStatus", "Open"),
@@ -67,7 +33,7 @@ class CalmTermsOfUseTest extends AnyFunSpec with Matchers with CalmRecordGenerat
     CalmTermsOfUse(record) shouldBe Some(TermsOfUse("Digital records cannot be ordered or viewed online. Requests to view digital records onsite are considered on a case by case basis. Please contact collections@wellcome.ac.uk for more details. Restricted."))
   }
 
-  it("creates the right note for an item where the date is in the access conditions") {
+  it("creates the right note for a closed item where the date is in the access conditions") {
     val record = createCalmRecordWith(
       ("AccessStatus", "Closed"),
       ("AccessConditions", "Closed under the Data Protection Act until 1st January 2039."),
@@ -75,6 +41,26 @@ class CalmTermsOfUseTest extends AnyFunSpec with Matchers with CalmRecordGenerat
     )
 
     CalmTermsOfUse(record) shouldBe Some(TermsOfUse("Closed under the Data Protection Act until 1st January 2039."))
+  }
+
+  it("creates the right note for a restricted item where the date is in the access conditions") {
+    val record = createCalmRecordWith(
+      ("AccessStatus", "Restricted Access (Data Protection Act)"),
+      ("AccessConditions", "This file is restricted until 01/01/2039 for data protection reasons. Readers must complete and sign a Restricted Access undertaking form to apply for access."),
+      ("UserDate1", "01/01/2039")
+    )
+
+    CalmTermsOfUse(record) shouldBe Some(TermsOfUse("This file is restricted until 01/01/2039 for data protection reasons. Readers must complete and sign a Restricted Access undertaking form to apply for access."))
+  }
+
+  it("creates a note for a restricted item where the date is not in the access conditions") {
+    val record = createCalmRecordWith(
+      ("AccessStatus", "Restricted"),
+      ("AccessConditions", "This file is restricted for data protection reasons. When a reader arrives onsite, they will be required to sign a Restricted Access form agreeing to anonymise personal data before viewing the file."),
+      ("UserDate1", "01/01/2060")
+    )
+
+    CalmTermsOfUse(record) shouldBe Some(TermsOfUse("This file is restricted for data protection reasons. When a reader arrives onsite, they will be required to sign a Restricted Access form agreeing to anonymise personal data before viewing the file. Restricted until 1 January 2060."))
   }
 
   it("creates the right note for a closed item where the date is not in the access conditions") {
@@ -87,6 +73,33 @@ class CalmTermsOfUseTest extends AnyFunSpec with Matchers with CalmRecordGenerat
     CalmTermsOfUse(record) shouldBe Some(TermsOfUse("Closed under the Data Protection Act. Closed until 1 January 2039."))
   }
 
+  it("creates a note for a closed item with no conditions") {
+    val record = createCalmRecordWith(
+      ("AccessStatus", "Closed"),
+      ("ClosedUntil", "01/01/2068")
+    )
+
+    CalmTermsOfUse(record) shouldBe Some(TermsOfUse("Closed until 1 January 2068."))
+  }
+
+  it("creates a note for an item with just a status") {
+    val record = createCalmRecordWith(
+      ("AccessStatus", "Open")
+    )
+
+    CalmTermsOfUse(record) shouldBe Some(TermsOfUse("Open."))
+  }
+
+  it("creates a note for an item with permission + restrictions") {
+    val record = createCalmRecordWith(
+      ("AccessStatus", "Donor Permission"),
+      ("AccessConditions", "Permission must be obtained from <a href=\"mailto:barbie.antonis@gmail.com\">the Winnicott Trust</a>, and the usual conditions of access to Archives and Manuscripts material apply; a Reader's Undertaking must be completed. In addition there are Data Protection restrictions on this item and an additional application for access must be completed."),
+      ("UserDate1", "01/01/2072")
+    )
+
+    CalmTermsOfUse(record) shouldBe Some(TermsOfUse("Permission must be obtained from <a href=\"mailto:barbie.antonis@gmail.com\">the Winnicott Trust</a>, and the usual conditions of access to Archives and Manuscripts material apply; a Reader's Undertaking must be completed. In addition there are Data Protection restrictions on this item and an additional application for access must be completed. Restricted until 1 January 2072."))
+  }
+
   it("adds a missing full stop to access conditions") {
     val record = createCalmRecordWith(
       ("AccessStatus", "Closed"),
@@ -95,5 +108,31 @@ class CalmTermsOfUseTest extends AnyFunSpec with Matchers with CalmRecordGenerat
     )
 
     CalmTermsOfUse(record) shouldBe Some(TermsOfUse("This file is closed for data protection reasons and cannot be accessed. Closed until 1 January 2055."))
+  }
+
+  it("removes trailing whitespace") {
+    val record = createCalmRecordWith(
+      ("AccessStatus", "Restricted"),
+      ("AccessConditions", "This file is restricted until 01/01/2024 for data protection reasons. Readers must complete and sign a Restricted Access undertaking form to apply for access.\n\n"),
+      ("UserDate1", "01/01/2024")
+    )
+
+    CalmTermsOfUse(record) shouldBe Some(TermsOfUse("This file is restricted until 01/01/2024 for data protection reasons. Readers must complete and sign a Restricted Access undertaking form to apply for access."))
+  }
+
+  it("handles the fallback case") {
+    val record = createCalmRecordWith(
+      ("AccessStatus", "By Appointment"),
+      ("UserDate1", "01/01/2066"),
+      ("AccessConditions", "The papers are available subject to the usual conditions of access to Archives and Manuscripts material. In addition a Restricted Access form must be completed to apply for access to this file.")
+    )
+
+    CalmTermsOfUse(record) shouldBe Some(TermsOfUse("The papers are available subject to the usual conditions of access to Archives and Manuscripts material. In addition a Restricted Access form must be completed to apply for access to this file. Restricted until 1 January 2066. By appointment."))
+  }
+
+  it("returns no note if there's no useful access info") {
+    val record = createCalmRecordWith()
+
+    CalmTermsOfUse(record) shouldBe None
   }
 }

--- a/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/transformers/CalmTermsOfUseTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/transformers/CalmTermsOfUseTest.scala
@@ -5,14 +5,20 @@ import org.scalatest.matchers.should.Matchers
 import weco.catalogue.internal_model.work.TermsOfUse
 import weco.catalogue.source_model.generators.CalmRecordGenerators
 
-class CalmTermsOfUseTest extends AnyFunSpec with Matchers with CalmRecordGenerators {
+class CalmTermsOfUseTest
+    extends AnyFunSpec
+    with Matchers
+    with CalmRecordGenerators {
   it("handles an item which is open") {
     val record = createCalmRecordWith(
       ("AccessStatus", "Open"),
-      ("AccessConditions", "The papers are available subject to the usual conditions of access to Archives and Manuscripts material.")
+      (
+        "AccessConditions",
+        "The papers are available subject to the usual conditions of access to Archives and Manuscripts material.")
     )
 
-    CalmTermsOfUse(record) shouldBe Some(TermsOfUse("The papers are available subject to the usual conditions of access to Archives and Manuscripts material. Open."))
+    CalmTermsOfUse(record) shouldBe Some(TermsOfUse(
+      "The papers are available subject to the usual conditions of access to Archives and Manuscripts material. Open."))
   }
 
   it("handles an item which is closed") {
@@ -21,56 +27,76 @@ class CalmTermsOfUseTest extends AnyFunSpec with Matchers with CalmRecordGenerat
       ("AccessConditions", "Closed on depositor agreement."),
     )
 
-    CalmTermsOfUse(record) shouldBe Some(TermsOfUse("Closed on depositor agreement."))
+    CalmTermsOfUse(record) shouldBe Some(
+      TermsOfUse("Closed on depositor agreement."))
   }
 
   it("handles an item which is restricted") {
     val record = createCalmRecordWith(
       ("AccessStatus", "Restricted"),
-      ("AccessConditions", "Digital records cannot be ordered or viewed online. Requests to view digital records onsite are considered on a case by case basis. Please contact collections@wellcome.ac.uk for more details."),
+      (
+        "AccessConditions",
+        "Digital records cannot be ordered or viewed online. Requests to view digital records onsite are considered on a case by case basis. Please contact collections@wellcome.ac.uk for more details."),
     )
 
-    CalmTermsOfUse(record) shouldBe Some(TermsOfUse("Digital records cannot be ordered or viewed online. Requests to view digital records onsite are considered on a case by case basis. Please contact collections@wellcome.ac.uk for more details. Restricted."))
+    CalmTermsOfUse(record) shouldBe Some(TermsOfUse(
+      "Digital records cannot be ordered or viewed online. Requests to view digital records onsite are considered on a case by case basis. Please contact collections@wellcome.ac.uk for more details. Restricted."))
   }
 
-  it("creates the right note for a closed item where the date is in the access conditions") {
+  it(
+    "creates the right note for a closed item where the date is in the access conditions") {
     val record = createCalmRecordWith(
       ("AccessStatus", "Closed"),
-      ("AccessConditions", "Closed under the Data Protection Act until 1st January 2039."),
+      (
+        "AccessConditions",
+        "Closed under the Data Protection Act until 1st January 2039."),
       ("ClosedUntil", "01/01/2039")
     )
 
-    CalmTermsOfUse(record) shouldBe Some(TermsOfUse("Closed under the Data Protection Act until 1st January 2039."))
+    CalmTermsOfUse(record) shouldBe Some(
+      TermsOfUse(
+        "Closed under the Data Protection Act until 1st January 2039."))
   }
 
-  it("creates the right note for a restricted item where the date is in the access conditions") {
+  it(
+    "creates the right note for a restricted item where the date is in the access conditions") {
     val record = createCalmRecordWith(
       ("AccessStatus", "Restricted Access (Data Protection Act)"),
-      ("AccessConditions", "This file is restricted until 01/01/2039 for data protection reasons. Readers must complete and sign a Restricted Access undertaking form to apply for access."),
+      (
+        "AccessConditions",
+        "This file is restricted until 01/01/2039 for data protection reasons. Readers must complete and sign a Restricted Access undertaking form to apply for access."),
       ("UserDate1", "01/01/2039")
     )
 
-    CalmTermsOfUse(record) shouldBe Some(TermsOfUse("This file is restricted until 01/01/2039 for data protection reasons. Readers must complete and sign a Restricted Access undertaking form to apply for access."))
+    CalmTermsOfUse(record) shouldBe Some(TermsOfUse(
+      "This file is restricted until 01/01/2039 for data protection reasons. Readers must complete and sign a Restricted Access undertaking form to apply for access."))
   }
 
-  it("creates a note for a restricted item where the date is not in the access conditions") {
+  it(
+    "creates a note for a restricted item where the date is not in the access conditions") {
     val record = createCalmRecordWith(
       ("AccessStatus", "Restricted"),
-      ("AccessConditions", "This file is restricted for data protection reasons. When a reader arrives onsite, they will be required to sign a Restricted Access form agreeing to anonymise personal data before viewing the file."),
+      (
+        "AccessConditions",
+        "This file is restricted for data protection reasons. When a reader arrives onsite, they will be required to sign a Restricted Access form agreeing to anonymise personal data before viewing the file."),
       ("UserDate1", "01/01/2060")
     )
 
-    CalmTermsOfUse(record) shouldBe Some(TermsOfUse("This file is restricted for data protection reasons. When a reader arrives onsite, they will be required to sign a Restricted Access form agreeing to anonymise personal data before viewing the file. Restricted until 1 January 2060."))
+    CalmTermsOfUse(record) shouldBe Some(TermsOfUse(
+      "This file is restricted for data protection reasons. When a reader arrives onsite, they will be required to sign a Restricted Access form agreeing to anonymise personal data before viewing the file. Restricted until 1 January 2060."))
   }
 
-  it("creates the right note for a closed item where the date is not in the access conditions") {
+  it(
+    "creates the right note for a closed item where the date is not in the access conditions") {
     val record = createCalmRecordWith(
       ("AccessStatus", "Closed"),
       ("AccessConditions", "Closed under the Data Protection Act."),
       ("ClosedUntil", "01/01/2039")
     )
 
-    CalmTermsOfUse(record) shouldBe Some(TermsOfUse("Closed under the Data Protection Act. Closed until 1 January 2039."))
+    CalmTermsOfUse(record) shouldBe Some(
+      TermsOfUse(
+        "Closed under the Data Protection Act. Closed until 1 January 2039."))
   }
 
   it("creates a note for a closed item with no conditions") {
@@ -79,7 +105,8 @@ class CalmTermsOfUseTest extends AnyFunSpec with Matchers with CalmRecordGenerat
       ("ClosedUntil", "01/01/2068")
     )
 
-    CalmTermsOfUse(record) shouldBe Some(TermsOfUse("Closed until 1 January 2068."))
+    CalmTermsOfUse(record) shouldBe Some(
+      TermsOfUse("Closed until 1 January 2068."))
   }
 
   it("creates a note for an item with just a status") {
@@ -93,41 +120,53 @@ class CalmTermsOfUseTest extends AnyFunSpec with Matchers with CalmRecordGenerat
   it("creates a note for an item with permission + restrictions") {
     val record = createCalmRecordWith(
       ("AccessStatus", "Donor Permission"),
-      ("AccessConditions", "Permission must be obtained from <a href=\"mailto:barbie.antonis@gmail.com\">the Winnicott Trust</a>, and the usual conditions of access to Archives and Manuscripts material apply; a Reader's Undertaking must be completed. In addition there are Data Protection restrictions on this item and an additional application for access must be completed."),
+      (
+        "AccessConditions",
+        "Permission must be obtained from <a href=\"mailto:barbie.antonis@gmail.com\">the Winnicott Trust</a>, and the usual conditions of access to Archives and Manuscripts material apply; a Reader's Undertaking must be completed. In addition there are Data Protection restrictions on this item and an additional application for access must be completed."),
       ("UserDate1", "01/01/2072")
     )
 
-    CalmTermsOfUse(record) shouldBe Some(TermsOfUse("Permission must be obtained from <a href=\"mailto:barbie.antonis@gmail.com\">the Winnicott Trust</a>, and the usual conditions of access to Archives and Manuscripts material apply; a Reader's Undertaking must be completed. In addition there are Data Protection restrictions on this item and an additional application for access must be completed. Restricted until 1 January 2072."))
+    CalmTermsOfUse(record) shouldBe Some(TermsOfUse(
+      "Permission must be obtained from <a href=\"mailto:barbie.antonis@gmail.com\">the Winnicott Trust</a>, and the usual conditions of access to Archives and Manuscripts material apply; a Reader's Undertaking must be completed. In addition there are Data Protection restrictions on this item and an additional application for access must be completed. Restricted until 1 January 2072."))
   }
 
   it("adds a missing full stop to access conditions") {
     val record = createCalmRecordWith(
       ("AccessStatus", "Closed"),
-      ("AccessConditions", "This file is closed for data protection reasons and cannot be accessed"),
+      (
+        "AccessConditions",
+        "This file is closed for data protection reasons and cannot be accessed"),
       ("ClosedUntil", "01/01/2055")
     )
 
-    CalmTermsOfUse(record) shouldBe Some(TermsOfUse("This file is closed for data protection reasons and cannot be accessed. Closed until 1 January 2055."))
+    CalmTermsOfUse(record) shouldBe Some(TermsOfUse(
+      "This file is closed for data protection reasons and cannot be accessed. Closed until 1 January 2055."))
   }
 
   it("removes trailing whitespace") {
     val record = createCalmRecordWith(
       ("AccessStatus", "Restricted"),
-      ("AccessConditions", "This file is restricted until 01/01/2024 for data protection reasons. Readers must complete and sign a Restricted Access undertaking form to apply for access.\n\n"),
+      (
+        "AccessConditions",
+        "This file is restricted until 01/01/2024 for data protection reasons. Readers must complete and sign a Restricted Access undertaking form to apply for access.\n\n"),
       ("UserDate1", "01/01/2024")
     )
 
-    CalmTermsOfUse(record) shouldBe Some(TermsOfUse("This file is restricted until 01/01/2024 for data protection reasons. Readers must complete and sign a Restricted Access undertaking form to apply for access."))
+    CalmTermsOfUse(record) shouldBe Some(TermsOfUse(
+      "This file is restricted until 01/01/2024 for data protection reasons. Readers must complete and sign a Restricted Access undertaking form to apply for access."))
   }
 
   it("handles the fallback case") {
     val record = createCalmRecordWith(
       ("AccessStatus", "By Appointment"),
       ("UserDate1", "01/01/2066"),
-      ("AccessConditions", "The papers are available subject to the usual conditions of access to Archives and Manuscripts material. In addition a Restricted Access form must be completed to apply for access to this file.")
+      (
+        "AccessConditions",
+        "The papers are available subject to the usual conditions of access to Archives and Manuscripts material. In addition a Restricted Access form must be completed to apply for access to this file.")
     )
 
-    CalmTermsOfUse(record) shouldBe Some(TermsOfUse("The papers are available subject to the usual conditions of access to Archives and Manuscripts material. In addition a Restricted Access form must be completed to apply for access to this file. Restricted until 1 January 2066. By appointment."))
+    CalmTermsOfUse(record) shouldBe Some(TermsOfUse(
+      "The papers are available subject to the usual conditions of access to Archives and Manuscripts material. In addition a Restricted Access form must be completed to apply for access to this file. Restricted until 1 January 2066. By appointment."))
   }
 
   it("returns no note if there's no useful access info") {

--- a/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/transformers/CalmTermsOfUseTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/transformers/CalmTermsOfUseTest.scala
@@ -4,13 +4,15 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.catalogue.source_model.calm.CalmRecord
 import uk.ac.wellcome.json.JsonUtil._
+import weco.catalogue.internal_model.work.TermsOfUse
+import weco.catalogue.source_model.generators.CalmRecordGenerators
 
 import scala.collection.JavaConverters._
 import java.io.{BufferedReader, FileReader}
 import java.time.Instant
 import scala.util.{Failure, Success, Try}
 
-class CalmTermsOfUseTest extends AnyFunSpec with Matchers {
+class CalmTermsOfUseTest extends AnyFunSpec with Matchers with CalmRecordGenerators {
   it("covers all cases") {
     val source = new BufferedReader(new FileReader("/users/alexwlchan/desktop/items.json"))
 
@@ -36,5 +38,32 @@ class CalmTermsOfUseTest extends AnyFunSpec with Matchers {
       }
 
     println(s"handled = $handled, unhandled = $unhandled")
+  }
+
+  it("handles an item which is open") {
+    val record = createCalmRecordWith(
+      ("AccessStatus", "Open"),
+      ("AccessConditions", "The papers are available subject to the usual conditions of access to Archives and Manuscripts material.")
+    )
+
+    CalmTermsOfUse(record) shouldBe Some(TermsOfUse("The papers are available subject to the usual conditions of access to Archives and Manuscripts material. Open."))
+  }
+
+  it("handles an item which is closed") {
+    val record = createCalmRecordWith(
+      ("AccessStatus", "Closed"),
+      ("AccessConditions", "Closed on depositor agreement."),
+    )
+
+    CalmTermsOfUse(record) shouldBe Some(TermsOfUse("Closed on depositor agreement. Closed."))
+  }
+
+  it("handles an item which is restricted") {
+    val record = createCalmRecordWith(
+      ("AccessStatus", "Restricted"),
+      ("AccessConditions", "Digital records cannot be ordered or viewed online. Requests to view digital records onsite are considered on a case by case basis. Please contact collections@wellcome.ac.uk for more details."),
+    )
+
+    CalmTermsOfUse(record) shouldBe Some(TermsOfUse("Digital records cannot be ordered or viewed online. Requests to view digital records onsite are considered on a case by case basis. Please contact collections@wellcome.ac.uk for more details. Restricted."))
   }
 }

--- a/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/transformers/CalmTermsOfUseTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/transformers/CalmTermsOfUseTest.scala
@@ -2,14 +2,14 @@ package uk.ac.wellcome.platform.transformer.calm.transformers
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import weco.catalogue.source_model.calm.CalmRecord
 import uk.ac.wellcome.json.JsonUtil._
 import weco.catalogue.internal_model.work.TermsOfUse
+import weco.catalogue.source_model.calm.CalmRecord
 import weco.catalogue.source_model.generators.CalmRecordGenerators
 
-import scala.collection.JavaConverters._
 import java.io.{BufferedReader, FileReader}
 import java.time.Instant
+import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
 
 class CalmTermsOfUseTest extends AnyFunSpec with Matchers with CalmRecordGenerators {
@@ -55,7 +55,7 @@ class CalmTermsOfUseTest extends AnyFunSpec with Matchers with CalmRecordGenerat
       ("AccessConditions", "Closed on depositor agreement."),
     )
 
-    CalmTermsOfUse(record) shouldBe Some(TermsOfUse("Closed on depositor agreement. Closed."))
+    CalmTermsOfUse(record) shouldBe Some(TermsOfUse("Closed on depositor agreement."))
   }
 
   it("handles an item which is restricted") {
@@ -65,5 +65,25 @@ class CalmTermsOfUseTest extends AnyFunSpec with Matchers with CalmRecordGenerat
     )
 
     CalmTermsOfUse(record) shouldBe Some(TermsOfUse("Digital records cannot be ordered or viewed online. Requests to view digital records onsite are considered on a case by case basis. Please contact collections@wellcome.ac.uk for more details. Restricted."))
+  }
+
+  it("creates the right note for an item where the date is in the access conditions") {
+    val record = createCalmRecordWith(
+      ("AccessStatus", "Closed"),
+      ("AccessConditions", "Closed under the Data Protection Act until 1st January 2039."),
+      ("ClosedUntil", "01/01/2039")
+    )
+
+    CalmTermsOfUse(record) shouldBe Some(TermsOfUse("Closed under the Data Protection Act until 1st January 2039."))
+  }
+
+  it("creates the right note for a closed item where the date is not in the access conditions") {
+    val record = createCalmRecordWith(
+      ("AccessStatus", "Closed"),
+      ("AccessConditions", "Closed under the Data Protection Act."),
+      ("ClosedUntil", "01/01/2039")
+    )
+
+    CalmTermsOfUse(record) shouldBe Some(TermsOfUse("Closed under the Data Protection Act. Closed until 1 January 2039."))
   }
 }

--- a/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/transformers/CalmTermsOfUseTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/transformers/CalmTermsOfUseTest.scala
@@ -86,4 +86,14 @@ class CalmTermsOfUseTest extends AnyFunSpec with Matchers with CalmRecordGenerat
 
     CalmTermsOfUse(record) shouldBe Some(TermsOfUse("Closed under the Data Protection Act. Closed until 1 January 2039."))
   }
+
+  it("adds a missing full stop to access conditions") {
+    val record = createCalmRecordWith(
+      ("AccessStatus", "Closed"),
+      ("AccessConditions", "This file is closed for data protection reasons and cannot be accessed"),
+      ("ClosedUntil", "01/01/2055")
+    )
+
+    CalmTermsOfUse(record) shouldBe Some(TermsOfUse("This file is closed for data protection reasons and cannot be accessed. Closed until 1 January 2055."))
+  }
 }

--- a/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/transformers/CalmTermsOfUseTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/uk/ac/wellcome/platform/transformer/calm/transformers/CalmTermsOfUseTest.scala
@@ -1,0 +1,40 @@
+package uk.ac.wellcome.platform.transformer.calm.transformers
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import weco.catalogue.source_model.calm.CalmRecord
+import uk.ac.wellcome.json.JsonUtil._
+
+import scala.collection.JavaConverters._
+import java.io.{BufferedReader, FileReader}
+import java.time.Instant
+import scala.util.{Failure, Success, Try}
+
+class CalmTermsOfUseTest extends AnyFunSpec with Matchers {
+  it("covers all cases") {
+    val source = new BufferedReader(new FileReader("/users/alexwlchan/desktop/items.json"))
+
+    var handled = 0
+    var unhandled = 0
+
+    source.lines()
+      .iterator().asScala
+      .map { line => CalmRecord(
+        id = "123",
+        retrievedAt = Instant.now,
+        data = fromJson[Map[String, List[String]]](line).get
+      ) }
+      .foreach { record =>
+        Try { CalmTermsOfUse(record) } match {
+          case Success(_) => handled += 1
+          case Failure(err) =>
+            println(record)
+            println(err)
+            println("")
+            unhandled += 1
+        }
+      }
+
+    println(s"handled = $handled, unhandled = $unhandled")
+  }
+}


### PR DESCRIPTION
Part of https://github.com/wellcomecollection/platform/issues/5204

Because the access data in Calm applies to the work rather than the item, we want to create a TermsOfUse note that will appear once on the page, rather than copying it to every individual item.

This is what those conditions look like when rendered in Encore (post-squashing into MARC):

<img width="913" alt="Screenshot 2021-06-22 at 14 55 23" src="https://user-images.githubusercontent.com/301220/122937416-e0b64300-d369-11eb-9e39-52dfda5dd1df.png">

I've added a few heuristics for making these notes look a bit nicer, in particular:

- Don't repeat the access status if it's already given in the free-text conditions
- Don't repeat the dates if they're already given in the conditions
- Dates are spelt out (e.g. "1 January 2065") to match how we display them elsewhere on the site

There are still some less-than-ideal cases it won't handle, but it's a reasonable improvement that I could implement quickly.

I'll do a separate PR to actually wire it up into the transformer.