### PR TITLE
Remove unused ItemStatus

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/ItemStatus.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/ItemStatus.scala
@@ -1,9 +1,0 @@
-package weco.catalogue.internal_model.locations
-
-sealed trait ItemStatus
-
-object ItemStatus {
-  case object Available extends ItemStatus
-  case object TemporarilyUnavailable extends ItemStatus
-  case object Unavailable extends ItemStatus
-}

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -95,7 +95,7 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           status = bibStatus
         )
 
-        (Some(ac), ItemStatus.Available)
+        Some(ac)
 
       // Note: it is possible for individual items within a restricted bib to be available
       // online, e.g. in archives.  The "restricted" on the bib applies to the archive as
@@ -126,7 +126,7 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           status = AccessStatus.Open,
         )
 
-        (Some(ac), ItemStatus.Available)
+        Some(ac)
 
       // Items on the open shelves don't have any access conditions.
       //
@@ -147,20 +147,20 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           Some(OpacMsg.OpenShelves),
           NotRequestable.OnOpenShelves(_),
           Some(LocationType.OpenShelves)) =>
-        (
-          Some(AccessCondition(method = AccessMethod.OpenShelves)),
-          ItemStatus.Available)
+
+          Some(AccessCondition(method = AccessMethod.OpenShelves))
 
       // There are some items that are labelled "bound in above" or "contained in above".
       //
       // These items aren't requestable on their own; you have to request the "primary" item.
       case (None, _, _, _, NotRequestable.RequestTopItem(message), _) =>
-        (
+
           Some(
             AccessCondition(
               method = AccessMethod.NotRequestable,
-              terms = Some(message))),
-          ItemStatus.Unavailable)
+              terms = Some(message)
+            )
+          )
 
       // Handle any cases that require a manual request.
       //
@@ -187,12 +187,12 @@ object SierraItemAccess extends SierraQueryOps with Logging {
             case _ => None
           }
 
-        (
           Some(
             AccessCondition(
               method = AccessMethod.ManualRequest,
-              note = accessNote)),
-          ItemStatus.Available)
+              note = accessNote)
+          )
+
 
       // Handle any cases where the item is closed.
       //
@@ -209,12 +209,12 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           locationType)
           if locationType.isEmpty || locationType.contains(
             LocationType.ClosedStores) =>
-        (
+
           Some(
             AccessCondition(
               method = AccessMethod.NotRequestable,
-              status = AccessStatus.Closed)),
-          ItemStatus.Unavailable)
+              status = AccessStatus.Closed)
+          )
 
       // Handle any cases where the item is explicitly unavailable.
       case (
@@ -224,12 +224,12 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           Some(OpacMsg.Unavailable),
           NotRequestable.ItemUnavailable(_),
           _) =>
-        (
+
           Some(
             AccessCondition(
               method = AccessMethod.NotRequestable,
-              status = AccessStatus.Unavailable)),
-          ItemStatus.Unavailable)
+              status = AccessStatus.Unavailable)
+          )
 
       case (
           None,
@@ -238,15 +238,15 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           Some(OpacMsg.AtDigitisation),
           NotRequestable.ItemUnavailable(_),
           _) =>
-        (
+
           Some(
             AccessCondition(
               method = AccessMethod.NotRequestable,
               status = Some(AccessStatus.TemporarilyUnavailable),
               note = Some(
                 "This item is being digitised and is currently unavailable.")
-            )),
-          ItemStatus.TemporarilyUnavailable)
+            )
+          )
 
       // An item which is restricted can be requested online -- the user will have to fill in
       // any paperwork when they actually visit the library.
@@ -259,12 +259,12 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           Some(OpacMsg.OnlineRequest),
           Requestable,
           Some(LocationType.ClosedStores)) =>
-        (
+
           Some(
             AccessCondition(
               method = AccessMethod.OnlineRequest,
-              status = AccessStatus.Restricted)),
-          ItemStatus.Available)
+              status = AccessStatus.Restricted)
+          )
 
       // The status "by appointment" takes precedence over "permission required".
       //
@@ -278,12 +278,12 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           Some(LocationType.ClosedStores))
           if bibStatus.isEmpty || bibStatus.contains(AccessStatus.ByAppointment) || bibStatus
             .contains(AccessStatus.PermissionRequired) =>
-        (
+
           Some(
             AccessCondition(
               method = AccessMethod.ManualRequest,
-              status = AccessStatus.ByAppointment)),
-          ItemStatus.Available)
+              status = AccessStatus.ByAppointment)
+          )
 
       case (
           bibStatus,
@@ -294,12 +294,12 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           Some(LocationType.ClosedStores))
           if bibStatus.isEmpty || bibStatus.contains(
             AccessStatus.PermissionRequired) =>
-        (
+
           Some(
             AccessCondition(
               method = AccessMethod.ManualRequest,
-              status = AccessStatus.PermissionRequired)),
-          ItemStatus.Available)
+              status = AccessStatus.PermissionRequired)
+          )
 
       // A missing status overrides all other values.
       //
@@ -311,13 +311,13 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           _,
           NotRequestable.ItemMissing(message),
           _) =>
-        (
+
           Some(
             AccessCondition(
               method = AccessMethod.NotRequestable,
               status = Some(AccessStatus.Unavailable),
-              note = Some(message))),
-          ItemStatus.Unavailable)
+              note = Some(message))
+          )
 
       // A withdrawn status also overrides all other values.
       case (
@@ -327,13 +327,13 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           _,
           NotRequestable.ItemWithdrawn(message),
           _) =>
-        (
+
           Some(
             AccessCondition(
               method = AccessMethod.NotRequestable,
               status = Some(AccessStatus.Unavailable),
-              note = Some(message))),
-          ItemStatus.Unavailable)
+              note = Some(message))
+          )
 
       // If an item is on hold for another reader, it can't be requested -- even
       // if it would ordinarily be requestable.
@@ -351,15 +351,15 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           _,
           Requestable,
           Some(LocationType.ClosedStores)) if holdCount > 0 =>
-        (
+
           Some(
             AccessCondition(
               method = AccessMethod.ManualRequest,
               status = Some(AccessStatus.TemporarilyUnavailable),
               note = Some(
                 "Item is in use by another reader. Please ask at Enquiry Desk.")
-            )),
-          ItemStatus.TemporarilyUnavailable)
+            )
+          )
 
       case (
           None,
@@ -368,15 +368,14 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           _,
           NotRequestable.OnHold(_),
           Some(LocationType.ClosedStores)) =>
-        (
+
           Some(
             AccessCondition(
               method = AccessMethod.ManualRequest,
               status = Some(AccessStatus.TemporarilyUnavailable),
               note = Some(
                 "Item is in use by another reader. Please ask at Enquiry Desk.")
-            )),
-          ItemStatus.TemporarilyUnavailable)
+            ))
 
       // If we can't work out how this item should be handled, then let's mark it
       // as unavailable for now.
@@ -393,15 +392,14 @@ object SierraItemAccess extends SierraQueryOps with Logging {
             s"bibStatus=$bibStatus, holdCount=$holdCount, status=$status, " +
             s"opacmsg=$opacmsg, isRequestable=$isRequestable, location=$location"
         )
-        (
+
           Some(
             AccessCondition(
               method = AccessMethod.NotRequestable,
               note = Some(
                 s"""Please check this item <a href="https://search.wellcomelibrary.org/iii/encore/record/C__Rb${bibId.withoutCheckDigit}?lang=eng">on the Wellcome Library website</a> for access information""")
             )
-          ),
-          ItemStatus.Unavailable)
+          )
     }
   }
 

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -147,20 +147,18 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           Some(OpacMsg.OpenShelves),
           NotRequestable.OnOpenShelves(_),
           Some(LocationType.OpenShelves)) =>
-
-          Some(AccessCondition(method = AccessMethod.OpenShelves))
+        Some(AccessCondition(method = AccessMethod.OpenShelves))
 
       // There are some items that are labelled "bound in above" or "contained in above".
       //
       // These items aren't requestable on their own; you have to request the "primary" item.
       case (None, _, _, _, NotRequestable.RequestTopItem(message), _) =>
-
-          Some(
-            AccessCondition(
-              method = AccessMethod.NotRequestable,
-              terms = Some(message)
-            )
+        Some(
+          AccessCondition(
+            method = AccessMethod.NotRequestable,
+            terms = Some(message)
           )
+        )
 
       // Handle any cases that require a manual request.
       //
@@ -187,12 +185,11 @@ object SierraItemAccess extends SierraQueryOps with Logging {
             case _ => None
           }
 
-          Some(
-            AccessCondition(
-              method = AccessMethod.ManualRequest,
-              note = accessNote)
-          )
-
+        Some(
+          AccessCondition(
+            method = AccessMethod.ManualRequest,
+            note = accessNote)
+        )
 
       // Handle any cases where the item is closed.
       //
@@ -209,12 +206,11 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           locationType)
           if locationType.isEmpty || locationType.contains(
             LocationType.ClosedStores) =>
-
-          Some(
-            AccessCondition(
-              method = AccessMethod.NotRequestable,
-              status = AccessStatus.Closed)
-          )
+        Some(
+          AccessCondition(
+            method = AccessMethod.NotRequestable,
+            status = AccessStatus.Closed)
+        )
 
       // Handle any cases where the item is explicitly unavailable.
       case (
@@ -224,12 +220,11 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           Some(OpacMsg.Unavailable),
           NotRequestable.ItemUnavailable(_),
           _) =>
-
-          Some(
-            AccessCondition(
-              method = AccessMethod.NotRequestable,
-              status = AccessStatus.Unavailable)
-          )
+        Some(
+          AccessCondition(
+            method = AccessMethod.NotRequestable,
+            status = AccessStatus.Unavailable)
+        )
 
       case (
           None,
@@ -238,15 +233,14 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           Some(OpacMsg.AtDigitisation),
           NotRequestable.ItemUnavailable(_),
           _) =>
-
-          Some(
-            AccessCondition(
-              method = AccessMethod.NotRequestable,
-              status = Some(AccessStatus.TemporarilyUnavailable),
-              note = Some(
-                "This item is being digitised and is currently unavailable.")
-            )
+        Some(
+          AccessCondition(
+            method = AccessMethod.NotRequestable,
+            status = Some(AccessStatus.TemporarilyUnavailable),
+            note =
+              Some("This item is being digitised and is currently unavailable.")
           )
+        )
 
       // An item which is restricted can be requested online -- the user will have to fill in
       // any paperwork when they actually visit the library.
@@ -259,12 +253,11 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           Some(OpacMsg.OnlineRequest),
           Requestable,
           Some(LocationType.ClosedStores)) =>
-
-          Some(
-            AccessCondition(
-              method = AccessMethod.OnlineRequest,
-              status = AccessStatus.Restricted)
-          )
+        Some(
+          AccessCondition(
+            method = AccessMethod.OnlineRequest,
+            status = AccessStatus.Restricted)
+        )
 
       // The status "by appointment" takes precedence over "permission required".
       //
@@ -278,12 +271,11 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           Some(LocationType.ClosedStores))
           if bibStatus.isEmpty || bibStatus.contains(AccessStatus.ByAppointment) || bibStatus
             .contains(AccessStatus.PermissionRequired) =>
-
-          Some(
-            AccessCondition(
-              method = AccessMethod.ManualRequest,
-              status = AccessStatus.ByAppointment)
-          )
+        Some(
+          AccessCondition(
+            method = AccessMethod.ManualRequest,
+            status = AccessStatus.ByAppointment)
+        )
 
       case (
           bibStatus,
@@ -294,12 +286,11 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           Some(LocationType.ClosedStores))
           if bibStatus.isEmpty || bibStatus.contains(
             AccessStatus.PermissionRequired) =>
-
-          Some(
-            AccessCondition(
-              method = AccessMethod.ManualRequest,
-              status = AccessStatus.PermissionRequired)
-          )
+        Some(
+          AccessCondition(
+            method = AccessMethod.ManualRequest,
+            status = AccessStatus.PermissionRequired)
+        )
 
       // A missing status overrides all other values.
       //
@@ -311,13 +302,12 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           _,
           NotRequestable.ItemMissing(message),
           _) =>
-
-          Some(
-            AccessCondition(
-              method = AccessMethod.NotRequestable,
-              status = Some(AccessStatus.Unavailable),
-              note = Some(message))
-          )
+        Some(
+          AccessCondition(
+            method = AccessMethod.NotRequestable,
+            status = Some(AccessStatus.Unavailable),
+            note = Some(message))
+        )
 
       // A withdrawn status also overrides all other values.
       case (
@@ -327,13 +317,12 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           _,
           NotRequestable.ItemWithdrawn(message),
           _) =>
-
-          Some(
-            AccessCondition(
-              method = AccessMethod.NotRequestable,
-              status = Some(AccessStatus.Unavailable),
-              note = Some(message))
-          )
+        Some(
+          AccessCondition(
+            method = AccessMethod.NotRequestable,
+            status = Some(AccessStatus.Unavailable),
+            note = Some(message))
+        )
 
       // If an item is on hold for another reader, it can't be requested -- even
       // if it would ordinarily be requestable.
@@ -351,15 +340,14 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           _,
           Requestable,
           Some(LocationType.ClosedStores)) if holdCount > 0 =>
-
-          Some(
-            AccessCondition(
-              method = AccessMethod.ManualRequest,
-              status = Some(AccessStatus.TemporarilyUnavailable),
-              note = Some(
-                "Item is in use by another reader. Please ask at Enquiry Desk.")
-            )
+        Some(
+          AccessCondition(
+            method = AccessMethod.ManualRequest,
+            status = Some(AccessStatus.TemporarilyUnavailable),
+            note = Some(
+              "Item is in use by another reader. Please ask at Enquiry Desk.")
           )
+        )
 
       case (
           None,
@@ -368,14 +356,13 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           _,
           NotRequestable.OnHold(_),
           Some(LocationType.ClosedStores)) =>
-
-          Some(
-            AccessCondition(
-              method = AccessMethod.ManualRequest,
-              status = Some(AccessStatus.TemporarilyUnavailable),
-              note = Some(
-                "Item is in use by another reader. Please ask at Enquiry Desk.")
-            ))
+        Some(
+          AccessCondition(
+            method = AccessMethod.ManualRequest,
+            status = Some(AccessStatus.TemporarilyUnavailable),
+            note = Some(
+              "Item is in use by another reader. Please ask at Enquiry Desk.")
+          ))
 
       // If we can't work out how this item should be handled, then let's mark it
       // as unavailable for now.
@@ -393,13 +380,13 @@ object SierraItemAccess extends SierraQueryOps with Logging {
             s"opacmsg=$opacmsg, isRequestable=$isRequestable, location=$location"
         )
 
-          Some(
-            AccessCondition(
-              method = AccessMethod.NotRequestable,
-              note = Some(
-                s"""Please check this item <a href="https://search.wellcomelibrary.org/iii/encore/record/C__Rb${bibId.withoutCheckDigit}?lang=eng">on the Wellcome Library website</a> for access information""")
-            )
+        Some(
+          AccessCondition(
+            method = AccessMethod.NotRequestable,
+            note = Some(
+              s"""Please check this item <a href="https://search.wellcomelibrary.org/iii/encore/record/C__Rb${bibId.withoutCheckDigit}?lang=eng">on the Wellcome Library website</a> for access information""")
           )
+        )
     }
   }
 

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -589,7 +589,6 @@ class SierraItemAccessTest
               note = Some("This item is withdrawn.")
             )
           )
-          itemStatus shouldBe ItemStatus.Unavailable
         }
       }
     }

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -6,7 +6,6 @@ import weco.catalogue.internal_model.locations.{
   AccessCondition,
   AccessMethod,
   AccessStatus,
-  ItemStatus,
   LocationType
 }
 import weco.catalogue.source_model.generators.SierraDataGenerators
@@ -41,7 +40,7 @@ class SierraItemAccessTest
             )
           )
 
-          val (ac, _, itemStatus) = SierraItemAccess(
+          val (ac, _) = SierraItemAccess(
             bibId = bibId,
             itemId = itemId,
             bibStatus = None,
@@ -50,7 +49,6 @@ class SierraItemAccessTest
           )
 
           ac shouldBe Some(AccessCondition(method = AccessMethod.OnlineRequest))
-          itemStatus shouldBe ItemStatus.Available
         }
 
         it("if it has no restrictions and the bib is open") {
@@ -71,7 +69,7 @@ class SierraItemAccessTest
             )
           )
 
-          val (ac, _, itemStatus) = SierraItemAccess(
+          val (ac, _) = SierraItemAccess(
             bibId = bibId,
             itemId = itemId,
             bibStatus = Some(AccessStatus.Open),
@@ -83,7 +81,6 @@ class SierraItemAccessTest
             AccessCondition(
               method = AccessMethod.OnlineRequest,
               status = AccessStatus.Open))
-          itemStatus shouldBe ItemStatus.Available
         }
 
         it("if it's restricted") {
@@ -104,7 +101,7 @@ class SierraItemAccessTest
             )
           )
 
-          val (ac, _, itemStatus) = SierraItemAccess(
+          val (ac, _) = SierraItemAccess(
             bibId = bibId,
             itemId = itemId,
             bibStatus = Some(AccessStatus.Restricted),
@@ -116,7 +113,6 @@ class SierraItemAccessTest
             AccessCondition(
               method = AccessMethod.OnlineRequest,
               status = AccessStatus.Restricted))
-          itemStatus shouldBe ItemStatus.Available
         }
 
         it("if the bib is restricted but the item is open") {
@@ -137,7 +133,7 @@ class SierraItemAccessTest
             )
           )
 
-          val (ac, _, itemStatus) = SierraItemAccess(
+          val (ac, _) = SierraItemAccess(
             bibId = bibId,
             itemId = itemId,
             bibStatus = Some(AccessStatus.Restricted),
@@ -149,7 +145,6 @@ class SierraItemAccessTest
             AccessCondition(
               method = AccessMethod.OnlineRequest,
               status = AccessStatus.Open))
-          itemStatus shouldBe ItemStatus.Available
         }
       }
 
@@ -176,7 +171,7 @@ class SierraItemAccessTest
             )
           )
 
-          val (ac, _, itemStatus) = SierraItemAccess(
+          val (ac, _) = SierraItemAccess(
             bibId = bibId,
             itemId = itemId,
             bibStatus = None,
@@ -185,7 +180,6 @@ class SierraItemAccessTest
           )
 
           ac shouldBe Some(AccessCondition(method = AccessMethod.ManualRequest))
-          itemStatus shouldBe ItemStatus.Available
         }
 
         it("if it's bound in the top item") {
@@ -206,7 +200,7 @@ class SierraItemAccessTest
             )
           )
 
-          val (ac, _, itemStatus) = SierraItemAccess(
+          val (ac, _) = SierraItemAccess(
             bibId = bibId,
             itemId = itemId,
             bibStatus = None,
@@ -218,7 +212,6 @@ class SierraItemAccessTest
             AccessCondition(
               method = AccessMethod.NotRequestable,
               terms = Some("Please request top item.")))
-          itemStatus shouldBe ItemStatus.Unavailable
         }
 
         it("if it's contained the top item") {
@@ -239,7 +232,7 @@ class SierraItemAccessTest
             )
           )
 
-          val (ac, _, itemStatus) = SierraItemAccess(
+          val (ac, _) = SierraItemAccess(
             bibId = bibId,
             itemId = itemId,
             bibStatus = None,
@@ -251,7 +244,6 @@ class SierraItemAccessTest
             AccessCondition(
               method = AccessMethod.NotRequestable,
               terms = Some("Please request top item.")))
-          itemStatus shouldBe ItemStatus.Unavailable
         }
 
         it("if the bib and the item are closed") {
@@ -272,7 +264,7 @@ class SierraItemAccessTest
             )
           )
 
-          val (ac, _, itemStatus) = SierraItemAccess(
+          val (ac, _) = SierraItemAccess(
             bibId = bibId,
             itemId = itemId,
             bibStatus = Some(AccessStatus.Closed),
@@ -285,7 +277,6 @@ class SierraItemAccessTest
               method = AccessMethod.NotRequestable,
               status = AccessStatus.Closed
             ))
-          itemStatus shouldBe ItemStatus.Unavailable
         }
 
         it("if the bib and the item are closed, and there's no location") {
@@ -306,7 +297,7 @@ class SierraItemAccessTest
             )
           )
 
-          val (ac, _, itemStatus) = SierraItemAccess(
+          val (ac, _) = SierraItemAccess(
             bibId = bibId,
             itemId = itemId,
             bibStatus = Some(AccessStatus.Closed),
@@ -318,7 +309,6 @@ class SierraItemAccessTest
             AccessCondition(
               method = AccessMethod.NotRequestable,
               status = AccessStatus.Closed))
-          itemStatus shouldBe ItemStatus.Unavailable
         }
 
         it("if the item is unavailable") {
@@ -339,7 +329,7 @@ class SierraItemAccessTest
             )
           )
 
-          val (ac, _, itemStatus) = SierraItemAccess(
+          val (ac, _) = SierraItemAccess(
             bibId = bibId,
             itemId = itemId,
             bibStatus = None,
@@ -351,7 +341,6 @@ class SierraItemAccessTest
             AccessCondition(
               method = AccessMethod.NotRequestable,
               status = AccessStatus.Unavailable))
-          itemStatus shouldBe ItemStatus.Unavailable
         }
 
         it("if the item is at digitisation") {
@@ -372,7 +361,7 @@ class SierraItemAccessTest
             )
           )
 
-          val (ac, _, itemStatus) = SierraItemAccess(
+          val (ac, _) = SierraItemAccess(
             bibId = bibId,
             itemId = itemId,
             bibStatus = None,
@@ -388,7 +377,6 @@ class SierraItemAccessTest
                 "This item is being digitised and is currently unavailable.")
             )
           )
-          itemStatus shouldBe ItemStatus.TemporarilyUnavailable
         }
 
         it("if doesn't double up the note about digitisation") {
@@ -416,7 +404,7 @@ class SierraItemAccessTest
             )
           )
 
-          val (ac, _, itemStatus) = SierraItemAccess(
+          val (ac, _) = SierraItemAccess(
             bibId = bibId,
             itemId = itemId,
             bibStatus = None,
@@ -432,7 +420,6 @@ class SierraItemAccessTest
                 "This item is being digitised and is currently unavailable.")
             )
           )
-          itemStatus shouldBe ItemStatus.TemporarilyUnavailable
         }
 
         it("if the bib and item are by appointment") {
@@ -453,7 +440,7 @@ class SierraItemAccessTest
             )
           )
 
-          val (ac, _, itemStatus) = SierraItemAccess(
+          val (ac, _) = SierraItemAccess(
             bibId = bibId,
             itemId = itemId,
             bibStatus = Some(AccessStatus.ByAppointment),
@@ -466,7 +453,6 @@ class SierraItemAccessTest
               method = AccessMethod.ManualRequest,
               status = AccessStatus.ByAppointment)
           )
-          itemStatus shouldBe ItemStatus.Available
         }
 
         it("if the bib and item need donor permission") {
@@ -487,7 +473,7 @@ class SierraItemAccessTest
             )
           )
 
-          val (ac, _, itemStatus) = SierraItemAccess(
+          val (ac, _) = SierraItemAccess(
             bibId = bibId,
             itemId = itemId,
             bibStatus = Some(AccessStatus.PermissionRequired),
@@ -500,7 +486,6 @@ class SierraItemAccessTest
               method = AccessMethod.ManualRequest,
               status = AccessStatus.PermissionRequired)
           )
-          itemStatus shouldBe ItemStatus.Available
         }
 
         it("if the bib and item needs donor permission") {
@@ -521,7 +506,7 @@ class SierraItemAccessTest
             )
           )
 
-          val (ac, _, itemStatus) = SierraItemAccess(
+          val (ac, _) = SierraItemAccess(
             bibId = bibId,
             itemId = itemId,
             bibStatus = None,
@@ -534,7 +519,6 @@ class SierraItemAccessTest
               method = AccessMethod.ManualRequest,
               status = AccessStatus.PermissionRequired)
           )
-          itemStatus shouldBe ItemStatus.Available
         }
 
         it("if the item is missing") {
@@ -555,7 +539,7 @@ class SierraItemAccessTest
             )
           )
 
-          val (ac, _, itemStatus) = SierraItemAccess(
+          val (ac, _) = SierraItemAccess(
             bibId = bibId,
             itemId = itemId,
             bibStatus = None,
@@ -570,7 +554,6 @@ class SierraItemAccessTest
               note = Some("This item is missing.")
             )
           )
-          itemStatus shouldBe ItemStatus.Unavailable
         }
 
         it("if the item is withdrawn") {
@@ -591,7 +574,7 @@ class SierraItemAccessTest
             )
           )
 
-          val (ac, _, itemStatus) = SierraItemAccess(
+          val (ac, _) = SierraItemAccess(
             bibId = bibId,
             itemId = itemId,
             bibStatus = None,
@@ -631,7 +614,7 @@ class SierraItemAccessTest
           )
         )
 
-        val (ac, _, itemStatus) = SierraItemAccess(
+        val (ac, _) = SierraItemAccess(
           bibId = bibId,
           itemId = itemId,
           bibStatus = None,
@@ -647,7 +630,6 @@ class SierraItemAccessTest
               "Item is in use by another reader. Please ask at Enquiry Desk.")
           )
         )
-        itemStatus shouldBe ItemStatus.TemporarilyUnavailable
       }
 
       it("can't be requested when it's on the hold shelf for another reader") {
@@ -669,7 +651,7 @@ class SierraItemAccessTest
           )
         )
 
-        val (ac, _, itemStatus) = SierraItemAccess(
+        val (ac, _) = SierraItemAccess(
           bibId = bibId,
           itemId = itemId,
           bibStatus = None,
@@ -685,7 +667,6 @@ class SierraItemAccessTest
               "Item is in use by another reader. Please ask at Enquiry Desk.")
           )
         )
-        itemStatus shouldBe ItemStatus.TemporarilyUnavailable
       }
     }
 
@@ -719,7 +700,7 @@ class SierraItemAccessTest
           )
         )
 
-        val (Some(ac), note, itemStatus) = SierraItemAccess(
+        val (Some(ac), note) = SierraItemAccess(
           bibId = bibId,
           itemId = itemId,
           bibStatus = None,
@@ -732,8 +713,8 @@ class SierraItemAccessTest
           note = Some(
             "Email library@wellcomecollection.org to tell us why you need access. We’ll reply within a week.")
         )
+
         note shouldBe None
-        itemStatus shouldBe ItemStatus.Available
       }
 
       it("doesn't overwrite the note if there's a hold on the item") {
@@ -762,7 +743,7 @@ class SierraItemAccessTest
           )
         )
 
-        val (Some(ac), note, _) = SierraItemAccess(
+        val (Some(ac), note) = SierraItemAccess(
           bibId = bibId,
           itemId = itemId,
           bibStatus = None,
@@ -805,7 +786,7 @@ class SierraItemAccessTest
           )
         )
 
-        val (Some(ac), _, _) = SierraItemAccess(
+        val (Some(ac), _) = SierraItemAccess(
           bibId = bibId,
           itemId = itemId,
           bibStatus = None,
@@ -842,7 +823,7 @@ class SierraItemAccessTest
           )
         )
 
-        val (_, Some(note), _) = SierraItemAccess(
+        val (_, Some(note)) = SierraItemAccess(
           bibId = bibId,
           itemId = itemId,
           bibStatus = None,
@@ -875,7 +856,7 @@ class SierraItemAccessTest
           )
         )
 
-        val (Some(ac), _, itemStatus) = SierraItemAccess(
+        val (Some(ac), _) = SierraItemAccess(
           bibId = bibId,
           itemId = itemId,
           bibStatus = None,
@@ -884,7 +865,6 @@ class SierraItemAccessTest
         )
 
         ac shouldBe AccessCondition(method = AccessMethod.OpenShelves)
-        itemStatus shouldBe ItemStatus.Available
       }
 
       it("gets a display note") {
@@ -912,7 +892,7 @@ class SierraItemAccessTest
           )
         )
 
-        val (ac, _, itemStatus) = SierraItemAccess(
+        val (ac, _) = SierraItemAccess(
           bibId = bibId,
           itemId = itemId,
           bibStatus = None,
@@ -927,7 +907,6 @@ class SierraItemAccessTest
               "Shelved at the end of the Quick Ref. section with the oversize Quick Ref. books.")
           )
         )
-        itemStatus shouldBe ItemStatus.Available
       }
     }
 
@@ -949,7 +928,7 @@ class SierraItemAccessTest
         )
       )
 
-      val (ac, _, itemStatus) = SierraItemAccess(
+      val (ac, _) = SierraItemAccess(
         bibId = bibId,
         itemId = itemId,
         bibStatus = None,
@@ -964,7 +943,6 @@ class SierraItemAccessTest
           note = Some("This item is missing.")
         )
       )
-      itemStatus shouldBe ItemStatus.Unavailable
     }
   }
 
@@ -983,7 +961,7 @@ class SierraItemAccessTest
       )
     )
 
-    val (Some(ac), _, _) = SierraItemAccess(
+    val (Some(ac), _) = SierraItemAccess(
       bibId = bibId,
       itemId = itemId,
       bibStatus = None,

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraItems.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraItems.scala
@@ -197,7 +197,7 @@ object SierraItems extends Logging with SierraLocation with SierraQueryOps {
     itemData: SierraItemData,
     bibData: SierraBibData,
     location: Option[PhysicalLocation]): Option[String] = {
-    val (_, note, _) = SierraItemAccess(
+    val (_, note) = SierraItemAccess(
       bibId,
       itemId,
       SierraAccessStatus.forBib(bibId, bibData),

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraLocation.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraLocation.scala
@@ -43,7 +43,7 @@ trait SierraLocation {
         }
       }
 
-      (accessCondition, _, _) = SierraItemAccess(
+      (accessCondition, _) = SierraItemAccess(
         bibId = bibNumber,
         itemId = itemNumber,
         bibStatus = SierraAccessStatus.forBib(bibNumber, bibData),


### PR DESCRIPTION
ItemStatus was intended to be used in the Items API, but we've changed our plans and now it is unnecessary.

Part of https://github.com/wellcomecollection/catalogue-api/issues/35