### PR TITLE
Allow consumers to specify all params on PhysicalLocation if they wish

### DIFF
--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/generators/LocationGenerators.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/generators/LocationGenerators.scala
@@ -10,18 +10,23 @@ trait LocationGenerators extends RandomGenerators {
       LocationType.OpenShelves
     ),
     accessConditions: List[AccessCondition] = Nil,
-    label: String = "locationLabel"
+    label: String = "locationLabel",
+    license: Option[License] = chooseFrom(
+      None,
+      Some(License.CCBY),
+      Some(License.OGL),
+      Some(License.PDM)
+    ),
+    shelfmark: Option[String] = chooseFrom(
+      None,
+      Some(s"Shelfmark: ${randomAlphanumeric()}")
+    )
   ): PhysicalLocation =
     PhysicalLocation(
       locationType = locationType,
       label = label,
-      license = chooseFrom(
-        None,
-        Some(License.CCBY),
-        Some(License.OGL),
-        Some(License.PDM)
-      ),
-      shelfmark = chooseFrom(None, Some(s"Shelfmark: ${randomAlphanumeric()}")),
+      license = license,
+      shelfmark = shelfmark,
       accessConditions = accessConditions
     )
 


### PR DESCRIPTION
This change allows consumers to set up any part of a generated `PhysicalLocation` in order to get a predictable output.

Comes from wanting to test output in https://github.com/wellcomecollection/catalogue-api/pull/164