### PR TITLE
Create an item title from the copyNo if no volume is specified

### DIFF
--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraItemData.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraItemData.scala
@@ -6,6 +6,7 @@ import weco.catalogue.source_model.sierra.source.SierraSourceLocation
 case class SierraItemData(
   deleted: Boolean = false,
   suppressed: Boolean = false,
+  copyNo: Option[Int] = None,
   holdCount: Option[Int] = Some(0),
   location: Option[SierraSourceLocation] = None,
   fixedFields: Map[String, FixedField] = Map(),

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/generators/SierraDataGenerators.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/generators/SierraDataGenerators.scala
@@ -32,12 +32,14 @@ trait SierraDataGenerators extends IdentifiersGenerators with SierraGenerators {
 
   def createSierraItemDataWith(
     location: Option[SierraSourceLocation] = None,
+    copyNo: Option[Int] = None,
     holdCount: Option[Int] = Some(0),
     fixedFields: Map[String, FixedField] = Map(),
     varFields: List[VarField] = Nil
   ): SierraItemData =
     SierraItemData(
       location = location,
+      copyNo = copyNo,
       holdCount = holdCount,
       fixedFields = fixedFields,
       varFields = varFields

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItems.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItems.scala
@@ -161,7 +161,10 @@ object SierraItems extends Logging with SierraLocation with SierraQueryOps {
 
     titleCandidates match {
       case Seq(title) => Some(title)
-      case Nil        => data.copyNo.map { copyNo => s"Copy $copyNo" }
+      case Nil =>
+        data.copyNo.map { copyNo =>
+          s"Copy $copyNo"
+        }
       case multipleTitles =>
         warn(
           s"Multiple title candidates on item $itemId: ${titleCandidates.mkString("; ")}")

--- a/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItems.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItems.scala
@@ -63,10 +63,8 @@ object SierraItems extends Logging with SierraLocation with SierraQueryOps {
     // non-above locations are unambiguous, we use them instead.
     val otherLocations =
       sierraItemDataMap
-        .collect {
-          case (id, SierraItemData(_, _, _, Some(location), _, _)) =>
-            id -> location
-        }
+        .collect { case (id, itemData) => id -> itemData.location }
+        .collect { case (id, Some(location)) => id -> location }
         .filterNot {
           case (_, loc) =>
             loc.name.toLowerCase.contains("above") || loc.name == "-" || loc.name == ""

--- a/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/uk/ac/wellcome/platform/transformer/sierra/transformers/SierraItemsTest.scala
@@ -99,8 +99,7 @@ class SierraItemsTest
       getTitle(itemData) shouldBe Some("Envelope")
     }
 
-    it(
-      "uses the contents of subfield ǂa if field tag ǂv doesn't have a contents field") {
+    it("uses subfield ǂa if field tag v doesn't have a contents field") {
       val itemData = createSierraItemDataWith(
         varFields = List(
           VarField(fieldTag = "b", content = "S11.1L"),
@@ -129,6 +128,12 @@ class SierraItemsTest
       )
 
       getTitle(itemData) shouldBe Some("Volumes 1–5")
+    }
+
+    it("uses the copy number if there's no field tag v") {
+      val itemData = createSierraItemDataWith(copyNo = Some(3))
+
+      getTitle(itemData) shouldBe Some("Copy 3")
     }
 
     def getTitle(itemData: SierraItemData): Option[String] = {


### PR DESCRIPTION
This is to expand the number of items without titles, so that users can distinguish between a long list of items.

Also, in some bibs (e.g. [b10796290](https://search.wellcomelibrary.org/iii/encore/record/C__Rb1079629?lang=eng)), the cataloguers specifically refer to the numbered copies in the notes -- but there's no way for a user to know which item they mean without putting the copy number in the title.

For https://github.com/wellcomecollection/platform/issues/5210