### PR TITLE
Don't require empty WorkData on deleted works

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Work.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Work.scala
@@ -43,8 +43,8 @@ sealed trait Work[State <: WorkState] {
         })
       case Work.Invisible(version, _, _, invisibilityReasons) =>
         Work.Invisible(version, outData, outState, invisibilityReasons)
-      case Work.Deleted(version, _, _, deletedReason) =>
-        Work.Deleted(version, outData, outState, deletedReason)
+      case Work.Deleted(version, _, deletedReason) =>
+        Work.Deleted(version, outState, deletedReason)
       case Work.Redirected(version, redirectTarget, _) =>
         Work.Redirected(version, transition.redirect(redirectTarget), outState)
     }
@@ -77,10 +77,11 @@ object Work {
 
   case class Deleted[State <: WorkState](
     version: Int,
-    data: WorkData[State#WorkDataState],
     state: State,
     deletedReason: DeletedReason,
-  ) extends Work[State]
+  ) extends Work[State] {
+    val data: WorkData[State#WorkDataState] = WorkData[State#WorkDataState]()
+  }
 }
 
 /** WorkData contains data common to all types of works that can exist at any

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/generators/WorkGenerators.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/generators/WorkGenerators.scala
@@ -147,7 +147,6 @@ trait WorkGenerators extends IdentifiersGenerators with InstantGenerators {
     ): Work.Deleted[State] =
       Work.Deleted[State](
         state = work.state,
-        data = work.data,
         version = work.version,
         deletedReason = deletedReason
       )

--- a/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/CalmTransformer.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/CalmTransformer.scala
@@ -70,7 +70,6 @@ object CalmTransformer
   ): Work.Deleted[Source] =
     Work.Deleted[Source](
       state = Source(sourceIdentifier(record), record.retrievedAt),
-      data = WorkData(),
       version = version,
       deletedReason = reason
     )

--- a/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/CalmTransformerTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/CalmTransformerTest.scala
@@ -585,7 +585,6 @@ class CalmTransformerTest
     )
     CalmTransformer(record, version) shouldBe Right(
       Work.Deleted[Source](
-        data = WorkData(),
         state = Source(
           SourceIdentifier(
             value = record.id,

--- a/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/MetsData.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/MetsData.scala
@@ -37,7 +37,6 @@ case class MetsData(
         Right(
           Work.Deleted[Source](
             version = version,
-            data = WorkData[DataState.Unidentified](),
             state = Source(sourceIdentifier, modifiedTime),
             deletedReason = DeletedFromSource("Mets")
           )

--- a/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformer/MetsDataTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformer/MetsDataTest.scala
@@ -81,7 +81,6 @@ class MetsDataTest
     metsData.toWork(version, createdDate).right.get shouldBe Work
       .Deleted[Source](
         version = version,
-        data = WorkData[DataState.Unidentified](),
         state = Source(expectedSourceIdentifier, createdDate),
         deletedReason = DeletedFromSource("Mets")
       )

--- a/pipeline/transformer/transformer_miro/src/main/scala/weco/pipeline/transformer/miro/MiroRecordTransformer.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/weco/pipeline/transformer/miro/MiroRecordTransformer.scala
@@ -82,7 +82,6 @@ class MiroRecordTransformer
       Success(
         Work.Deleted[Source](
           version = version,
-          data = WorkData(),
           state = state,
           deletedReason =
             SuppressedFromSource("Miro: isClearedForCatalogueAPI = false")
@@ -97,7 +96,6 @@ class MiroRecordTransformer
       Success(
         Work.Deleted[Source](
           version = version,
-          data = WorkData(),
           state = state,
           deletedReason = SuppressedFromSource(
             s"Miro: image_copyright_cleared = ${originalMiroRecord.copyrightCleared
@@ -137,7 +135,6 @@ class MiroRecordTransformer
         case e: ShouldSuppressException =>
           Work.Deleted[Source](
             version = version,
-            data = WorkData(),
             state = state,
             deletedReason = SuppressedFromSource(s"Miro: ${e.getMessage}")
           )

--- a/pipeline/transformer/transformer_miro/src/test/scala/weco/pipeline/transformer/miro/transformers/MiroRecordTransformerTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/weco/pipeline/transformer/miro/transformers/MiroRecordTransformerTest.scala
@@ -438,7 +438,6 @@ class MiroRecordTransformerTest
         sourceModifiedTime = Instant.EPOCH
       ),
       version = 1,
-      data = WorkData(),
       deletedReason = deletedReason
     )
   }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/SierraTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/SierraTransformer.scala
@@ -63,15 +63,13 @@ class SierraTransformer(sierraTransformable: SierraTransformable, version: Int)
           Work.Deleted[Source](
             version = version,
             state = state,
-            deletedReason = DeletedFromSource("Sierra"),
-            data = WorkData()
+            deletedReason = DeletedFromSource("Sierra")
           )
         } else if (bibData.suppressed) {
           Work.Deleted[Source](
             version = version,
             state = state,
-            deletedReason = SuppressedFromSource("Sierra"),
-            data = WorkData()
+            deletedReason = SuppressedFromSource("Sierra")
           )
         } else {
           Work.Visible[Source](

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiTransformer.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiTransformer.scala
@@ -8,7 +8,6 @@ import weco.catalogue.internal_model.work.WorkState.Source
 import weco.catalogue.internal_model.work.{
   DeletedReason,
   Work,
-  WorkData,
   WorkState
 }
 import weco.catalogue.source_model.tei.{

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiTransformer.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiTransformer.scala
@@ -5,11 +5,7 @@ import weco.catalogue.internal_model.identifiers.{
   SourceIdentifier
 }
 import weco.catalogue.internal_model.work.WorkState.Source
-import weco.catalogue.internal_model.work.{
-  DeletedReason,
-  Work,
-  WorkState
-}
+import weco.catalogue.internal_model.work.{DeletedReason, Work, WorkState}
 import weco.catalogue.source_model.tei.{
   TeiChangedMetadata,
   TeiDeletedMetadata,

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiTransformer.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiTransformer.scala
@@ -39,7 +39,6 @@ class TeiTransformer(store: Store[S3ObjectLocation, String])
     Right(
       Work.Deleted[Source](
         version = version,
-        data = WorkData(),
         state = Source(SourceIdentifier(IdentifierType.Tei, "Work", id), time),
         deletedReason = DeletedReason.DeletedFromSource("Deleted by TEI source")
       ))

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiTransformerTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiTransformerTest.scala
@@ -63,7 +63,6 @@ class TeiTransformerTest
     transformer(id, TeiDeletedMetadata(timeModified), 1) shouldBe Right(
       Work.Deleted[Source](
         version = 1,
-        data = WorkData[Unidentified](),
         state = Source(sourceIdentifier, timeModified),
         deletedReason = DeletedReason.DeletedFromSource("Deleted by TEI source")
       )


### PR DESCRIPTION
We can hard-code this as empty data, because deleted works will never be merged or combined with anything else -- this is what we already do on redirected works.

This is done with an eye towards more radical changes to WorkData, in particular making "title" compulsory in some future revision.

Because Circe ignores fields in the JSON that it doesn't care about, this should be fine to drop into an existing pipeline.  Additionally, this might make reindexes a bit cheaper!  We have a lot of deleted works, and not having to send an empty `WorkData` JSON blob back and forth will reduce the amount of traffic we have to send over the VPC endpoint.