### PR TITLE
Update run_terraform.sh to generate own profile

### DIFF
--- a/pipeline/terraform/run_terraform.sh
+++ b/pipeline/terraform/run_terraform.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 
-AWS_CLI_PROFILE=${AWS_PROFILE:-platform-developer}
+AWS_CLI_PROFILE="catalogue-pipeline-terraform"
+PLATFORM_DEVELOPER_ARN="arn:aws:iam::760097843905:role/platform-developer"
+
+aws configure set region eu-west-1 --profile $AWS_CLI_PROFILE
+aws configure set role_arn $PLATFORM_DEVELOPER_ARN --profile $AWS_CLI_PROFILE
+aws configure set source_profile default --profile $AWS_CLI_PROFILE
 
 EC_API_KEY=$(aws secretsmanager get-secret-value --secret-id elastic_cloud/api_key --profile "$AWS_CLI_PROFILE" --output text --query 'SecretString')
 


### PR DESCRIPTION
[Follow the pattern](https://github.com/wellcomecollection/catalogue-api/blob/main/terraform/shared/run_terraform.sh#L3) of creating an AWS profile for users, rather than expecting particular profile/role combinations to exist.