### PR TITLE
Remove the inferred "Copy N" title if it's the same on all items

### DIFF
--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraItems.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraItems.scala
@@ -101,18 +101,16 @@ object SierraItems extends Logging with SierraLocation with SierraQueryOps {
         require(!itemData.suppressed)
       }
 
-    val items = sierraItemDataMap
-      .map {
-        case (itemId, itemData) =>
-          transformItemData(
-            bibId = bibId,
-            itemId = itemId,
-            itemData = itemData,
-            bibData = bibData,
-            fallbackLocation = fallbackLocation
-          )
-      }
-      .toList
+    val items = sierraItemDataMap.map {
+      case (itemId, itemData) =>
+        transformItemData(
+          bibId = bibId,
+          itemId = itemId,
+          itemData = itemData,
+          bibData = bibData,
+          fallbackLocation = fallbackLocation
+        )
+    }.toList
 
     tidyInferredTitles(items)
   }
@@ -165,8 +163,9 @@ object SierraItems extends Logging with SierraLocation with SierraQueryOps {
     *     create a string like "Copy 2".
     *
     */
-  private def getItemTitle(itemId: SierraItemNumber,
-                           data: SierraItemData): (Option[String], HasInferredTitle) = {
+  private def getItemTitle(
+    itemId: SierraItemNumber,
+    data: SierraItemData): (Option[String], HasInferredTitle) = {
     val titleCandidates: List[String] =
       data.varFields
         .filter { _.fieldTag.contains("v") }
@@ -214,9 +213,14 @@ object SierraItems extends Logging with SierraLocation with SierraQueryOps {
     * can only be applied when looking at the items together.
     *
     */
-  private def tidyInferredTitles(items: List[(Item[IdState.Identifiable], HasInferredTitle)]): List[Item[IdState.Identifiable]] = {
+  private def tidyInferredTitles(
+    items: List[(Item[IdState.Identifiable], HasInferredTitle)])
+    : List[Item[IdState.Identifiable]] = {
     val inferredTitles =
-      items.collect { case (Item(_, Some(title), _, _), inferredTitle) if inferredTitle => title }
+      items.collect {
+        case (Item(_, Some(title), _, _), inferredTitle) if inferredTitle =>
+          title
+      }
 
     val everyItemHasTheSameInferredTitle =
       inferredTitles.size == items.size && inferredTitles.toSet.size == 1

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraItems.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraItems.scala
@@ -207,7 +207,7 @@ object SierraItems extends Logging with SierraLocation with SierraQueryOps {
     *   1) There's only one item, and it has an inferred title
     *   2) Every item has the same inferred title
     *
-    * Note: (1) is really a special case of (1) for the case when there's a single item.
+    * Note: (1) is really a special case of (2) for the case when there's a single item.
     *
     * Note: we can't do this when we add the title to the individual items, because this rule
     * can only be applied when looking at the items together.

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraItems.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraItems.scala
@@ -219,7 +219,7 @@ object SierraItems extends Logging with SierraLocation with SierraQueryOps {
     * can only be applied when looking at the items together.
     *
     */
-  private def tidyInferredTitles(
+  private def tidyTitles(
     items: List[(Item[IdState.Identifiable], HasAutomatedTitle)])
     : List[Item[IdState.Identifiable]] = {
     val inferredTitles =

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraItemsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraItemsTest.scala
@@ -144,7 +144,7 @@ class SierraItemsTest
         "Copy 4")
     }
 
-    it("omits the copy number if there's only a single item") {
+    it("omits the copy number title if there's only a single item") {
       val itemDataMap = Map(
         createSierraItemNumber -> createSierraItemDataWith(copyNo = Some(1))
       )
@@ -152,6 +152,36 @@ class SierraItemsTest
       val items = getTransformedItems(itemDataMap = itemDataMap)
 
       items.map { _.title } shouldBe Seq(None)
+    }
+
+    it("omits the copy number title if every item has the same copy number") {
+      val itemDataMap = Map(
+        createSierraItemNumber -> createSierraItemDataWith(copyNo = Some(1)),
+        createSierraItemNumber -> createSierraItemDataWith(copyNo = Some(1)),
+        createSierraItemNumber -> createSierraItemDataWith(copyNo = Some(1))
+      )
+
+      val items = getTransformedItems(itemDataMap = itemDataMap)
+
+      items.map { _.title } shouldBe Seq(None, None, None)
+    }
+
+    it("uses the title if every item has the same explicitly set title") {
+      val itemData = createSierraItemDataWith(
+        varFields = List(
+          VarField(fieldTag = "v", content = "Impression")
+        )
+      )
+
+      val itemDataMap = Map(
+        createSierraItemNumber -> itemData,
+        createSierraItemNumber -> itemData,
+        createSierraItemNumber -> itemData
+      )
+
+      val items = getTransformedItems(itemDataMap = itemDataMap)
+
+      items.map { _.title } shouldBe Seq(Some("Impression"), Some("Impression"), Some("Impression"))
     }
 
     def getTitle(itemData: SierraItemData): Option[String] = {

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraItemsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraItemsTest.scala
@@ -181,7 +181,10 @@ class SierraItemsTest
 
       val items = getTransformedItems(itemDataMap = itemDataMap)
 
-      items.map { _.title } shouldBe Seq(Some("Impression"), Some("Impression"), Some("Impression"))
+      items.map { _.title } shouldBe Seq(
+        Some("Impression"),
+        Some("Impression"),
+        Some("Impression"))
     }
 
     def getTitle(itemData: SierraItemData): Option[String] = {


### PR DESCRIPTION
It's not helpful to have a work where every item is titled "Copy 1", say. This affects ~38k items.

Closes https://github.com/wellcomecollection/platform/issues/5237