### PR TITLE
Move the terms of use back into a top-level note

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessCondition.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessCondition.scala
@@ -3,7 +3,6 @@ package weco.catalogue.internal_model.locations
 case class AccessCondition(
   method: AccessMethod,
   status: Option[AccessStatus] = None,
-  terms: Option[String] = None,
   note: Option[String] = None
 ) {
   def isEmpty: Boolean =

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Availability.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Availability.scala
@@ -47,7 +47,9 @@ object Availabilities {
         data.holdings.flatMap { _.location }
 
     Set(
-      when(locations.exists(_.isAvailableInLibrary) && !data.notes.exists(_.isInOtherLibrary)) {
+      when(
+        locations.exists(_.isAvailableInLibrary) && !data.notes.exists(
+          _.isInOtherLibrary)) {
         Availability.InLibrary
       },
       when(locations.exists(_.isAvailableOnline)) {
@@ -90,7 +92,7 @@ object Availabilities {
     def isInOtherLibrary: Boolean =
       n match {
         case t: TermsOfUse => termsAreOtherInstitution(t)
-        case _ => false
+        case _             => false
       }
 
     def termsAreOtherInstitution(termsOfUse: TermsOfUse): Boolean =
@@ -106,7 +108,7 @@ object Availabilities {
         case t if t.contains("at the Army Medical Services Museum") =>
           true
         case t
-          if t.contains("currently remains with the Martin Leake family") =>
+            if t.contains("currently remains with the Martin Leake family") =>
           true
 
         case _ => false

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Availability.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Availability.scala
@@ -3,7 +3,6 @@ package weco.catalogue.internal_model.work
 import enumeratum.{Enum, EnumEntry}
 import io.circe.{Decoder, Encoder}
 import weco.catalogue.internal_model.locations.{
-  AccessCondition,
   DigitalLocation,
   Location,
   LocationType,
@@ -48,7 +47,7 @@ object Availabilities {
         data.holdings.flatMap { _.location }
 
     Set(
-      when(locations.exists(_.isAvailableInLibrary)) {
+      when(locations.exists(_.isAvailableInLibrary) && !data.notes.exists(_.isInOtherLibrary)) {
         Availability.InLibrary
       },
       when(locations.exists(_.isAvailableOnline)) {
@@ -67,20 +66,6 @@ object Availabilities {
             if physicalLoc.locationType == LocationType.OnOrder =>
           false
 
-        // Don't include items if they have a physical location but are actually
-        // held in another institution.
-        //
-        // Right now we do crude string matching on the terms in the access condition.
-        // There might be something better we can do that looks at the reference numbers,
-        // but for now this is a significant improvement without much effort.
-        //
-        // See https://github.com/wellcomecollection/platform/issues/5190
-        case physicalLoc: PhysicalLocation
-            if physicalLoc.accessConditions.exists {
-              _.termsAreOtherInstitution
-            } =>
-          false
-
         case _: PhysicalLocation => true
 
         case _ => false
@@ -93,21 +78,35 @@ object Availabilities {
       }
   }
 
-  private implicit class OptionalAccessConditionOps(ac: AccessCondition) {
-    def termsAreOtherInstitution: Boolean =
-      ac.terms match {
-        case Some(t) if t.toLowerCase.contains("available at") => true
-        case Some(t) if t.toLowerCase.contains("available by appointment at") =>
+  private implicit class NoteOps(n: Note) {
+    // Don't include items if they have a physical location but are actually
+    // held in another institution.
+    //
+    // Right now we do crude string matching on the terms in the access condition.
+    // There might be something better we can do that looks at the reference numbers,
+    // but for now this is a significant improvement without much effort.
+    //
+    // See https://github.com/wellcomecollection/platform/issues/5190
+    def isInOtherLibrary: Boolean =
+      n match {
+        case t: TermsOfUse => termsAreOtherInstitution(t)
+        case _ => false
+      }
+
+    def termsAreOtherInstitution(termsOfUse: TermsOfUse): Boolean =
+      termsOfUse.content match {
+        case t if t.toLowerCase.contains("available at") => true
+        case t if t.toLowerCase.contains("available by appointment at") =>
           true
 
-        case Some(t) if t.contains("Churchill Archives Centre") => true
-        case Some(t) if t.contains("UCL Special Collections and Archives") =>
+        case t if t.contains("Churchill Archives Centre") => true
+        case t if t.contains("UCL Special Collections and Archives") =>
           true
-        case Some(t) if t.contains("at King's College London") => true
-        case Some(t) if t.contains("at the Army Medical Services Museum") =>
+        case t if t.contains("at King's College London") => true
+        case t if t.contains("at the Army Medical Services Museum") =>
           true
-        case Some(t)
-            if t.contains("currently remains with the Martin Leake family") =>
+        case t
+          if t.contains("currently remains with the Martin Leake family") =>
           true
 
         case _ => false

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/index/WorksIndexConfigTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/index/WorksIndexConfigTest.scala
@@ -169,8 +169,7 @@ class WorksIndexConfigTest
   it("puts a work with a access condition") {
     val accessCondition: AccessCondition = AccessCondition(
       method = AccessMethod.OnlineRequest,
-      status = Some(AccessStatus.Open),
-      terms = Some("ask nicely"))
+      status = AccessStatus.Open)
 
     withLocalWorksIndex { index =>
       val sampleWork = identifiedWork().items(

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/AvailabilityTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/AvailabilityTest.scala
@@ -2,13 +2,7 @@ package weco.catalogue.internal_model.work
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import weco.catalogue.internal_model.work.generators.WorkGenerators
-import weco.catalogue.internal_model.locations.{
-  AccessCondition,
-  AccessMethod,
-  AccessStatus,
-  LocationType
-}
+import weco.catalogue.internal_model.locations.{AccessStatus, LocationType}
 import weco.catalogue.internal_model.work.generators.{
   ItemsGenerators,
   WorkGenerators
@@ -64,20 +58,9 @@ class AvailabilityTest
 
     it("does not add Availability.InLibrary if the location is offsite") {
       val work = denormalisedWork()
-        .items(
-          List(
-            createIdentifiedItemWith(
-              locations = List(
-                createPhysicalLocationWith(
-                  accessConditions = List(
-                    AccessCondition(
-                      method = AccessMethod.ManualRequest,
-                      terms = Some("Available at Churchill Archives Centre")
-                    )
-                  )
-                )
-              ))
-          )
+        .items(List(createIdentifiedPhysicalItem))
+        .notes(
+          List(TermsOfUse("Available at Churchill Archives Centre"))
         )
       val workAvailabilities = Availabilities.forWorkData(work.data)
 

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -43,12 +43,7 @@ object SierraItemAccess extends SierraQueryOps with Logging {
     itemData: SierraItemData
   ): (Option[AccessCondition], Option[String]) =
     (
-      createAccessCondition(
-        bibId,
-        itemId,
-        bibStatus,
-        location,
-        itemData),
+      createAccessCondition(bibId, itemId, bibStatus, location, itemData),
       itemData.displayNote) match {
       // If the item note is already on the access condition, we don't need to copy it.
       case ((Some(ac), displayNote)) if ac.note == displayNote =>

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -8,7 +8,7 @@ import weco.catalogue.internal_model.locations.{
   LocationType,
   PhysicalLocationType
 }
-import weco.catalogue.source_model.sierra.{SierraBibData, SierraItemData}
+import weco.catalogue.source_model.sierra.SierraItemData
 import weco.catalogue.source_model.sierra.identifiers.{
   SierraBibNumber,
   SierraItemNumber
@@ -40,7 +40,6 @@ object SierraItemAccess extends SierraQueryOps with Logging {
     itemId: SierraItemNumber,
     bibStatus: Option[AccessStatus],
     location: Option[PhysicalLocationType],
-    bibData: SierraBibData,
     itemData: SierraItemData
   ): (Option[AccessCondition], Option[String]) =
     (
@@ -49,7 +48,6 @@ object SierraItemAccess extends SierraQueryOps with Logging {
         itemId,
         bibStatus,
         location,
-        bibData,
         itemData),
       itemData.displayNote) match {
       // If the item note is already on the access condition, we don't need to copy it.
@@ -77,7 +75,6 @@ object SierraItemAccess extends SierraQueryOps with Logging {
     itemId: SierraItemNumber,
     bibStatus: Option[AccessStatus],
     location: Option[PhysicalLocationType],
-    bibData: SierraBibData,
     itemData: SierraItemData
   ): Option[AccessCondition] = {
     val holdCount = itemData.holdCount
@@ -396,27 +393,6 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           )
         )
     }
-  } match {
-    case Some(accessCondition) =>
-      // We set the access terms on an item from the access terms on the bib.
-      // Note that we need to be careful about merging terms from Calm/Sierra harvested
-      // items, which is why we assert that we haven't set terms based on anything
-      // *except* 506 subfield ǂa.
-      require(accessCondition.terms.isEmpty)
-
-      val bibTerms = {
-        val terms = bibData
-          .varfieldsWithTag("506")
-          .subfieldsWithTag("a")
-          .map(_.content)
-          .mkString(" ")
-
-        if (terms.isEmpty) None else Some(terms)
-      }
-
-      Some(accessCondition.copy(terms = bibTerms))
-
-    case condition => condition
   }
 
   implicit class ItemDataAccessOps(itemData: SierraItemData) {

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -10,13 +10,9 @@ import weco.catalogue.internal_model.locations.{
   PhysicalLocationType
 }
 import weco.catalogue.source_model.generators.SierraDataGenerators
-import weco.catalogue.source_model.sierra.{SierraBibData, SierraItemData}
+import weco.catalogue.source_model.sierra.SierraItemData
 import weco.catalogue.source_model.sierra.identifiers.SierraBibNumber
-import weco.catalogue.source_model.sierra.marc.{
-  FixedField,
-  MarcSubfield,
-  VarField
-}
+import weco.catalogue.source_model.sierra.marc.{FixedField, VarField}
 
 class SierraItemAccessTest
     extends AnyFunSpec
@@ -754,7 +750,6 @@ class SierraItemAccessTest
 
         ac.note shouldBe Some(
           "Email library@wellcomecollection.org to tell us why you need the physical copy. We'll reply within a week.")
-        ac.terms shouldBe None
       }
 
       it("returns the note if it's unrelated to access data") {
@@ -926,36 +921,17 @@ class SierraItemAccessTest
     )
   }
 
-  it("sets terms based on 506 subfield ǂa") {
-    val bibData = createSierraBibDataWith(
-      varFields = List(
-        VarField(
-          marcTag = Some("506"),
-          subfields = List(
-            MarcSubfield(tag = "a", content = "Available to subscribers only.")
-          )
-        )
-      )
-    )
-
-    val (Some(ac), _) = getItemAccess(bibData = bibData)
-
-    ac.terms shouldBe Some("Available to subscribers only.")
-  }
-
   private def getItemAccess(
     bibId: SierraBibNumber = createSierraBibNumber,
-    bibStatus: Option[AccessStatus] = None,
-    location: Option[PhysicalLocationType] = None,
-    bibData: SierraBibData = createSierraBibData,
-    itemData: SierraItemData = createSierraItemData
+    bibStatus: Option[AccessStatus],
+    location: Option[PhysicalLocationType],
+    itemData: SierraItemData
   ): (Option[AccessCondition], Option[String]) =
     SierraItemAccess(
       bibId = bibId,
       itemId = createSierraItemNumber,
       bibStatus = bibStatus,
       location = location,
-      bibData = bibData,
       itemData = itemData
     )
 }

--- a/pipeline/merger/src/main/scala/weco/pipeline/merger/rules/ItemsRule.scala
+++ b/pipeline/merger/src/main/scala/weco/pipeline/merger/rules/ItemsRule.scala
@@ -138,22 +138,18 @@ object ItemsRule extends FieldMergeRule with MergerLogging {
     }
 
   /** When records are harvested from Calm, both a bib and an item record are
-    * created in Sierra.  How we combine these is slightly complicated:
+    * created in Sierra.  The Sierra item will have more interesting information
+    * about access status, hold count, etc.  The Calm items are just stubs.
     *
-    *     - We can’t just take the Calm item – we would lose any access information,
-    *       which is only populated in Sierra.
-    *     - We can’t just take the Sierra item – when the Calm/Sierra harvest happens,
-    *       it smushes all the access data into 506 $a, undoing all the work we’ve done
-    *       to tidy up the terms in the Calm transformer, e.g. de-duplicated "closed until".
+    * See CalmItems.scala -- the Calm item is only:
     *
-    * For now, we choose to just take the Sierra item (or rather, take any items except
-    * the Calm item).  We lose some of the Calm transformer niceties, but they're not worth
-    * the additional complexity it would add here.
+    *     Item {
+    *       locations: [
+    *         Location { locationType = ClosedStores }
+    *       ]
+    *     }
     *
-    * Additionally, it's possible the CALM fields will be split into separate 506 subfields
-    * in a future version of the Calm/Sierra harvest, which would allow us to mirror the tidy-up
-    * logic in the Sierra transformer.
-    * For now, we keep all the items *except* the Calm item.  This means
+    * For this reason, we keep all the items *except* the Calm item.  This means
     * we'll also pick up any items linked to the Sierra work from METS or Miro.
     *
     */

--- a/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/CalmTransformer.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/CalmTransformer.scala
@@ -174,7 +174,7 @@ object CalmTransformer
         physicalDescription = physicalDescription(record),
         production = production(record),
         workType = workType,
-        notes = CalmNotes(record) ++ languageNotes
+        notes = CalmNotes(record) ++ languageNotes ++ CalmTermsOfUse(record)
       )
   }
 

--- a/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/transformers/CalmItems.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/transformers/CalmItems.scala
@@ -20,7 +20,7 @@ object CalmItems extends CalmRecordOps {
           PhysicalLocation(
             locationType = LocationType.ClosedStores,
             label = LocationType.ClosedStores.label,
-            accessConditions = createAccessCondition(record: CalmRecord)
+            accessConditions = createAccessCondition(record)
           )
         )
       )
@@ -29,15 +29,13 @@ object CalmItems extends CalmRecordOps {
   private def createAccessCondition(
     record: CalmRecord): List[AccessCondition] = {
     val accessStatus = CalmAccessStatus(record)
-    val terms = CalmAccessTerms(record, accessStatus = accessStatus)
 
     List(
       AccessCondition(
         // Items cannot be requested directly from Calm.  If this record gets merged
         // with a Sierra record, then we'll change the AccessMethod to match.
         method = AccessMethod.NotRequestable,
-        status = accessStatus,
-        terms = terms
+        status = accessStatus
       )
     ).filterNot(_.isEmpty)
   }

--- a/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/CalmTransformerTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/CalmTransformerTest.scala
@@ -13,7 +13,8 @@ import weco.catalogue.internal_model.work.DeletedReason._
 import weco.catalogue.internal_model.work._
 import weco.pipeline.transformer.calm.models.CalmSourceData
 
-class CalmTransformerTest
+class
+CalmTransformerTest
     extends AnyFunSpec
     with Matchers
     with CalmRecordGenerators {
@@ -150,16 +151,32 @@ class CalmTransformerTest
           reason = Some("CALM/Miro work")
         ),
         MergeCandidate(
-          id = IdState.Identifiable(
-            SourceIdentifier(
-              value = "M0000002",
-              identifierType = IdentifierType.MiroImageNumber,
-              ontologyType = "Work"
-            )
+          identifier = SourceIdentifier(
+            value = "M0000002",
+            identifierType = IdentifierType.MiroImageNumber,
+            ontologyType = "Work"
           ),
-          reason = Some("CALM/Miro work")
+          reason = "CALM/Miro work"
         )
       )
+  }
+
+  it("transforms access conditions") {
+    val record = createCalmRecordWith(
+      "Title" -> "abc",
+      "Level" -> "Collection",
+      "RefNo" -> "a/b/c",
+      "AltRefNo" -> "a.b.c",
+      "AccessStatus" -> "Restricted",
+      "UserDate1" -> "10/10/2050",
+      "AccessConditions" -> "nope.",
+      "AccessConditions" -> "nope.",
+      "CatalogueStatus" -> "Catalogued"
+    )
+    val termsOfUse = CalmTransformer(record, version).right.get.data.notes
+      .collectFirst { case TermsOfUse(content) => content }
+
+    termsOfUse shouldBe Some("nope. nope. Restricted until 10 October 2050.")
   }
 
   it("transforms description") {

--- a/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/CalmTransformerTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/CalmTransformerTest.scala
@@ -13,8 +13,7 @@ import weco.catalogue.internal_model.work.DeletedReason._
 import weco.catalogue.internal_model.work._
 import weco.pipeline.transformer.calm.models.CalmSourceData
 
-class
-CalmTransformerTest
+class CalmTransformerTest
     extends AnyFunSpec
     with Matchers
     with CalmRecordGenerators {

--- a/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/transformers/CalmItemsTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/transformers/CalmItemsTest.scala
@@ -26,8 +26,7 @@ class CalmItemsTest
       getAccessConditions(items) shouldBe empty
     }
 
-    it(
-      "sets access conditions based on the terms and access status if there's nothing useful to show") {
+    it("sets access conditions based on the access status") {
       val record = createCalmRecordWith(
         "AccessStatus" -> "Open",
         "AccessConditions" -> "The papers are available subject to the usual conditions of access to Archives and Manuscripts material."
@@ -38,42 +37,8 @@ class CalmItemsTest
       getAccessConditions(items) shouldBe List(
         AccessCondition(
           method = AccessMethod.NotRequestable,
-          status = Some(AccessStatus.Open),
-          terms = Some(
-            "The papers are available subject to the usual conditions of access to Archives and Manuscripts material.")
+          status = AccessStatus.Open
         )
-      )
-    }
-
-    it("uses ClosedUntil if the access status is Closed") {
-      val record = createCalmRecordWith(
-        "AccessStatus" -> "Closed",
-        "ClosedUntil" -> "02/02/2002"
-      )
-
-      val items = CalmItems(record)
-
-      getAccessConditions(items) shouldBe List(
-        AccessCondition(
-          method = AccessMethod.NotRequestable,
-          status = Some(AccessStatus.Closed),
-          terms = Some("Closed until 2 February 2002."))
-      )
-    }
-
-    it("uses UserDate1 if the access status is Restricted") {
-      val record = createCalmRecordWith(
-        "AccessStatus" -> "Restricted",
-        "UserDate1" -> "02/02/2002"
-      )
-
-      val items = CalmItems(record)
-
-      getAccessConditions(items) shouldBe List(
-        AccessCondition(
-          method = AccessMethod.NotRequestable,
-          status = Some(AccessStatus.Restricted),
-          terms = Some("Restricted until 2 February 2002."))
       )
     }
 

--- a/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/transformers/CalmTermsOfUseTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/transformers/CalmTermsOfUseTest.scala
@@ -27,7 +27,8 @@ class CalmTermsOfUseTest
       ("AccessConditions", "Closed on depositor agreement."),
     )
 
-    CalmTermsOfUse(record) shouldBe List(TermsOfUse("Closed on depositor agreement."))
+    CalmTermsOfUse(record) shouldBe List(
+      TermsOfUse("Closed on depositor agreement."))
   }
 
   it("handles an item which is restricted") {
@@ -52,8 +53,9 @@ class CalmTermsOfUseTest
       ("ClosedUntil", "01/01/2039")
     )
 
-    CalmTermsOfUse(record) shouldBe List(TermsOfUse(
-      "Closed under the Data Protection Act until 1st January 2039."))
+    CalmTermsOfUse(record) shouldBe List(
+      TermsOfUse(
+        "Closed under the Data Protection Act until 1st January 2039."))
   }
 
   it(
@@ -92,8 +94,9 @@ class CalmTermsOfUseTest
       ("ClosedUntil", "01/01/2039")
     )
 
-    CalmTermsOfUse(record) shouldBe List(TermsOfUse(
-      "Closed under the Data Protection Act. Closed until 1 January 2039."))
+    CalmTermsOfUse(record) shouldBe List(
+      TermsOfUse(
+        "Closed under the Data Protection Act. Closed until 1 January 2039."))
   }
 
   it("creates a note for a closed item with no conditions") {
@@ -102,7 +105,8 @@ class CalmTermsOfUseTest
       ("ClosedUntil", "01/01/2068")
     )
 
-    CalmTermsOfUse(record) shouldBe List(TermsOfUse("Closed until 1 January 2068."))
+    CalmTermsOfUse(record) shouldBe List(
+      TermsOfUse("Closed until 1 January 2068."))
   }
 
   it("doesn't create a note for an item with just a status") {

--- a/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/MetsData.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/MetsData.scala
@@ -105,7 +105,7 @@ case class MetsData(
           AccessCondition(
             method = AccessMethod.ViewOnline,
             status = accessStatus,
-            terms = accessConditionUsage
+            note = accessConditionUsage
           )
         )
     }

--- a/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformer/MetsDataTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformer/MetsDataTest.scala
@@ -461,7 +461,7 @@ class MetsDataTest
           AccessCondition(
             method = AccessMethod.ViewOnline,
             status = Some(AccessStatus.Restricted),
-            terms = Some("Please ask nicely")
+            note = Some("Please ask nicely")
           )
         )
     }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraItems.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraItems.scala
@@ -255,7 +255,6 @@ object SierraItems extends Logging with SierraLocation with SierraQueryOps {
       itemId,
       SierraAccessStatus.forBib(bibId, bibData),
       location.map(_.locationType),
-      bibData,
       itemData
     )
 

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraLocation.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraLocation.scala
@@ -48,7 +48,6 @@ trait SierraLocation {
         itemId = itemNumber,
         bibStatus = SierraAccessStatus.forBib(bibNumber, bibData),
         location = Some(locationType),
-        bibData,
         itemData = itemData
       )
 

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraNotes.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraNotes.scala
@@ -16,6 +16,7 @@ object SierraNotes extends SierraDataTransformer with SierraQueryOps {
     "502" -> createNoteFromContents(DissertationNote),
     "504" -> createNoteFromContents(BibliographicalInformation),
     "505" -> createNoteFromContents(ContentsNote),
+    "506" -> createNoteFromContents(TermsOfUse),
     "508" -> createNoteFromContents(CreditsNote),
     "510" -> createNoteFromContents(ReferencesNote),
     "511" -> createNoteFromContents(CreditsNote),

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraLocationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraLocationTest.scala
@@ -139,8 +139,7 @@ class SierraLocationTest
       location.accessConditions shouldBe List(
         AccessCondition(
           method = AccessMethod.OnlineRequest,
-          status = Some(AccessStatus.Open),
-          terms = Some("You can look at this"))
+          status = Some(AccessStatus.Open))
       )
     }
 
@@ -244,7 +243,6 @@ class SierraLocationTest
       location.accessConditions shouldBe List(
         AccessCondition(
           method = AccessMethod.NotRequestable,
-          terms = Some("You're not allowed yet"),
           note = Some(
             s"""Please check this item <a href="https://search.wellcomelibrary.org/iii/encore/record/C__Rb${bibId.withoutCheckDigit}?lang=eng">on the Wellcome Library website</a> for access information""")
         )

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraNotesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraNotesTest.scala
@@ -10,8 +10,7 @@ import weco.catalogue.source_model.generators.{
 import weco.catalogue.source_model.sierra.SierraBibData
 import weco.catalogue.source_model.sierra.marc.{MarcSubfield, VarField}
 
-class
-SierraNotesTest
+class SierraNotesTest
     extends AnyFunSpec
     with Matchers
     with MarcGenerators

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraNotesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraNotesTest.scala
@@ -10,7 +10,8 @@ import weco.catalogue.source_model.generators.{
 import weco.catalogue.source_model.sierra.SierraBibData
 import weco.catalogue.source_model.sierra.marc.{MarcSubfield, VarField}
 
-class SierraNotesTest
+class
+SierraNotesTest
     extends AnyFunSpec
     with Matchers
     with MarcGenerators
@@ -23,6 +24,7 @@ class SierraNotesTest
       "502" -> DissertationNote("dissertation note"),
       "504" -> BibliographicalInformation("bib info a"),
       "505" -> ContentsNote("contents note"),
+      "506" -> TermsOfUse("typical terms of use"),
       "508" -> CreditsNote("credits note a"),
       "510" -> ReferencesNote("references a"),
       "511" -> CreditsNote("credits note b"),


### PR DESCRIPTION
This reverts some of the changes in https://github.com/wellcomecollection/catalogue-pipeline/pull/1724, and bins the "terms" field from access conditions. Now the access terms go (back) on the top-level and aren't repeated onto the items.