### PR TITLE
add monitoring to pipeline EC deployment

### DIFF
--- a/pipeline/terraform/locals.tf
+++ b/pipeline/terraform/locals.tf
@@ -49,4 +49,6 @@ locals {
   traffic_filter_platform_vpce_id   = local.shared_infra["ec_platform_privatelink_traffic_filter_id"]
   traffic_filter_catalogue_vpce_id  = local.shared_infra["ec_catalogue_privatelink_traffic_filter_id"]
   traffic_filter_public_internet_id = local.shared_infra["ec_public_internet_traffic_filter_id"]
+
+  logging_cluster_id = data.terraform_remote_state.shared_infra.outputs.logging_cluster_id
 }

--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -73,6 +73,8 @@ module "catalogue_pipeline_2021-06-08" {
   providers = {
     aws.catalogue = aws.catalogue
   }
+
+  logging_cluster_id = local.logging_cluster_id
 }
 
 module "catalogue_pipeline_2021-06-27" {
@@ -150,4 +152,6 @@ module "catalogue_pipeline_2021-06-27" {
   providers = {
     aws.catalogue = aws.catalogue
   }
+
+  logging_cluster_id = local.logging_cluster_id
 }

--- a/pipeline/terraform/stack/elastic_pipeline.tf
+++ b/pipeline/terraform/stack/elastic_pipeline.tf
@@ -1,3 +1,6 @@
+data "ec_deployment" "logging" {
+  id = local.logging_cluster_id
+}
 locals {
   es_memory = var.is_reindexing ? "58g" : "15g"
 }
@@ -27,6 +30,10 @@ resource "ec_deployment" "pipeline" {
       zone_count = 1
       size       = "1g"
     }
+  }
+
+  observability {
+    deployment_id = data.ec_deployment.logging.id
   }
 }
 

--- a/pipeline/terraform/stack/locals.tf
+++ b/pipeline/terraform/stack/locals.tf
@@ -74,5 +74,7 @@ locals {
   miro_adapter_topic_arns   = var.is_reindexing ? concat(var.adapters["miro"].topics, [var.adapters["miro"].reindex_topic]) : var.adapters["miro"].topics
   mets_adapter_topic_arns   = var.is_reindexing ? concat(var.adapters["mets"].topics, [var.adapters["mets"].reindex_topic]) : var.adapters["mets"].topics
   calm_adapter_topic_arns   = var.is_reindexing ? concat(var.adapters["calm"].topics, [var.adapters["calm"].reindex_topic]) : var.adapters["calm"].topics
+
+  logging_cluster_id = var.logging_cluster_id
 }
 

--- a/pipeline/terraform/stack/variables.tf
+++ b/pipeline/terraform/stack/variables.tf
@@ -80,3 +80,7 @@ variable "adapters" {
     reindex_topic = string
   }))
 }
+
+variable "logging_cluster_id" {
+  type = string
+}


### PR DESCRIPTION
Adds monitoring the pipeline deployments - shippings logs and metrics to `logging.`