### PR TITLE
We always create an AccessCondition in SierraItemAccess

### DIFF
--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -37,7 +37,7 @@ object SierraItemAccess extends SierraQueryOps with Logging {
     bibStatus: Option[AccessStatus],
     location: Option[PhysicalLocationType],
     itemData: SierraItemData
-  ): (Option[AccessCondition], Option[String]) =
+  ): (AccessCondition, Option[String]) =
     (
       createAccessCondition(
         bibId = bibId,
@@ -47,19 +47,19 @@ object SierraItemAccess extends SierraQueryOps with Logging {
       ),
       itemData.displayNote) match {
       // If the item note is already on the access condition, we don't need to copy it.
-      case ((Some(ac), displayNote)) if ac.note == displayNote =>
-        (Some(ac), None)
+      case (ac, displayNote) if ac.note == displayNote =>
+        (ac, None)
 
       // If the item note is an access note but there's already an access note on the
       // access condition, we discard the item note.
       //
       // Otherwise, we copy the item note onto the access condition.
-      case (Some(ac), Some(displayNote))
+      case (ac, Some(displayNote))
           if ac.note.isDefined && displayNote.isAccessNote =>
-        (Some(ac), None)
-      case (Some(ac), Some(displayNote))
+        (ac, None)
+      case (ac, Some(displayNote))
           if ac.note.isEmpty && displayNote.isAccessNote =>
-        (Some(ac.copy(note = Some(displayNote))), None)
+        (ac.copy(note = Some(displayNote)), None)
 
       // If the item note is nothing to do with the access condition, we return it to
       // be copied onto the item.
@@ -71,7 +71,7 @@ object SierraItemAccess extends SierraQueryOps with Logging {
     bibStatus: Option[AccessStatus],
     location: Option[PhysicalLocationType],
     itemData: SierraItemData
-  ): Option[AccessCondition] = {
+  ): AccessCondition = {
     val holdCount = itemData.holdCount
     val status = itemData.status
     val opacmsg = itemData.opacmsg
@@ -90,12 +90,10 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           Requestable,
           Some(LocationType.ClosedStores))
           if bibStatus.isEmpty || bibStatus.contains(AccessStatus.Open) =>
-        val ac = AccessCondition(
+        AccessCondition(
           method = AccessMethod.OnlineRequest,
           status = bibStatus
         )
-
-        Some(ac)
 
       // Note: it is possible for individual items within a restricted bib to be available
       // online, e.g. in archives.  The "restricted" on the bib applies to the archive as
@@ -121,12 +119,10 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           Some(OpacMsg.OnlineRequest),
           Requestable,
           Some(LocationType.ClosedStores)) =>
-        val ac = AccessCondition(
+        AccessCondition(
           method = AccessMethod.OnlineRequest,
           status = AccessStatus.Open,
         )
-
-        Some(ac)
 
       // Items on the open shelves don't have any access conditions.
       //
@@ -147,17 +143,15 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           Some(OpacMsg.OpenShelves),
           NotRequestable.OnOpenShelves(_),
           Some(LocationType.OpenShelves)) =>
-        Some(AccessCondition(method = AccessMethod.OpenShelves))
+        AccessCondition(method = AccessMethod.OpenShelves)
 
       // There are some items that are labelled "bound in above" or "contained in above".
       //
       // These items aren't requestable on their own; you have to request the "primary" item.
       case (None, _, _, _, NotRequestable.RequestTopItem(message), _) =>
-        Some(
-          AccessCondition(
-            method = AccessMethod.NotRequestable,
-            note = Some(message)
-          )
+        AccessCondition(
+          method = AccessMethod.NotRequestable,
+          note = Some(message)
         )
 
       // Handle any cases that require a manual request.
@@ -185,11 +179,9 @@ object SierraItemAccess extends SierraQueryOps with Logging {
             case _ => None
           }
 
-        Some(
-          AccessCondition(
-            method = AccessMethod.ManualRequest,
-            note = accessNote)
-        )
+        AccessCondition(
+          method = AccessMethod.ManualRequest,
+          note = accessNote)
 
       // Handle any cases where the item is closed.
       //
@@ -206,11 +198,9 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           locationType)
           if locationType.isEmpty || locationType.contains(
             LocationType.ClosedStores) =>
-        Some(
-          AccessCondition(
-            method = AccessMethod.NotRequestable,
-            status = AccessStatus.Closed)
-        )
+        AccessCondition(
+          method = AccessMethod.NotRequestable,
+          status = AccessStatus.Closed)
 
       // Handle any cases where the item is explicitly unavailable.
       case (
@@ -220,11 +210,9 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           Some(OpacMsg.Unavailable),
           NotRequestable.ItemUnavailable(_),
           _) =>
-        Some(
-          AccessCondition(
-            method = AccessMethod.NotRequestable,
-            status = AccessStatus.Unavailable)
-        )
+        AccessCondition(
+          method = AccessMethod.NotRequestable,
+          status = AccessStatus.Unavailable)
 
       case (
           None,
@@ -233,13 +221,11 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           Some(OpacMsg.AtDigitisation),
           NotRequestable.ItemUnavailable(_),
           _) =>
-        Some(
-          AccessCondition(
-            method = AccessMethod.NotRequestable,
-            status = Some(AccessStatus.TemporarilyUnavailable),
-            note =
-              Some("This item is being digitised and is currently unavailable.")
-          )
+        AccessCondition(
+          method = AccessMethod.NotRequestable,
+          status = Some(AccessStatus.TemporarilyUnavailable),
+          note =
+            Some("This item is being digitised and is currently unavailable.")
         )
 
       // An item which is restricted can be requested online -- the user will have to fill in
@@ -253,11 +239,9 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           Some(OpacMsg.OnlineRequest),
           Requestable,
           Some(LocationType.ClosedStores)) =>
-        Some(
-          AccessCondition(
-            method = AccessMethod.OnlineRequest,
-            status = AccessStatus.Restricted)
-        )
+        AccessCondition(
+          method = AccessMethod.OnlineRequest,
+          status = AccessStatus.Restricted)
 
       // The status "by appointment" takes precedence over "permission required".
       //
@@ -271,11 +255,9 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           Some(LocationType.ClosedStores))
           if bibStatus.isEmpty || bibStatus.contains(AccessStatus.ByAppointment) || bibStatus
             .contains(AccessStatus.PermissionRequired) =>
-        Some(
-          AccessCondition(
-            method = AccessMethod.ManualRequest,
-            status = AccessStatus.ByAppointment)
-        )
+        AccessCondition(
+          method = AccessMethod.ManualRequest,
+          status = AccessStatus.ByAppointment)
 
       case (
           bibStatus,
@@ -286,11 +268,9 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           Some(LocationType.ClosedStores))
           if bibStatus.isEmpty || bibStatus.contains(
             AccessStatus.PermissionRequired) =>
-        Some(
-          AccessCondition(
-            method = AccessMethod.ManualRequest,
-            status = AccessStatus.PermissionRequired)
-        )
+        AccessCondition(
+          method = AccessMethod.ManualRequest,
+          status = AccessStatus.PermissionRequired)
 
       // A missing status overrides all other values.
       //
@@ -302,12 +282,10 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           _,
           NotRequestable.ItemMissing(message),
           _) =>
-        Some(
-          AccessCondition(
-            method = AccessMethod.NotRequestable,
-            status = Some(AccessStatus.Unavailable),
-            note = Some(message))
-        )
+        AccessCondition(
+          method = AccessMethod.NotRequestable,
+          status = Some(AccessStatus.Unavailable),
+          note = Some(message))
 
       // A withdrawn status also overrides all other values.
       case (
@@ -317,12 +295,10 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           _,
           NotRequestable.ItemWithdrawn(message),
           _) =>
-        Some(
-          AccessCondition(
-            method = AccessMethod.NotRequestable,
-            status = Some(AccessStatus.Unavailable),
-            note = Some(message))
-        )
+        AccessCondition(
+          method = AccessMethod.NotRequestable,
+          status = Some(AccessStatus.Unavailable),
+          note = Some(message))
 
       // If an item is on hold for another reader, it can't be requested -- even
       // if it would ordinarily be requestable.
@@ -340,13 +316,11 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           _,
           Requestable,
           Some(LocationType.ClosedStores)) if holdCount > 0 =>
-        Some(
-          AccessCondition(
-            method = AccessMethod.ManualRequest,
-            status = Some(AccessStatus.TemporarilyUnavailable),
-            note = Some(
-              "Item is in use by another reader. Please ask at Enquiry Desk.")
-          )
+        AccessCondition(
+          method = AccessMethod.ManualRequest,
+          status = Some(AccessStatus.TemporarilyUnavailable),
+          note = Some(
+            "Item is in use by another reader. Please ask at Enquiry Desk.")
         )
 
       case (
@@ -356,13 +330,12 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           _,
           NotRequestable.OnHold(_),
           Some(LocationType.ClosedStores)) =>
-        Some(
-          AccessCondition(
-            method = AccessMethod.ManualRequest,
-            status = Some(AccessStatus.TemporarilyUnavailable),
-            note = Some(
-              "Item is in use by another reader. Please ask at Enquiry Desk.")
-          ))
+        AccessCondition(
+          method = AccessMethod.ManualRequest,
+          status = Some(AccessStatus.TemporarilyUnavailable),
+          note = Some(
+            "Item is in use by another reader. Please ask at Enquiry Desk.")
+        )
 
       // If we can't work out how this item should be handled, then let's mark it
       // as unavailable for now.
@@ -380,12 +353,10 @@ object SierraItemAccess extends SierraQueryOps with Logging {
             s"opacmsg=$opacmsg, isRequestable=$isRequestable, location=$location"
         )
 
-        Some(
-          AccessCondition(
-            method = AccessMethod.NotRequestable,
-            note = Some(
-              s"""Please check this item <a href="https://search.wellcomelibrary.org/iii/encore/record/C__Rb${bibId.withoutCheckDigit}?lang=eng">on the Wellcome Library website</a> for access information""")
-          )
+        AccessCondition(
+          method = AccessMethod.NotRequestable,
+          note = Some(
+            s"""Please check this item <a href="https://search.wellcomelibrary.org/iii/encore/record/C__Rb${bibId.withoutCheckDigit}?lang=eng">on the Wellcome Library website</a> for access information""")
         )
     }
   }

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -179,9 +179,7 @@ object SierraItemAccess extends SierraQueryOps with Logging {
             case _ => None
           }
 
-        AccessCondition(
-          method = AccessMethod.ManualRequest,
-          note = accessNote)
+        AccessCondition(method = AccessMethod.ManualRequest, note = accessNote)
 
       // Handle any cases where the item is closed.
       //

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -45,7 +45,7 @@ class SierraItemAccessTest
             itemData = itemData
           )
 
-          ac shouldBe Some(AccessCondition(method = AccessMethod.OnlineRequest))
+          ac shouldBe AccessCondition(method = AccessMethod.OnlineRequest)
         }
 
         it("if it has no restrictions and the bib is open") {
@@ -72,10 +72,10 @@ class SierraItemAccessTest
             itemData = itemData
           )
 
-          ac shouldBe Some(
+          ac shouldBe
             AccessCondition(
               method = AccessMethod.OnlineRequest,
-              status = AccessStatus.Open))
+              status = AccessStatus.Open)
         }
 
         it("if it's restricted") {
@@ -102,10 +102,10 @@ class SierraItemAccessTest
             itemData = itemData
           )
 
-          ac shouldBe Some(
+          ac shouldBe
             AccessCondition(
               method = AccessMethod.OnlineRequest,
-              status = AccessStatus.Restricted))
+              status = AccessStatus.Restricted)
         }
 
         it("if the bib is restricted but the item is open") {
@@ -132,10 +132,10 @@ class SierraItemAccessTest
             itemData = itemData
           )
 
-          ac shouldBe Some(
+          ac shouldBe
             AccessCondition(
               method = AccessMethod.OnlineRequest,
-              status = AccessStatus.Open))
+              status = AccessStatus.Open)
         }
       }
 
@@ -168,7 +168,7 @@ class SierraItemAccessTest
             itemData = itemData
           )
 
-          ac shouldBe Some(AccessCondition(method = AccessMethod.ManualRequest))
+          ac shouldBe AccessCondition(method = AccessMethod.ManualRequest)
         }
 
         it("if it's bound in the top item") {
@@ -195,10 +195,10 @@ class SierraItemAccessTest
             itemData = itemData
           )
 
-          ac shouldBe Some(
+          ac shouldBe
             AccessCondition(
               method = AccessMethod.NotRequestable,
-              note = Some("Please request top item.")))
+              note = Some("Please request top item."))
         }
 
         it("if it's contained the top item") {
@@ -225,10 +225,10 @@ class SierraItemAccessTest
             itemData = itemData
           )
 
-          ac shouldBe Some(
+          ac shouldBe
             AccessCondition(
               method = AccessMethod.NotRequestable,
-              note = Some("Please request top item.")))
+              note = Some("Please request top item."))
         }
 
         it("if the bib and the item are closed") {
@@ -255,11 +255,11 @@ class SierraItemAccessTest
             itemData = itemData
           )
 
-          ac shouldBe Some(
+          ac shouldBe
             AccessCondition(
               method = AccessMethod.NotRequestable,
               status = AccessStatus.Closed
-            ))
+            )
         }
 
         it("if the bib and the item are closed, and there's no location") {
@@ -286,10 +286,10 @@ class SierraItemAccessTest
             itemData = itemData
           )
 
-          ac shouldBe Some(
+          ac shouldBe
             AccessCondition(
               method = AccessMethod.NotRequestable,
-              status = AccessStatus.Closed))
+              status = AccessStatus.Closed)
         }
 
         it("if the item is unavailable") {
@@ -316,10 +316,10 @@ class SierraItemAccessTest
             itemData = itemData
           )
 
-          ac shouldBe Some(
+          ac shouldBe
             AccessCondition(
               method = AccessMethod.NotRequestable,
-              status = AccessStatus.Unavailable))
+              status = AccessStatus.Unavailable)
         }
 
         it("if the item is at digitisation") {
@@ -346,14 +346,13 @@ class SierraItemAccessTest
             itemData = itemData
           )
 
-          ac shouldBe Some(
+          ac shouldBe
             AccessCondition(
               method = AccessMethod.NotRequestable,
               status = Some(AccessStatus.TemporarilyUnavailable),
               note = Some(
                 "This item is being digitised and is currently unavailable.")
             )
-          )
         }
 
         it("if doesn't double up the note about digitisation") {
@@ -387,14 +386,13 @@ class SierraItemAccessTest
             itemData = itemData
           )
 
-          ac shouldBe Some(
+          ac shouldBe
             AccessCondition(
               method = AccessMethod.NotRequestable,
               status = Some(AccessStatus.TemporarilyUnavailable),
               note = Some(
                 "This item is being digitised and is currently unavailable.")
             )
-          )
         }
 
         it("if the bib and item are by appointment") {
@@ -421,11 +419,10 @@ class SierraItemAccessTest
             itemData = itemData
           )
 
-          ac shouldBe Some(
+          ac shouldBe
             AccessCondition(
               method = AccessMethod.ManualRequest,
               status = AccessStatus.ByAppointment)
-          )
         }
 
         it("if the bib and item need donor permission") {
@@ -452,11 +449,10 @@ class SierraItemAccessTest
             itemData = itemData
           )
 
-          ac shouldBe Some(
+          ac shouldBe
             AccessCondition(
               method = AccessMethod.ManualRequest,
               status = AccessStatus.PermissionRequired)
-          )
         }
 
         it("if the bib and item needs donor permission") {
@@ -483,11 +479,10 @@ class SierraItemAccessTest
             itemData = itemData
           )
 
-          ac shouldBe Some(
+          ac shouldBe
             AccessCondition(
               method = AccessMethod.ManualRequest,
               status = AccessStatus.PermissionRequired)
-          )
         }
 
         it("if the item is missing") {
@@ -514,13 +509,12 @@ class SierraItemAccessTest
             itemData = itemData
           )
 
-          ac shouldBe Some(
+          ac shouldBe
             AccessCondition(
               method = AccessMethod.NotRequestable,
               status = Some(AccessStatus.Unavailable),
               note = Some("This item is missing.")
             )
-          )
         }
 
         it("if the item is withdrawn") {
@@ -547,13 +541,12 @@ class SierraItemAccessTest
             itemData = itemData
           )
 
-          ac shouldBe Some(
+          ac shouldBe
             AccessCondition(
               method = AccessMethod.NotRequestable,
               status = Some(AccessStatus.Unavailable),
               note = Some("This item is withdrawn.")
             )
-          )
         }
       }
     }
@@ -584,14 +577,13 @@ class SierraItemAccessTest
           itemData = itemData
         )
 
-        ac shouldBe Some(
+        ac shouldBe
           AccessCondition(
             method = AccessMethod.ManualRequest,
             status = Some(AccessStatus.TemporarilyUnavailable),
             note = Some(
               "Item is in use by another reader. Please ask at Enquiry Desk.")
           )
-        )
       }
 
       it("can't be requested when it's on the hold shelf for another reader") {
@@ -619,14 +611,13 @@ class SierraItemAccessTest
           itemData = itemData
         )
 
-        ac shouldBe Some(
+        ac shouldBe
           AccessCondition(
             method = AccessMethod.ManualRequest,
             status = Some(AccessStatus.TemporarilyUnavailable),
             note = Some(
               "Item is in use by another reader. Please ask at Enquiry Desk.")
           )
-        )
       }
     }
 
@@ -660,7 +651,7 @@ class SierraItemAccessTest
           )
         )
 
-        val (Some(ac), note) = getItemAccess(
+        val (ac, note) = getItemAccess(
           bibStatus = None,
           location = Some(LocationType.ClosedStores),
           itemData = itemData
@@ -701,7 +692,7 @@ class SierraItemAccessTest
           )
         )
 
-        val (Some(ac), note) = getItemAccess(
+        val (ac, note) = getItemAccess(
           bibStatus = None,
           location = Some(LocationType.ClosedStores),
           itemData = itemData
@@ -742,7 +733,7 @@ class SierraItemAccessTest
           )
         )
 
-        val (Some(ac), _) = getItemAccess(
+        val (ac, _) = getItemAccess(
           bibStatus = None,
           location = Some(LocationType.ClosedStores),
           itemData = itemData
@@ -807,7 +798,7 @@ class SierraItemAccessTest
           )
         )
 
-        val (Some(ac), _) = getItemAccess(
+        val (ac, _) = getItemAccess(
           bibStatus = None,
           location = Some(LocationType.OpenShelves),
           itemData = itemData
@@ -847,13 +838,12 @@ class SierraItemAccessTest
           itemData = itemData
         )
 
-        ac shouldBe Some(
+        ac shouldBe
           AccessCondition(
             method = AccessMethod.OpenShelves,
             note = Some(
               "Shelved at the end of the Quick Ref. section with the oversize Quick Ref. books.")
           )
-        )
       }
     }
 
@@ -881,13 +871,12 @@ class SierraItemAccessTest
         itemData = itemData
       )
 
-      ac shouldBe Some(
+      ac shouldBe
         AccessCondition(
           method = AccessMethod.NotRequestable,
           status = Some(AccessStatus.Unavailable),
           note = Some("This item is missing.")
         )
-      )
     }
   }
 
@@ -907,7 +896,7 @@ class SierraItemAccessTest
       )
     )
 
-    val (Some(ac), _) = getItemAccess(
+    val (ac, _) = getItemAccess(
       bibId = bibId,
       bibStatus = None,
       location = Some(LocationType.ClosedStores),
@@ -926,7 +915,7 @@ class SierraItemAccessTest
     bibStatus: Option[AccessStatus],
     location: Option[PhysicalLocationType],
     itemData: SierraItemData
-  ): (Option[AccessCondition], Option[String]) =
+  ): (AccessCondition, Option[String]) =
     SierraItemAccess(
       bibId = bibId,
       bibStatus = bibStatus,

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraLocation.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraLocation.scala
@@ -51,7 +51,7 @@ trait SierraLocation {
 
       physicalLocation = PhysicalLocation(
         locationType = locationType,
-        accessConditions = accessCondition.toList,
+        accessConditions = List(accessCondition),
         label = label,
         shelfmark = SierraShelfmark(bibData, itemData)
       )


### PR DESCRIPTION
Reflecting this in the type signature should make things a bit simpler downstream.  I don't think this was always the case -- possibly we returned None as a fallback or unhandled case?  But now it is, we can bin the Option[…] and all the Some(…) wrappers.

I think this might help https://github.com/wellcomecollection/catalogue-api/pull/197