### PR TITLE
Cap the ID minter at 1 task while reindexing

### DIFF
--- a/pipeline/terraform/stack/service_id_minter.tf
+++ b/pipeline/terraform/stack/service_id_minter.tf
@@ -54,7 +54,7 @@ module "id_minter" {
     floor(
       local.id_minter_rds_max_connections / local.id_minter_task_max_connections
     ),
-    var.max_capacity
+    local.max_capacity
   )
 
   scale_down_adjustment = local.scale_down_adjustment

--- a/tei_adapter/tei_id_extractor/src/test/scala/weco/catalogue/tei/id_extractor/GitHubBlobContentReaderTest.scala
+++ b/tei_adapter/tei_id_extractor/src/test/scala/weco/catalogue/tei/id_extractor/GitHubBlobContentReaderTest.scala
@@ -5,7 +5,11 @@ import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.akka.fixtures.Akka
-import weco.catalogue.tei.id_extractor.fixtures.{LocalResources, Wiremock, XmlAssertions}
+import weco.catalogue.tei.id_extractor.fixtures.{
+  LocalResources,
+  Wiremock,
+  XmlAssertions
+}
 import weco.http.client.AkkaHttpClient
 
 import java.net.URI

--- a/tei_adapter/tei_id_extractor/src/test/scala/weco/catalogue/tei/id_extractor/TeiIdExtractorWorkerServiceTest.scala
+++ b/tei_adapter/tei_id_extractor/src/test/scala/weco/catalogue/tei/id_extractor/TeiIdExtractorWorkerServiceTest.scala
@@ -5,9 +5,18 @@ import io.circe.Encoder
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import org.scalatest.funspec.AnyFunSpec
 import weco.akka.fixtures.Akka
-import weco.catalogue.source_model.tei.{TeiIdChangeMessage, TeiIdDeletedMessage, TeiIdMessage}
+import weco.catalogue.source_model.tei.{
+  TeiIdChangeMessage,
+  TeiIdDeletedMessage,
+  TeiIdMessage
+}
 import weco.catalogue.tei.id_extractor.database.TableProvisioner
-import weco.catalogue.tei.id_extractor.fixtures.{LocalResources, PathIdDatabase, Wiremock, XmlAssertions}
+import weco.catalogue.tei.id_extractor.fixtures.{
+  LocalResources,
+  PathIdDatabase,
+  Wiremock,
+  XmlAssertions
+}
 import weco.fixtures.TestWith
 import weco.http.client.AkkaHttpClient
 import weco.json.JsonUtil._
@@ -379,7 +388,9 @@ class TeiIdExtractorWorkerServiceTest
     val expectedS3Location = S3ObjectLocation(bucket.name, expectedKey)
     store.entries.keySet should contain(expectedS3Location)
 
-    assertXmlStringsAreEqual(store.entries(expectedS3Location), readResource(filename))
+    assertXmlStringsAreEqual(
+      store.entries(expectedS3Location),
+      readResource(filename))
 
     expectedS3Location
   }


### PR DESCRIPTION
When we're reindexing, we add extra RDS capacity so we can run lots of ID minter instances.  When we're not reindexing, we only run a single task in each service to avoid overwhelming RDS and Elasticsearch.

Unfortunately, we were using the var value(=15) instead of the local (if_reindexing ? 15 : 1), so it was trying to run 15 ID minters. This quickly falls over because the RDS cluster can't keep up, oops.