### PR TITLE
Add some helpers to extract different types of InstantRange 

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/InstantRange.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/InstantRange.scala
@@ -1,7 +1,6 @@
 package weco.catalogue.internal_model.work
 
 import weco.catalogue.internal_model.parse.Parser
-import weco.catalogue.internal_model.work.InstantRange.instantOrdering
 
 import java.time.{Instant, LocalDate, LocalDateTime, ZoneOffset}
 
@@ -13,6 +12,8 @@ case class InstantRange(from: Instant, to: Instant, label: String = "") {
   def withLabel(label: String): InstantRange =
     InstantRange(from, to, label)
 
+  private val instantOrdering: Ordering[Instant] = _ compareTo _
+
   def +(x: InstantRange): InstantRange = InstantRange(
     from = instantOrdering.min(x.from, from),
     to = instantOrdering.max(x.to, to),
@@ -21,8 +22,6 @@ case class InstantRange(from: Instant, to: Instant, label: String = "") {
 }
 
 object InstantRange {
-  val instantOrdering: Ordering[Instant] = _ compareTo _
-
   def apply(from: LocalDate, to: LocalDate, label: String): InstantRange =
     InstantRange(
       from.atStartOfDay(),

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/InstantRange.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/InstantRange.scala
@@ -58,11 +58,27 @@ object InstantRange {
     label = start.label
   )
 
+  object AfterDate {
+    def unapply(range: InstantRange): Option[Instant] =
+      range.to match {
+        case `positiveInfinity` => Some(range.from)
+        case _                  => None
+      }
+  }
+
   def before(end: InstantRange): InstantRange = InstantRange(
     from = negativeInfinity,
     to = end.to,
     label = end.label
   )
+
+  object BeforeDate {
+    def unapply(range: InstantRange): Option[Instant] =
+      range.from match {
+        case `negativeInfinity` => Some(range.to)
+        case _                  => None
+      }
+  }
 
   def parse(label: String)(
     implicit parser: Parser[InstantRange]): Option[InstantRange] =

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/InstantRangeTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/InstantRangeTest.scala
@@ -1,0 +1,54 @@
+package weco.catalogue.internal_model.work
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import weco.fixtures.RandomGenerators
+
+class InstantRangeTest
+    extends AnyFunSpec
+    with Matchers
+    with RandomGenerators {
+
+  describe("unapply") {
+    it("extracts an AfterDate") {
+      val from = randomInstant
+      val to = randomInstant
+
+      val range = InstantRange(from = from, to = to)
+      val afterRange = InstantRange.after(range)
+
+      afterRange match {
+        case InstantRange.AfterDate(extractedFrom) => extractedFrom shouldBe from
+        case _                                     => assert(false)
+      }
+    }
+
+    it("extracts a BeforeDate") {
+      val from = randomInstant
+      val to = randomInstant
+
+      val range = InstantRange(from = from, to = to)
+      val beforeRange = InstantRange.before(range)
+
+      beforeRange match {
+        case InstantRange.BeforeDate(extractedTo) => extractedTo shouldBe to
+        case _                                    => assert(false)
+      }
+    }
+
+    it("extracts a regular InstantDate") {
+      val from = randomInstant
+      val to = randomInstant
+
+      val range = InstantRange(from = from, to = to)
+
+      range match {
+        case InstantRange.AfterDate(from) => assert(false)
+        case InstantRange.BeforeDate(to)  => assert(false)
+        case InstantRange(extractedFrom, extractedTo, _) =>
+          extractedFrom shouldBe from
+          extractedTo shouldBe to
+      }
+    }
+  }
+}

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/InstantRangeTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/InstantRangeTest.scala
@@ -4,10 +4,7 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.fixtures.RandomGenerators
 
-class InstantRangeTest
-    extends AnyFunSpec
-    with Matchers
-    with RandomGenerators {
+class InstantRangeTest extends AnyFunSpec with Matchers with RandomGenerators {
 
   describe("unapply") {
     it("extracts an AfterDate") {
@@ -18,8 +15,9 @@ class InstantRangeTest
       val afterRange = InstantRange.after(range)
 
       afterRange match {
-        case InstantRange.AfterDate(extractedFrom) => extractedFrom shouldBe from
-        case _                                     => assert(false)
+        case InstantRange.AfterDate(extractedFrom) =>
+          extractedFrom shouldBe from
+        case _ => assert(false)
       }
     }
 


### PR DESCRIPTION
The idea is that rather than pushing knowledge of positive/negative infinity into the display models, we can do something like:

```scala
range match {
  case InstantRange.AfterDate(from) => DisplayRange(from = from, to = None)
  case InstantRange.BeforeDate(to)  => DisplayRange(from = None, to = to)
  case InstantRange(from, to)       => DisplayRange(from = from, to = to)
}
```

which would allow us to hide the "9999" infinity values we do from displaying in the front-end.

This sets us up for fixing https://github.com/wellcomecollection/platform/issues/5178