### PR TITLE
Map TEI languages to the same MARC language codes as the rest of the pipeline

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/languages/Language.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/languages/Language.scala
@@ -4,12 +4,15 @@ import grizzled.slf4j.Logging
 
 case class Language(id: String, label: String) extends Logging {
 
-  // We use the three-digit language codes in several of the transformers
-  // (Sierra, Calm) and consistency allows us to aggregate/filter across sources.
+  // We use the three-digit MARC language codes throughout the pipeline.
+  // This consistency allows us to aggregate/filter across sources.
   //
-  // This isn't a hard requirement (yet), but a warning for us if we're putting
-  // something obviously different in this field.
-  if (id.length != 3) {
-    warn(s"Expected a three-digit MARC language code as the ID, got $id. Is that correct?")
-  }
+  // Right now all the transformers should be writing three-digit codes here --
+  // if they're not, that's something we should investigate.  This assertion is
+  // to draw our attention to places where that might be the case, and we can
+  // remove it if we find a legitimate reason to use other IDs here.
+  require(
+    id.length == 3,
+    s"Expected a three-digit MARC language code as the ID, got $id"
+  )
 }

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/languages/Language.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/languages/Language.scala
@@ -1,3 +1,15 @@
 package weco.catalogue.internal_model.languages
 
-case class Language(id: String, label: String)
+import grizzled.slf4j.Logging
+
+case class Language(id: String, label: String) extends Logging {
+
+  // We use the three-digit language codes in several of the transformers
+  // (Sierra, Calm) and consistency allows us to aggregate/filter across sources.
+  //
+  // This isn't a hard requirement (yet), but a warning for us if we're putting
+  // something obviously different in this field.
+  if (id.length != 3) {
+    warn(s"Expected a three-digit MARC language code as the ID, got $id. Is that correct?")
+  }
+}

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/index/WorksIndexConfigTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/index/WorksIndexConfigTest.scala
@@ -18,6 +18,7 @@ import weco.catalogue.internal_model.identifiers.{
   IdState,
   SourceIdentifier
 }
+import weco.catalogue.internal_model.languages.Language
 import weco.catalogue.internal_model.locations.{
   AccessCondition,
   AccessMethod,
@@ -80,6 +81,12 @@ class WorksIndexConfigTest
   implicit val arbitraryCanonicalId: Arbitrary[CanonicalId] =
     Arbitrary {
       createCanonicalId
+    }
+
+  // We have a rule that says language codes should be exactly 3 characters long
+  implicit val arbitraryLanguage: Arbitrary[Language] =
+    Arbitrary {
+      Language(id = randomAlphanumeric(length = 3), label = randomAlphanumeric())
     }
 
   implicit val badObjectEncoder: Encoder[BadTestObject] = deriveEncoder

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/index/WorksIndexConfigTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/index/WorksIndexConfigTest.scala
@@ -86,7 +86,9 @@ class WorksIndexConfigTest
   // We have a rule that says language codes should be exactly 3 characters long
   implicit val arbitraryLanguage: Arbitrary[Language] =
     Arbitrary {
-      Language(id = randomAlphanumeric(length = 3), label = randomAlphanumeric())
+      Language(
+        id = randomAlphanumeric(length = 3),
+        label = randomAlphanumeric())
     }
 
   implicit val badObjectEncoder: Encoder[BadTestObject] = deriveEncoder

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/languages/MarcLanguageCodeListTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/languages/MarcLanguageCodeListTest.scala
@@ -22,6 +22,11 @@ class MarcLanguageCodeListTest extends AnyFunSpec with Matchers {
       Language(label = "German", id = "ger"))
   }
 
+  it("finds Arabic by name") {
+    MarcLanguageCodeList.fromName(name = "Arabic") shouldBe Some(
+      Language(id = "ara", label = "Arabic"))
+  }
+
   it("finds a language by variant name") {
     MarcLanguageCodeList.fromName(name = "Flemish") shouldBe Some(
       Language(label = "Flemish", id = "dut"))

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiDataParser.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiDataParser.scala
@@ -24,7 +24,7 @@ object TeiDataParser {
       summary <- teiXml.summary
       bNumber <- teiXml.bNumber
       title <- teiXml.title
-      languages <- TeiLanguages(teiXml)
+      languages = TeiLanguages(teiXml)
     } yield TeiData(teiXml.id, title, bNumber, summary, languages)
 }
 

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiDataParser.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiDataParser.scala
@@ -24,7 +24,7 @@ object TeiDataParser {
       summary <- teiXml.summary
       bNumber <- teiXml.bNumber
       title <- teiXml.title
-      languages = TeiLanguages(teiXml)
+      languages <- TeiLanguages(teiXml)
     } yield TeiData(teiXml.id, title, bNumber, summary, languages)
 }
 

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/data/TeiLanguageData.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/data/TeiLanguageData.scala
@@ -84,7 +84,7 @@ object TeiLanguageData extends Logging {
       case ("bbc", "Toba-Batak")           => Some(Language(id = "btk", label = "Toba-Batak"))
       case ("btk", "Toba-Batak")           => Some(Language(id = "btk", label = "Toba-Batak"))
       case ("gu", "(Old) Gujarati")        => Some(Language(id = "guj", label = "(Old) Gujarati"))
-      case ("btd", "Batak Dairi")          => Some(Language(id = "btd", label = "Batak Dairi"))
+      case ("btd", "Batak Dairi")          => Some(Language(id = "btk", label = "Batak Dairi"))
       case ("ms", "Middle Malay")          => Some(Language(id = "may", label = "Middle Malay"))
       case ("pka", "Ardhamāgadhi Prakrit") => Some(Language(id = "pra", label = "Ardhamāgadhi Prakrit"))
       case ("pka", "Ardhamāgadhī Prākrit") => Some(Language(id = "pra", label = "Ardhamāgadhī Prākrit"))

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/data/TeiLanguageData.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/data/TeiLanguageData.scala
@@ -26,11 +26,9 @@ object TeiLanguageData extends Logging {
     *
     * Create a Language based on the MARC language code list.
     */
-  def apply(id: String, label: Option[String]): Option[Language] =
+  def apply(id: String, label: String): Option[Language] =
     (id, label) match {
 
-      case ("", None) => None
-      case ("", Some(s)) if s.trim.isEmpty => None
 
       // Map languages where there's a 1:1 correspondence between the IANA language
       // and the MARC language codes.
@@ -39,46 +37,45 @@ object TeiLanguageData extends Logging {
       // help spot problems that should be fixed in the source data,
       // e.g. mismatched code/label or the wrong code for a language.
       //
-      case ("ar", Some("Arabic"))             => MarcLanguageCodeList.fromName("Arabic")
-      case ("sa", Some("Sanskrit"))           => MarcLanguageCodeList.fromName("Sanskrit")
-      case ("he", Some("Hebrew"))             => MarcLanguageCodeList.fromName("Hebrew")
-      case ("ms", Some("Malay"))              => MarcLanguageCodeList.fromName("Malay")
-      case ("eng", Some("English"))           => MarcLanguageCodeList.fromName("English")
-      case ("en", Some("English"))            => MarcLanguageCodeList.fromName("English")
-      case ("hi", Some("Hindi"))              => MarcLanguageCodeList.fromName("Hindi")
-      case ("jv", Some("Javanese"))           => MarcLanguageCodeList.fromName("Javanese")
-      case ("pra", Some("Prakrit languages")) => MarcLanguageCodeList.fromName("Prakrit languages")
-      case ("it", Some("Italian"))            => MarcLanguageCodeList.fromName("Italian")
-      case ("ta", Some("Tamil"))              => MarcLanguageCodeList.fromName("Tamil")
-      case ("jpr", Some("Judeo-Persian"))     => MarcLanguageCodeList.fromName("Judeo-Persian")
-      case ("la", Some("Latin"))              => MarcLanguageCodeList.fromName("Latin")
-      case ("la", Some("Latin"))              => MarcLanguageCodeList.fromName("Latin")
-      case ("cop", Some("Coptic"))            => MarcLanguageCodeList.fromName("Coptic")
-      case ("es", Some("Spanish"))            => MarcLanguageCodeList.fromName("Spanish")
-      case ("btk", Some("Batak"))             => MarcLanguageCodeList.fromName("Batak")
-      case ("fa", Some("Persian"))            => MarcLanguageCodeList.fromName("Persian")
-      case ("ji", Some("Yiddish"))            => MarcLanguageCodeList.fromName("Yiddish")
-      case ("yi", Some("Yiddish"))            => MarcLanguageCodeList.fromName("Yiddish")
-      case ("fr", Some("French"))             => MarcLanguageCodeList.fromName("French")
+      case ("ar", "Arabic")             => MarcLanguageCodeList.fromName("Arabic")
+      case ("sa", "Sanskrit")           => MarcLanguageCodeList.fromName("Sanskrit")
+      case ("he", "Hebrew")             => MarcLanguageCodeList.fromName("Hebrew")
+      case ("ms", "Malay")              => MarcLanguageCodeList.fromName("Malay")
+      case ("eng", "English")           => MarcLanguageCodeList.fromName("English")
+      case ("en", "English")            => MarcLanguageCodeList.fromName("English")
+      case ("hi", "Hindi")              => MarcLanguageCodeList.fromName("Hindi")
+      case ("jv", "Javanese")           => MarcLanguageCodeList.fromName("Javanese")
+      case ("pra", "Prakrit languages") => MarcLanguageCodeList.fromName("Prakrit languages")
+      case ("it", "Italian")            => MarcLanguageCodeList.fromName("Italian")
+      case ("ta", "Tamil")              => MarcLanguageCodeList.fromName("Tamil")
+      case ("jpr", "Judeo-Persian")     => MarcLanguageCodeList.fromName("Judeo-Persian")
+      case ("la", "Latin")              => MarcLanguageCodeList.fromName("Latin")
+      case ("cop", "Coptic")            => MarcLanguageCodeList.fromName("Coptic")
+      case ("es", "Spanish")            => MarcLanguageCodeList.fromName("Spanish")
+      case ("btk", "Batak")             => MarcLanguageCodeList.fromName("Batak")
+      case ("fa", "Persian")            => MarcLanguageCodeList.fromName("Persian")
+      case ("ji", "Yiddish")            => MarcLanguageCodeList.fromName("Yiddish")
+      case ("yi", "Yiddish")            => MarcLanguageCodeList.fromName("Yiddish")
+      case ("fr", "French")             => MarcLanguageCodeList.fromName("French")
 
       // The IANA entry for "grc" is "Ancient Greek (to 1453)"
-      case ("grc", Some("Ancient Greek")) => MarcLanguageCodeList.fromName("Greek, Ancient (to 1453)")
-      case ("grc", Some("Greek"))         => MarcLanguageCodeList.fromName("Greek, Ancient (to 1453)")
+      case ("grc", "Ancient Greek") => MarcLanguageCodeList.fromName("Greek, Ancient (to 1453)")
+      case ("grc", "Greek")         => MarcLanguageCodeList.fromName("Greek, Ancient (to 1453)")
 
       // The IANA entry for "el" is "Modern Greek (1453-)"
-      case ("el", Some("Greek")) => MarcLanguageCodeList.fromName("Greek, Modern (1453- )")
+      case ("el", "Greek") => MarcLanguageCodeList.fromName("Greek, Modern (1453- )")
 
       // The IANA entry for "egy" is "Egyptian (Ancient)".  There doesn't seem to be
       // a distinction for this in MARC.
-      case ("egy", Some("Ancient Egyptian"))   => MarcLanguageCodeList.fromName("Egyptian")
-      case ("egy", Some("Egyptian (Ancient)")) => MarcLanguageCodeList.fromName("Egyptian")
+      case ("egy", "Ancient Egyptian")   => MarcLanguageCodeList.fromName("Egyptian")
+      case ("egy", "Egyptian (Ancient)") => MarcLanguageCodeList.fromName("Egyptian")
 
       // The IANA entry for "spq" is "Loreto-Ucayali Spanish".  For now we file it under
       // "Spanish", but we should ask the TEI team if they want to use the longer form.
-      case ("spq", Some("Spanish")) => MarcLanguageCodeList.fromName("Spanish")
+      case ("spq", "Spanish") => MarcLanguageCodeList.fromName("Spanish")
 
       // This is a weird one that might want fixing in the TEI data.
-      case ("es-ES", Some("Spanish Spain")) => MarcLanguageCodeList.fromName("Spanish")
+      case ("es-ES", "Spanish Spain") => MarcLanguageCodeList.fromName("Spanish")
 
       // Map languages where there isn't a 1:1 distinction, or where the IANA language
       // is an alternative name for one of the MARC languages.  We use the MARC code, but
@@ -87,16 +84,16 @@ object TeiLanguageData extends Logging {
       // This means we'll display the most accurate label on the individual work pages,
       // but these works will filter/aggregate alongside the "parent" language.
       //
-      case ("btx", Some("Karo-Batak"))           => Some(Language(id = "btk", label = "Karo-Batak"))
-      case ("bbc", Some("Toba-Batak"))           => Some(Language(id = "btk", label = "Toba-Batak"))
-      case ("btk", Some("Toba-Batak"))           => Some(Language(id = "btk", label = "Toba-Batak"))
-      case ("gu", Some("(Old) Gujarati"))        => Some(Language(id = "guj", label = "(Old) Gujarati"))
-      case ("btd", Some("Batak Dairi"))          => Some(Language(id = "btd", label = "Batak Dairi"))
-      case ("ms", Some("Middle Malay"))          => Some(Language(id = "may", label = "Middle Malay"))
-      case ("pka", Some("Ardhamāgadhi Prakrit")) => Some(Language(id = "pra", label = "Ardhamāgadhi Prakrit"))
-      case ("pka", Some("Ardhamāgadhī Prākrit")) => Some(Language(id = "pra", label = "Ardhamāgadhī Prākrit"))
-      case ("itk", Some("Judeo-Italian"))         => Some(Language(id = "ita", label = "Judeo-Italian"))
-      case ("jv", Some("Java"))                   => Some(Language(id = "jav", label = "Java"))
+      case ("btx", "Karo-Batak")           => Some(Language(id = "btk", label = "Karo-Batak"))
+      case ("bbc", "Toba-Batak")           => Some(Language(id = "btk", label = "Toba-Batak"))
+      case ("btk", "Toba-Batak")           => Some(Language(id = "btk", label = "Toba-Batak"))
+      case ("gu", "(Old) Gujarati")        => Some(Language(id = "guj", label = "(Old) Gujarati"))
+      case ("btd", "Batak Dairi")          => Some(Language(id = "btd", label = "Batak Dairi"))
+      case ("ms", "Middle Malay")          => Some(Language(id = "may", label = "Middle Malay"))
+      case ("pka", "Ardhamāgadhi Prakrit") => Some(Language(id = "pra", label = "Ardhamāgadhi Prakrit"))
+      case ("pka", "Ardhamāgadhī Prākrit") => Some(Language(id = "pra", label = "Ardhamāgadhī Prākrit"))
+      case ("itk", "Judeo-Italian")        => Some(Language(id = "ita", label = "Judeo-Italian"))
+      case ("jv", "Java")                  => Some(Language(id = "jav", label = "Java"))
 
       // If we're not sure what to do, don't map any language for now.  Drop a warning in
       // the logs for us to come back and investigate further.

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/data/TeiLanguageData.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/data/TeiLanguageData.scala
@@ -1,0 +1,107 @@
+package weco.pipeline.transformer.tei.data
+
+import grizzled.slf4j.Logging
+import weco.catalogue.internal_model.languages.{Language, MarcLanguageCodeList}
+
+/** The TEI language data uses the IANA language codes from:
+  * https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry
+  *
+  * In the rest of the pipeline, we use MARC language codes.  We need to be consistent
+  * so we can filter/aggregate languages across sources.
+  *
+  * This object maps languages from the TEI files into MARC-based language codes.
+  * Trying to create a complete IANA-to-MARC mapper is beyond the scope of the pipeline,
+  * and unnecessary -- our TEI files only use a small subset of IANA languages.
+  *
+  */
+object TeiLanguageData extends Logging {
+
+  /** Given a <textLang> element of the form
+    *
+    *     <textLang mainLang={id}>{label}</textLang>
+    *
+    * or
+    *
+    *     <textLang otherLangs={id}>{label}</textLang>
+    *
+    * Create a Language based on the MARC language code list.
+    */
+  def apply(id: String, label: Option[String]): Option[Language] =
+    (id, label) match {
+
+      case ("", None) => None
+      case ("", Some(s)) if s.trim.isEmpty => None
+
+      // Map languages where there's a 1:1 correspondence between the IANA language
+      // and the MARC language codes.
+      //
+      // Note that we match based on both the code *and* the name -- this is to
+      // help spot problems that should be fixed in the source data,
+      // e.g. mismatched code/label or the wrong code for a language.
+      //
+      case ("ar", Some("Arabic"))             => MarcLanguageCodeList.fromName("Arabic")
+      case ("sa", Some("Sanskrit"))           => MarcLanguageCodeList.fromName("Sanskrit")
+      case ("he", Some("Hebrew"))             => MarcLanguageCodeList.fromName("Hebrew")
+      case ("ms", Some("Malay"))              => MarcLanguageCodeList.fromName("Malay")
+      case ("eng", Some("English"))           => MarcLanguageCodeList.fromName("English")
+      case ("en", Some("English"))            => MarcLanguageCodeList.fromName("English")
+      case ("hi", Some("Hindi"))              => MarcLanguageCodeList.fromName("Hindi")
+      case ("jv", Some("Javanese"))           => MarcLanguageCodeList.fromName("Javanese")
+      case ("pra", Some("Prakrit languages")) => MarcLanguageCodeList.fromName("Prakrit languages")
+      case ("it", Some("Italian"))            => MarcLanguageCodeList.fromName("Italian")
+      case ("ta", Some("Tamil"))              => MarcLanguageCodeList.fromName("Tamil")
+      case ("jpr", Some("Judeo-Persian"))     => MarcLanguageCodeList.fromName("Judeo-Persian")
+      case ("la", Some("Latin"))              => MarcLanguageCodeList.fromName("Latin")
+      case ("la", Some("Latin"))              => MarcLanguageCodeList.fromName("Latin")
+      case ("cop", Some("Coptic"))            => MarcLanguageCodeList.fromName("Coptic")
+      case ("es", Some("Spanish"))            => MarcLanguageCodeList.fromName("Spanish")
+      case ("btk", Some("Batak"))             => MarcLanguageCodeList.fromName("Batak")
+      case ("fa", Some("Persian"))            => MarcLanguageCodeList.fromName("Persian")
+      case ("ji", Some("Yiddish"))            => MarcLanguageCodeList.fromName("Yiddish")
+      case ("yi", Some("Yiddish"))            => MarcLanguageCodeList.fromName("Yiddish")
+      case ("fr", Some("French"))             => MarcLanguageCodeList.fromName("French")
+
+      // The IANA entry for "grc" is "Ancient Greek (to 1453)"
+      case ("grc", Some("Ancient Greek")) => MarcLanguageCodeList.fromName("Greek, Ancient (to 1453)")
+      case ("grc", Some("Greek"))         => MarcLanguageCodeList.fromName("Greek, Ancient (to 1453)")
+
+      // The IANA entry for "el" is "Modern Greek (1453-)"
+      case ("el", Some("Greek")) => MarcLanguageCodeList.fromName("Greek, Modern (1453- )")
+
+      // The IANA entry for "egy" is "Egyptian (Ancient)".  There doesn't seem to be
+      // a distinction for this in MARC.
+      case ("egy", Some("Ancient Egyptian"))   => MarcLanguageCodeList.fromName("Egyptian")
+      case ("egy", Some("Egyptian (Ancient)")) => MarcLanguageCodeList.fromName("Egyptian")
+
+      // The IANA entry for "spq" is "Loreto-Ucayali Spanish".  For now we file it under
+      // "Spanish", but we should ask the TEI team if they want to use the longer form.
+      case ("spq", Some("Spanish")) => MarcLanguageCodeList.fromName("Spanish")
+
+      // This is a weird one that might want fixing in the TEI data.
+      case ("es-ES", Some("Spanish Spain")) => MarcLanguageCodeList.fromName("Spanish")
+
+      // Map languages where there isn't a 1:1 distinction, or where the IANA language
+      // is an alternative name for one of the MARC languages.  We use the MARC code, but
+      // the TEI label.
+      //
+      // This means we'll display the most accurate label on the individual work pages,
+      // but these works will filter/aggregate alongside the "parent" language.
+      //
+      case ("btx", Some("Karo-Batak"))           => Some(Language(id = "btk", label = "Karo-Batak"))
+      case ("bbc", Some("Toba-Batak"))           => Some(Language(id = "btk", label = "Toba-Batak"))
+      case ("btk", Some("Toba-Batak"))           => Some(Language(id = "btk", label = "Toba-Batak"))
+      case ("gu", Some("(Old) Gujarati"))        => Some(Language(id = "guj", label = "(Old) Gujarati"))
+      case ("btd", Some("Batak Dairi"))          => Some(Language(id = "btd", label = "Batak Dairi"))
+      case ("ms", Some("Middle Malay"))          => Some(Language(id = "may", label = "Middle Malay"))
+      case ("pka", Some("Ardhamāgadhi Prakrit")) => Some(Language(id = "pra", label = "Ardhamāgadhi Prakrit"))
+      case ("pka", Some("Ardhamāgadhī Prākrit")) => Some(Language(id = "pra", label = "Ardhamāgadhī Prākrit"))
+      case ("itk", Some("Judeo-Italian"))         => Some(Language(id = "ita", label = "Judeo-Italian"))
+      case ("jv", Some("Java"))                   => Some(Language(id = "jav", label = "Java"))
+
+      // If we're not sure what to do, don't map any language for now.  Drop a warning in
+      // the logs for us to come back and investigate further.
+      case (id, label) =>
+        warn(s"Unable to map TEI language to catalogue language: id=$id, label=$label")
+        None
+    }
+}

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/data/TeiLanguageData.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/data/TeiLanguageData.scala
@@ -38,40 +38,46 @@ object TeiLanguageData extends Logging {
       // help spot problems that should be fixed in the source data,
       // e.g. mismatched code/label or the wrong code for a language.
       //
-      case ("ar", "Arabic")             => MarcLanguageCodeList.fromName("Arabic")
-      case ("sa", "Sanskrit")           => MarcLanguageCodeList.fromName("Sanskrit")
-      case ("he", "Hebrew")             => MarcLanguageCodeList.fromName("Hebrew")
-      case ("ms", "Malay")              => MarcLanguageCodeList.fromName("Malay")
-      case ("eng", "English")           => MarcLanguageCodeList.fromName("English")
-      case ("en", "English")            => MarcLanguageCodeList.fromName("English")
-      case ("hi", "Hindi")              => MarcLanguageCodeList.fromName("Hindi")
-      case ("jv", "Javanese")           => MarcLanguageCodeList.fromName("Javanese")
-      case ("pra", "Prakrit languages") => MarcLanguageCodeList.fromName("Prakrit languages")
-      case ("it", "Italian")            => MarcLanguageCodeList.fromName("Italian")
-      case ("ta", "Tamil")              => MarcLanguageCodeList.fromName("Tamil")
-      case ("jpr", "Judeo-Persian")     => MarcLanguageCodeList.fromName("Judeo-Persian")
-      case ("la", "Latin")              => MarcLanguageCodeList.fromName("Latin")
-      case ("cop", "Coptic")            => MarcLanguageCodeList.fromName("Coptic")
-      case ("es", "Spanish")            => MarcLanguageCodeList.fromName("Spanish")
-      case ("btk", "Batak")             => MarcLanguageCodeList.fromName("Batak")
-      case ("fa", "Persian")            => MarcLanguageCodeList.fromName("Persian")
-      case ("ji", "Yiddish")            => MarcLanguageCodeList.fromName("Yiddish")
-      case ("yi", "Yiddish")            => MarcLanguageCodeList.fromName("Yiddish")
-      case ("fr", "French")             => MarcLanguageCodeList.fromName("French")
+      case ("ar", "Arabic")   => MarcLanguageCodeList.fromName("Arabic")
+      case ("sa", "Sanskrit") => MarcLanguageCodeList.fromName("Sanskrit")
+      case ("he", "Hebrew")   => MarcLanguageCodeList.fromName("Hebrew")
+      case ("ms", "Malay")    => MarcLanguageCodeList.fromName("Malay")
+      case ("eng", "English") => MarcLanguageCodeList.fromName("English")
+      case ("en", "English")  => MarcLanguageCodeList.fromName("English")
+      case ("hi", "Hindi")    => MarcLanguageCodeList.fromName("Hindi")
+      case ("jv", "Javanese") => MarcLanguageCodeList.fromName("Javanese")
+      case ("pra", "Prakrit languages") =>
+        MarcLanguageCodeList.fromName("Prakrit languages")
+      case ("it", "Italian") => MarcLanguageCodeList.fromName("Italian")
+      case ("ta", "Tamil")   => MarcLanguageCodeList.fromName("Tamil")
+      case ("jpr", "Judeo-Persian") =>
+        MarcLanguageCodeList.fromName("Judeo-Persian")
+      case ("la", "Latin")   => MarcLanguageCodeList.fromName("Latin")
+      case ("cop", "Coptic") => MarcLanguageCodeList.fromName("Coptic")
+      case ("es", "Spanish") => MarcLanguageCodeList.fromName("Spanish")
+      case ("btk", "Batak")  => MarcLanguageCodeList.fromName("Batak")
+      case ("fa", "Persian") => MarcLanguageCodeList.fromName("Persian")
+      case ("ji", "Yiddish") => MarcLanguageCodeList.fromName("Yiddish")
+      case ("yi", "Yiddish") => MarcLanguageCodeList.fromName("Yiddish")
+      case ("fr", "French")  => MarcLanguageCodeList.fromName("French")
 
       // The IANA entry for "grc" is "Ancient Greek (to 1453)"
-      case ("grc", "Ancient Greek") => MarcLanguageCodeList.fromName("Greek, Ancient (to 1453)")
-      case ("grc", "Greek")         => MarcLanguageCodeList.fromName("Greek, Ancient (to 1453)")
+      case ("grc", "Ancient Greek") =>
+        MarcLanguageCodeList.fromName("Greek, Ancient (to 1453)")
+      case ("grc", "Greek") =>
+        MarcLanguageCodeList.fromName("Greek, Ancient (to 1453)")
 
       // The IANA entry for "el" is "Modern Greek (1453-)"
-      case ("el", "Greek") => MarcLanguageCodeList.fromName("Greek, Modern (1453- )")
+      case ("el", "Greek") =>
+        MarcLanguageCodeList.fromName("Greek, Modern (1453- )")
 
       // The IANA entry for "spq" is "Loreto-Ucayali Spanish".  For now we file it under
       // "Spanish", but we should ask the TEI team if they want to use the longer form.
       case ("spq", "Spanish") => MarcLanguageCodeList.fromName("Spanish")
 
       // This is a weird one that might want fixing in the TEI data.
-      case ("es-es", "Spanish Spain") => MarcLanguageCodeList.fromName("Spanish")
+      case ("es-es", "Spanish Spain") =>
+        MarcLanguageCodeList.fromName("Spanish")
 
       // Map languages where there isn't a 1:1 distinction, or where the IANA language
       // is an alternative name for one of the MARC languages.  We use the MARC code, but
@@ -80,34 +86,55 @@ object TeiLanguageData extends Logging {
       // This means we'll display the most accurate label on the individual work pages,
       // but these works will filter/aggregate alongside the "parent" language.
       //
-      case ("egy", "Ancient Egyptian")     => customLanguage("Egyptian", overrideLabel = "Ancient Egyptian")
-      case ("egy", "Egyptian (Ancient)")   => customLanguage("Egyptian", overrideLabel = "Ancient Egyptian")
-      case ("btx", "Karo-Batak")           => customLanguage("Batak", overrideLabel = "Karo-Batak")
-      case ("bbc", "Toba-Batak")           => customLanguage("Batak", overrideLabel = "Toba-Batak")
-      case ("btk", "Toba-Batak")           => customLanguage("Batak", overrideLabel = "Toba-Batak")
-      case ("btd", "Batak Dairi")          => customLanguage("Batak", overrideLabel = "Batak Dairi")
-      case ("gu", "(Old) Gujarati")        => customLanguage("Gujarati", overrideLabel = "(Old) Gujarati")
-      case ("ms", "Middle Malay")          => customLanguage("Malay", overrideLabel = "Middle Malay")
-      case ("pka", "Ardhamāgadhi Prakrit") => customLanguage("Prakrit languages", overrideLabel = "Ardhamāgadhi Prakrit")
-      case ("pka", "Ardhamāgadhī Prākrit") => customLanguage("Prakrit languages", overrideLabel = "Ardhamāgadhī Prākrit")
-      case ("itk", "Judeo-Italian")        => customLanguage("Italian", overrideLabel = "Judeo-Italian")
-      case ("jv", "Java")                  => customLanguage("Javanese", overrideLabel = "Java")
+      case ("egy", "Ancient Egyptian") =>
+        customLanguage("Egyptian", overrideLabel = "Ancient Egyptian")
+      case ("egy", "Egyptian (Ancient)") =>
+        customLanguage("Egyptian", overrideLabel = "Ancient Egyptian")
+      case ("btx", "Karo-Batak") =>
+        customLanguage("Batak", overrideLabel = "Karo-Batak")
+      case ("bbc", "Toba-Batak") =>
+        customLanguage("Batak", overrideLabel = "Toba-Batak")
+      case ("btk", "Toba-Batak") =>
+        customLanguage("Batak", overrideLabel = "Toba-Batak")
+      case ("btd", "Batak Dairi") =>
+        customLanguage("Batak", overrideLabel = "Batak Dairi")
+      case ("gu", "(Old) Gujarati") =>
+        customLanguage("Gujarati", overrideLabel = "(Old) Gujarati")
+      case ("ms", "Middle Malay") =>
+        customLanguage("Malay", overrideLabel = "Middle Malay")
+      case ("pka", "Ardhamāgadhi Prakrit") =>
+        customLanguage(
+          "Prakrit languages",
+          overrideLabel = "Ardhamāgadhi Prakrit")
+      case ("pka", "Ardhamāgadhī Prākrit") =>
+        customLanguage(
+          "Prakrit languages",
+          overrideLabel = "Ardhamāgadhī Prākrit")
+      case ("itk", "Judeo-Italian") =>
+        customLanguage("Italian", overrideLabel = "Judeo-Italian")
+      case ("jv", "Java") => customLanguage("Javanese", overrideLabel = "Java")
 
       // If we're not sure what to do, don't map any language for now.  Drop a warning in
       // the logs for us to come back and investigate further.
       case (id, label) =>
-        warn(s"Unable to map TEI language to catalogue language: id=$id, label=$label")
+        warn(
+          s"Unable to map TEI language to catalogue language: id=$id, label=$label")
         None
     }
 
     result match {
       case Some(lang) => Success(lang)
-      case None => Failure(new Throwable(s"Unable to map TEI language to catalogue language: id=$id, label=$label"))
+      case None =>
+        Failure(new Throwable(
+          s"Unable to map TEI language to catalogue language: id=$id, label=$label"))
     }
   }
 
-  private def customLanguage(name: String, overrideLabel: String): Option[Language] =
+  private def customLanguage(name: String,
+                             overrideLabel: String): Option[Language] =
     MarcLanguageCodeList
       .fromName(name)
-      .map { lang => lang.copy(label = overrideLabel) }
+      .map { lang =>
+        lang.copy(label = overrideLabel)
+      }
 }

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/data/TeiLanguageData.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/data/TeiLanguageData.scala
@@ -65,11 +65,6 @@ object TeiLanguageData extends Logging {
       // The IANA entry for "el" is "Modern Greek (1453-)"
       case ("el", "Greek") => MarcLanguageCodeList.fromName("Greek, Modern (1453- )")
 
-      // The IANA entry for "egy" is "Egyptian (Ancient)".  There doesn't seem to be
-      // a distinction for this in MARC.
-      case ("egy", "Ancient Egyptian")   => MarcLanguageCodeList.fromName("Egyptian")
-      case ("egy", "Egyptian (Ancient)") => MarcLanguageCodeList.fromName("Egyptian")
-
       // The IANA entry for "spq" is "Loreto-Ucayali Spanish".  For now we file it under
       // "Spanish", but we should ask the TEI team if they want to use the longer form.
       case ("spq", "Spanish") => MarcLanguageCodeList.fromName("Spanish")
@@ -84,6 +79,8 @@ object TeiLanguageData extends Logging {
       // This means we'll display the most accurate label on the individual work pages,
       // but these works will filter/aggregate alongside the "parent" language.
       //
+      case ("egy", "Ancient Egyptian")     => Some(Language(id = "egy", label = "Ancient Egyptian"))
+      case ("egy", "Egyptian (Ancient)")   => Some(Language(id = "egy", label = "Ancient Egyptian"))
       case ("btx", "Karo-Batak")           => Some(Language(id = "btk", label = "Karo-Batak"))
       case ("bbc", "Toba-Batak")           => Some(Language(id = "btk", label = "Toba-Batak"))
       case ("btk", "Toba-Batak")           => Some(Language(id = "btk", label = "Toba-Batak"))

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/data/TeiLanguageData.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/data/TeiLanguageData.scala
@@ -3,6 +3,8 @@ package weco.pipeline.transformer.tei.data
 import grizzled.slf4j.Logging
 import weco.catalogue.internal_model.languages.{Language, MarcLanguageCodeList}
 
+import scala.util.{Failure, Success, Try}
+
 /** The TEI language data uses the IANA language codes from:
   * https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry
   *
@@ -26,8 +28,8 @@ object TeiLanguageData extends Logging {
     *
     * create a Language based on the MARC language code list.
     */
-  def apply(id: String, label: String): Option[Language] =
-    (id, label) match {
+  def apply(id: String, label: String): Try[Language] = {
+    val result = (id, label) match {
 
       // Map languages where there's a 1:1 correspondence between the IANA language
       // and the MARC language codes.
@@ -97,6 +99,12 @@ object TeiLanguageData extends Logging {
         warn(s"Unable to map TEI language to catalogue language: id=$id, label=$label")
         None
     }
+
+    result match {
+      case Some(lang) => Success(lang)
+      case None => Failure(new Throwable(s"Unable to map TEI language to catalogue language: id=$id, label=$label"))
+    }
+  }
 
   private def customLanguage(name: String, overrideLabel: String): Option[Language] =
     MarcLanguageCodeList

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/data/TeiLanguageData.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/data/TeiLanguageData.scala
@@ -29,7 +29,6 @@ object TeiLanguageData extends Logging {
   def apply(id: String, label: String): Option[Language] =
     (id, label) match {
 
-
       // Map languages where there's a 1:1 correspondence between the IANA language
       // and the MARC language codes.
       //

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/data/TeiLanguageData.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/data/TeiLanguageData.scala
@@ -75,7 +75,7 @@ object TeiLanguageData extends Logging {
       case ("spq", "Spanish") => MarcLanguageCodeList.fromName("Spanish")
 
       // This is a weird one that might want fixing in the TEI data.
-      case ("es-ES", "Spanish Spain") => MarcLanguageCodeList.fromName("Spanish")
+      case ("es-es", "Spanish Spain") => MarcLanguageCodeList.fromName("Spanish")
 
       // Map languages where there isn't a 1:1 distinction, or where the IANA language
       // is an alternative name for one of the MARC languages.  We use the MARC code, but

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/data/TeiLanguageData.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/data/TeiLanguageData.scala
@@ -16,7 +16,7 @@ import weco.catalogue.internal_model.languages.{Language, MarcLanguageCodeList}
   */
 object TeiLanguageData extends Logging {
 
-  /** Given a <textLang> element of the form
+  /** Given the ID and label from a <textLang> element of the form
     *
     *     <textLang mainLang={id}>{label}</textLang>
     *
@@ -24,7 +24,7 @@ object TeiLanguageData extends Logging {
     *
     *     <textLang otherLangs={id}>{label}</textLang>
     *
-    * Create a Language based on the MARC language code list.
+    * create a Language based on the MARC language code list.
     */
   def apply(id: String, label: String): Option[Language] =
     (id, label) match {

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/data/TeiLanguageData.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/data/TeiLanguageData.scala
@@ -78,18 +78,18 @@ object TeiLanguageData extends Logging {
       // This means we'll display the most accurate label on the individual work pages,
       // but these works will filter/aggregate alongside the "parent" language.
       //
-      case ("egy", "Ancient Egyptian")     => Some(Language(id = "egy", label = "Ancient Egyptian"))
-      case ("egy", "Egyptian (Ancient)")   => Some(Language(id = "egy", label = "Ancient Egyptian"))
-      case ("btx", "Karo-Batak")           => Some(Language(id = "btk", label = "Karo-Batak"))
-      case ("bbc", "Toba-Batak")           => Some(Language(id = "btk", label = "Toba-Batak"))
-      case ("btk", "Toba-Batak")           => Some(Language(id = "btk", label = "Toba-Batak"))
-      case ("gu", "(Old) Gujarati")        => Some(Language(id = "guj", label = "(Old) Gujarati"))
-      case ("btd", "Batak Dairi")          => Some(Language(id = "btk", label = "Batak Dairi"))
-      case ("ms", "Middle Malay")          => Some(Language(id = "may", label = "Middle Malay"))
-      case ("pka", "Ardhamāgadhi Prakrit") => Some(Language(id = "pra", label = "Ardhamāgadhi Prakrit"))
-      case ("pka", "Ardhamāgadhī Prākrit") => Some(Language(id = "pra", label = "Ardhamāgadhī Prākrit"))
-      case ("itk", "Judeo-Italian")        => Some(Language(id = "ita", label = "Judeo-Italian"))
-      case ("jv", "Java")                  => Some(Language(id = "jav", label = "Java"))
+      case ("egy", "Ancient Egyptian")     => customLanguage("Egyptian", overrideLabel = "Ancient Egyptian")
+      case ("egy", "Egyptian (Ancient)")   => customLanguage("Egyptian", overrideLabel = "Ancient Egyptian")
+      case ("btx", "Karo-Batak")           => customLanguage("Batak", overrideLabel = "Karo-Batak")
+      case ("bbc", "Toba-Batak")           => customLanguage("Batak", overrideLabel = "Toba-Batak")
+      case ("btk", "Toba-Batak")           => customLanguage("Batak", overrideLabel = "Toba-Batak")
+      case ("btd", "Batak Dairi")          => customLanguage("Batak", overrideLabel = "Batak Dairi")
+      case ("gu", "(Old) Gujarati")        => customLanguage("Gujarati", overrideLabel = "(Old) Gujarati")
+      case ("ms", "Middle Malay")          => customLanguage("Malay", overrideLabel = "Middle Malay")
+      case ("pka", "Ardhamāgadhi Prakrit") => customLanguage("Prakrit languages", overrideLabel = "Ardhamāgadhi Prakrit")
+      case ("pka", "Ardhamāgadhī Prākrit") => customLanguage("Prakrit languages", overrideLabel = "Ardhamāgadhī Prākrit")
+      case ("itk", "Judeo-Italian")        => customLanguage("Italian", overrideLabel = "Judeo-Italian")
+      case ("jv", "Java")                  => customLanguage("Javanese", overrideLabel = "Java")
 
       // If we're not sure what to do, don't map any language for now.  Drop a warning in
       // the logs for us to come back and investigate further.
@@ -97,4 +97,9 @@ object TeiLanguageData extends Logging {
         warn(s"Unable to map TEI language to catalogue language: id=$id, label=$label")
         None
     }
+
+  private def customLanguage(name: String, overrideLabel: String): Option[Language] =
+    MarcLanguageCodeList
+      .fromName(name)
+      .map { lang => lang.copy(label = overrideLabel) }
 }

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiLanguages.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiLanguages.scala
@@ -42,7 +42,7 @@ object TeiLanguages {
 
         (langId, label) match {
           case (Some(id), label) if label.trim.nonEmpty => Some((id, label))
-          case _ => None
+          case _                                        => None
         }
       }
     }
@@ -54,11 +54,10 @@ object TeiLanguages {
     findNodes(xml) match {
       case Success(languages) =>
         Right(
-          languages
-            .map { case (id, label) =>
+          languages.map {
+            case (id, label) =>
               TeiLanguageData(id = id, label = label).get
-            }
-            .toList
+          }.toList
         )
 
       case Failure(err) => Left(err)

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiLanguages.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiLanguages.scala
@@ -1,19 +1,57 @@
 package weco.pipeline.transformer.tei.transformers
 
 import cats.implicits._
+import grizzled.slf4j.Logging
 import weco.catalogue.internal_model.languages.Language
 import weco.pipeline.transformer.result.Result
 import weco.pipeline.transformer.tei.TeiXml
 
 import scala.xml.Elem
 
-object TeiLanguages {
+object TeiLanguages extends Logging {
 
   def apply(teiXml: TeiXml): Result[List[Language]] =
     apply(teiXml.xml)
 
-  /**
-    * The languages of the TEI are in `textLang` nodes under `msContents`.
+  /** The languages of the TEI are in `textLang` nodes under `msContents`.
+    *
+    * <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id={id}>
+    *  <teiHeader>
+    *    <fileDesc>
+    *      <sourceDesc>
+    *        <msDesc xml:lang="en" xml:id="MS_Arabic_1">
+    *          <msContents>
+    *            <textLang mainLang={id} source="IANA">{label}</textLang>
+    *
+    * This function extracts all the nodes from a parsed XML and returns
+    * a list of (id, label) pairs.
+    */
+  def findNodes(xml: Elem): Seq[(String, String)] =
+    (xml \\ "msDesc" \ "msContents" \ "textLang").flatMap { n =>
+      val label = n.text
+
+      val mainLangId = (n \@ "mainLang").toLowerCase
+      val otherLangId = (n \@ "otherLangs").toLowerCase
+
+      val langId = (mainLangId, otherLangId) match {
+        case (id1, id2) if id2.isEmpty && id1.nonEmpty => Some(id1)
+        case (id1, id2) if id1.isEmpty && id2.nonEmpty => Some(id2)
+        case (id1, id2) if id2.isEmpty && id1.isEmpty =>
+          warn(s"Cannot find a language ID in $n")
+          None
+        case _ =>
+          warn(s"Multiple language IDs in $n")
+          None
+      }
+
+      (langId, label) match {
+        case (Some(id), label) if label.trim.nonEmpty => Some((id, label))
+        case _ => None
+      }
+    }
+
+  /** The languages of the TEI are in `textLang` nodes under `msContents`.
+    *
     * <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id={id}>
     *  <teiHeader>
     *    <fileDesc>

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiLanguages.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiLanguages.scala
@@ -55,8 +55,8 @@ object TeiLanguages {
       case Success(languages) =>
         Right(
           languages
-            .flatMap { case (id, label) =>
-              TeiLanguageData(id = id, label = label)
+            .map { case (id, label) =>
+              TeiLanguageData(id = id, label = label).get
             }
             .toList
         )

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiLanguages.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiLanguages.scala
@@ -1,17 +1,13 @@
 package weco.pipeline.transformer.tei.transformers
 
-import cats.implicits._
 import grizzled.slf4j.Logging
 import weco.catalogue.internal_model.languages.Language
-import weco.pipeline.transformer.result.Result
 import weco.pipeline.transformer.tei.TeiXml
+import weco.pipeline.transformer.tei.data.TeiLanguageData
 
 import scala.xml.Elem
 
 object TeiLanguages extends Logging {
-
-  def apply(teiXml: TeiXml): Result[List[Language]] =
-    apply(teiXml.xml)
 
   /** The languages of the TEI are in `textLang` nodes under `msContents`.
     *
@@ -50,40 +46,13 @@ object TeiLanguages extends Logging {
       }
     }
 
-  /** The languages of the TEI are in `textLang` nodes under `msContents`.
-    *
-    * <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id={id}>
-    *  <teiHeader>
-    *    <fileDesc>
-    *      <sourceDesc>
-    *        <msDesc xml:lang="en" xml:id="MS_Arabic_1">
-    *          <msContents>
-    *            <textLang mainLang={id} source="IANA">{label}</textLang>
-    *
-    */
-  def apply(xml: Elem): Result[List[Language]] = {
-    val nodes = (xml \\ "msDesc" \ "msContents" \ "textLang").toList
+  def apply(teiXml: TeiXml): List[Language] =
+    apply(teiXml.xml)
 
-    val eitherLanguages = nodes.map { n =>
-      val label = n.text
-      val mainLangId = (n \@ "mainLang").toLowerCase
-      val otherLangId = (n \@ "otherLangs").toLowerCase
-      val langId = (mainLangId, otherLangId) match {
-        case (id1, id2) if id2.isEmpty && id1.nonEmpty => Right(id1)
-        case (id1, id2) if id1.isEmpty && id2.nonEmpty => Right(id2)
-        case (id1, id2) if id2.isEmpty && id1.isEmpty =>
-          Left(
-            new RuntimeException(
-              s"Cannot find a language id in ${n.toString()}"
-            )
-          )
-        case _ =>
-          Left(
-            new RuntimeException(s"Multiple language ids in ${n.toString()}")
-          )
+  def apply(xml: Elem): List[Language] =
+    findNodes(xml)
+      .flatMap { case (id, label) =>
+        TeiLanguageData(id = id, label = label)
       }
-      langId.map(id => Language(id = id, label = label))
-    }
-    eitherLanguages.sequence
-  }
+      .toList
 }

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiDataParserTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiDataParserTest.scala
@@ -1,5 +1,6 @@
 package weco.pipeline.transformer.tei
 
+import org.scalatest.EitherValues
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.catalogue.internal_model.languages.Language
@@ -9,6 +10,7 @@ import weco.pipeline.transformer.tei.fixtures.TeiGenerators
 class TeiDataParserTest
     extends AnyFunSpec
     with Matchers
+    with EitherValues
     with TeiGenerators
     with SierraDataGenerators {
   val id = "manuscript_15651"
@@ -43,12 +45,7 @@ class TeiDataParserTest
   }
 
   it("add the languages from a TEI into the WorkData") {
-    val expectedTeiData = TeiData(
-      id = id,
-      title = "test title",
-      bNumber = None,
-      description = None,
-      languages = List(Language(id = "sa", label = "Sanskrit")))
+    val expectedLanguages = List(Language(id = "san", label = "Sanskrit"))
 
     val xml =
       TeiXml(
@@ -63,7 +60,7 @@ class TeiDataParserTest
         ).toString()
       ).right.get
 
-    TeiDataParser.parse(xml) shouldBe Right(expectedTeiData)
+    TeiDataParser.parse(xml).value.languages shouldBe expectedLanguages
   }
 
   it("strips xml from descriptions TeiData") {

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiTransformerTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiTransformerTest.scala
@@ -67,7 +67,7 @@ class TeiTransformerTest
     val timeModified = instantInLast30Days
     val id = "Wellcome_Javanese_4"
     transformer(id, TeiChangedMetadata(location, timeModified), 1).right.get.data.languages shouldBe List(
-      Language(id = "jv", label = "Javanese"))
+      Language(id = "jav", label = "Javanese"))
   }
 
   it("handles delete messages") {

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/data/TeiLanguageDataTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/data/TeiLanguageDataTest.scala
@@ -1,0 +1,22 @@
+package weco.pipeline.transformer.tei.data
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks
+import weco.catalogue.internal_model.languages.Language
+
+class TeiLanguageDataTest extends AnyFunSpec with Matchers with TableDrivenPropertyChecks {
+  val testCases = Table(
+    ("id", "label", "expectedLanguage"),
+    ("ar", "Arabic", Language(id = "ara", label = "Arabic")),
+    ("jv", "Javanese", Language(id = "jav", label = "Javanese")),
+    ("grc", "Ancient Greek", Language(id = "grc", label = "Greek, Ancient (to 1453)")),
+    ("btk", "Toba-Batak", Language(id = "btk", label = "Toba-Batak"))
+  )
+
+  it("handles the test cases") {
+    forAll(testCases) { case (id, label, expectedLanguage) =>
+      TeiLanguageData(id = id, label = label) shouldBe Some(expectedLanguage)
+    }
+  }
+}

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/data/TeiLanguageDataTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/data/TeiLanguageDataTest.scala
@@ -24,8 +24,12 @@ class TeiLanguageDataTest extends AnyFunSpec with Matchers with TableDrivenPrope
 
   it("handles the test cases") {
     forAll(testCases) { case (id, label, expectedLanguage) =>
-      TeiLanguageData(id = id, label = label) shouldBe Some(expectedLanguage)
+      TeiLanguageData(id = id, label = label) shouldBe Success(expectedLanguage)
     }
+  }
+
+  it("fails if it sees an unexpected language") {
+    TeiLanguageData(id = "xyz", label = "???") shouldBe a[Failure[_]]
   }
 
   /** This test is to help you find languages in the TEI files that aren't currently
@@ -62,8 +66,8 @@ class TeiLanguageDataTest extends AnyFunSpec with Matchers with TableDrivenPrope
 
       textLangNodes.foreach { case (id, label) =>
         TeiLanguageData(id = id, label = label) match {
-          case Some(_) => ()
-          case None =>
+          case Success(_) => ()
+          case Failure(_) =>
             println(s"$p: Unable to map TEI <textLang> node id=$id label=$label")
         }
       }

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/data/TeiLanguageDataTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/data/TeiLanguageDataTest.scala
@@ -4,6 +4,13 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
 import weco.catalogue.internal_model.languages.Language
+import weco.pipeline.transformer.tei.transformers.TeiLanguages
+
+import java.io.FileInputStream
+import java.nio.file.{Files, Path, Paths}
+import java.util.stream.Collectors
+import scala.collection.JavaConverters._
+import scala.xml.XML
 
 class TeiLanguageDataTest extends AnyFunSpec with Matchers with TableDrivenPropertyChecks {
   val testCases = Table(
@@ -17,6 +24,43 @@ class TeiLanguageDataTest extends AnyFunSpec with Matchers with TableDrivenPrope
   it("handles the test cases") {
     forAll(testCases) { case (id, label, expectedLanguage) =>
       TeiLanguageData(id = id, label = label) shouldBe Some(expectedLanguage)
+    }
+  }
+
+  /** This test is to help you find languages in the TEI files that aren't currently
+    * mapped by TeiLanguageData.  It walks a local checkout of the TEI repo, tries
+    * to extract all the language codes, and warns for anything it can't map.
+    *
+    * This is possible because the TEI repository is small compared to other sources,
+    * and can be saved in a single snapshot.
+    *
+    * This test is provided for the benefit of other devs working on this code, not
+    * something to run continually in CI.  Additionally, it may not be possible for us
+    * to get this running cleanly on our own -- if it flags inconsistent data, that
+    * should be fixed in the source files rather than a workaround in our code.
+    *
+    */
+  ignore("handles all the TEI languages") {
+    val root = Paths.get("/Users/alexwlchan/repos", "wellcome-collection-tei")
+    val xmlPaths =
+      Files.walk(root)
+        .collect(Collectors.toList[Path])
+        .asScala
+        .filter { Files.isRegularFile(_) }
+        .filter { _.getFileName.toString.endsWith(".xml") }
+
+    xmlPaths.foreach { p =>
+      val xml = XML.load(new FileInputStream(p.toAbsolutePath.toString))
+
+      val textLangNodes = TeiLanguages.findNodes(xml)
+
+      textLangNodes.foreach { case (id, label) =>
+        TeiLanguageData(id = id, label = label) match {
+          case Some(_) => ()
+          case None =>
+            println(s"$p: Unable to map TEI <textLang> node id=$id label=$label")
+        }
+      }
     }
   }
 }

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/data/TeiLanguageDataTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/data/TeiLanguageDataTest.scala
@@ -13,18 +13,26 @@ import scala.collection.JavaConverters._
 import scala.util.{Failure, Success}
 import scala.xml.XML
 
-class TeiLanguageDataTest extends AnyFunSpec with Matchers with TableDrivenPropertyChecks {
+class TeiLanguageDataTest
+    extends AnyFunSpec
+    with Matchers
+    with TableDrivenPropertyChecks {
   val testCases = Table(
     ("id", "label", "expectedLanguage"),
     ("ar", "Arabic", Language(id = "ara", label = "Arabic")),
     ("jv", "Javanese", Language(id = "jav", label = "Javanese")),
-    ("grc", "Ancient Greek", Language(id = "grc", label = "Greek, Ancient (to 1453)")),
+    (
+      "grc",
+      "Ancient Greek",
+      Language(id = "grc", label = "Greek, Ancient (to 1453)")),
     ("btk", "Toba-Batak", Language(id = "btk", label = "Toba-Batak"))
   )
 
   it("handles the test cases") {
-    forAll(testCases) { case (id, label, expectedLanguage) =>
-      TeiLanguageData(id = id, label = label) shouldBe Success(expectedLanguage)
+    forAll(testCases) {
+      case (id, label, expectedLanguage) =>
+        TeiLanguageData(id = id, label = label) shouldBe Success(
+          expectedLanguage)
     }
   }
 
@@ -48,7 +56,8 @@ class TeiLanguageDataTest extends AnyFunSpec with Matchers with TableDrivenPrope
   ignore("handles all the TEI languages") {
     val root = Paths.get("/Users/alexwlchan/repos", "wellcome-collection-tei")
     val xmlPaths =
-      Files.walk(root)
+      Files
+        .walk(root)
         .collect(Collectors.toList[Path])
         .asScala
         .filter { Files.isRegularFile(_) }
@@ -64,12 +73,14 @@ class TeiLanguageDataTest extends AnyFunSpec with Matchers with TableDrivenPrope
           Seq[(String, String)]()
       }
 
-      textLangNodes.foreach { case (id, label) =>
-        TeiLanguageData(id = id, label = label) match {
-          case Success(_) => ()
-          case Failure(_) =>
-            println(s"$p: Unable to map TEI <textLang> node id=$id label=$label")
-        }
+      textLangNodes.foreach {
+        case (id, label) =>
+          TeiLanguageData(id = id, label = label) match {
+            case Success(_) => ()
+            case Failure(_) =>
+              println(
+                s"$p: Unable to map TEI <textLang> node id=$id label=$label")
+          }
       }
     }
   }

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/data/TeiLanguageDataTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/data/TeiLanguageDataTest.scala
@@ -10,6 +10,7 @@ import java.io.FileInputStream
 import java.nio.file.{Files, Path, Paths}
 import java.util.stream.Collectors
 import scala.collection.JavaConverters._
+import scala.util.{Failure, Success}
 import scala.xml.XML
 
 class TeiLanguageDataTest extends AnyFunSpec with Matchers with TableDrivenPropertyChecks {
@@ -52,7 +53,12 @@ class TeiLanguageDataTest extends AnyFunSpec with Matchers with TableDrivenPrope
     xmlPaths.foreach { p =>
       val xml = XML.load(new FileInputStream(p.toAbsolutePath.toString))
 
-      val textLangNodes = TeiLanguages.findNodes(xml)
+      val textLangNodes = TeiLanguages.findNodes(xml) match {
+        case Success(nodes) => nodes
+        case Failure(err) =>
+          println(s"$p: error while reading <textLang> nodes: $err")
+          Seq[(String, String)]()
+      }
 
       textLangNodes.foreach { case (id, label) =>
         TeiLanguageData(id = id, label = label) match {

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/transformers/TeiLanguagesTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/transformers/TeiLanguagesTest.scala
@@ -23,13 +23,10 @@ class TeiLanguagesTest
         )
       )
 
-    val languages = TeiLanguages(xml)
-
-    languages shouldBe a[Right[_, _]]
-    languages.value shouldBe List(Language(id = "sa", label = "Sanskrit"))
+    TeiLanguages(xml) shouldBe List(Language(id = "san", label = "Sanskrit"))
   }
 
-  it("gets multiple languages from tei") {
+  it("gets multiple languages from TEI") {
     val xml: Elem =
       teiXml(
         languages = List(
@@ -42,16 +39,13 @@ class TeiLanguagesTest
         )
       )
 
-    val languages = TeiLanguages(xml)
-
-    languages shouldBe a[Right[_, _]]
-    languages.value shouldBe List(
-      Language(id = "sa", label = "Sanskrit"),
-      Language(id = "la", label = "Latin")
+    TeiLanguages(xml) shouldBe List(
+      Language(id = "san", label = "Sanskrit"),
+      Language(id = "lat", label = "Latin")
     )
   }
 
-  it("fails if it cannot parse the language id") {
+  it("skips languages that it can't parse") {
     val xml =
       teiXml(
         languages = List(
@@ -59,13 +53,10 @@ class TeiLanguagesTest
         )
       )
 
-    val result = TeiLanguages(xml)
-
-    result shouldBe a[Left[_, _]]
-    result.left.get.getMessage should include("language id")
+    TeiLanguages(xml) shouldBe empty
   }
 
-  it("fails if it there is more than one language id attribute") {
+  it("skips languages that have more than one lang attribute") {
     val xml =
       teiXml(
         languages = List(
@@ -73,9 +64,6 @@ class TeiLanguagesTest
         )
       )
 
-    val result = TeiLanguages(xml)
-
-    result shouldBe a[Left[_, _]]
-    result.left.get.getMessage should include("language id")
+    TeiLanguages(xml) shouldBe empty
   }
 }

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/transformers/TeiLanguagesTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/transformers/TeiLanguagesTest.scala
@@ -23,7 +23,7 @@ class TeiLanguagesTest
         )
       )
 
-    TeiLanguages(xml) shouldBe List(Language(id = "san", label = "Sanskrit"))
+    TeiLanguages(xml).value shouldBe List(Language(id = "san", label = "Sanskrit"))
   }
 
   it("gets multiple languages from TEI") {
@@ -39,7 +39,7 @@ class TeiLanguagesTest
         )
       )
 
-    TeiLanguages(xml) shouldBe List(
+    TeiLanguages(xml).value shouldBe List(
       Language(id = "san", label = "Sanskrit"),
       Language(id = "lat", label = "Latin")
     )
@@ -53,10 +53,13 @@ class TeiLanguagesTest
         )
       )
 
-    TeiLanguages(xml) shouldBe empty
+    val result = TeiLanguages(xml)
+
+    result shouldBe a[Left[_, _]]
+    result.left.get.getMessage should include("language ID")
   }
 
-  it("skips languages that have more than one lang attribute") {
+  it("errors on languages that have more than one lang attribute") {
     val xml =
       teiXml(
         languages = List(
@@ -64,6 +67,9 @@ class TeiLanguagesTest
         )
       )
 
-    TeiLanguages(xml) shouldBe empty
+    val result = TeiLanguages(xml)
+
+    result shouldBe a[Left[_, _]]
+    result.left.get.getMessage should include("language ID")
   }
 }

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/transformers/TeiLanguagesTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/transformers/TeiLanguagesTest.scala
@@ -23,7 +23,8 @@ class TeiLanguagesTest
         )
       )
 
-    TeiLanguages(xml).value shouldBe List(Language(id = "san", label = "Sanskrit"))
+    TeiLanguages(xml).value shouldBe List(
+      Language(id = "san", label = "Sanskrit"))
   }
 
   it("gets multiple languages from TEI") {


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/platform/issues/5243

TEI is using IANA language codes, which are a mixture of 2 and 3 characters, and not consistent with the Sierra/Calm transformer. This PR modifies the TEI transformer to map these codes to MARC language codes, so we can filter/aggregate TEI works by language alongside other works.

The key object is `TeiLanguageData`, which contains the language mapping.

I wrote it iteratively, and I've included the core code in this PR. I started by writing a test that walks every file in the TEI repo, extracts the `<textLang>` elements, and tries to map them to the MARC codes with the new object. If an element can't be mapped, it prints a warning and carries on. I kept adding cases or fixing the data (see https://github.com/wellcomecollection/wellcome-collection-tei/pull/33) until I got down to two warnings:

```
./Indic/Indic_Alpha_978.xml: Unable to map TEI <textLang> node id=sa label=Sanskrit, with additional title entries in Persian script.
./Indic/Tamil/Tamil_3.xml: Unable to map TEI <textLang> node id=ta label=TamilOne side gives the Tamil version
```

The test is disabled by default because it requires a local checkout of the TEI repo, but I include it for reference and in case it's useful for other TEI work.

This patch also changes the behaviour of the TEI transformer to match our other transformers: if it can't map a `<textLang>` element, it logs a warning and skips the element rather than failing the entire work. This is based on the idea that it's better to push incomplete data through the pipeline than have works vanish post-reindex because of a data issue.