### PR TITLE
Don't warn if the Sierra language code is just whitespace

### DIFF
--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraBibData.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraBibData.scala
@@ -1,6 +1,5 @@
 package weco.catalogue.source_model.sierra
 
-import io.circe.Decoder
 import weco.catalogue.source_model.sierra.marc.{FixedField, VarField}
 import weco.catalogue.source_model.sierra.source.{
   SierraMaterialType,
@@ -42,17 +41,4 @@ case class SierraBibData(
             varFieldsWithPosition
               .map { case (_, position, vf) => (position, vf) }
       }
-}
-
-object SierraBibData {
-
-  // the "lang" field in sierra can be "lang": {"code": " "} for example for paintings that don't have a language.
-  // We want those records to be decoded as `None` as this effectively means the record doesn't have a language,
-  // so we use a custom decoder to achieve that
-  implicit def d(implicit dec: Decoder[Option[SierraSourceLanguage]])
-    : Decoder[Option[SierraSourceLanguage]] =
-    dec.map {
-      case Some(SierraSourceLanguage(code, _)) if code.trim.isEmpty => None
-      case other                                                    => other
-    }
 }

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/SierraBibDataTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/SierraBibDataTest.scala
@@ -6,8 +6,6 @@ import org.scalatest.matchers.should.Matchers
 import weco.json.JsonUtil._
 import weco.catalogue.source_model.sierra.source.SierraSourceLanguage
 
-import SierraBibData._
-
 class SierraBibDataTest extends AnyFunSpec with Matchers with TryValues {
   it("decodes a bibData with language") {
     val bibDataJson =
@@ -21,18 +19,6 @@ class SierraBibDataTest extends AnyFunSpec with Matchers with TryValues {
 
     fromJson[SierraBibData](bibDataJson).get shouldBe SierraBibData(
       lang = Some(SierraSourceLanguage("eng", "English")))
-  }
-
-  it("decodes a language with empty code as None") {
-    val bibDataJson =
-      s"""
-         |{
-         |  "lang": {
-         |    "code": " "
-         |  }
-         |}""".stripMargin
-
-    fromJson[SierraBibData](bibDataJson).get shouldBe SierraBibData()
   }
 
   it("decodes a bib with no language name") {

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraLanguages.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraLanguages.scala
@@ -72,6 +72,13 @@ object SierraLanguages
     (lang, MarcLanguageCodeList.fromCode(lang.code)) match {
       case (_, Some(deducedLang)) => Some(deducedLang)
       case (SierraSourceLanguage(code, Some(name)), _) => Some(Language(label = name, id = code))
+
+      // Some records in Sierra don't have a language, e.g. paintings, and this is
+      // represented by a string that is only whitespace "   ".  This isn't a data error,
+      // and we shouldn't warn for it.
+      case (SierraSourceLanguage(code, _), _) if code.trim.isEmpty =>
+        None
+
       case _ =>
         warn(s"$bibId: Unrecognised primary language: $lang")
         None

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraLanguagesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraLanguagesTest.scala
@@ -195,6 +195,14 @@ class SierraLanguagesTest
     getLanguages(bibData) shouldBe empty
   }
 
+  it("ignores a language code which is only whitespace") {
+    val bibData = createSierraBibDataWith(
+      lang = Some(SierraSourceLanguage(code = "   ", name = None))
+    )
+
+    getLanguages(bibData) shouldBe empty
+  }
+
   private def getLanguages(bibData: SierraBibData): List[Language] =
     SierraLanguages(bibId = createSierraBibNumber, bibData = bibData)
 }


### PR DESCRIPTION
There are warnings in the Sierra transformer logs like:

    WARN  w.p.t.s.t.SierraLanguages$ - 3182204: Unrecognised primary language: SierraSourceLanguage(   ,None)

This warning is meant to help us spot malformed language codes or data errors that need correcting, but we know whitespace strings are fine -- they're used for records that don't have a language (e.g. paintings).

The previous mechanism was a bit clever and tried to use a custom decoder; instead let's handle this just before we log the warning.