### PR TITLE
Add id field to SierraItemData

### DIFF
--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraItemData.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraItemData.scala
@@ -1,9 +1,11 @@
 package weco.catalogue.source_model.sierra
 
+import weco.catalogue.source_model.sierra.identifiers.SierraItemNumber
 import weco.catalogue.source_model.sierra.marc.{FixedField, VarField}
 import weco.catalogue.source_model.sierra.source.SierraSourceLocation
 
 case class SierraItemData(
+  id: SierraItemNumber,
   deleted: Boolean = false,
   suppressed: Boolean = false,
   copyNo: Option[Int] = None,

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -9,10 +9,7 @@ import weco.catalogue.internal_model.locations.{
   PhysicalLocationType
 }
 import weco.catalogue.source_model.sierra.SierraItemData
-import weco.catalogue.source_model.sierra.identifiers.{
-  SierraBibNumber,
-  SierraItemNumber
-}
+import weco.catalogue.source_model.sierra.identifiers.SierraBibNumber
 import weco.catalogue.source_model.sierra.source.{
   OpacMsg,
   SierraQueryOps,

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -37,13 +37,17 @@ import weco.catalogue.source_model.sierra.source.{
 object SierraItemAccess extends SierraQueryOps with Logging {
   def apply(
     bibId: SierraBibNumber,
-    itemId: SierraItemNumber,
     bibStatus: Option[AccessStatus],
     location: Option[PhysicalLocationType],
     itemData: SierraItemData
   ): (Option[AccessCondition], Option[String]) =
     (
-      createAccessCondition(bibId, itemId, bibStatus, location, itemData),
+      createAccessCondition(
+        bibId = bibId,
+        bibStatus = bibStatus,
+        location = location,
+        itemData = itemData
+      ),
       itemData.displayNote) match {
       // If the item note is already on the access condition, we don't need to copy it.
       case ((Some(ac), displayNote)) if ac.note == displayNote =>
@@ -67,7 +71,6 @@ object SierraItemAccess extends SierraQueryOps with Logging {
 
   private def createAccessCondition(
     bibId: SierraBibNumber,
-    itemId: SierraItemNumber,
     bibStatus: Option[AccessStatus],
     location: Option[PhysicalLocationType],
     itemData: SierraItemData
@@ -375,7 +378,7 @@ object SierraItemAccess extends SierraQueryOps with Logging {
       // this apply() method.
       case (bibStatus, holdCount, status, opacmsg, isRequestable, location) =>
         warn(
-          s"Unable to assign access status for item ${itemId.withCheckDigit}: " +
+          s"Unable to assign access status for item ${itemData.id.withCheckDigit}: " +
             s"bibStatus=$bibStatus, holdCount=$holdCount, status=$status, " +
             s"opacmsg=$opacmsg, isRequestable=$isRequestable, location=$location"
         )

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/generators/SierraDataGenerators.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/generators/SierraDataGenerators.scala
@@ -4,8 +4,16 @@ import weco.catalogue.internal_model.generators.IdentifiersGenerators
 import weco.catalogue.source_model
 import weco.catalogue.source_model.sierra.identifiers.SierraItemNumber
 import weco.catalogue.source_model.sierra.marc.{FixedField, VarField}
-import weco.catalogue.source_model.sierra.source.{SierraMaterialType, SierraSourceLanguage, SierraSourceLocation}
-import weco.catalogue.source_model.sierra.{SierraBibData, SierraItemData, SierraOrderData}
+import weco.catalogue.source_model.sierra.source.{
+  SierraMaterialType,
+  SierraSourceLanguage,
+  SierraSourceLocation
+}
+import weco.catalogue.source_model.sierra.{
+  SierraBibData,
+  SierraItemData,
+  SierraOrderData
+}
 
 trait SierraDataGenerators extends IdentifiersGenerators with SierraGenerators {
   def createSierraBibDataWith(
@@ -24,12 +32,12 @@ trait SierraDataGenerators extends IdentifiersGenerators with SierraGenerators {
   def createSierraBibData: SierraBibData = createSierraBibDataWith()
 
   def createSierraItemDataWith(
-                                id: SierraItemNumber = createSierraItemNumber,
-                                location: Option[SierraSourceLocation] = None,
-                                copyNo: Option[Int] = None,
-                                holdCount: Option[Int] = Some(0),
-                                fixedFields: Map[String, FixedField] = Map(),
-                                varFields: List[VarField] = Nil
+    id: SierraItemNumber = createSierraItemNumber,
+    location: Option[SierraSourceLocation] = None,
+    copyNo: Option[Int] = None,
+    holdCount: Option[Int] = Some(0),
+    fixedFields: Map[String, FixedField] = Map(),
+    varFields: List[VarField] = Nil
   ): SierraItemData =
     SierraItemData(
       id = id,

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/generators/SierraDataGenerators.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/generators/SierraDataGenerators.scala
@@ -2,17 +2,10 @@ package weco.catalogue.source_model.generators
 
 import weco.catalogue.internal_model.generators.IdentifiersGenerators
 import weco.catalogue.source_model
+import weco.catalogue.source_model.sierra.identifiers.SierraItemNumber
 import weco.catalogue.source_model.sierra.marc.{FixedField, VarField}
-import weco.catalogue.source_model.sierra.source.{
-  SierraMaterialType,
-  SierraSourceLanguage,
-  SierraSourceLocation
-}
-import weco.catalogue.source_model.sierra.{
-  SierraBibData,
-  SierraItemData,
-  SierraOrderData
-}
+import weco.catalogue.source_model.sierra.source.{SierraMaterialType, SierraSourceLanguage, SierraSourceLocation}
+import weco.catalogue.source_model.sierra.{SierraBibData, SierraItemData, SierraOrderData}
 
 trait SierraDataGenerators extends IdentifiersGenerators with SierraGenerators {
   def createSierraBibDataWith(
@@ -31,13 +24,15 @@ trait SierraDataGenerators extends IdentifiersGenerators with SierraGenerators {
   def createSierraBibData: SierraBibData = createSierraBibDataWith()
 
   def createSierraItemDataWith(
-    location: Option[SierraSourceLocation] = None,
-    copyNo: Option[Int] = None,
-    holdCount: Option[Int] = Some(0),
-    fixedFields: Map[String, FixedField] = Map(),
-    varFields: List[VarField] = Nil
+                                id: SierraItemNumber = createSierraItemNumber,
+                                location: Option[SierraSourceLocation] = None,
+                                copyNo: Option[Int] = None,
+                                holdCount: Option[Int] = Some(0),
+                                fixedFields: Map[String, FixedField] = Map(),
+                                varFields: List[VarField] = Nil
   ): SierraItemData =
     SierraItemData(
+      id = id,
       location = location,
       copyNo = copyNo,
       holdCount = holdCount,

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/SierraItemDataTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/SierraItemDataTest.scala
@@ -1,0 +1,72 @@
+package weco.catalogue.source_model.sierra
+
+import org.scalatest.TryValues
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import weco.catalogue.source_model.sierra.identifiers.SierraItemNumber
+import weco.catalogue.source_model.sierra.marc.{FixedField, MarcSubfield, VarField}
+import weco.json.JsonUtil._
+
+class SierraItemDataTest extends AnyFunSpec with Matchers with TryValues {
+  it("decodes itemData") {
+    val itemDataJson =
+      s"""
+         |{
+         |  "id": "1146055",
+         |  "deleted": false,
+         |  "suppressed": false,
+         |  "holdCount": 1,
+         |  "fixedFields": {
+         |    "57": {
+         |      "label": "BIB HOLD",
+         |      "value": "false"
+         |    }
+         |  },
+         |  "varFields": [
+         |    {
+         |      "fieldTag": "a",
+         |      "marcTag": "949",
+         |      "ind1": "0",
+         |      "ind2": "0",
+         |      "subfields": [
+         |        {
+         |          "tag": "1",
+         |          "content": "STAX"
+         |        },
+         |        {
+         |          "tag": "2",
+         |          "content": "sepam"
+         |        }
+         |      ]
+         |    }
+         |  ]
+         |}""".stripMargin
+
+    fromJson[SierraItemData](itemDataJson).get shouldBe SierraItemData(
+      id = SierraItemNumber("1146055"),
+      deleted = false,
+      suppressed = false,
+      copyNo = None,
+      holdCount = Some(1),
+      location = None,
+      fixedFields = Map(
+        "57" -> FixedField(
+          label="BIB HOLD",
+          value="false",
+          display=None
+        )
+      ),
+      varFields = List(VarField(
+        content = None,
+        marcTag = Some("949"),
+        fieldTag = Some("a"),
+        indicator1 = Some("0"),
+        indicator2 = Some("0"),
+        subfields = List(
+          MarcSubfield("1","STAX"),
+          MarcSubfield("2","sepam")
+        ))
+      )
+    )
+  }
+}

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/SierraItemDataTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/SierraItemDataTest.scala
@@ -4,7 +4,11 @@ import org.scalatest.TryValues
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.catalogue.source_model.sierra.identifiers.SierraItemNumber
-import weco.catalogue.source_model.sierra.marc.{FixedField, MarcSubfield, VarField}
+import weco.catalogue.source_model.sierra.marc.{
+  FixedField,
+  MarcSubfield,
+  VarField
+}
 import weco.json.JsonUtil._
 
 class SierraItemDataTest extends AnyFunSpec with Matchers with TryValues {
@@ -51,22 +55,23 @@ class SierraItemDataTest extends AnyFunSpec with Matchers with TryValues {
       location = None,
       fixedFields = Map(
         "57" -> FixedField(
-          label="BIB HOLD",
-          value="false",
-          display=None
+          label = "BIB HOLD",
+          value = "false",
+          display = None
         )
       ),
-      varFields = List(VarField(
-        content = None,
-        marcTag = Some("949"),
-        fieldTag = Some("a"),
-        indicator1 = Some("0"),
-        indicator2 = Some("0"),
-        subfields = List(
-          MarcSubfield("1","STAX"),
-          MarcSubfield("2","sepam")
+      varFields = List(
+        VarField(
+          content = None,
+          marcTag = Some("949"),
+          fieldTag = Some("a"),
+          indicator1 = Some("0"),
+          indicator2 = Some("0"),
+          subfields = List(
+            MarcSubfield("1", "STAX"),
+            MarcSubfield("2", "sepam")
+          )
         ))
-      )
     )
   }
 }

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -929,7 +929,6 @@ class SierraItemAccessTest
   ): (Option[AccessCondition], Option[String]) =
     SierraItemAccess(
       bibId = bibId,
-      itemId = createSierraItemNumber,
       bibStatus = bibStatus,
       location = location,
       itemData = itemData

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/SierraTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/SierraTransformer.scala
@@ -17,7 +17,6 @@ import weco.pipeline.transformer.sierra.exceptions.{
 import weco.pipeline.transformer.sierra.transformers._
 import java.time.Instant
 
-import scala.collection.immutable
 import scala.util.{Failure, Success, Try}
 
 class SierraTransformer(sierraTransformable: SierraTransformable, version: Int)

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/SierraTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/SierraTransformer.scala
@@ -10,7 +10,10 @@ import weco.catalogue.source_model.sierra._
 import weco.catalogue.source_model.sierra.identifiers._
 import weco.json.JsonUtil._
 import weco.json.exceptions.JsonDecodingError
-import weco.pipeline.transformer.sierra.exceptions.{ShouldNotTransformException, SierraTransformerException}
+import weco.pipeline.transformer.sierra.exceptions.{
+  ShouldNotTransformException,
+  SierraTransformerException
+}
 import weco.pipeline.transformer.sierra.transformers._
 import java.time.Instant
 
@@ -135,16 +138,15 @@ class SierraTransformer(sierraTransformable: SierraTransformable, version: Int)
     sierraTransformable.itemRecords.nonEmpty
 
   lazy val itemDataEntries: Seq[SierraItemData] =
-    sierraTransformable.itemRecords
-      .map { case (_, itemRecord) =>
-          fromJson[SierraItemData](itemRecord.data) match {
-            case Success(itemData) => itemData
-            case Failure(_) =>
-              throw SierraTransformerException(
-                s"Unable to parse item data for ${itemRecord.id} as JSON: <<${itemRecord.data}>>")
-          }
-      }
-      .toSeq
+    sierraTransformable.itemRecords.map {
+      case (_, itemRecord) =>
+        fromJson[SierraItemData](itemRecord.data) match {
+          case Success(itemData) => itemData
+          case Failure(_) =>
+            throw SierraTransformerException(
+              s"Unable to parse item data for ${itemRecord.id} as JSON: <<${itemRecord.data}>>")
+        }
+    }.toSeq
 
   lazy val holdingsDataMap: Map[SierraHoldingsNumber, SierraHoldingsData] =
     sierraTransformable.holdingsRecords

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraItems.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraItems.scala
@@ -125,13 +125,23 @@ object SierraItems extends Logging with SierraLocation with SierraQueryOps {
     debug(s"Attempting to transform ${itemData.id}")
 
     val location =
-      getPhysicalLocation(bibId, itemData.id, itemData, bibData, fallbackLocation)
+      getPhysicalLocation(
+        bibNumber = bibId,
+        itemData = itemData,
+        bibData = bibData,
+        fallbackLocation = fallbackLocation
+      )
 
-    val (title, hasInferredTitle) = getItemTitle(itemData.id, itemData)
+    val (title, hasInferredTitle) = getItemTitle(itemData)
 
     val item = Item(
       title = title,
-      note = getItemNote(bibId, itemData.id, itemData, bibData, location),
+      note = getItemNote(
+        bibId = bibId,
+        itemData = itemData,
+        bibData = bibData,
+        location = location
+      ),
       locations = List(location).flatten,
       id = IdState.Identifiable(
         sourceIdentifier = SourceIdentifier(
@@ -167,9 +177,7 @@ object SierraItems extends Logging with SierraLocation with SierraQueryOps {
     *     In general, we prefer the human-written title where possible.
     *
     */
-  private def getItemTitle(
-    itemId: SierraItemNumber,
-    data: SierraItemData): (Option[String], HasAutomatedTitle) = {
+  private def getItemTitle(data: SierraItemData): (Option[String], HasAutomatedTitle) = {
     val titleCandidates: List[String] =
       data.varFields
         .filter { _.fieldTag.contains("v") }
@@ -190,7 +198,7 @@ object SierraItems extends Logging with SierraLocation with SierraQueryOps {
 
       case multipleTitles =>
         warn(
-          s"Multiple title candidates on item $itemId: ${titleCandidates.mkString("; ")}")
+          s"Multiple title candidates on item ${data.id}: ${titleCandidates.mkString("; ")}")
         (Some(multipleTitles.head), false)
     }
   }
@@ -244,16 +252,14 @@ object SierraItems extends Logging with SierraLocation with SierraQueryOps {
     */
   private def getItemNote(
     bibId: SierraBibNumber,
-    itemId: SierraItemNumber,
     itemData: SierraItemData,
     bibData: SierraBibData,
     location: Option[PhysicalLocation]): Option[String] = {
     val (_, note) = SierraItemAccess(
-      bibId,
-      itemId,
-      SierraAccessStatus.forBib(bibId, bibData),
-      location.map(_.locationType),
-      itemData
+      bibId = bibId,
+      bibStatus = SierraAccessStatus.forBib(bibId, bibData),
+      location = location.map(_.locationType),
+      itemData = itemData
     )
 
     note

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraItems.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraItems.scala
@@ -18,10 +18,7 @@ import weco.catalogue.source_model.sierra.rules.{
   SierraPhysicalLocationType
 }
 import weco.catalogue.source_model.sierra.source.SierraQueryOps
-import weco.catalogue.source_model.sierra.identifiers.{
-  SierraBibNumber,
-  SierraItemNumber
-}
+import weco.catalogue.source_model.sierra.identifiers.SierraBibNumber
 import weco.catalogue.source_model.sierra.marc.VarField
 import weco.catalogue.source_model.sierra.{SierraBibData, SierraItemData}
 import weco.pipeline.transformer.sierra.data.SierraPhysicalItemOrder

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraItems.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraItems.scala
@@ -177,7 +177,8 @@ object SierraItems extends Logging with SierraLocation with SierraQueryOps {
     *     In general, we prefer the human-written title where possible.
     *
     */
-  private def getItemTitle(data: SierraItemData): (Option[String], HasAutomatedTitle) = {
+  private def getItemTitle(
+    data: SierraItemData): (Option[String], HasAutomatedTitle) = {
     val titleCandidates: List[String] =
       data.varFields
         .filter { _.fieldTag.contains("v") }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraItems.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraItems.scala
@@ -37,10 +37,10 @@ object SierraItems extends Logging with SierraLocation with SierraQueryOps {
     * sierra-identifier.  We want to revisit this at some point.
     * See https://github.com/wellcomecollection/platform/issues/4993
     */
-  def apply(bibId: SierraBibNumber,
-            bibData: SierraBibData,
-            itemDataEntries: Seq[SierraItemData])
-    : List[Item[IdState.Identifiable]] = {
+  def apply(
+    bibId: SierraBibNumber,
+    bibData: SierraBibData,
+    itemDataEntries: Seq[SierraItemData]): List[Item[IdState.Identifiable]] = {
     val visibleItems =
       itemDataEntries
         .filterNot { itemData =>
@@ -69,7 +69,9 @@ object SierraItems extends Logging with SierraLocation with SierraQueryOps {
     // non-above locations are unambiguous, we use them instead.
     val otherLocations =
       itemDataEntries
-        .map { itemData => itemData.id -> itemData.location }
+        .map { itemData =>
+          itemData.id -> itemData.location
+        }
         .collect { case (id, Some(location)) => id -> location }
         .filterNot {
           case (_, loc) =>
@@ -99,13 +101,13 @@ object SierraItems extends Logging with SierraLocation with SierraQueryOps {
       }
 
     val items = itemDataEntries.map { itemData =>
-        transformItemData(
-          bibId = bibId,
-          itemId = itemData.id,
-          itemData = itemData,
-          bibData = bibData,
-          fallbackLocation = fallbackLocation
-        )
+      transformItemData(
+        bibId = bibId,
+        itemId = itemData.id,
+        itemData = itemData,
+        bibData = bibData,
+        fallbackLocation = fallbackLocation
+      )
     }.toList
 
     tidyTitles(items)

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraItems.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraItems.scala
@@ -103,7 +103,6 @@ object SierraItems extends Logging with SierraLocation with SierraQueryOps {
     val items = itemDataEntries.map { itemData =>
       transformItemData(
         bibId = bibId,
-        itemId = itemData.id,
         itemData = itemData,
         bibData = bibData,
         fallbackLocation = fallbackLocation
@@ -119,33 +118,32 @@ object SierraItems extends Logging with SierraLocation with SierraQueryOps {
 
   private def transformItemData(
     bibId: SierraBibNumber,
-    itemId: SierraItemNumber,
     itemData: SierraItemData,
     bibData: SierraBibData,
     fallbackLocation: Option[(PhysicalLocationType, String)]
   ): (Item[IdState.Identifiable], HasAutomatedTitle) = {
-    debug(s"Attempting to transform $itemId")
+    debug(s"Attempting to transform ${itemData.id}")
 
     val location =
-      getPhysicalLocation(bibId, itemId, itemData, bibData, fallbackLocation)
+      getPhysicalLocation(bibId, itemData.id, itemData, bibData, fallbackLocation)
 
-    val (title, hasInferredTitle) = getItemTitle(itemId, itemData)
+    val (title, hasInferredTitle) = getItemTitle(itemData.id, itemData)
 
     val item = Item(
       title = title,
-      note = getItemNote(bibId, itemId, itemData, bibData, location),
+      note = getItemNote(bibId, itemData.id, itemData, bibData, location),
       locations = List(location).flatten,
       id = IdState.Identifiable(
         sourceIdentifier = SourceIdentifier(
           identifierType = IdentifierType.SierraSystemNumber,
           ontologyType = "Item",
-          value = itemId.withCheckDigit
+          value = itemData.id.withCheckDigit
         ),
         otherIdentifiers = List(
           SourceIdentifier(
             identifierType = IdentifierType.SierraIdentifier,
             ontologyType = "Item",
-            value = itemId.withoutCheckDigit
+            value = itemData.id.withoutCheckDigit
           )
         )
       )

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraLocation.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraLocation.scala
@@ -15,7 +15,6 @@ import weco.catalogue.source_model.sierra.{SierraBibData, SierraItemData}
 trait SierraLocation {
   def getPhysicalLocation(
     bibNumber: SierraBibNumber,
-    itemNumber: SierraItemNumber,
     itemData: SierraItemData,
     bibData: SierraBibData,
     fallbackLocation: Option[(PhysicalLocationType, String)] = None)
@@ -25,7 +24,10 @@ trait SierraLocation {
 
       (locationType, label) <- {
         val parsedLocationType =
-          SierraPhysicalLocationType.fromName(itemNumber, sourceLocation.name)
+          SierraPhysicalLocationType.fromName(
+            id = itemData.id,
+            name = sourceLocation.name
+          )
 
         (parsedLocationType, fallbackLocation) match {
           case (Some(locationType), _) =>

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraLocation.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraLocation.scala
@@ -47,7 +47,6 @@ trait SierraLocation {
 
       (accessCondition, _) = SierraItemAccess(
         bibId = bibNumber,
-        itemId = itemNumber,
         bibStatus = SierraAccessStatus.forBib(bibNumber, bibData),
         location = Some(locationType),
         itemData = itemData

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraLocation.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraLocation.scala
@@ -1,10 +1,7 @@
 package weco.pipeline.transformer.sierra.transformers
 
 import weco.catalogue.internal_model.locations._
-import weco.catalogue.source_model.sierra.identifiers.{
-  SierraBibNumber,
-  SierraItemNumber
-}
+import weco.catalogue.source_model.sierra.identifiers.SierraBibNumber
 import weco.catalogue.source_model.sierra.rules.{
   SierraAccessStatus,
   SierraItemAccess,

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraItemsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraItemsTest.scala
@@ -60,7 +60,7 @@ class SierraItemsTest
     )
 
     val itemData = createSierraItemDataWith(
-      id=itemId
+      id = itemId
     )
 
     val transformedItem = getTransformedItems(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraItemsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraItemsTest.scala
@@ -31,7 +31,7 @@ class SierraItemsTest
 
   it("creates both forms of the Sierra ID in 'identifiers'") {
     val itemData = createSierraItemData
-    val itemId = createSierraItemNumber
+    val itemId = itemData.id
 
     val sourceIdentifier1 = createSierraSystemSourceIdentifierWith(
       ontologyType = "Item",
@@ -58,7 +58,10 @@ class SierraItemsTest
       ontologyType = "Item",
       value = itemId.withCheckDigit
     )
-    val itemData = createSierraItemData
+
+    val itemData = createSierraItemDataWith(
+      id=itemId
+    )
 
     val transformedItem = getTransformedItems(
       itemDataEntries = Seq(itemData)

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraItemsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraItemsTest.scala
@@ -46,7 +46,7 @@ class SierraItemsTest
     val expectedIdentifiers = List(sourceIdentifier1, sourceIdentifier2)
 
     val transformedItem = getTransformedItems(
-      itemDataMap = Map(itemId -> itemData)
+      itemDataEntries = Seq(itemData)
     ).head
 
     transformedItem.id.allSourceIdentifiers shouldBe expectedIdentifiers
@@ -61,7 +61,7 @@ class SierraItemsTest
     val itemData = createSierraItemData
 
     val transformedItem = getTransformedItems(
-      itemDataMap = Map(itemId -> itemData)
+      itemDataEntries = Seq(itemData)
     ).head
 
     transformedItem.id
@@ -131,12 +131,13 @@ class SierraItemsTest
     }
 
     it("uses the copy number if there are multiple items and no field tag v") {
-      val itemDataMap = Seq(1, 2, 4).map { copyNo =>
-        createSierraItemNumber -> createSierraItemDataWith(
-          copyNo = Some(copyNo))
-      }.toMap
+      val itemDataEntries = Seq(1, 2, 4).map { copyNo =>
+        createSierraItemDataWith(
+          copyNo = Some(copyNo)
+        )
+      }
 
-      val items = getTransformedItems(itemDataMap = itemDataMap)
+      val items = getTransformedItems(itemDataEntries = itemDataEntries)
 
       items.map { _.title.get } should contain theSameElementsAs Seq(
         "Copy 1",
@@ -145,41 +146,47 @@ class SierraItemsTest
     }
 
     it("omits the copy number title if there's only a single item") {
-      val itemDataMap = Map(
-        createSierraItemNumber -> createSierraItemDataWith(copyNo = Some(1))
+      val itemDataEntries = Seq(
+        createSierraItemDataWith(copyNo = Some(1))
       )
 
-      val items = getTransformedItems(itemDataMap = itemDataMap)
+      val items = getTransformedItems(itemDataEntries = itemDataEntries)
 
       items.map { _.title } shouldBe Seq(None)
     }
 
     it("omits the copy number title if every item has the same copy number") {
-      val itemDataMap = Map(
-        createSierraItemNumber -> createSierraItemDataWith(copyNo = Some(1)),
-        createSierraItemNumber -> createSierraItemDataWith(copyNo = Some(1)),
-        createSierraItemNumber -> createSierraItemDataWith(copyNo = Some(1))
+      val itemDataEntries = Seq(
+        createSierraItemDataWith(copyNo = Some(1)),
+        createSierraItemDataWith(copyNo = Some(1)),
+        createSierraItemDataWith(copyNo = Some(1))
       )
 
-      val items = getTransformedItems(itemDataMap = itemDataMap)
+      val items = getTransformedItems(itemDataEntries = itemDataEntries)
 
       items.map { _.title } shouldBe Seq(None, None, None)
     }
 
     it("uses the title if every item has the same explicitly set title") {
-      val itemData = createSierraItemDataWith(
-        varFields = List(
-          VarField(fieldTag = "v", content = "Impression")
+      val itemDataEntries = Seq(
+        createSierraItemDataWith(
+          varFields = List(
+            VarField(fieldTag = "v", content = "Impression")
+          )
+        ),
+        createSierraItemDataWith(
+          varFields = List(
+            VarField(fieldTag = "v", content = "Impression")
+          )
+        ),
+        createSierraItemDataWith(
+          varFields = List(
+            VarField(fieldTag = "v", content = "Impression")
+          )
         )
       )
 
-      val itemDataMap = Map(
-        createSierraItemNumber -> itemData,
-        createSierraItemNumber -> itemData,
-        createSierraItemNumber -> itemData
-      )
-
-      val items = getTransformedItems(itemDataMap = itemDataMap)
+      val items = getTransformedItems(itemDataEntries = itemDataEntries)
 
       items.map { _.title } shouldBe Seq(
         Some("Impression"),
@@ -189,7 +196,7 @@ class SierraItemsTest
 
     def getTitle(itemData: SierraItemData): Option[String] = {
       val transformedItem = getTransformedItems(
-        itemDataMap = Map(createSierraItemNumber -> itemData)
+        itemDataEntries = Seq(itemData)
       ).head
 
       transformedItem.title
@@ -197,39 +204,41 @@ class SierraItemsTest
   }
 
   it("skips deleted items") {
-    val itemDataMap = (1 to 3).map { _ =>
-      createSierraItemNumber -> createSierraItemData
-    }.toMap
+    val itemDataEntries = Seq(
+      createSierraItemData,
+      createSierraItemData,
+      createSierraItemData
+    )
 
     // First we transform the items without deleting them, to
     // check they're not being skipped for a reason unrelated
     // to deleted=true
-    getTransformedItems(itemDataMap = itemDataMap) should have size itemDataMap.size
+    getTransformedItems(itemDataEntries = itemDataEntries) should have size itemDataEntries.size
 
     // Then we mark them as deleted, and check they're all ignored.
-    val deletedItemDataMap =
-      itemDataMap
-        .map { case (id, itemData) => id -> itemData.copy(deleted = true) }
+    val deleteditemDataEntries = itemDataEntries.map(_.copy(deleted = true))
 
-    getTransformedItems(itemDataMap = deletedItemDataMap) shouldBe empty
+    getTransformedItems(itemDataEntries = deleteditemDataEntries) should have size 0
   }
 
   it("skips suppressed items") {
-    val itemDataMap = (1 to 3).map { _ =>
-      createSierraItemNumber -> createSierraItemData
-    }.toMap
+    val itemDataEntries = Seq(
+      createSierraItemData,
+      createSierraItemData,
+      createSierraItemData
+    )
 
     // First we transform the items without suppressing them, to
     // check they're not being skipped for a reason unrelated
     // to suppressing=true
-    getTransformedItems(itemDataMap = itemDataMap) should have size itemDataMap.size
+    getTransformedItems(itemDataEntries = itemDataEntries) should have size itemDataEntries.size
 
     // Then we mark them as deleted, and check they're all ignored.
-    val suppressedItemDataMap =
-      itemDataMap
-        .map { case (id, itemData) => id -> itemData.copy(suppressed = true) }
+    val suppresseditemDataEntries =
+      itemDataEntries
+        .map(_.copy(suppressed = true))
 
-    getTransformedItems(itemDataMap = suppressedItemDataMap) shouldBe empty
+    getTransformedItems(itemDataEntries = suppresseditemDataEntries) should have size 0
   }
 
   it("ignores all digital locations - 'dlnk', 'digi'") {
@@ -267,9 +276,9 @@ class SierraItemsTest
       )
     )
 
-    val itemDataMap = Map(createSierraItemNumber -> itemData)
+    val itemDataEntries = Seq(itemData)
 
-    val item = getTransformedItems(itemDataMap = itemDataMap).head
+    val item = getTransformedItems(itemDataEntries = itemDataEntries).head
     item.locations shouldBe List(
       PhysicalLocation(
         locationType = LocationType.ClosedStores,
@@ -309,9 +318,9 @@ class SierraItemsTest
       )
     )
 
-    val itemDataMap = Map(createSierraItemNumber -> itemData)
+    val itemDataEntries = Seq(itemData)
 
-    val item = getTransformedItems(itemDataMap = itemDataMap).head
+    val item = getTransformedItems(itemDataEntries = itemDataEntries).head
     item.note shouldBe Some("uncoloured impression")
   }
 
@@ -320,11 +329,12 @@ class SierraItemsTest
       code = "wghib",
       name = "Biographies"
     )
-    val itemData = createSierraItemDataWith(location = Some(openLocation))
 
-    val itemDataMap = Map(createSierraItemNumber -> itemData)
+    val itemDataEntries = Seq(
+      createSierraItemDataWith(location = Some(openLocation))
+    )
 
-    val item = getTransformedItems(itemDataMap = itemDataMap).head
+    val item = getTransformedItems(itemDataEntries = itemDataEntries).head
     item.locations should have size 1
     item.locations.head
       .asInstanceOf[PhysicalLocation]
@@ -363,7 +373,7 @@ class SierraItemsTest
     val results =
       getTransformedItems(
         bibData = bibData,
-        itemDataMap = Map(createSierraItemNumber -> itemData))
+        itemDataEntries = Seq(itemData))
 
     results.head.locations should be(
       List(
@@ -379,38 +389,37 @@ class SierraItemsTest
   describe(
     "handling locations which are 'contained in above' or 'bound in above'") {
     it("skips adding a location if the Sierra location is 'bound in above'") {
-      val itemDataMap = Map(
-        createSierraItemNumber -> createSierraItemDataWith(
+      val itemDataEntries = Seq(
+        createSierraItemDataWith(
           location = Some(SierraSourceLocation("bwith", "bound in above"))
         )
       )
 
-      val items = getTransformedItems(itemDataMap = itemDataMap)
+      val items = getTransformedItems(itemDataEntries = itemDataEntries)
 
       items should have size 1
-      items.head.locations shouldBe empty
+      items.head.locations should have size 0
     }
 
     it(
       "adds a location to 'bound/contained in above' if the other locations are unambiguous") {
-      val itemDataMap = Map(
-        createSierraItemNumber -> createSierraItemDataWith(
+      val itemDataEntries = Seq(
+        createSierraItemDataWith(
           location = Some(SierraSourceLocation("bwith", "bound in above"))
         ),
-        createSierraItemNumber -> createSierraItemDataWith(
-          location =
-            Some(SierraSourceLocation("sicon", "Closed stores Iconographic"))
+        createSierraItemDataWith(
+          location = Some(SierraSourceLocation("sicon", "Closed stores Iconographic"))
         ),
-        createSierraItemNumber -> createSierraItemDataWith(
+        createSierraItemDataWith(
           location = Some(SierraSourceLocation("cwith", "contained in above"))
         ),
-        createSierraItemNumber -> createSierraItemDataWith(
+        createSierraItemDataWith(
           location =
             Some(SierraSourceLocation("sicon", "Closed stores Iconographic"))
         )
       )
 
-      val items = getTransformedItems(itemDataMap = itemDataMap)
+      val items = getTransformedItems(itemDataEntries = itemDataEntries)
 
       items should have size 4
       items.foreach {
@@ -424,24 +433,23 @@ class SierraItemsTest
 
     it(
       "adds a location to 'bound/contained in above' if the other locations are all closed") {
-      val itemDataMap = Map(
-        createSierraItemNumber -> createSierraItemDataWith(
+      val itemDataEntries = Seq(createSierraItemDataWith(
           location = Some(SierraSourceLocation("bwith", "bound in above"))
         ),
-        createSierraItemNumber -> createSierraItemDataWith(
+        createSierraItemDataWith(
           location =
             Some(SierraSourceLocation("sicon", "Closed stores Iconographic"))
         ),
-        createSierraItemNumber -> createSierraItemDataWith(
+        createSierraItemDataWith(
           location = Some(SierraSourceLocation("cwith", "contained in above"))
         ),
-        createSierraItemNumber -> createSierraItemDataWith(
+        createSierraItemDataWith(
           location =
             Some(SierraSourceLocation("sobhi", "Closed stores P.B. Hindi"))
         )
       )
 
-      val items = getTransformedItems(itemDataMap = itemDataMap)
+      val items = getTransformedItems(itemDataEntries = itemDataEntries)
 
       items should have size 4
       items.foreach {
@@ -455,23 +463,22 @@ class SierraItemsTest
 
     it(
       "skips adding a location to 'bound/contained in above' if the other locations are ambiguous") {
-      val itemDataMap = Map(
-        createSierraItemNumber -> createSierraItemDataWith(
+      val itemDataEntries = Seq(createSierraItemDataWith(
           location = Some(SierraSourceLocation("bwith", "bound in above"))
         ),
-        createSierraItemNumber -> createSierraItemDataWith(
+        createSierraItemDataWith(
           location =
             Some(SierraSourceLocation("sicon", "Closed stores Iconographic"))
         ),
-        createSierraItemNumber -> createSierraItemDataWith(
+        createSierraItemDataWith(
           location = Some(SierraSourceLocation("cwith", "contained in above"))
         ),
-        createSierraItemNumber -> createSierraItemDataWith(
+        createSierraItemDataWith(
           location = Some(SierraSourceLocation("info", "Open shelves"))
         )
       )
 
-      val items = getTransformedItems(itemDataMap = itemDataMap)
+      val items = getTransformedItems(itemDataEntries = itemDataEntries)
 
       items should have size 4
 
@@ -480,13 +487,13 @@ class SierraItemsTest
   }
 
   it("sorts items by sierra-identifier") {
-    val itemData = Map(
-      SierraItemNumber("0000002") -> createSierraItemData,
-      SierraItemNumber("0000001") -> createSierraItemData,
-      SierraItemNumber("0000004") -> createSierraItemData,
-      SierraItemNumber("0000003") -> createSierraItemData,
+    val itemData = Seq(
+      createSierraItemDataWith(id=SierraItemNumber("0000002")),
+      createSierraItemDataWith(id=SierraItemNumber("0000001")),
+      createSierraItemDataWith(id=SierraItemNumber("0000004")),
+      createSierraItemDataWith(id=SierraItemNumber("0000003")),
     )
-    getTransformedItems(itemDataMap = itemData)
+    getTransformedItems(itemDataEntries = itemData)
       .map(_.id.asInstanceOf[IdState.Identifiable].otherIdentifiers.head.value) shouldBe
       List(
         "0000001",
@@ -498,7 +505,11 @@ class SierraItemsTest
 
   private def getTransformedItems(
     bibData: SierraBibData = createSierraBibData,
-    itemDataMap: Map[SierraItemNumber, SierraItemData] = Map())
+    itemDataEntries: Seq[SierraItemData] = Seq())
     : List[Item[IdState.Unminted]] =
-    SierraItems(createSierraBibNumber, bibData, itemDataMap)
+    SierraItems(
+      bibId = createSierraBibNumber, 
+      bibData = bibData, 
+      itemDataEntries = itemDataEntries
+    )
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraItemsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraItemsTest.scala
@@ -371,9 +371,7 @@ class SierraItemsTest
     )
 
     val results =
-      getTransformedItems(
-        bibData = bibData,
-        itemDataEntries = Seq(itemData))
+      getTransformedItems(bibData = bibData, itemDataEntries = Seq(itemData))
 
     results.head.locations should be(
       List(
@@ -408,7 +406,8 @@ class SierraItemsTest
           location = Some(SierraSourceLocation("bwith", "bound in above"))
         ),
         createSierraItemDataWith(
-          location = Some(SierraSourceLocation("sicon", "Closed stores Iconographic"))
+          location =
+            Some(SierraSourceLocation("sicon", "Closed stores Iconographic"))
         ),
         createSierraItemDataWith(
           location = Some(SierraSourceLocation("cwith", "contained in above"))
@@ -433,7 +432,8 @@ class SierraItemsTest
 
     it(
       "adds a location to 'bound/contained in above' if the other locations are all closed") {
-      val itemDataEntries = Seq(createSierraItemDataWith(
+      val itemDataEntries = Seq(
+        createSierraItemDataWith(
           location = Some(SierraSourceLocation("bwith", "bound in above"))
         ),
         createSierraItemDataWith(
@@ -463,7 +463,8 @@ class SierraItemsTest
 
     it(
       "skips adding a location to 'bound/contained in above' if the other locations are ambiguous") {
-      val itemDataEntries = Seq(createSierraItemDataWith(
+      val itemDataEntries = Seq(
+        createSierraItemDataWith(
           location = Some(SierraSourceLocation("bwith", "bound in above"))
         ),
         createSierraItemDataWith(
@@ -488,10 +489,10 @@ class SierraItemsTest
 
   it("sorts items by sierra-identifier") {
     val itemData = Seq(
-      createSierraItemDataWith(id=SierraItemNumber("0000002")),
-      createSierraItemDataWith(id=SierraItemNumber("0000001")),
-      createSierraItemDataWith(id=SierraItemNumber("0000004")),
-      createSierraItemDataWith(id=SierraItemNumber("0000003")),
+      createSierraItemDataWith(id = SierraItemNumber("0000002")),
+      createSierraItemDataWith(id = SierraItemNumber("0000001")),
+      createSierraItemDataWith(id = SierraItemNumber("0000004")),
+      createSierraItemDataWith(id = SierraItemNumber("0000003")),
     )
     getTransformedItems(itemDataEntries = itemData)
       .map(_.id.asInstanceOf[IdState.Identifiable].otherIdentifiers.head.value) shouldBe
@@ -503,13 +504,12 @@ class SierraItemsTest
       )
   }
 
-  private def getTransformedItems(
-    bibData: SierraBibData = createSierraBibData,
-    itemDataEntries: Seq[SierraItemData] = Seq())
+  private def getTransformedItems(bibData: SierraBibData = createSierraBibData,
+                                  itemDataEntries: Seq[SierraItemData] = Seq())
     : List[Item[IdState.Unminted]] =
     SierraItems(
-      bibId = createSierraBibNumber, 
-      bibData = bibData, 
+      bibId = createSierraBibNumber,
+      bibData = bibData,
       itemDataEntries = itemDataEntries
     )
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraLocationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraLocationTest.scala
@@ -64,7 +64,7 @@ class SierraLocationTest
           List(AccessCondition(method = AccessMethod.OnlineRequest))
       )
 
-      transformer.getPhysicalLocation(bibId, itemId, itemData, bibData) shouldBe Some(
+      transformer.getPhysicalLocation(bibId, itemData, bibData) shouldBe Some(
         expectedLocation)
     }
 
@@ -74,7 +74,7 @@ class SierraLocationTest
       )
 
       val location =
-        transformer.getPhysicalLocation(bibId, itemId, itemData, bibData).get
+        transformer.getPhysicalLocation(bibId, itemData, bibData).get
       location.label shouldBe "Folios"
     }
 
@@ -83,14 +83,14 @@ class SierraLocationTest
         location = Some(SierraSourceLocation("", ""))
       )
 
-      transformer.getPhysicalLocation(bibId, itemId, itemData, bibData) shouldBe None
+      transformer.getPhysicalLocation(bibId, itemData, bibData) shouldBe None
     }
 
     it("returns None if the location field only contains the string 'none'") {
       val itemData = createSierraItemDataWith(
         location = Some(SierraSourceLocation("none", "none"))
       )
-      transformer.getPhysicalLocation(bibId, itemId, itemData, bibData) shouldBe None
+      transformer.getPhysicalLocation(bibId, itemData, bibData) shouldBe None
     }
 
     it("returns None if there is no location in the item data") {
@@ -98,7 +98,7 @@ class SierraLocationTest
         location = None
       )
 
-      transformer.getPhysicalLocation(bibId, itemId, itemData, bibData) shouldBe None
+      transformer.getPhysicalLocation(bibId, itemData, bibData) shouldBe None
     }
 
     it("adds access conditions to the items") {
@@ -135,7 +135,7 @@ class SierraLocationTest
       )
 
       val location =
-        transformer.getPhysicalLocation(bibId, itemId, itemData, bibData).get
+        transformer.getPhysicalLocation(bibId, itemData, bibData).get
       location.accessConditions shouldBe List(
         AccessCondition(
           method = AccessMethod.OnlineRequest,
@@ -158,7 +158,7 @@ class SierraLocationTest
       )
 
       val location =
-        transformer.getPhysicalLocation(bibId, itemId, itemData, bibData).get
+        transformer.getPhysicalLocation(bibId, itemData, bibData).get
 
       location.shelfmark shouldBe Some("AX1234:Box 1")
     }
@@ -167,7 +167,6 @@ class SierraLocationTest
       it("returns an empty location if location name is 'bound in above'") {
         val result = transformer.getPhysicalLocation(
           bibNumber = createSierraBibNumber,
-          itemNumber = createSierraItemNumber,
           bibData = createSierraBibData,
           itemData = createSierraItemDataWith(
             location = Some(SierraSourceLocation("bwith", "bound in above"))
@@ -180,7 +179,6 @@ class SierraLocationTest
       it("uses the fallback location if location name is 'bound in above'") {
         val result = transformer.getPhysicalLocation(
           bibNumber = createSierraBibNumber,
-          itemNumber = createSierraItemNumber,
           bibData = createSierraBibData,
           itemData = createSierraItemDataWith(
             location = Some(SierraSourceLocation("bwith", "bound in above"))
@@ -197,7 +195,6 @@ class SierraLocationTest
       it("returns an empty location if location name is 'contained in above'") {
         val result = transformer.getPhysicalLocation(
           bibNumber = createSierraBibNumber,
-          itemNumber = createSierraItemNumber,
           bibData = createSierraBibData,
           itemData = createSierraItemDataWith(
             location = Some(SierraSourceLocation("cwith", "contained in above"))
@@ -210,7 +207,6 @@ class SierraLocationTest
       it("uses the fallback location if location name is 'contained in above'") {
         val result = transformer.getPhysicalLocation(
           bibNumber = createSierraBibNumber,
-          itemNumber = createSierraItemNumber,
           bibData = createSierraBibData,
           itemData = createSierraItemDataWith(
             location = Some(SierraSourceLocation("cwith", "contained in above"))

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraLocationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraLocationTest.scala
@@ -31,7 +31,6 @@ class SierraLocationTest
 
   describe("Physical locations") {
     val bibId = createSierraBibNumber
-    val itemId = createSierraItemNumber
     val bibData = createSierraBibData
 
     val itemData = createSierraItemDataWith(
@@ -235,7 +234,12 @@ class SierraLocationTest
       )
 
       val location =
-        transformer.getPhysicalLocation(bibId, itemId, itemData, bibData).get
+        transformer.getPhysicalLocation(
+          bibNumber = bibId,
+          itemData = itemData,
+          bibData = bibData
+        ).get
+
       location.accessConditions shouldBe List(
         AccessCondition(
           method = AccessMethod.NotRequestable,

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraLocationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraLocationTest.scala
@@ -234,11 +234,13 @@ class SierraLocationTest
       )
 
       val location =
-        transformer.getPhysicalLocation(
-          bibNumber = bibId,
-          itemData = itemData,
-          bibData = bibData
-        ).get
+        transformer
+          .getPhysicalLocation(
+            bibNumber = bibId,
+            itemData = itemData,
+            bibData = bibData
+          )
+          .get
 
       location.accessConditions shouldBe List(
         AccessCondition(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,6 +20,7 @@ object WellcomeDependencies {
     name = "internal_model",
     version = versions.internalModel
   )
+
   val jsonLibrary: Seq[ModuleID] = library(
     name = "json",
     version = versions.json


### PR DESCRIPTION
For https://github.com/wellcomecollection/catalogue-api/pull/191

If we request items from the Sierra API directly, we can't serialise them into a shape with an ID which makes it quite confusing if you have a list of them! This change adds the ID to `SierraItemData` which is present in the response from Sierra source data, but up till now we haven't needed it.

This allows us to simplify some things in the `SierraTransformer` also.