### PR TITLE
description.copy_to search.relations

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksIndexConfig.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksIndexConfig.scala
@@ -74,7 +74,7 @@ object WorksIndexConfig extends IndexConfigFields {
             .copyTo(relationsPath ++ titlesAndContributorsPath),
           multilingualFieldWithKeyword("alternativeTitles")
             .copyTo(relationsPath ++ titlesAndContributorsPath),
-          englishTextField("description"),
+          englishTextField("description").copyTo(relationsPath),
           englishTextKeywordField("physicalDescription"),
           multilingualField("lettering"),
           objectField("contributors").fields(

--- a/common/internal_model/src/test/resources/WorksIndexConfig.json
+++ b/common/internal_model/src/test/resources/WorksIndexConfig.json
@@ -483,7 +483,10 @@
                 "type" : "text",
                 "analyzer" : "english"
               }
-            }
+            },
+            "copy_to": [
+              "search.relations"
+            ]
           },
           "physicalDescription" : {
             "type" : "text",


### PR DESCRIPTION
fixes https://github.com/wellcomecollection/catalogue-api/issues/137

This mappings was used to craete the index searched here:
https://catalogue-api-rank-gqzbh7lkw-weco1.vercel.app/index2?worksIndex=works-candidate (test `wa/hmm benin.`)

Mind the interface there, it's very prototype while we tidy up rank.

We're looking at how we might get the mappings into the `catalogue-api` repo so we can avoid these deps.