### PR TITLE
Always require a reason in the MergeCandidate

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/MergeCandidate.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/MergeCandidate.scala
@@ -18,7 +18,7 @@ import weco.catalogue.internal_model.identifiers.{
   */
 case class MergeCandidate[+State](
   id: State,
-  reason: Option[String] = None
+  reason: String
 ) extends HasId[State]
 
 case object MergeCandidate {
@@ -26,6 +26,6 @@ case object MergeCandidate {
             reason: String): MergeCandidate[IdState.Identifiable] =
     MergeCandidate(
       id = IdState.Identifiable(sourceIdentifier = identifier),
-      reason = Some(reason)
+      reason = reason
     )
 }

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/generators/SierraWorkGenerators.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/generators/SierraWorkGenerators.scala
@@ -24,10 +24,10 @@ trait SierraWorkGenerators extends WorkGenerators with ItemsGenerators {
         List(
           MergeCandidate(
             id = IdState.Identified(
-              digitisedWork.state.canonicalId,
-              digitisedWork.sourceIdentifier
+              canonicalId = digitisedWork.state.canonicalId,
+              sourceIdentifier = digitisedWork.sourceIdentifier
             ),
-            reason = Some("Physical/digitised Sierra work")
+            reason = "Physical/digitised Sierra work"
           )
         )
       )

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/storage/elastic/ElasticWorkLinksRetrieverTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/storage/elastic/ElasticWorkLinksRetrieverTest.scala
@@ -36,7 +36,7 @@ class ElasticWorkLinksRetrieverTest
                     canonicalId = id,
                     sourceIdentifier = createSourceIdentifier
                   ),
-                  reason = None
+                  reason = "Linked in the matcher tests"
                 )
               }.toList
             )

--- a/pipeline/merger/src/test/scala/weco/pipeline/merger/MergerScenarioTest.scala
+++ b/pipeline/merger/src/test/scala/weco/pipeline/merger/MergerScenarioTest.scala
@@ -165,7 +165,7 @@ class MergerScenarioTest
                   sourceIdentifier = digitisedVideo.sourceIdentifier,
                   canonicalId = digitisedVideo.state.canonicalId
                 ),
-                reason = Some("Physical/digitised Sierra work")
+                reason = "Physical/digitised Sierra work"
               )
             )
           )
@@ -296,7 +296,7 @@ class MergerScenarioTest
                   sourceIdentifier =
                     workWithPhysicalVideoFormats.sourceIdentifier
                 ),
-                reason = Some("Physical/digitised Sierra work")
+                reason = "Physical/digitised Sierra work"
               )
             )
           )
@@ -311,7 +311,7 @@ class MergerScenarioTest
                   canonicalId = workForEbib.state.canonicalId,
                   sourceIdentifier = workForEbib.sourceIdentifier
                 ),
-                reason = Some("METS work")
+                reason = "METS work"
               )
             )
           )

--- a/pipeline/merger/src/test/scala/weco/pipeline/merger/models/SourcesTest.scala
+++ b/pipeline/merger/src/test/scala/weco/pipeline/merger/models/SourcesTest.scala
@@ -36,13 +36,13 @@ class SourcesTest
                 id = IdState.Identified(
                   sourceIdentifier = digitisedWork1.sourceIdentifier,
                   canonicalId = digitisedWork1.state.canonicalId),
-                reason = Some("Physical/digitised Sierra work")
+                reason = "Physical/digitised Sierra work"
               ),
               MergeCandidate(
                 id = IdState.Identified(
                   sourceIdentifier = digitisedWork2.sourceIdentifier,
                   canonicalId = digitisedWork2.state.canonicalId),
-                reason = Some("Physical/digitised Sierra work")
+                reason = "Physical/digitised Sierra work"
               )
             )
           )
@@ -66,7 +66,7 @@ class SourcesTest
                 id = IdState.Identified(
                   sourceIdentifier = digitisedWork.sourceIdentifier,
                   canonicalId = digitisedWork.state.canonicalId),
-                reason = Some("Linked for a mystery reason")
+                reason = "Linked for a mystery reason"
               )
             )
           )
@@ -90,7 +90,7 @@ class SourcesTest
                 id = IdState.Identified(
                   sourceIdentifier = createSierraIdentifierSourceIdentifier,
                   canonicalId = createCanonicalId),
-                reason = Some("Physical/digitised Sierra work")
+                reason = "Physical/digitised Sierra work"
               )
             )
           )
@@ -114,7 +114,7 @@ class SourcesTest
                 id = IdState.Identified(
                   sourceIdentifier = digitisedWork.sourceIdentifier,
                   canonicalId = digitisedWork.state.canonicalId),
-                reason = Some("Physical/digitised Sierra work")
+                reason = "Physical/digitised Sierra work"
               )
             )
           )
@@ -138,7 +138,7 @@ class SourcesTest
                 id = IdState.Identified(
                   sourceIdentifier = digitisedWork.sourceIdentifier,
                   canonicalId = digitisedWork.state.canonicalId),
-                reason = Some("Physical/digitised Sierra work")
+                reason = "Physical/digitised Sierra work"
               )
             )
           )
@@ -163,7 +163,7 @@ class SourcesTest
                 id = IdState.Identified(
                   sourceIdentifier = digitisedWork.sourceIdentifier,
                   canonicalId = digitisedWork.state.canonicalId),
-                reason = Some("Physical/digitised Sierra work")
+                reason = "Physical/digitised Sierra work"
               )
             )
           )

--- a/pipeline/merger/src/test/scala/weco/pipeline/merger/rules/ItemsRuleTest.scala
+++ b/pipeline/merger/src/test/scala/weco/pipeline/merger/rules/ItemsRuleTest.scala
@@ -125,7 +125,7 @@ class ItemsRuleTest
                 canonicalId = digitisedWork.state.canonicalId,
                 sourceIdentifier = digitisedWork.state.sourceIdentifier
               ),
-              reason = Some("Physical/digitised Sierra work")
+              reason = "Physical/digitised Sierra work"
             )
           )
         )

--- a/pipeline/merger/src/test/scala/weco/pipeline/merger/rules/OtherIdentifiersRuleTest.scala
+++ b/pipeline/merger/src/test/scala/weco/pipeline/merger/rules/OtherIdentifiersRuleTest.scala
@@ -68,10 +68,10 @@ class OtherIdentifiersRuleTest
       .mergeCandidates(
         List(
           MergeCandidate(
-            IdState.Identified(
+            id = IdState.Identified(
               sourceIdentifier = mergeCandidate.sourceIdentifier,
               canonicalId = mergeCandidate.state.canonicalId),
-            Some("Physical/digitised Sierra work")
+            reason = "Physical/digitised Sierra work"
           )
         )
       )

--- a/pipeline/merger/src/test/scala/weco/pipeline/merger/services/MergerWorkerServiceTest.scala
+++ b/pipeline/merger/src/test/scala/weco/pipeline/merger/services/MergerWorkerServiceTest.scala
@@ -342,9 +342,9 @@ class MergerWorkerServiceTest
         List(
           MergeCandidate(
             id = IdState.Identified(
-              deletedWork.state.canonicalId,
-              deletedWork.sourceIdentifier),
-            reason = Some("Physical/digitised Sierra work")
+              canonicalId = deletedWork.state.canonicalId,
+              sourceIdentifier = deletedWork.sourceIdentifier),
+            reason = "Physical/digitised Sierra work"
           )
         )
       )

--- a/pipeline/merger/src/test/scala/weco/pipeline/merger/services/PlatformMergerTest.scala
+++ b/pipeline/merger/src/test/scala/weco/pipeline/merger/services/PlatformMergerTest.scala
@@ -40,7 +40,7 @@ class PlatformMergerTest
             id = IdState.Identified(
               sourceIdentifier = sierraDigitisedWork.sourceIdentifier,
               canonicalId = sierraDigitisedWork.state.canonicalId),
-            reason = Some("Physical/digitised Sierra work")
+            reason = "Physical/digitised Sierra work"
           )
         )
       )
@@ -61,7 +61,7 @@ class PlatformMergerTest
             id = IdState.Identified(
               sourceIdentifier = sierraDigitisedWork.sourceIdentifier,
               canonicalId = sierraDigitisedWork.state.canonicalId),
-            reason = Some("Physical/digitised Sierra work")
+            reason = "Physical/digitised Sierra work"
           )
         )
       )
@@ -693,7 +693,7 @@ class PlatformMergerTest
               id = IdState.Identified(
                 sourceIdentifier = digitisedVideo.sourceIdentifier,
                 canonicalId = digitisedVideo.state.canonicalId),
-              reason = Some("Physical/digitised Sierra work")
+              reason = "Physical/digitised Sierra work"
             )
           )
         )
@@ -744,7 +744,7 @@ class PlatformMergerTest
                 canonicalId = workWithPhysicalVideoFormats.state.canonicalId,
                 sourceIdentifier = workWithPhysicalVideoFormats.sourceIdentifier
               ),
-              reason = Some("Physical/digitised Sierra work")
+              reason = "Physical/digitised Sierra work"
             )
           )
         )
@@ -759,7 +759,7 @@ class PlatformMergerTest
                 canonicalId = workForEbib.state.canonicalId,
                 sourceIdentifier = workForEbib.sourceIdentifier
               ),
-              reason = Some("METS work")
+              reason = "METS work"
             )
           )
         )
@@ -776,7 +776,7 @@ class PlatformMergerTest
                 canonicalId = workForEbib.state.canonicalId,
                 sourceIdentifier = workForEbib.sourceIdentifier
               ),
-              reason = Some("Physical/digitised Sierra work")
+              reason = "Physical/digitised Sierra work"
             )
           )
         )
@@ -854,7 +854,7 @@ class PlatformMergerTest
                 canonicalId = eVideoWork.state.canonicalId,
                 sourceIdentifier = eVideoWork.sourceIdentifier
               ),
-              reason = Some("Physical/digitised Sierra work")
+              reason = "Physical/digitised Sierra work"
             )
           )
         )
@@ -870,7 +870,7 @@ class PlatformMergerTest
                 canonicalId = eVideoWork.state.canonicalId,
                 sourceIdentifier = eVideoWork.sourceIdentifier
               ),
-              reason = Some("METS work")
+              reason = "METS work"
             )
           )
         )
@@ -928,7 +928,7 @@ class PlatformMergerTest
                 canonicalId = digitisedWork.state.canonicalId,
                 sourceIdentifier = digitisedWork.state.sourceIdentifier
               ),
-              reason = Some("Physical/digitised Sierra work")
+              reason = "Physical/digitised Sierra work"
             )
           )
         )
@@ -960,7 +960,7 @@ class PlatformMergerTest
             canonicalId = physicalWork.state.canonicalId,
             sourceIdentifier = physicalWork.state.sourceIdentifier
           ),
-          reason = Some("Physical/digitised Sierra work")
+          reason = "Physical/digitised Sierra work"
         )
       )
     )

--- a/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/transformers/CalmMergeCandidates.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/transformers/CalmMergeCandidates.scala
@@ -27,8 +27,8 @@ object CalmMergeCandidates extends CalmRecordOps {
       }
       .map { sourceIdentifier =>
         MergeCandidate(
-          id = IdState.Identifiable(sourceIdentifier),
-          reason = Some("CALM/Miro work")
+          identifier = sourceIdentifier,
+          reason = "CALM/Miro work"
         )
       }
 
@@ -44,8 +44,8 @@ object CalmMergeCandidates extends CalmRecordOps {
       }
       .map { sourceIdentifier =>
         MergeCandidate(
-          id = IdState.Identifiable(sourceIdentifier),
-          reason = Some("CALM/Sierra harvest work")
+          identifier = sourceIdentifier,
+          reason = "CALM/Sierra harvest work"
         )
       }
 }

--- a/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/CalmTransformerTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/CalmTransformerTest.scala
@@ -130,34 +130,28 @@ class CalmTransformerTest
     CalmTransformer(record, version).right.get.data.mergeCandidates shouldBe
       List(
         MergeCandidate(
-          id = IdState.Identifiable(
-            SourceIdentifier(
-              value = "b12345672",
-              identifierType = IdentifierType.SierraSystemNumber,
-              ontologyType = "Work"
-            )
+          identifier = SourceIdentifier(
+            value = "b12345672",
+            identifierType = IdentifierType.SierraSystemNumber,
+            ontologyType = "Work"
           ),
-          reason = Some("CALM/Sierra harvest work")
+          reason = "CALM/Sierra harvest work"
         ),
         MergeCandidate(
-          id = IdState.Identifiable(
-            SourceIdentifier(
-              value = "M0000001",
-              identifierType = IdentifierType.MiroImageNumber,
-              ontologyType = "Work"
-            )
+          identifier = SourceIdentifier(
+            value = "M0000001",
+            identifierType = IdentifierType.MiroImageNumber,
+            ontologyType = "Work"
           ),
-          reason = Some("CALM/Miro work")
+          reason = "CALM/Miro work"
         ),
         MergeCandidate(
-          id = IdState.Identifiable(
-            SourceIdentifier(
-              value = "M0000002",
-              identifierType = IdentifierType.MiroImageNumber,
-              ontologyType = "Work"
-            )
+          identifier = SourceIdentifier(
+            value = "M0000002",
+            identifierType = IdentifierType.MiroImageNumber,
+            ontologyType = "Work"
           ),
-          reason = Some("CALM/Miro work")
+          reason = "CALM/Miro work"
         )
       )
   }

--- a/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/transformers/CalmMergeCandidatesTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/transformers/CalmMergeCandidatesTest.scala
@@ -3,7 +3,6 @@ package weco.pipeline.transformer.calm.transformers
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.catalogue.internal_model.identifiers.{
-  IdState,
   IdentifierType,
   SourceIdentifier
 }
@@ -23,14 +22,12 @@ class CalmMergeCandidatesTest
     val mergeCandidates = CalmMergeCandidates(record)
 
     mergeCandidates should contain only MergeCandidate(
-      id = IdState.Identifiable(
-        SourceIdentifier(
-          identifierType = IdentifierType.SierraSystemNumber,
-          ontologyType = "Work",
-          value = bnumber
-        )
+      identifier = SourceIdentifier(
+        identifierType = IdentifierType.SierraSystemNumber,
+        ontologyType = "Work",
+        value = bnumber
       ),
-      reason = Some("CALM/Sierra harvest work")
+      reason = "CALM/Sierra harvest work"
     )
   }
 
@@ -44,14 +41,12 @@ class CalmMergeCandidatesTest
     mergeCandidates should contain allElementsOf miroIds.map(
       id =>
         MergeCandidate(
-          id = IdState.Identifiable(
-            SourceIdentifier(
-              identifierType = IdentifierType.MiroImageNumber,
-              ontologyType = "Work",
-              value = id
-            )
+          identifier = SourceIdentifier(
+            identifierType = IdentifierType.MiroImageNumber,
+            ontologyType = "Work",
+            value = id
           ),
-          reason = Some("CALM/Miro work")
+          reason = "CALM/Miro work"
       )
     )
   }
@@ -67,27 +62,23 @@ class CalmMergeCandidatesTest
 
     mergeCandidates should contain(
       MergeCandidate(
-        id = IdState.Identifiable(
-          SourceIdentifier(
-            identifierType = IdentifierType.SierraSystemNumber,
-            ontologyType = "Work",
-            value = bnumber
-          )
+        identifier = SourceIdentifier(
+          identifierType = IdentifierType.SierraSystemNumber,
+          ontologyType = "Work",
+          value = bnumber
         ),
-        reason = Some("CALM/Sierra harvest work")
+        reason = "CALM/Sierra harvest work"
       )
     )
     mergeCandidates should contain allElementsOf miroIds.map(
       id =>
         MergeCandidate(
-          id = IdState.Identifiable(
-            SourceIdentifier(
-              identifierType = IdentifierType.MiroImageNumber,
-              ontologyType = "Work",
-              value = id
-            )
+          identifier = SourceIdentifier(
+            identifierType = IdentifierType.MiroImageNumber,
+            ontologyType = "Work",
+            value = id
           ),
-          reason = Some("CALM/Miro work")
+          reason = "CALM/Miro work"
       )
     )
   }


### PR DESCRIPTION
This is effectively true in all our transformers and good practice (I only had to add one reason and it was in a test), so let's enforce it in the type system.

Note that this is probably a breaking change: there will be existing Works with a merge candidate reason of "none", so we'll need to spin up a new pipeline to deploy this into.