### PR TITLE
Simplify our Dockerfile layers

### DIFF
--- a/calm_adapter/calm_adapter/Dockerfile
+++ b/calm_adapter/calm_adapter/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:104
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT calm_adapter
+ENTRYPOINT ["/opt/docker/bin/calm_adapter"]

--- a/calm_adapter/calm_deletion_checker/Dockerfile
+++ b/calm_adapter/calm_deletion_checker/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:104
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT calm_deletion_checker
+ENTRYPOINT ["/opt/docker/bin/calm_deletion_checker"]

--- a/mets_adapter/mets_adapter/Dockerfile
+++ b/mets_adapter/mets_adapter/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:104
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT mets_adapter
+ENTRYPOINT ["/opt/docker/bin/mets_adapter"]

--- a/pipeline/id_minter/Dockerfile
+++ b/pipeline/id_minter/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:104
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT id_minter
+ENTRYPOINT ["/opt/docker/bin/id_minter"]

--- a/pipeline/inferrer/inference_manager/Dockerfile
+++ b/pipeline/inferrer/inference_manager/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:104
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT inference_manager
+ENTRYPOINT ["/opt/docker/bin/inference_manager"]

--- a/pipeline/ingestor/ingestor_images/Dockerfile
+++ b/pipeline/ingestor/ingestor_images/Dockerfile
@@ -1,6 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:104
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT ingestor_images
-
+ENTRYPOINT ["/opt/docker/bin/ingestor_images"]

--- a/pipeline/ingestor/ingestor_works/Dockerfile
+++ b/pipeline/ingestor/ingestor_works/Dockerfile
@@ -1,6 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:104
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT ingestor_works
-
+ENTRYPOINT ["/opt/docker/bin/ingestor_works"]

--- a/pipeline/matcher/Dockerfile
+++ b/pipeline/matcher/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:104
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT matcher
+ENTRYPOINT ["/opt/docker/bin/matcher"]

--- a/pipeline/merger/Dockerfile
+++ b/pipeline/merger/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:104
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT merger
+ENTRYPOINT ["/opt/docker/bin/merger"]

--- a/pipeline/relation_embedder/batcher/Dockerfile
+++ b/pipeline/relation_embedder/batcher/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:104
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT batcher
+ENTRYPOINT ["/opt/docker/bin/batcher"]

--- a/pipeline/relation_embedder/relation_embedder/Dockerfile
+++ b/pipeline/relation_embedder/relation_embedder/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:104
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT relation_embedder
+ENTRYPOINT ["/opt/docker/bin/relation_embedder"]

--- a/pipeline/relation_embedder/router/Dockerfile
+++ b/pipeline/relation_embedder/router/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:104
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT router
+ENTRYPOINT ["/opt/docker/bin/router"]

--- a/pipeline/transformer/transformer_calm/Dockerfile
+++ b/pipeline/transformer/transformer_calm/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:104
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT transformer_calm
+ENTRYPOINT ["/opt/docker/bin/transformer_calm"]

--- a/pipeline/transformer/transformer_mets/Dockerfile
+++ b/pipeline/transformer/transformer_mets/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:104
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT transformer_mets
+ENTRYPOINT ["/opt/docker/bin/transformer_mets"]

--- a/pipeline/transformer/transformer_miro/Dockerfile
+++ b/pipeline/transformer/transformer_miro/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:104
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT transformer_miro
+ENTRYPOINT ["/opt/docker/bin/transformer_miro"]

--- a/pipeline/transformer/transformer_sierra/Dockerfile
+++ b/pipeline/transformer/transformer_sierra/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:104
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT transformer_sierra
+ENTRYPOINT ["/opt/docker/bin/transformer_sierra"]

--- a/pipeline/transformer/transformer_tei/Dockerfile
+++ b/pipeline/transformer/transformer_tei/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:104
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT transformer_tei
+ENTRYPOINT ["/opt/docker/bin/transformer_tei"]

--- a/reindexer/reindex_worker/Dockerfile
+++ b/reindexer/reindex_worker/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:21
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT reindex_worker
+ENTRYPOINT ["/opt/docker/bin/reindex_worker"]

--- a/sierra_adapter/sierra_indexer/Dockerfile
+++ b/sierra_adapter/sierra_indexer/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:104
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT sierra_indexer
+ENTRYPOINT ["/opt/docker/bin/sierra_indexer"]

--- a/sierra_adapter/sierra_linker/Dockerfile
+++ b/sierra_adapter/sierra_linker/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:104
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT sierra_linker
+ENTRYPOINT ["/opt/docker/bin/sierra_linker"]

--- a/sierra_adapter/sierra_merger/Dockerfile
+++ b/sierra_adapter/sierra_merger/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:21
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT sierra_merger
+ENTRYPOINT ["/opt/docker/bin/sierra_merger"]

--- a/sierra_adapter/sierra_reader/Dockerfile
+++ b/sierra_adapter/sierra_reader/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:104
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT sierra_reader
+ENTRYPOINT ["/opt/docker/bin/sierra_reader"]

--- a/tei_adapter/tei_adapter/Dockerfile
+++ b/tei_adapter/tei_adapter/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:104
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT tei_adapter
+ENTRYPOINT ["/opt/docker/bin/tei_adapter"]

--- a/tei_adapter/tei_id_extractor/Dockerfile
+++ b/tei_adapter/tei_id_extractor/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:104
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT tei_id_extractor
+ENTRYPOINT ["/opt/docker/bin/tei_id_extractor"]


### PR DESCRIPTION
The typesafe_config_base image has a couple of issues:

- It fetches ECS_METADATA_URI on startup, even though we no longer need to do this – it's a holdover from an old approach to doing logging.
- It obscures exactly how the image is being built, and what's available.
- Actually finding the Dockerfile for this image is very hard to impossible.

Since we don't need it, let's simplify the Dockerfile.

For wellcomecollection/platform#4619