### PR TITLE
Display item-level shelfmarks like 12345i.1

### DIFF
--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraShelfmark.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraShelfmark.scala
@@ -37,7 +37,9 @@ object SierraShelfmark extends SierraQueryOps {
       //
       // e.g. 12345i, 12346i, 12347i
       //
-      case _ if bibData.hasIconographicNumber && itemData.shelfmarkStartsWith(bibData.iconographicNumber + ".") =>
+      case _
+          if bibData.hasIconographicNumber && itemData.shelfmarkStartsWith(
+            bibData.iconographicNumber + ".") =>
         itemData.shelfmark
 
       case _ if bibData.hasIconographicNumber =>
@@ -58,12 +60,12 @@ object SierraShelfmark extends SierraQueryOps {
       // Field tag c is for "call number" data.  In particular, we don't want
       // to expose field tag a, which has legacy data we don't want to display.
       // See https://wellcome.slack.com/archives/CGXDT2GSH/p1622719935015500?thread_ts=1622719185.015400&cid=CGXDT2GSH
-        itemData.varFields
-          .filter { _.marcTag.contains("949") }
-          .filter { _.fieldTag.contains("c") }
-          .subfieldsWithTags("a")
-          .headOption
-          .map { _.content.trim }
+      itemData.varFields
+        .filter { _.marcTag.contains("949") }
+        .filter { _.fieldTag.contains("c") }
+        .subfieldsWithTags("a")
+        .headOption
+        .map { _.content.trim }
 
     def shelfmarkStartsWith(prefix: String): Boolean =
       shelfmark match {

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraShelfmark.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraShelfmark.scala
@@ -25,7 +25,10 @@ object SierraShelfmark extends SierraQueryOps {
       // e.g. 12345i
       //
       // Note that the iconographic number in 001 on the bib may not match 949 ǂa
-      // on the item -- that's fine and expected.
+      // on the item -- if they have a common prefix, we copy across the shelfmark,
+      // but otherwise we discard it.
+      //
+      // e.g. 12345i and 12345i.1
       //
       // If several pictures have been mounted on the same frame, they get a single
       // item (because you request them all together).  Each picture would get its
@@ -34,27 +37,40 @@ object SierraShelfmark extends SierraQueryOps {
       //
       // e.g. 12345i, 12346i, 12347i
       //
+      case _ if bibData.hasIconographicNumber && itemData.shelfmarkStartsWith(bibData.iconographicNumber + ".") =>
+        itemData.shelfmark
+
       case _ if bibData.hasIconographicNumber =>
         None
 
-      case _ =>
-        // We use the contents of field 949 subfield ǂa for now.  We expect we'll
-        // gradually be pickier about whether we use this value, or whether we
-        // suppress it.
-        //
-        // We used to use the callNumber field on Sierra item records, but this
-        // draws from some MARC fields that we don't want (including 999).
-        //
-        // Field tag c is for "call number" data.  In particular, we don't want
-        // to expose field tag a, which has legacy data we don't want to display.
-        // See https://wellcome.slack.com/archives/CGXDT2GSH/p1622719935015500?thread_ts=1622719185.015400&cid=CGXDT2GSH
+      case _ => itemData.shelfmark
+    }
+
+  private implicit class ItemShelfmarkOps(itemData: SierraItemData) {
+    def shelfmark: Option[String] =
+      // We use the contents of field 949 subfield ǂa for now.  We expect we'll
+      // gradually be pickier about whether we use this value, or whether we
+      // suppress it.
+      //
+      // We used to use the callNumber field on Sierra item records, but this
+      // draws from some MARC fields that we don't want (including 999).
+      //
+      // Field tag c is for "call number" data.  In particular, we don't want
+      // to expose field tag a, which has legacy data we don't want to display.
+      // See https://wellcome.slack.com/archives/CGXDT2GSH/p1622719935015500?thread_ts=1622719185.015400&cid=CGXDT2GSH
         itemData.varFields
           .filter { _.marcTag.contains("949") }
           .filter { _.fieldTag.contains("c") }
           .subfieldsWithTags("a")
           .headOption
           .map { _.content.trim }
-    }
+
+    def shelfmarkStartsWith(prefix: String): Boolean =
+      shelfmark match {
+        case Some(s) if s.startsWith(prefix) && s != prefix => true
+        case _                                              => false
+      }
+  }
 
   private implicit class BibShelfmarkOps(bibData: SierraBibData) {
     def isArchivesAndManuscripts: Boolean =
@@ -62,5 +78,8 @@ object SierraShelfmark extends SierraQueryOps {
 
     def hasIconographicNumber: Boolean =
       SierraIconographicNumber(bibData).isDefined
+
+    def iconographicNumber: String =
+      SierraIconographicNumber(bibData).get
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraShelfmarkTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraShelfmarkTest.scala
@@ -138,6 +138,52 @@ class SierraShelfmarkTest
     getShelfmarkWith001(s = "12345i") shouldBe None
   }
 
+  it("shows the shelfmark if the iconographic number on the bib and item have a common prefix") {
+    val bibData = createSierraBibDataWith(
+      materialType = Some(SierraMaterialType("k")),
+      varFields = List(
+        VarField(marcTag = Some("001"), content = Some("12345i"))
+      )
+    )
+
+    val varFields = List(
+      VarField(
+        marcTag = Some("949"),
+        fieldTag = Some("c"),
+        subfields = List(
+          MarcSubfield(tag = "a", content = "12345i.1")
+        )
+      )
+    )
+
+    val itemData = createSierraItemDataWith(varFields = varFields)
+
+    getShelfmark(bibData = bibData, itemData = itemData) shouldBe Some("12345i.1")
+  }
+
+  it("skips the shelfmark if the iconographic number on the bib and item are the same") {
+    val bibData = createSierraBibDataWith(
+      materialType = Some(SierraMaterialType("k")),
+      varFields = List(
+        VarField(marcTag = Some("001"), content = Some("12345i"))
+      )
+    )
+
+    val varFields = List(
+      VarField(
+        marcTag = Some("949"),
+        fieldTag = Some("c"),
+        subfields = List(
+          MarcSubfield(tag = "a", content = "12345i")
+        )
+      )
+    )
+
+    val itemData = createSierraItemDataWith(varFields = varFields)
+
+    getShelfmark(bibData = bibData, itemData = itemData) shouldBe None
+  }
+
   private def getShelfmark(
     bibData: SierraBibData = createSierraBibData,
     itemData: SierraItemData

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraShelfmarkTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraShelfmarkTest.scala
@@ -138,7 +138,8 @@ class SierraShelfmarkTest
     getShelfmarkWith001(s = "12345i") shouldBe None
   }
 
-  it("shows the shelfmark if the iconographic number on the bib and item have a common prefix") {
+  it(
+    "shows the shelfmark if the iconographic number on the bib and item have a common prefix") {
     val bibData = createSierraBibDataWith(
       materialType = Some(SierraMaterialType("k")),
       varFields = List(
@@ -158,10 +159,12 @@ class SierraShelfmarkTest
 
     val itemData = createSierraItemDataWith(varFields = varFields)
 
-    getShelfmark(bibData = bibData, itemData = itemData) shouldBe Some("12345i.1")
+    getShelfmark(bibData = bibData, itemData = itemData) shouldBe Some(
+      "12345i.1")
   }
 
-  it("skips the shelfmark if the iconographic number on the bib and item are the same") {
+  it(
+    "skips the shelfmark if the iconographic number on the bib and item are the same") {
     val bibData = createSierraBibDataWith(
       materialType = Some(SierraMaterialType("k")),
       varFields = List(


### PR DESCRIPTION
It's possible for a bib to have a reference number like 12345i, and then different parts of the item to have individual shelfmarks like .1, .2, and so on.  These are sometimes referred to in the notes, and help readers distinguish between them.

So in very specific cases, we'll let the shelfmark back through when it:

* Has a common prefix with the reference number
* Isn't the same as the reference number
* Isn't a comma-separated list of i-numbers

For https://github.com/wellcomecollection/platform/issues/5205