### PR TITLE
Set the match time when still holding the locks

### DIFF
--- a/pipeline/matcher/src/main/scala/weco/pipeline/matcher/Main.scala
+++ b/pipeline/matcher/src/main/scala/weco/pipeline/matcher/Main.scala
@@ -1,22 +1,22 @@
 package weco.pipeline.matcher
 
 import akka.actor.ActorSystem
+import com.sksamuel.elastic4s.Index
 import com.typesafe.config.Config
 import org.scanamo.generic.auto._
+import weco.catalogue.internal_model.matcher.MatcherResult
 import weco.elasticsearch.typesafe.ElasticBuilder
 import weco.messaging.sns.NotificationMessage
 import weco.messaging.typesafe.{SNSBuilder, SQSBuilder}
-import weco.catalogue.internal_model.matcher.MatchedIdentifiers
+import weco.pipeline.matcher.matcher.WorkMatcher
+import weco.pipeline.matcher.services.MatcherWorkerService
+import weco.pipeline.matcher.storage.elastic.ElasticWorkLinksRetriever
+import weco.pipeline.matcher.storage.{WorkGraphStore, WorkNodeDao}
+import weco.pipeline_storage.typesafe.PipelineStorageStreamBuilder
 import weco.storage.typesafe.{DynamoBuilder, LockingBuilder}
 import weco.typesafe.WellcomeTypesafeApp
 import weco.typesafe.config.builders.AkkaBuilder
 import weco.typesafe.config.builders.EnrichConfig._
-import com.sksamuel.elastic4s.Index
-import weco.pipeline.matcher.matcher.WorkMatcher
-import weco.pipeline.matcher.services.MatcherWorkerService
-import weco.pipeline.matcher.storage.{WorkGraphStore, WorkNodeDao}
-import weco.pipeline.matcher.storage.elastic.ElasticWorkLinksRetriever
-import weco.pipeline_storage.typesafe.PipelineStorageStreamBuilder
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.language.higherKinds
@@ -39,7 +39,7 @@ object Main extends WellcomeTypesafeApp {
 
     val lockingService =
       LockingBuilder
-        .buildDynamoLockingService[Set[MatchedIdentifiers], Future](
+        .buildDynamoLockingService[MatcherResult, Future](
           config,
           namespace = "locking")
 

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/fixtures/MatcherFixtures.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/fixtures/MatcherFixtures.scala
@@ -3,7 +3,12 @@ package weco.pipeline.matcher.fixtures
 import org.apache.commons.codec.digest.DigestUtils
 import org.scanamo.generic.semiauto.deriveDynamoFormat
 import org.scanamo.query.UniqueKey
-import org.scanamo.{DynamoFormat, DynamoReadError, Scanamo, Table => ScanamoTable}
+import org.scanamo.{
+  DynamoFormat,
+  DynamoReadError,
+  Scanamo,
+  Table => ScanamoTable
+}
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import weco.catalogue.internal_model.identifiers.CanonicalId
 import weco.catalogue.internal_model.matcher.{MatcherResult, WorkNode}
@@ -18,7 +23,11 @@ import weco.pipeline.matcher.storage.{WorkGraphStore, WorkNodeDao}
 import weco.pipeline_storage.fixtures.PipelineStorageStreamFixtures
 import weco.pipeline_storage.memory.MemoryRetriever
 import weco.storage.fixtures.DynamoFixtures.Table
-import weco.storage.locking.dynamo.{DynamoLockDaoFixtures, DynamoLockingService, ExpiringLock}
+import weco.storage.locking.dynamo.{
+  DynamoLockDaoFixtures,
+  DynamoLockingService,
+  ExpiringLock
+}
 import weco.storage.locking.memory.{MemoryLockDao, MemoryLockingService}
 
 import java.util.UUID

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/matcher/WorkMatcherConcurrencyTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/matcher/WorkMatcherConcurrencyTest.scala
@@ -3,7 +3,7 @@ package weco.pipeline.matcher.matcher
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import weco.catalogue.internal_model.matcher.{MatchedIdentifiers, MatcherResult}
+import weco.catalogue.internal_model.matcher.MatcherResult
 import weco.pipeline.matcher.exceptions.MatcherException
 import weco.pipeline.matcher.fixtures.MatcherFixtures
 import weco.pipeline.matcher.generators.WorkLinksGenerators
@@ -24,7 +24,7 @@ class WorkMatcherConcurrencyTest
     implicit val lockDao: MemoryLockDao[String, UUID] =
       new MemoryLockDao[String, UUID]
     val lockingService =
-      new MemoryLockingService[Set[MatchedIdentifiers], Future]()
+      new MemoryLockingService[MatcherResult, Future]()
 
     withWorkGraphTable { graphTable =>
       withWorkGraphStore(graphTable) { workGraphStore =>

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/matcher/WorkMatcherTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/matcher/WorkMatcherTest.scala
@@ -8,11 +8,7 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 import org.scanamo.syntax._
-import weco.catalogue.internal_model.matcher.{
-  MatchedIdentifiers,
-  WorkIdentifier,
-  WorkNode
-}
+import weco.catalogue.internal_model.matcher.{MatchedIdentifiers, MatcherResult, WorkIdentifier, WorkNode}
 import weco.storage.locking.LockFailure
 import weco.storage.locking.memory.{MemoryLockDao, MemoryLockingService}
 import weco.fixtures.TimeAssertions
@@ -206,7 +202,7 @@ class WorkMatcherTest
       }
 
     val lockingService =
-      new MemoryLockingService[Set[MatchedIdentifiers], Future]()
+      new MemoryLockingService[MatcherResult, Future]()
 
     withWorkGraphTable { graphTable =>
       withWorkGraphStore(graphTable) { workGraphStore =>
@@ -257,7 +253,7 @@ class WorkMatcherTest
             }
 
           val lockingService =
-            new MemoryLockingService[Set[MatchedIdentifiers], Future]()
+            new MemoryLockingService[MatcherResult, Future]()
 
           val workMatcher = new WorkMatcher(workGraphStore, lockingService)
 

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/matcher/WorkMatcherTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/matcher/WorkMatcherTest.scala
@@ -8,7 +8,12 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 import org.scanamo.syntax._
-import weco.catalogue.internal_model.matcher.{MatchedIdentifiers, MatcherResult, WorkIdentifier, WorkNode}
+import weco.catalogue.internal_model.matcher.{
+  MatchedIdentifiers,
+  MatcherResult,
+  WorkIdentifier,
+  WorkNode
+}
 import weco.storage.locking.LockFailure
 import weco.storage.locking.memory.{MemoryLockDao, MemoryLockingService}
 import weco.fixtures.TimeAssertions


### PR DESCRIPTION
This is implementing what is discussed here https://wellcome.slack.com/archives/C3TQSF63C/p1626278361497300?thread_ts=1626276850.494900&cid=C3TQSF63C
Basically, there was an issue with merging where something wasn't merged at all when it should have. Resending the same work unchanged to the matcher solved the issue. I'm not 100% sure what caused it but a race condition due to when we create the timestamp is the only thing I could think of.
Even if it isn't the cause of the problem, creating the timestamp while holding the locks seems more robust in general.