### PR TITLE
Fix a bug with unrecognised materialTypes in the Sierra transformer

### DIFF
--- a/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/TransformerWorker.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/TransformerWorker.scala
@@ -188,8 +188,8 @@ trait TransformerWorker[Payload <: SourcePayload, SourceData, SenderDest]
                 error(s"$name: DecodePayloadError from $notificationMsg")
               case StoreReadError(_, key) =>
                 error(s"$name: StoreReadError on $key")
-              case TransformerError(_, sourceData, key) =>
-                error(s"$name: TransformerError on $sourceData with $key")
+              case TransformerError(t, sourceData, key) =>
+                error(s"$name: TransformerError on $sourceData with $key ($t)")
             }
 
             throw err

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/data/SierraMaterialTypes.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/data/SierraMaterialTypes.scala
@@ -1,23 +1,23 @@
 package weco.pipeline.transformer.sierra.data
 
+import grizzled.slf4j.Logging
 import weco.catalogue.internal_model.work.Format
 import weco.catalogue.internal_model.work.Format.{Linked, Unlinked}
-import weco.pipeline.transformer.sierra.exceptions.SierraTransformerException
 
-object SierraMaterialTypes {
+object SierraMaterialTypes extends Logging {
 
-  def fromCode(code: String): Format = {
+  def fromCode(code: String): Option[Format] =
     code.toList match {
       case List(c) =>
         Format.fromCode(c.toString) match {
-          case Some(format: Unlinked) => format
-          case Some(format: Linked)   => format.linksTo
+          case Some(format: Unlinked) => Some(format)
+          case Some(format: Linked)   => Some(format.linksTo)
           case None =>
-            throw SierraTransformerException(s"Unrecognised work type code: $c")
+            warn(s"Unrecognised work type code: $c")
+            None
         }
       case _ =>
-        throw SierraTransformerException(
-          s"Work type code is not a single character: <<$code>>")
+        warn(s"Work type code is not a single character: <<$code>>")
+        None
     }
-  }
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraFormat.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraFormat.scala
@@ -23,8 +23,8 @@ object SierraFormat extends SierraDataTransformer {
    *
    * Note: will map to a controlled vocabulary terms in future
    */
-  def apply(bibData: SierraBibData) =
-    bibData.materialType.map { t =>
+  def apply(bibData: SierraBibData): Option[Format] =
+    bibData.materialType.flatMap { t =>
       SierraMaterialTypes.fromCode(t.code)
     }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/data/SierraMaterialTypesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/data/SierraMaterialTypesTest.scala
@@ -5,7 +5,10 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.catalogue.internal_model.work.Format.{Books, StudentDissertations}
 
-class SierraMaterialTypesTest extends AnyFunSpec with Matchers with OptionValues {
+class SierraMaterialTypesTest
+    extends AnyFunSpec
+    with Matchers
+    with OptionValues {
   it("looks up a Format by code") {
     SierraMaterialTypes.fromCode("w").value shouldBe StudentDissertations
   }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/data/SierraMaterialTypesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/data/SierraMaterialTypesTest.scala
@@ -1,38 +1,29 @@
 package weco.pipeline.transformer.sierra.data
 
+import org.scalatest.OptionValues
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.catalogue.internal_model.work.Format.{Books, StudentDissertations}
-import weco.pipeline.transformer.sierra.exceptions.SierraTransformerException
 
-class SierraMaterialTypesTest extends AnyFunSpec with Matchers {
+class SierraMaterialTypesTest extends AnyFunSpec with Matchers with OptionValues {
   it("looks up a Format by code") {
-    SierraMaterialTypes.fromCode("w") shouldBe StudentDissertations
+    SierraMaterialTypes.fromCode("w").value shouldBe StudentDissertations
   }
 
   it("uses the linked format") {
     // v maps to E-books material type which is linked to Books
-    SierraMaterialTypes.fromCode("v") shouldBe Books
+    SierraMaterialTypes.fromCode("v").value shouldBe Books
   }
 
-  it("throws an exception if passed an unrecognised code") {
-    val caught = intercept[SierraTransformerException] {
-      SierraMaterialTypes.fromCode("?")
-    }
-    caught.e.getMessage shouldBe "Unrecognised work type code: ?"
+  it("returns None if passed an unrecognised code") {
+    SierraMaterialTypes.fromCode("?") shouldBe None
   }
 
-  it("throws an exception if passed an empty string") {
-    val caught = intercept[SierraTransformerException] {
-      SierraMaterialTypes.fromCode("")
-    }
-    caught.e.getMessage shouldBe "Work type code is not a single character: <<>>"
+  it("returns None if passed an empty string") {
+    SierraMaterialTypes.fromCode("") shouldBe None
   }
 
-  it("throws an exception if passed a code which is more than a single char") {
-    val caught = intercept[SierraTransformerException] {
-      SierraMaterialTypes.fromCode("XXX")
-    }
-    caught.e.getMessage shouldBe "Work type code is not a single character: <<XXX>>"
+  it("returns None if passed a code which is more than a single char") {
+    SierraMaterialTypes.fromCode("XXX") shouldBe None
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraTransformerTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraTransformerTest.scala
@@ -1202,7 +1202,6 @@ class SierraTransformerTest
     )
 
     val work = transformToWork(transformable)
-    println(work)
 
     work.data.referenceNumber shouldBe Some(ReferenceNumber("12345i"))
     work.data.collectionPath shouldBe None
@@ -1222,6 +1221,32 @@ class SierraTransformerTest
 
     val location = item.locations.head.asInstanceOf[PhysicalLocation]
     location.shelfmark shouldBe None
+  }
+
+  it("transforms a work with an unrecognised material type") {
+    val bibId = createSierraBibNumber
+    val bibData =
+      s"""
+         |{
+         |  "id": "$bibId",
+         |  "materialType": {"code": "-", "label": "Pictures"},
+         |  "varFields": [
+         |    ${createTitleVarfield()}
+         |  ]
+         |}
+       """.stripMargin
+
+    val transformable = SierraTransformable(
+      bibRecord = SierraBibRecord(
+        id = createSierraBibNumber,
+        data = bibData,
+        modifiedDate = Instant.now()
+      )
+    )
+
+    val work = transformToWork(transformable)
+
+    work.data.format shouldBe None
   }
 
   describe("throws a TransformerException when passed invalid data") {


### PR DESCRIPTION
Today we got a work on order with materialType

```json
{"code": "-"}
```

See https://search.wellcomelibrary.org/iii/encore/record/C__Rb3272507?lang=eng

I assume the proper material type will be added when it arrives and gets catalogued. Currently we throw an exception and don't let the work through; the better behaviour is letting it through with an empty `"format"` until we get more information.