### PR TITLE
Update thumbnail URLs to use iiif.wellcomecollection.org

### DIFF
--- a/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/ImageUtils.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/ImageUtils.scala
@@ -27,7 +27,8 @@ object ImageUtils {
     )
 
   private final val thumbnailDim = "200"
-  private final val thumbnailPathSuffix = s"full/!$thumbnailDim,$thumbnailDim/0/default.jpg"
+  private final val thumbnailPathSuffix =
+    s"full/!$thumbnailDim,$thumbnailDim/0/default.jpg"
 
   // The /thumbs URL is routed to DLCS which handles only images
   // other asset types are routed to the iiif-builder service at /thumb
@@ -40,7 +41,8 @@ object ImageUtils {
   ): Option[String] =
     validThumbnailFile.mimeType match {
       case Some(mimeType) if mimeType.startsWith("image/") =>
-        Some(s"${imagesThumbBaseUrl}/${validThumbnailFile.location}/${thumbnailPathSuffix}")
+        Some(
+          s"${imagesThumbBaseUrl}/${validThumbnailFile.location}/${thumbnailPathSuffix}")
       case _ =>
         Some(s"${notImagesThumbBaseUrl}/thumb/${bnumber}")
     }

--- a/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/ImageUtils.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/ImageUtils.scala
@@ -27,19 +27,22 @@ object ImageUtils {
     )
 
   private final val thumbnailDim = "200"
+  private final val thumbnailPathSuffix = s"full/!$thumbnailDim,$thumbnailDim/0/default.jpg"
 
-  def buildThumbnailUrl(bnumber: String,
-                        validThumbnailFile: FileReference): Option[String] =
+  // The /thumbs URL is routed to DLCS which handles only images
+  // other asset types are routed to the iiif-builder service at /thumb
+  val imagesThumbBaseUrl = "https://iiif.wellcomecollection.org/thumbs"
+  val notImagesThumbBaseUrl = "https://iiif.wellcomecollection.org/thumb"
+
+  def buildThumbnailUrl(
+    bnumber: String,
+    validThumbnailFile: FileReference
+  ): Option[String] =
     validThumbnailFile.mimeType match {
-      case Some("application/pdf") =>
-        // TODO: This URL pattern should either be updated to use iiif.wellcomecollection.org
-        // or removed entirely.  I couldn't find any uses of it in a snapshot (2021-07-05),
-        // so it's possible this path is unused or wrong.
-        Some(
-          s"https://wellcomelibrary.org/pdfthumbs/$bnumber/0/${validThumbnailFile.location}.jpg")
+      case Some(mimeType) if mimeType.startsWith("image/") =>
+        Some(s"${imagesThumbBaseUrl}/${validThumbnailFile.location}/${thumbnailPathSuffix}")
       case _ =>
-        Some(
-          s"https://dlcs.io/thumbs/wellcome/5/${validThumbnailFile.location}/full/!$thumbnailDim,$thumbnailDim/0/default.jpg")
+        Some(s"${notImagesThumbBaseUrl}/thumb/${bnumber}")
     }
 
   def buildImageUrl(validImageFile: FileReference): Option[String] =


### PR DESCRIPTION
Attempting to implement the rules about where to route thumbnails described here: 

https://github.com/wellcomecollection/iiif-builder/blob/master/docs/thumbnails.md

Our rules for deciding what file to use as a thumbnails described in METS seem to be as follows:
- If there is a file with an id that matches the `TitlePage` value, then use it.

  [MetsData.scala#L152](https://github.com/wellcomecollection/catalogue-pipeline/blob/main/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/MetsData.scala#L152) -> [MetsData.scala#L142](https://github.com/wellcomecollection/catalogue-pipeline/blob/main/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/MetsData.scala#L142)
- Else use the first of:
  - file has mime-type application/pdf
  - file has a mime-type that starts with image

  [MetsData.scala#L153](https://github.com/wellcomecollection/catalogue-pipeline/blob/main/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/MetsData.scala#L153) -> [ImageUtils.scala#L9](https://github.com/wellcomecollection/catalogue-pipeline/blob/main/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/ImageUtils.scala#L9)

This change updates `buildThumbnailUrl` to map from mime-type to URL as follows:

| mime-type     | url                                                                | service      |
|---------------|--------------------------------------------------------------------|--------------|
| image/*       | https://iiif.wellcomecollection.org/thumbs/:fileLocation:/full/... | DLCS         |
| anything else | https://iiif.wellcomecollection.org/thumb/:bnumber:                | iiif-builder |
|               |                                                                    |              |

See also this Slack discussion: https://wellcome.slack.com/archives/CBT40CMKQ/p1626426822285500