### PR TITLE
Warn if you try to reindex the wrong form of a Sierra ID

### DIFF
--- a/reindexer/start_reindex.py
+++ b/reindexer/start_reindex.py
@@ -160,10 +160,7 @@ def verify_specific_ids(*, source, specific_ids):
     if source == "sierra":
         bad_ids = [id for id in specific_ids if len(id) != 7 or not id.isnumeric()]
         if bad_ids:
-            raise ValueError(
-                f"Sierra IDs should be 7-digit numeric IDs, got {bad_ids}"
-            )
-
+            raise ValueError(f"Sierra IDs should be 7-digit numeric IDs, got {bad_ids}")
 
 
 @click.command()


### PR DESCRIPTION
I regularly forget that Sierra IDs are stored in the numeric form with no check digit/prefix, reindex the wrong ID, and we get messages on the DLQ. (You'll see one shortly.)

This adds a bit of awareness to the "start reindex" script of what these IDs should look like, so it can warn you if you're doing it wrong.