### PR TITLE
Use v1.2.1 of our SQS queue module

### DIFF
--- a/calm_adapter/terraform/adapter_worker.tf
+++ b/calm_adapter/terraform/adapter_worker.tf
@@ -1,8 +1,7 @@
 module "calm_windows_queue" {
-  source                     = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.1.2"
+  source                     = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.2.1"
   queue_name                 = "calm-windows"
   topic_arns                 = [aws_sns_topic.calm_windows_topic.arn]
-  aws_region                 = local.aws_region
   alarm_topic_arn            = local.dlq_alarm_arn
   visibility_timeout_seconds = 10800
 }
@@ -72,7 +71,7 @@ data "aws_iam_policy_document" "allow_cloudwatch_push_metrics" {
 }
 
 module "adapter_scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.2"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.2.1"
   queue_name = module.calm_windows_queue.name
 
   queue_high_actions = [

--- a/calm_adapter/terraform/deletion_checker_worker.tf
+++ b/calm_adapter/terraform/deletion_checker_worker.tf
@@ -1,8 +1,7 @@
 module "calm_deletion_checker_queue" {
-  source                     = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.1.2"
+  source                     = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.2.1"
   queue_name                 = "calm-deletion-checker-input"
   topic_arns                 = [local.calm_deletion_checker_topic_arn]
-  aws_region                 = local.aws_region
   alarm_topic_arn            = local.dlq_alarm_arn
   visibility_timeout_seconds = 30 * 60
 }
@@ -65,7 +64,7 @@ resource "aws_iam_role_policy" "read_from_deletion_checker_queue" {
 
 
 module "deletion_checker_scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.2"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.2.1"
   queue_name = module.calm_deletion_checker_queue.name
 
   queue_high_actions = [

--- a/calm_adapter/terraform/indexer.tf
+++ b/calm_adapter/terraform/indexer.tf
@@ -1,5 +1,5 @@
 module "calm_indexer_queue" {
-  source = "github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.1.2"
+  source = "github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.2.1"
 
   queue_name = "calm-indexer-input"
   topic_arns = [
@@ -7,7 +7,6 @@ module "calm_indexer_queue" {
     local.calm_reporting_topic_arn
   ]
 
-  aws_region      = local.aws_region
   alarm_topic_arn = local.dlq_alarm_arn
 }
 
@@ -63,7 +62,7 @@ resource "aws_iam_role_policy" "indexer_read_from_vhs" {
 }
 
 module "indexer_scaling" {
-  source     = "github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.2"
+  source     = "github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.2.1"
   queue_name = module.calm_indexer_queue.name
 
   queue_high_actions = [

--- a/calm_adapter/terraform/locals.tf
+++ b/calm_adapter/terraform/locals.tf
@@ -4,7 +4,6 @@ locals {
 
   infra_bucket           = data.terraform_remote_state.shared_infra.outputs.infra_bucket
   account_id             = data.aws_caller_identity.current.account_id
-  aws_region             = "eu-west-1"
   dlq_alarm_arn          = data.terraform_remote_state.shared_infra.outputs.dlq_alarm_arn
   vpc_id                 = local.catalogue_vpcs["catalogue_vpc_delta_id"]
   private_subnets        = local.catalogue_vpcs["catalogue_vpc_delta_private_subnets"]

--- a/calm_adapter/terraform/provider.tf
+++ b/calm_adapter/terraform/provider.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  region = local.aws_region
+  region = "eu-west-1"
 
   assume_role {
     role_arn = "arn:aws:iam::760097843905:role/platform-developer"

--- a/mets_adapter/terraform/locals.tf
+++ b/mets_adapter/terraform/locals.tf
@@ -12,8 +12,6 @@ locals {
   mets_adapter_table_name = aws_dynamodb_table.mets_adapter_table.id
 
   # Infra stuff
-  aws_region = "eu-west-1"
-
   dlq_alarm_arn   = data.terraform_remote_state.shared_infra.outputs.dlq_alarm_arn
   vpc_id          = local.catalogue_vpcs["catalogue_vpc_delta_id"]
   private_subnets = local.catalogue_vpcs["catalogue_vpc_delta_private_subnets"]

--- a/mets_adapter/terraform/provider.tf
+++ b/mets_adapter/terraform/provider.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  region = local.aws_region
+  region = "eu-west-1"
 
   assume_role {
     role_arn = "arn:aws:iam::760097843905:role/platform-developer"

--- a/mets_adapter/terraform/queue.tf
+++ b/mets_adapter/terraform/queue.tf
@@ -1,5 +1,5 @@
 module "queue" {
-  source = "github.com/wellcomecollection/terraform-aws-sqs.git//queue?ref=v1.1.2"
+  source = "github.com/wellcomecollection/terraform-aws-sqs.git//queue?ref=v1.2.1"
 
   queue_name = "mets_adapter_queue"
 
@@ -8,13 +8,11 @@ module "queue" {
     module.repopulate_script_topic.arn,
   ]
 
-  aws_region = local.aws_region
-
   alarm_topic_arn = local.dlq_alarm_arn
 }
 
 module "scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.2"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.2.1"
   queue_name = module.queue.name
 
   queue_high_actions = [

--- a/pipeline/terraform/locals.tf
+++ b/pipeline/terraform/locals.tf
@@ -36,7 +36,6 @@ locals {
   calm_reindexer_topic_arn   = data.terraform_remote_state.reindexer.outputs.calm_reindexer_topic_arn
 
   # Infra stuff
-  aws_region      = "eu-west-1"
   dlq_alarm_arn   = data.terraform_remote_state.shared_infra.outputs.dlq_alarm_arn
   vpc_id          = local.catalogue_vpcs["catalogue_vpc_delta_id"]
   private_subnets = local.catalogue_vpcs["catalogue_vpc_delta_private_subnets"]

--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -41,9 +41,8 @@ module "catalogue_pipeline_2021-07-06" {
     }
   }
 
-  aws_region = local.aws_region
-  vpc_id     = local.vpc_id
-  subnets    = local.private_subnets
+  vpc_id  = local.vpc_id
+  subnets = local.private_subnets
 
   dlq_alarm_arn = local.dlq_alarm_arn
 
@@ -128,9 +127,8 @@ module "catalogue_pipeline_2021-07-13" {
     }
   }
 
-  aws_region = local.aws_region
-  vpc_id     = local.vpc_id
-  subnets    = local.private_subnets
+  vpc_id  = local.vpc_id
+  subnets = local.private_subnets
 
   dlq_alarm_arn = local.dlq_alarm_arn
 

--- a/pipeline/terraform/stack/service_id_minter.tf
+++ b/pipeline/terraform/stack/service_id_minter.tf
@@ -1,6 +1,6 @@
 module "id_minter_queue" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.1.2"
-  queue_name = "${local.namespace_hyphen}_id_minter"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.2.1"
+  queue_name = "${local.namespace}_id_minter"
   topic_arns = [
     module.calm_transformer_output_topic.arn,
     module.mets_transformer_output_topic.arn,
@@ -8,7 +8,6 @@ module "id_minter_queue" {
     module.sierra_transformer_output_topic.arn,
     module.tei_transformer_output_topic.arn,
   ]
-  aws_region                 = var.aws_region
   alarm_topic_arn            = var.dlq_alarm_arn
   visibility_timeout_seconds = 120
 }
@@ -83,12 +82,12 @@ module "id_minter" {
 module "id_minter_topic" {
   source = "../modules/topic"
 
-  name       = "${local.namespace_hyphen}_id_minter_output"
+  name       = "${local.namespace}_id_minter_output"
   role_names = [module.id_minter.task_role_name]
 }
 
 module "id_minter_scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.3"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.2.1"
   queue_name = module.id_minter_queue.name
 
   queue_high_actions = [module.id_minter.scale_up_arn]

--- a/pipeline/terraform/stack/service_image_inferrer.tf
+++ b/pipeline/terraform/stack/service_image_inferrer.tf
@@ -20,10 +20,9 @@ locals {
 }
 
 module "image_inferrer_queue" {
-  source                     = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.1.2"
-  queue_name                 = "${local.namespace_hyphen}_image_inferrer"
+  source                     = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.2.1"
+  queue_name                 = "${local.namespace}_image_inferrer"
   topic_arns                 = [module.merger_images_topic.arn]
-  aws_region                 = var.aws_region
   alarm_topic_arn            = var.dlq_alarm_arn
   visibility_timeout_seconds = local.queue_visibility_timeout
 }
@@ -198,12 +197,12 @@ data "aws_iam_policy_document" "allow_inferrer_data_access" {
 module "image_inferrer_topic" {
   source = "../modules/topic"
 
-  name       = "${local.namespace_hyphen}_image_inferrer"
+  name       = "${local.namespace}_image_inferrer"
   role_names = [module.image_inferrer.task_role_name]
 }
 
 module "image_inferrer_scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.3"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.2.1"
   queue_name = module.image_inferrer_queue.name
 
   queue_high_actions = [module.image_inferrer.scale_up_arn]

--- a/pipeline/terraform/stack/service_ingestor_images.tf
+++ b/pipeline/terraform/stack/service_ingestor_images.tf
@@ -3,10 +3,9 @@ locals {
 }
 
 module "ingestor_images_queue" {
-  source          = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.1.2"
-  queue_name      = "${local.namespace_hyphen}_ingestor_images"
+  source          = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.2.1"
+  queue_name      = "${local.namespace}_ingestor_images"
   topic_arns      = [module.image_inferrer_topic.arn]
-  aws_region      = var.aws_region
   alarm_topic_arn = var.dlq_alarm_arn
 
   visibility_timeout_seconds = local.image_ingestor_flush_interval_seconds + 60
@@ -90,12 +89,12 @@ module "ingestor_images" {
 module "image_ingestor_topic" {
   source = "../modules/topic"
 
-  name       = "${local.namespace_hyphen}_image_ingestor_output"
+  name       = "${local.namespace}_image_ingestor_output"
   role_names = [module.ingestor_images.task_role_name]
 }
 
 module "ingestor_images_scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.3"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.2.1"
   queue_name = module.ingestor_images_queue.name
 
   queue_high_actions = [module.ingestor_images.scale_up_arn]

--- a/pipeline/terraform/stack/service_ingestor_works.tf
+++ b/pipeline/terraform/stack/service_ingestor_works.tf
@@ -3,10 +3,9 @@ locals {
 }
 
 module "ingestor_works_queue" {
-  source          = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.1.2"
-  queue_name      = "${local.namespace_hyphen}_ingestor_works"
+  source          = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.2.1"
+  queue_name      = "${local.namespace}_ingestor_works"
   topic_arns      = [module.router_work_output_topic.arn, module.relation_embedder_output_topic.arn]
-  aws_region      = var.aws_region
   alarm_topic_arn = var.dlq_alarm_arn
 
   max_receive_count = 6
@@ -79,12 +78,12 @@ module "ingestor_works" {
 module "work_ingestor_topic" {
   source = "../modules/topic"
 
-  name       = "${local.namespace_hyphen}_work_ingestor"
+  name       = "${local.namespace}_work_ingestor"
   role_names = [module.ingestor_works.task_role_name]
 }
 
 module "ingestor_works_scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.3"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.2.1"
   queue_name = module.ingestor_works_queue.name
 
   queue_high_actions = [module.ingestor_works.scale_up_arn]

--- a/pipeline/terraform/stack/service_matcher.tf
+++ b/pipeline/terraform/stack/service_matcher.tf
@@ -3,14 +3,13 @@ locals {
 }
 
 module "matcher_input_queue" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.1.2"
-  queue_name = "${local.namespace_hyphen}_matcher_input"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.2.1"
+  queue_name = "${local.namespace}_matcher_input"
 
   topic_arns = [
     module.id_minter_topic.arn
   ]
 
-  aws_region      = var.aws_region
   alarm_topic_arn = var.dlq_alarm_arn
 
   # The records in the locktable expire after local.lock_timeout
@@ -108,12 +107,12 @@ resource "aws_iam_role_policy" "matcher_lock_readwrite" {
 module "matcher_topic" {
   source = "../modules/topic"
 
-  name       = "${local.namespace_hyphen}_matcher"
+  name       = "${local.namespace}_matcher"
   role_names = [module.matcher.task_role_name]
 }
 
 module "matcher_scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.3"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.2.1"
   queue_name = module.matcher_input_queue.name
 
   queue_high_actions = [module.matcher.scale_up_arn]

--- a/pipeline/terraform/stack/service_merger.tf
+++ b/pipeline/terraform/stack/service_merger.tf
@@ -1,7 +1,7 @@
 module "merger_queue" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.2.1"
-  queue_name = "${local.namespace}_merger"
-  topic_arns = [module.matcher_topic.arn]
+  source          = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.2.1"
+  queue_name      = "${local.namespace}_merger"
+  topic_arns      = [module.matcher_topic.arn]
   alarm_topic_arn = var.dlq_alarm_arn
 
   # This has to be longer than the `flush_interval_seconds` in the merger.

--- a/pipeline/terraform/stack/service_merger.tf
+++ b/pipeline/terraform/stack/service_merger.tf
@@ -1,9 +1,7 @@
 module "merger_queue" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.1.2"
-  queue_name = "${local.namespace_hyphen}_merger"
-  topic_arns = [
-  module.matcher_topic.arn]
-  aws_region      = var.aws_region
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.2.1"
+  queue_name = "${local.namespace}_merger"
+  topic_arns = [module.matcher_topic.arn]
   alarm_topic_arn = var.dlq_alarm_arn
 
   # This has to be longer than the `flush_interval_seconds` in the merger.
@@ -69,19 +67,19 @@ module "merger" {
 module "merger_works_topic" {
   source = "../modules/topic"
 
-  name       = "${local.namespace_hyphen}_merger_works"
+  name       = "${local.namespace}_merger_works"
   role_names = [module.merger.task_role_name]
 }
 
 module "merger_images_topic" {
   source = "../modules/topic"
 
-  name       = "${local.namespace_hyphen}_merger_images"
+  name       = "${local.namespace}_merger_images"
   role_names = [module.merger.task_role_name]
 }
 
 module "merger_scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.3"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.2.1"
   queue_name = module.merger_queue.name
 
   queue_high_actions = [module.merger.scale_up_arn]

--- a/pipeline/terraform/stack/service_transformer_calm.tf
+++ b/pipeline/terraform/stack/service_transformer_calm.tf
@@ -1,9 +1,8 @@
 module "calm_transformer_queue" {
-  source          = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.1.2"
-  queue_name      = "${local.namespace_hyphen}_calm_transformer"
+  source          = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.2.1"
+  queue_name      = "${local.namespace}_calm_transformer"
   topic_arns      = local.calm_adapter_topic_arns
   alarm_topic_arn = var.dlq_alarm_arn
-  aws_region      = var.aws_region
 }
 
 module "calm_transformer" {
@@ -62,7 +61,7 @@ resource "aws_iam_role_policy" "calm_transformer_vhs_calm_adapter_read" {
 module "calm_transformer_output_topic" {
   source = "github.com/wellcomecollection/terraform-aws-sns-topic?ref=v1.0.1"
 
-  name = "${local.namespace_hyphen}_calm_transformer_output"
+  name = "${local.namespace}_calm_transformer_output"
 }
 
 resource "aws_iam_role_policy" "allow_calm_transformer_sns_publish" {
@@ -71,7 +70,7 @@ resource "aws_iam_role_policy" "allow_calm_transformer_sns_publish" {
 }
 
 module "calm_transformer_scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.3"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.2.1"
   queue_name = module.calm_transformer_queue.name
 
   queue_high_actions = [module.calm_transformer.scale_up_arn]

--- a/pipeline/terraform/stack/service_transformer_mets.tf
+++ b/pipeline/terraform/stack/service_transformer_mets.tf
@@ -1,8 +1,7 @@
 module "mets_transformer_queue" {
-  source          = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.1.2"
-  queue_name      = "${local.namespace_hyphen}_mets_transformer"
+  source          = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.2.1"
+  queue_name      = "${local.namespace}_mets_transformer"
   topic_arns      = local.mets_adapter_topic_arns
-  aws_region      = var.aws_region
   alarm_topic_arn = var.dlq_alarm_arn
 
   # The default visibility timeout is 30 seconds, and occasionally we see
@@ -70,7 +69,7 @@ module "mets_transformer" {
 module "mets_transformer_output_topic" {
   source = "github.com/wellcomecollection/terraform-aws-sns-topic?ref=v1.0.1"
 
-  name = "${local.namespace_hyphen}_mets_transformer_output"
+  name = "${local.namespace}_mets_transformer_output"
 }
 
 resource "aws_iam_role_policy" "allow_mets_transformer_sns_publish" {
@@ -79,7 +78,7 @@ resource "aws_iam_role_policy" "allow_mets_transformer_sns_publish" {
 }
 
 module "mets_transformer_scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.3"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.2.1"
   queue_name = module.mets_transformer_queue.name
 
   queue_high_actions = [module.mets_transformer.scale_up_arn]

--- a/pipeline/terraform/stack/service_transformer_miro.tf
+++ b/pipeline/terraform/stack/service_transformer_miro.tf
@@ -1,8 +1,7 @@
 module "miro_transformer_queue" {
-  source          = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.1.2"
-  queue_name      = "${local.namespace_hyphen}_miro_transformer"
+  source          = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.2.1"
+  queue_name      = "${local.namespace}_miro_transformer"
   topic_arns      = local.miro_adapter_topic_arns
-  aws_region      = var.aws_region
   alarm_topic_arn = var.dlq_alarm_arn
 }
 
@@ -65,7 +64,7 @@ resource "aws_iam_role_policy" "miro_transformer_vhs_miro_adapter_read" {
 module "miro_transformer_output_topic" {
   source = "github.com/wellcomecollection/terraform-aws-sns-topic?ref=v1.0.1"
 
-  name = "${local.namespace_hyphen}_miro_transformer_output"
+  name = "${local.namespace}_miro_transformer_output"
 }
 
 resource "aws_iam_role_policy" "allow_miro_transformer_sns_publish" {
@@ -74,7 +73,7 @@ resource "aws_iam_role_policy" "allow_miro_transformer_sns_publish" {
 }
 
 module "miro_transformer_scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.3"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.2.1"
   queue_name = module.miro_transformer_queue.name
 
   queue_high_actions = [module.miro_transformer.scale_up_arn]

--- a/pipeline/terraform/stack/service_transformer_sierra.tf
+++ b/pipeline/terraform/stack/service_transformer_sierra.tf
@@ -1,9 +1,8 @@
 module "sierra_transformer_queue" {
-  source          = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.1.2"
-  queue_name      = "${local.namespace_hyphen}_sierra_transformer"
+  source          = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.2.1"
+  queue_name      = "${local.namespace}_sierra_transformer"
   topic_arns      = local.sierra_adapter_topic_arns
   alarm_topic_arn = var.dlq_alarm_arn
-  aws_region      = var.aws_region
 }
 
 module "sierra_transformer" {
@@ -63,7 +62,7 @@ resource "aws_iam_role_policy" "sierra_transformer_vhs_sierra_adapter_read" {
 module "sierra_transformer_output_topic" {
   source = "github.com/wellcomecollection/terraform-aws-sns-topic?ref=v1.0.1"
 
-  name = "${local.namespace_hyphen}_sierra_transformer_output"
+  name = "${local.namespace}_sierra_transformer_output"
 }
 
 resource "aws_iam_role_policy" "allow_sierra_transformer_sns_publish" {
@@ -72,7 +71,7 @@ resource "aws_iam_role_policy" "allow_sierra_transformer_sns_publish" {
 }
 
 module "sierra_transformer_scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.3"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.2.1"
   queue_name = module.sierra_transformer_queue.name
 
   queue_high_actions = [module.sierra_transformer.scale_up_arn]

--- a/pipeline/terraform/stack/service_transformer_tei.tf
+++ b/pipeline/terraform/stack/service_transformer_tei.tf
@@ -1,8 +1,7 @@
 module "tei_transformer_queue" {
-  source          = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.1.2"
-  queue_name      = "${local.namespace_hyphen}_tei_transformer"
+  source          = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.2.1"
+  queue_name      = "${local.namespace}_tei_transformer"
   topic_arns      = local.tei_adapter_topic_arns
-  aws_region      = var.aws_region
   alarm_topic_arn = var.dlq_alarm_arn
 
   # The default visibility timeout is 30 seconds, and occasionally we see
@@ -70,7 +69,7 @@ module "tei_transformer" {
 module "tei_transformer_output_topic" {
   source = "github.com/wellcomecollection/terraform-aws-sns-topic?ref=v1.0.1"
 
-  name = "${local.namespace_hyphen}_tei_transformer_output"
+  name = "${local.namespace}_tei_transformer_output"
 }
 
 resource "aws_iam_role_policy" "allow_tei_transformer_sns_publish" {
@@ -79,7 +78,7 @@ resource "aws_iam_role_policy" "allow_tei_transformer_sns_publish" {
 }
 
 module "tei_transformer_scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.3"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.2.1"
   queue_name = module.tei_transformer_queue.name
 
   queue_high_actions = [module.tei_transformer.scale_up_arn]

--- a/pipeline/terraform/stack/service_work_batcher.tf
+++ b/pipeline/terraform/stack/service_work_batcher.tf
@@ -3,11 +3,10 @@ locals {
 }
 
 module "batcher_queue" {
-  source                     = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.1.2"
-  queue_name                 = "${local.namespace_hyphen}_batcher"
+  source                     = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.2.1"
+  queue_name                 = "${local.namespace}_batcher"
   topic_arns                 = [module.router_path_output_topic.arn]
   visibility_timeout_seconds = (local.wait_minutes + 5) * 60
-  aws_region                 = var.aws_region
   alarm_topic_arn            = var.dlq_alarm_arn
 }
 
@@ -68,12 +67,12 @@ module "batcher" {
 module "batcher_output_topic" {
   source = "../modules/topic"
 
-  name       = "${local.namespace_hyphen}_batcher_output"
+  name       = "${local.namespace}_batcher_output"
   role_names = [module.batcher.task_role_name]
 }
 
 module "batcher_scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.3"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.2.1"
   queue_name = module.batcher_queue.name
 
   queue_high_actions = [module.batcher.scale_up_arn]

--- a/pipeline/terraform/stack/service_work_relation_embedder.tf
+++ b/pipeline/terraform/stack/service_work_relation_embedder.tf
@@ -1,8 +1,7 @@
 module "relation_embedder_queue" {
-  source          = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.1.2"
-  queue_name      = "${local.namespace_hyphen}_relation_embedder"
+  source          = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.2.1"
+  queue_name      = "${local.namespace}_relation_embedder"
   topic_arns      = [module.batcher_output_topic.arn]
-  aws_region      = var.aws_region
   alarm_topic_arn = var.dlq_alarm_arn
 
   # We know that 10 minutes is too short; some big archives can't be
@@ -72,12 +71,12 @@ module "relation_embedder" {
 module "relation_embedder_output_topic" {
   source = "../modules/topic"
 
-  name       = "${local.namespace_hyphen}_relation_embedder_output"
+  name       = "${local.namespace}_relation_embedder_output"
   role_names = [module.relation_embedder.task_role_name]
 }
 
 module "relation_embedder_scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.3"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.2.1"
   queue_name = module.relation_embedder_queue.name
 
   queue_high_actions = [module.relation_embedder.scale_up_arn]

--- a/pipeline/terraform/stack/service_work_router.tf
+++ b/pipeline/terraform/stack/service_work_router.tf
@@ -1,8 +1,7 @@
 module "router_queue" {
-  source          = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.1.2"
-  queue_name      = "${local.namespace_hyphen}_router"
+  source          = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.2.1"
+  queue_name      = "${local.namespace}_router"
   topic_arns      = [module.merger_works_topic.arn]
-  aws_region      = var.aws_region
   alarm_topic_arn = var.dlq_alarm_arn
 
   visibility_timeout_seconds = 60
@@ -68,19 +67,19 @@ module "router" {
 module "router_path_output_topic" {
   source = "../modules/topic"
 
-  name       = "${local.namespace_hyphen}_router_path_output"
+  name       = "${local.namespace}_router_path_output"
   role_names = [module.router.task_role_name]
 }
 
 module "router_work_output_topic" {
   source = "../modules/topic"
 
-  name       = "${local.namespace_hyphen}_router_work_output"
+  name       = "${local.namespace}_router_work_output"
   role_names = [module.router.task_role_name]
 }
 
 module "router_scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.3"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.2.1"
   queue_name = module.router_queue.name
 
   queue_high_actions = [module.router.scale_up_arn]

--- a/pipeline/terraform/stack/variables.tf
+++ b/pipeline/terraform/stack/variables.tf
@@ -22,8 +22,6 @@ variable "shared_logging_secrets" {
 
 variable "vpc_id" {}
 
-variable "aws_region" {}
-
 variable "dlq_alarm_arn" {}
 
 variable "rds_cluster_id" {

--- a/reindexer/terraform/main.tf
+++ b/reindexer/terraform/main.tf
@@ -13,6 +13,7 @@ module "reindex_worker" {
   elastic_cloud_vpce_sg_id         = data.terraform_remote_state.shared_infra.outputs["ec_platform_privatelink_sg_id"]
 
   account_id = data.aws_caller_identity.current.account_id
+  aws_region = data.aws_region.current.name
 
   private_subnets = local.private_subnets
   dlq_alarm_arn   = local.dlq_alarm_arn

--- a/reindexer/terraform/provider.tf
+++ b/reindexer/terraform/provider.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  region = var.aws_region
+  region = "eu-west-1"
 
   assume_role {
     role_arn = "arn:aws:iam::760097843905:role/platform-developer"
@@ -7,3 +7,4 @@ provider "aws" {
 }
 
 data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}

--- a/reindexer/terraform/reindex_worker/messaging.tf
+++ b/reindexer/terraform/reindex_worker/messaging.tf
@@ -1,8 +1,7 @@
 module "reindexer_queue" {
-  source          = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.1.2"
+  source          = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.2.1"
   queue_name      = "reindex_worker_queue"
   topic_arns      = [module.reindex_jobs_topic.arn]
-  aws_region      = var.aws_region
   alarm_topic_arn = var.dlq_alarm_arn
 
   # Messages take a while to process in the reindexer, so up from the default

--- a/reindexer/terraform/reindex_worker/service.tf
+++ b/reindexer/terraform/reindex_worker/service.tf
@@ -38,7 +38,7 @@ module "service" {
 }
 
 module "reindexer_scaling" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.3"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.2.1"
   queue_name = module.reindexer_queue.name
 
   queue_high_actions = [module.service.scale_up_arn]

--- a/reindexer/terraform/reindex_worker/variables.tf
+++ b/reindexer/terraform/reindex_worker/variables.tf
@@ -1,5 +1,5 @@
 variable "aws_region" {
-  default = "eu-west-1"
+  type = string
 }
 
 variable "account_id" {}

--- a/reindexer/terraform/variables.tf
+++ b/reindexer/terraform/variables.tf
@@ -1,4 +1,0 @@
-variable "aws_region" {
-  description = "The AWS region to create things in."
-  default     = "eu-west-1"
-}

--- a/sierra_adapter/terraform/provider.tf
+++ b/sierra_adapter/terraform/provider.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  region = var.aws_region
+  region = "eu-west-1"
 
   assume_role {
     role_arn = "arn:aws:iam::760097843905:role/platform-admin"

--- a/sierra_adapter/terraform/sierra_indexer/queues.tf
+++ b/sierra_adapter/terraform/sierra_indexer/queues.tf
@@ -1,16 +1,14 @@
 module "indexer_input_queue" {
-  source = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.1.2"
+  source = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.2.1"
 
   queue_name = "${local.service_name}_input"
   topic_arns = var.topic_arns
 
   alarm_topic_arn = var.dlq_alarm_arn
-
-  aws_region = var.aws_region
 }
 
 module "scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.2"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.2.1"
   queue_name = module.indexer_input_queue.name
 
   queue_high_actions = [module.service.scale_up_arn]

--- a/sierra_adapter/terraform/sierra_indexer/variables.tf
+++ b/sierra_adapter/terraform/sierra_indexer/variables.tf
@@ -14,10 +14,6 @@ variable "cluster_arn" {}
 variable "dlq_alarm_arn" {}
 variable "lambda_error_alarm_arn" {}
 
-variable "aws_region" {
-  default = "eu-west-1"
-}
-
 variable "subnets" {
   type = list(string)
 }

--- a/sierra_adapter/terraform/sierra_linker/queues.tf
+++ b/sierra_adapter/terraform/sierra_linker/queues.tf
@@ -1,5 +1,5 @@
 module "input_queue" {
-  source = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.1.2"
+  source = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.2.1"
 
   queue_name = "${local.service_name}_input"
   topic_arns = [var.demultiplexer_topic_arn]
@@ -7,12 +7,10 @@ module "input_queue" {
   max_receive_count = 10
 
   alarm_topic_arn = var.dlq_alarm_arn
-
-  aws_region = var.aws_region
 }
 
 module "scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.2"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.2.1"
   queue_name = module.input_queue.name
 
   queue_high_actions = [module.service.scale_up_arn]

--- a/sierra_adapter/terraform/sierra_linker/variables.tf
+++ b/sierra_adapter/terraform/sierra_linker/variables.tf
@@ -11,10 +11,6 @@ variable "cluster_arn" {}
 
 variable "dlq_alarm_arn" {}
 
-variable "aws_region" {
-  default = "eu-west-1"
-}
-
 variable "subnets" {
   type = list(string)
 }

--- a/sierra_adapter/terraform/sierra_merger/queues.tf
+++ b/sierra_adapter/terraform/sierra_merger/queues.tf
@@ -1,5 +1,5 @@
 module "input_queue" {
-  source = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.1.2"
+  source = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.2.1"
 
   queue_name = "${var.namespace}-sierra_${var.resource_type}_merger_input"
 
@@ -10,12 +10,10 @@ module "input_queue" {
   visibility_timeout_seconds = 300
 
   alarm_topic_arn = var.dlq_alarm_arn
-
-  aws_region = var.aws_region
 }
 
 module "scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.2"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.2.1"
   queue_name = module.input_queue.name
 
   queue_high_actions = [module.service.scale_up_arn]

--- a/sierra_adapter/terraform/sierra_merger/variables.tf
+++ b/sierra_adapter/terraform/sierra_merger/variables.tf
@@ -22,10 +22,6 @@ variable "container_image" {}
 
 variable "dlq_alarm_arn" {}
 
-variable "aws_region" {
-  default = "eu-west-1"
-}
-
 variable "subnets" {
   type = list(string)
 }

--- a/sierra_adapter/terraform/sierra_reader/queues.tf
+++ b/sierra_adapter/terraform/sierra_reader/queues.tf
@@ -1,5 +1,5 @@
 module "windows_queue" {
-  source = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.1.2"
+  source = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.2.1"
 
   queue_name = "${var.namespace}-sierra_${var.resource_type}_windows"
   topic_arns = var.windows_topic_arns
@@ -18,12 +18,10 @@ module "windows_queue" {
   max_receive_count = 12
 
   alarm_topic_arn = var.dlq_alarm_arn
-
-  aws_region = var.aws_region
 }
 
 module "scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.2"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.2.1"
   queue_name = module.windows_queue.name
 
   queue_high_actions = [module.sierra_reader_service.scale_up_arn]

--- a/sierra_adapter/terraform/sierra_reader/variables.tf
+++ b/sierra_adapter/terraform/sierra_reader/variables.tf
@@ -15,10 +15,6 @@ variable "cluster_arn" {}
 variable "dlq_alarm_arn" {}
 variable "lambda_error_alarm_arn" {}
 
-variable "aws_region" {
-  default = "eu-west-1"
-}
-
 variable "infra_bucket" {}
 
 variable "subnets" {

--- a/sierra_adapter/terraform/variables.tf
+++ b/sierra_adapter/terraform/variables.tf
@@ -1,8 +1,3 @@
-variable "aws_region" {
-  description = "The AWS region to create things in."
-  default     = "eu-west-1"
-}
-
 variable "infra_bucket" {
   default = "wellcomecollection-platform-infra"
 }

--- a/tei_adapter/terraform/locals.tf
+++ b/tei_adapter/terraform/locals.tf
@@ -1,6 +1,5 @@
 locals {
   infra_bucket                     = data.terraform_remote_state.shared_infra.outputs.infra_bucket
-  aws_region                       = "eu-west-1"
   lambda_error_alarm_arn           = data.terraform_remote_state.shared_infra.outputs.lambda_error_alarm_arn
   namespace                        = "tei-adapter"
   release_label                    = "prod"

--- a/tei_adapter/terraform/provider.tf
+++ b/tei_adapter/terraform/provider.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  region = local.aws_region
+  region = "eu-west-1"
 
   assume_role {
     role_arn = "arn:aws:iam::760097843905:role/platform-developer"

--- a/tei_adapter/terraform/tei_adapter.tf
+++ b/tei_adapter/terraform/tei_adapter.tf
@@ -1,8 +1,7 @@
 module "tei_adapter_queue" {
-  source                     = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.1.2"
+  source                     = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.2.1"
   queue_name                 = "tei-adapter"
   topic_arns                 = [module.tei_id_extractor_topic.arn]
-  aws_region                 = local.aws_region
   alarm_topic_arn            = local.dlq_alarm_arn
   visibility_timeout_seconds = 60
 }
@@ -67,7 +66,7 @@ resource "aws_iam_role_policy" "tei_adapter_dynamo_full_access" {
 }
 
 module "tei_adapter_scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.2"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.2.1"
   queue_name = module.tei_adapter_queue.name
 
   queue_high_actions = [

--- a/tei_adapter/terraform/tei_id_extractor.tf
+++ b/tei_adapter/terraform/tei_id_extractor.tf
@@ -1,8 +1,7 @@
 module "tei_id_extractor_queue" {
-  source                     = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.1.2"
+  source                     = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.2.1"
   queue_name                 = "tei-id-extractor"
   topic_arns                 = [module.tei_updater_lambda.topic_arn]
-  aws_region                 = local.aws_region
   alarm_topic_arn            = local.dlq_alarm_arn
   visibility_timeout_seconds = local.rds_lock_timeout_seconds + 30
 }
@@ -92,7 +91,7 @@ resource "aws_iam_role_policy" "tei_id_extractor_put_policy" {
 }
 
 module "tei_id_extractor_scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.2"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.2.1"
   queue_name = module.tei_id_extractor_queue.name
 
   queue_high_actions = [


### PR DESCRIPTION
This gets us consistent autoscaling behaviour everywhere, and we're no longer passing around an unnecessary region variable. Part of https://github.com/wellcomecollection/platform/issues/5241 and https://github.com/wellcomecollection/terraform-aws-sqs/pull/7