### PR TITLE
Add some scalacheck implicits to use upstream

### DIFF
--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/generators/IdentifiersGenerators.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/generators/IdentifiersGenerators.scala
@@ -1,17 +1,27 @@
 package weco.catalogue.internal_model.generators
 
+import org.scalacheck.Arbitrary
 import weco.fixtures.RandomGenerators
-import weco.catalogue.internal_model.identifiers.{
-  CanonicalId,
-  IdentifierType,
-  SourceIdentifier
-}
+import weco.catalogue.internal_model.identifiers.{CanonicalId, IdentifierType, SourceIdentifier}
 
 import scala.util.Random
 
 trait IdentifiersGenerators extends RandomGenerators {
-  def createCanonicalId: CanonicalId =
-    CanonicalId(randomAlphanumeric(length = 8).toLowerCase())
+  implicit val arbitraryCanonicalId: Arbitrary[CanonicalId] =
+    Arbitrary {
+      createCanonicalId
+    }
+
+  // We have a rule that says SourceIdentifier isn't allowed to contain whitespace,
+  // but sometimes scalacheck will happen to generate such a string, which breaks
+  // tests in CI.  This generator is meant to create SourceIdentifiers that
+  // don't contain whitespace.
+  implicit val arbitrarySourceIdentifier: Arbitrary[SourceIdentifier] =
+    Arbitrary {
+      createSourceIdentifier
+    }
+
+  def createCanonicalId: CanonicalId = CanonicalId(randomAlphanumeric(length = 8).toLowerCase())
 
   def createSourceIdentifier: SourceIdentifier = createSourceIdentifierWith()
 

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/index/WorksIndexConfigTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/index/WorksIndexConfigTest.scala
@@ -13,10 +13,13 @@ import weco.json.utils.JsonAssertions
 import weco.catalogue.internal_model.Implicits._
 import weco.catalogue.internal_model.generators.ImageGenerators
 import weco.catalogue.internal_model.identifiers.IdState
-import weco.catalogue.internal_model.locations.{AccessCondition, AccessMethod, AccessStatus}
+import weco.catalogue.internal_model.locations.{
+  AccessCondition,
+  AccessMethod,
+  AccessStatus
+}
 import weco.catalogue.internal_model.work._
 import weco.catalogue.internal_model.work.generators.WorkGenerators
-
 
 class WorksIndexConfigTest
     extends AnyFunSpec

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/generators/InstantGenerators.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/generators/InstantGenerators.scala
@@ -1,12 +1,32 @@
 package weco.catalogue.internal_model.work.generators
 
 import weco.catalogue.internal_model.work.InstantRange
-
 import java.time.{Instant, LocalDateTime}
+
+import org.scalacheck.Arbitrary
+import org.scalacheck.Gen.chooseNum
+
 import scala.concurrent.duration._
 import scala.util.Random
 
 trait InstantGenerators {
+
+  // We use this for the scalacheck of the java.time.Instant type
+  // We could just import the library, but I might wait until we need more
+  // Taken from here:
+  // https://github.com/rallyhealth/scalacheck-ops/blob/master/core/src/main/scala/org/scalacheck/ops/time/ImplicitJavaTimeGenerators.scala
+  implicit val arbitraryInstant: Arbitrary[Instant] =
+    Arbitrary {
+      for {
+        millis <- chooseNum(
+          Instant.MIN.getEpochSecond,
+          Instant.MAX.getEpochSecond
+        )
+        nanos <- chooseNum(Instant.MIN.getNano, Instant.MAX.getNano)
+      } yield {
+        Instant.ofEpochMilli(millis).plusNanos(nanos)
+      }
+    }
 
   val now: Instant = Instant.now
 

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/generators/LanguageGenerators.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/generators/LanguageGenerators.scala
@@ -1,0 +1,16 @@
+package weco.catalogue.internal_model.work.generators
+
+import org.scalacheck.Arbitrary
+import weco.catalogue.internal_model.languages.Language
+import weco.fixtures.RandomGenerators
+
+trait LanguageGenerators extends RandomGenerators {
+  // We have a rule that says language codes should be exactly 3 characters long
+  implicit val arbitraryLanguage: Arbitrary[Language] =
+    Arbitrary {
+      Language(
+        id = randomAlphanumeric(length = 3),
+        label = randomAlphanumeric()
+      )
+    }
+}

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/generators/WorkGenerators.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/generators/WorkGenerators.scala
@@ -17,7 +17,7 @@ import java.time.Instant
 import scala.util.Random
 
 trait WorkGenerators
-  extends IdentifiersGenerators
+    extends IdentifiersGenerators
     with InstantGenerators
     with LanguageGenerators {
 

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/generators/WorkGenerators.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/generators/WorkGenerators.scala
@@ -16,7 +16,11 @@ import weco.catalogue.internal_model.work._
 import java.time.Instant
 import scala.util.Random
 
-trait WorkGenerators extends IdentifiersGenerators with InstantGenerators {
+trait WorkGenerators
+  extends IdentifiersGenerators
+    with InstantGenerators
+    with LanguageGenerators {
+
   private def createVersion: Int =
     Random.nextInt(100) + 1
 


### PR DESCRIPTION
Following https://github.com/wellcomecollection/catalogue-api/pull/202#pullrequestreview-714796274

Moving some implicits for scalacheck into generators in the internal model. The internal model is defined in this repo so it makes sense for any generators to be provided here too.