### PR TITLE
Don't mark digital items as "available online" if 856 ind2 = '2'

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessStatus.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessStatus.scala
@@ -22,7 +22,8 @@ sealed trait AccessStatus extends EnumEntry { this: AccessStatus =>
     //
     // We still want these items on the work, we just don't want these items
     // to match the "available online" filter.
-    case AccessStatus.LicensedResources(LicensedResources.RelatedResource) => false
+    case AccessStatus.LicensedResources(LicensedResources.RelatedResource) =>
+      false
 
     case _ => false
   }
@@ -96,7 +97,9 @@ object AccessStatus extends Enum[AccessStatus] {
     case object RelatedResource extends Relationship
   }
 
-  case class LicensedResources(relationship: LicensedResources.Relationship = LicensedResources.Resource) extends AccessStatus {
+  case class LicensedResources(
+    relationship: LicensedResources.Relationship = LicensedResources.Resource)
+      extends AccessStatus {
     override val id: String = "licensed-resources"
     override val label: String = "Licensed resources"
   }

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessStatus.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessStatus.scala
@@ -1,6 +1,7 @@
 package weco.catalogue.internal_model.locations
 
 import enumeratum.{Enum, EnumEntry}
+import weco.catalogue.internal_model.locations.AccessStatus.LicensedResources
 
 class UnknownAccessStatus(status: String) extends Exception(status)
 
@@ -11,10 +12,19 @@ sealed trait AccessStatus extends EnumEntry { this: AccessStatus =>
   val label: String
 
   def isAvailable: Boolean = this match {
-    case AccessStatus.Open              => true
-    case AccessStatus.OpenWithAdvisory  => true
-    case AccessStatus.LicensedResources => true
-    case _                              => false
+    case AccessStatus.Open                                          => true
+    case AccessStatus.OpenWithAdvisory                              => true
+    case AccessStatus.LicensedResources(LicensedResources.Resource) => true
+
+    // This is used for cases where we have items that link to something
+    // related to the item (e.g. a description on a publisher website),
+    // but which isn't the same as the item itself.
+    //
+    // We still want these items on the work, we just don't want these items
+    // to match the "available online" filter.
+    case AccessStatus.LicensedResources(LicensedResources.RelatedResource) => false
+
+    case _ => false
   }
 
   def hasRestrictions: Boolean = this match {
@@ -75,7 +85,18 @@ object AccessStatus extends Enum[AccessStatus] {
     override val label: String = "Closed"
   }
 
-  case object LicensedResources extends AccessStatus {
+  object LicensedResources {
+    // This is based on MARC field 856 indicator 2
+    // See https://www.loc.gov/marc/bibliographic/bd856.html
+    //
+    // We don't expose this distinction in the public API, but we need it for
+    // the "available online" filter (see above).
+    sealed trait Relationship
+    case object Resource extends Relationship
+    case object RelatedResource extends Relationship
+  }
+
+  case class LicensedResources(relationship: LicensedResources.Relationship = LicensedResources.Resource) extends AccessStatus {
     override val id: String = "licensed-resources"
     override val label: String = "Licensed resources"
   }

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/AvailabilityTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/AvailabilityTest.scala
@@ -2,6 +2,7 @@ package weco.catalogue.internal_model.work
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+import weco.catalogue.internal_model.locations.AccessStatus.LicensedResources
 import weco.catalogue.internal_model.locations.{AccessStatus, LocationType}
 import weco.catalogue.internal_model.work.generators.{
   ItemsGenerators,
@@ -23,7 +24,7 @@ class AvailabilityTest
           createDigitalItemWith(accessStatus = AccessStatus.OpenWithAdvisory)))
       val licensedResourcesWork = denormalisedWork().items(
         List(
-          createDigitalItemWith(accessStatus = AccessStatus.LicensedResources)))
+          createDigitalItemWith(accessStatus = AccessStatus.LicensedResources())))
       val availabilities =
         List(openWork, openWithAdvisoryWork, licensedResourcesWork)
           .map(work => Availabilities.forWorkData(work.data))
@@ -37,6 +38,19 @@ class AvailabilityTest
       val workAvailabilities = Availabilities.forWorkData(work.data)
 
       workAvailabilities should contain only Availability.InLibrary
+    }
+
+    it("doesn't add Availability.Online if the only digital location is a related resource") {
+      val items =
+        List(
+          createDigitalItemWith(
+            accessStatus = AccessStatus.LicensedResources(LicensedResources.RelatedResource)
+          )
+        )
+
+      val work = denormalisedWork().items(items)
+
+      Availabilities.forWorkData(work.data) shouldBe empty
     }
 
     it("does not add Availability.InLibrary if the only location is OnOrder") {

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/AvailabilityTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/AvailabilityTest.scala
@@ -22,9 +22,8 @@ class AvailabilityTest
       val openWithAdvisoryWork = denormalisedWork().items(
         List(
           createDigitalItemWith(accessStatus = AccessStatus.OpenWithAdvisory)))
-      val licensedResourcesWork = denormalisedWork().items(
-        List(
-          createDigitalItemWith(accessStatus = AccessStatus.LicensedResources())))
+      val licensedResourcesWork = denormalisedWork().items(List(
+        createDigitalItemWith(accessStatus = AccessStatus.LicensedResources())))
       val availabilities =
         List(openWork, openWithAdvisoryWork, licensedResourcesWork)
           .map(work => Availabilities.forWorkData(work.data))
@@ -40,11 +39,13 @@ class AvailabilityTest
       workAvailabilities should contain only Availability.InLibrary
     }
 
-    it("doesn't add Availability.Online if the only digital location is a related resource") {
+    it(
+      "doesn't add Availability.Online if the only digital location is a related resource") {
       val items =
         List(
           createDigitalItemWith(
-            accessStatus = AccessStatus.LicensedResources(LicensedResources.RelatedResource)
+            accessStatus =
+              AccessStatus.LicensedResources(LicensedResources.RelatedResource)
           )
         )
 

--- a/pipeline/merger/src/test/scala/weco/pipeline/merger/rules/ItemsRuleTest.scala
+++ b/pipeline/merger/src/test/scala/weco/pipeline/merger/rules/ItemsRuleTest.scala
@@ -107,7 +107,7 @@ class ItemsRuleTest
           accessConditions = List(
             AccessCondition(
               method = AccessMethod.ViewOnline,
-              status = AccessStatus.LicensedResources
+              status = AccessStatus.LicensedResources()
             )
           )
         )

--- a/pipeline/merger/src/test/scala/weco/pipeline/merger/services/PlatformMergerTest.scala
+++ b/pipeline/merger/src/test/scala/weco/pipeline/merger/services/PlatformMergerTest.scala
@@ -836,7 +836,7 @@ class PlatformMergerTest
                   accessConditions = List(
                     AccessCondition(
                       method = AccessMethod.ViewOnline,
-                      status = AccessStatus.LicensedResources
+                      status = AccessStatus.LicensedResources()
                     )
                   )
                 )
@@ -910,7 +910,7 @@ class PlatformMergerTest
           accessConditions = List(
             AccessCondition(
               method = AccessMethod.ViewOnline,
-              status = AccessStatus.LicensedResources
+              status = AccessStatus.LicensedResources()
             )
           )
         )

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraElectronicResources.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraElectronicResources.scala
@@ -95,7 +95,7 @@ object SierraElectronicResources extends SierraQueryOps with Logging {
             accessConditions = List(
               AccessCondition(
                 method = AccessMethod.ViewOnline,
-                status = AccessStatus.LicensedResources)
+                status = AccessStatus.LicensedResources())
             )
           )
         )

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraElectronicResources.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraElectronicResources.scala
@@ -54,8 +54,12 @@ object SierraElectronicResources extends SierraQueryOps with Logging {
     // This allows us to include URLs that are related to the work, but not the
     // work itself (e.g. a description on a publisher website).
     val status = vf.indicator2 match {
-      case Some("2") => AccessStatus.LicensedResources(relationship = LicensedResources.RelatedResource)
-      case _         => AccessStatus.LicensedResources(relationship = LicensedResources.Resource)
+      case Some("2") =>
+        AccessStatus.LicensedResources(
+          relationship = LicensedResources.RelatedResource)
+      case _ =>
+        AccessStatus.LicensedResources(
+          relationship = LicensedResources.Resource)
     }
 
     getUrl(id, vf).map { url =>
@@ -110,9 +114,7 @@ object SierraElectronicResources extends SierraQueryOps with Logging {
             // See https://github.com/wellcomecollection/platform/issues/5062 for
             // more discussion and conversations about this.
             accessConditions = List(
-              AccessCondition(
-                method = AccessMethod.ViewOnline,
-                status = status)
+              AccessCondition(method = AccessMethod.ViewOnline, status = status)
             )
           )
         )

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraHoldings.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraHoldings.scala
@@ -3,7 +3,14 @@ package weco.pipeline.transformer.sierra.transformers
 import com.github.tototoshi.csv.CSVReader
 import weco.catalogue.internal_model.locations.AccessStatus.LicensedResources
 import weco.catalogue.internal_model.locations.LocationType.ClosedStores
-import weco.catalogue.internal_model.locations.{AccessCondition, AccessMethod, AccessStatus, DigitalLocation, LocationType, PhysicalLocation}
+import weco.catalogue.internal_model.locations.{
+  AccessCondition,
+  AccessMethod,
+  AccessStatus,
+  DigitalLocation,
+  LocationType,
+  PhysicalLocation
+}
 import weco.catalogue.internal_model.work.{Holdings, Item}
 import weco.catalogue.source_model.sierra.marc.FixedField
 import weco.catalogue.source_model.sierra.rules.SierraPhysicalLocationType
@@ -256,7 +263,8 @@ object SierraHoldings extends SierraQueryOps {
                       // relationship "Related resources" -- see SierraElectronicResources --
                       // but at time of writing (Aug 2021), there are no holdings records
                       // where this is the case.
-                      status = AccessStatus.LicensedResources(relationship = LicensedResources.Resource)
+                      status = AccessStatus.LicensedResources(
+                        relationship = LicensedResources.Resource)
                     )
                   )
                 )

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraHoldings.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraHoldings.scala
@@ -1,15 +1,9 @@
 package weco.pipeline.transformer.sierra.transformers
 
 import com.github.tototoshi.csv.CSVReader
+import weco.catalogue.internal_model.locations.AccessStatus.LicensedResources
 import weco.catalogue.internal_model.locations.LocationType.ClosedStores
-import weco.catalogue.internal_model.locations.{
-  AccessCondition,
-  AccessMethod,
-  AccessStatus,
-  DigitalLocation,
-  LocationType,
-  PhysicalLocation
-}
+import weco.catalogue.internal_model.locations.{AccessCondition, AccessMethod, AccessStatus, DigitalLocation, LocationType, PhysicalLocation}
 import weco.catalogue.internal_model.work.{Holdings, Item}
 import weco.catalogue.source_model.sierra.marc.FixedField
 import weco.catalogue.source_model.sierra.rules.SierraPhysicalLocationType
@@ -258,7 +252,12 @@ object SierraHoldings extends SierraQueryOps {
                   accessConditions = List(
                     AccessCondition(
                       method = AccessMethod.ViewOnline,
-                      status = AccessStatus.LicensedResources())
+                      // Note: it's theoretically possible for an 856 URL to have the
+                      // relationship "Related resources" -- see SierraElectronicResources --
+                      // but at time of writing (Aug 2021), there are no holdings records
+                      // where this is the case.
+                      status = AccessStatus.LicensedResources(relationship = LicensedResources.Resource)
+                    )
                   )
                 )
               )

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraHoldings.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraHoldings.scala
@@ -258,7 +258,7 @@ object SierraHoldings extends SierraQueryOps {
                   accessConditions = List(
                     AccessCondition(
                       method = AccessMethod.ViewOnline,
-                      status = AccessStatus.LicensedResources)
+                      status = AccessStatus.LicensedResources())
                   )
                 )
               )

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraElectronicResourcesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraElectronicResourcesTest.scala
@@ -38,7 +38,7 @@ class SierraElectronicResourcesTest
             accessConditions = List(
               AccessCondition(
                 method = AccessMethod.ViewOnline,
-                status = AccessStatus.LicensedResources)
+                status = AccessStatus.LicensedResources())
             )
           )
         )
@@ -74,7 +74,7 @@ class SierraElectronicResourcesTest
             accessConditions = List(
               AccessCondition(
                 method = AccessMethod.ViewOnline,
-                status = AccessStatus.LicensedResources)
+                status = AccessStatus.LicensedResources())
             )
           )
         )
@@ -88,7 +88,7 @@ class SierraElectronicResourcesTest
             accessConditions = List(
               AccessCondition(
                 method = AccessMethod.ViewOnline,
-                status = AccessStatus.LicensedResources)
+                status = AccessStatus.LicensedResources())
             )
           )
         )
@@ -123,7 +123,7 @@ class SierraElectronicResourcesTest
               accessConditions = List(
                 AccessCondition(
                   method = AccessMethod.ViewOnline,
-                  status = AccessStatus.LicensedResources)
+                  status = AccessStatus.LicensedResources())
               )
             )
           )
@@ -168,7 +168,7 @@ class SierraElectronicResourcesTest
               accessConditions = List(
                 AccessCondition(
                   method = AccessMethod.ViewOnline,
-                  status = AccessStatus.LicensedResources)
+                  status = AccessStatus.LicensedResources())
               )
             )
           )
@@ -183,7 +183,7 @@ class SierraElectronicResourcesTest
               accessConditions = List(
                 AccessCondition(
                   method = AccessMethod.ViewOnline,
-                  status = AccessStatus.LicensedResources)
+                  status = AccessStatus.LicensedResources())
               )
             )
           )
@@ -198,7 +198,7 @@ class SierraElectronicResourcesTest
               accessConditions = List(
                 AccessCondition(
                   method = AccessMethod.ViewOnline,
-                  status = AccessStatus.LicensedResources)
+                  status = AccessStatus.LicensedResources())
               )
             )
           )
@@ -228,7 +228,7 @@ class SierraElectronicResourcesTest
               accessConditions = List(
                 AccessCondition(
                   method = AccessMethod.ViewOnline,
-                  status = AccessStatus.LicensedResources)
+                  status = AccessStatus.LicensedResources())
               )
             )
           )
@@ -258,7 +258,7 @@ class SierraElectronicResourcesTest
               accessConditions = List(
                 AccessCondition(
                   method = AccessMethod.ViewOnline,
-                  status = AccessStatus.LicensedResources)
+                  status = AccessStatus.LicensedResources())
               )
             )
           )
@@ -288,7 +288,7 @@ class SierraElectronicResourcesTest
               accessConditions = List(
                 AccessCondition(
                   method = AccessMethod.ViewOnline,
-                  status = AccessStatus.LicensedResources)
+                  status = AccessStatus.LicensedResources())
               )
             )
           )
@@ -318,7 +318,7 @@ class SierraElectronicResourcesTest
               accessConditions = List(
                 AccessCondition(
                   method = AccessMethod.ViewOnline,
-                  status = AccessStatus.LicensedResources)
+                  status = AccessStatus.LicensedResources())
               )
             )
           )
@@ -350,7 +350,7 @@ class SierraElectronicResourcesTest
               accessConditions = List(
                 AccessCondition(
                   method = AccessMethod.ViewOnline,
-                  status = AccessStatus.LicensedResources)
+                  status = AccessStatus.LicensedResources())
               )
             )
           )

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraElectronicResourcesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraElectronicResourcesTest.scala
@@ -39,7 +39,8 @@ class SierraElectronicResourcesTest
             accessConditions = List(
               AccessCondition(
                 method = AccessMethod.ViewOnline,
-                status = AccessStatus.LicensedResources(relationship = LicensedResources.Resource))
+                status = AccessStatus.LicensedResources(
+                  relationship = LicensedResources.Resource))
             )
           )
         )
@@ -118,7 +119,8 @@ class SierraElectronicResourcesTest
             accessConditions = List(
               AccessCondition(
                 method = AccessMethod.ViewOnline,
-                status = AccessStatus.LicensedResources(relationship = LicensedResources.RelatedResource))
+                status = AccessStatus.LicensedResources(
+                  relationship = LicensedResources.RelatedResource))
             )
           )
         )

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraElectronicResourcesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraElectronicResourcesTest.scala
@@ -2,6 +2,7 @@ package weco.pipeline.transformer.sierra.transformers
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+import weco.catalogue.internal_model.locations.AccessStatus.LicensedResources
 import weco.catalogue.internal_model.locations.LocationType.OnlineResource
 import weco.catalogue.internal_model.locations.{
   AccessCondition,
@@ -38,7 +39,7 @@ class SierraElectronicResourcesTest
             accessConditions = List(
               AccessCondition(
                 method = AccessMethod.ViewOnline,
-                status = AccessStatus.LicensedResources())
+                status = AccessStatus.LicensedResources(relationship = LicensedResources.Resource))
             )
           )
         )
@@ -89,6 +90,35 @@ class SierraElectronicResourcesTest
               AccessCondition(
                 method = AccessMethod.ViewOnline,
                 status = AccessStatus.LicensedResources())
+            )
+          )
+        )
+      )
+    )
+  }
+
+  it("marks the item as a related resource if 856 ind2 = 2") {
+    val varFields = List(
+      createVarFieldWith(
+        marcTag = "856",
+        indicator2 = "2",
+        subfields = List(
+          MarcSubfield(tag = "u", content = "https://example.org/journal")
+        )
+      )
+    )
+
+    getElectronicResources(varFields) shouldBe List(
+      Item(
+        title = None,
+        locations = List(
+          DigitalLocation(
+            url = "https://example.org/journal",
+            locationType = OnlineResource,
+            accessConditions = List(
+              AccessCondition(
+                method = AccessMethod.ViewOnline,
+                status = AccessStatus.LicensedResources(relationship = LicensedResources.RelatedResource))
             )
           )
         )

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraHoldingsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraHoldingsTest.scala
@@ -111,7 +111,7 @@ class SierraHoldingsTest
               accessConditions = List(
                 AccessCondition(
                   method = AccessMethod.ViewOnline,
-                  status = AccessStatus.LicensedResources)
+                  status = AccessStatus.LicensedResources())
               )
             )
           )
@@ -159,7 +159,7 @@ class SierraHoldingsTest
               accessConditions = List(
                 AccessCondition(
                   method = AccessMethod.ViewOnline,
-                  status = AccessStatus.LicensedResources)
+                  status = AccessStatus.LicensedResources())
               )
             )
           ),
@@ -174,7 +174,7 @@ class SierraHoldingsTest
               accessConditions = List(
                 AccessCondition(
                   method = AccessMethod.ViewOnline,
-                  status = AccessStatus.LicensedResources)
+                  status = AccessStatus.LicensedResources())
               )
             )
           ),
@@ -228,7 +228,7 @@ class SierraHoldingsTest
               accessConditions = List(
                 AccessCondition(
                   method = AccessMethod.ViewOnline,
-                  status = AccessStatus.LicensedResources)
+                  status = AccessStatus.LicensedResources())
               )
             )
           ),
@@ -243,7 +243,7 @@ class SierraHoldingsTest
               accessConditions = List(
                 AccessCondition(
                   method = AccessMethod.ViewOnline,
-                  status = AccessStatus.LicensedResources)
+                  status = AccessStatus.LicensedResources())
               )
             )
           ),
@@ -348,7 +348,7 @@ class SierraHoldingsTest
               accessConditions = List(
                 AccessCondition(
                   method = AccessMethod.ViewOnline,
-                  status = AccessStatus.LicensedResources)
+                  status = AccessStatus.LicensedResources())
               )
             )
           )

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraTransformerTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraTransformerTest.scala
@@ -1023,7 +1023,7 @@ class SierraTransformerTest
             accessConditions = List(
               AccessCondition(
                 method = AccessMethod.ViewOnline,
-                status = AccessStatus.LicensedResources)
+                status = AccessStatus.LicensedResources())
             )
           )
         )


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5250

This means links like "description on publisher website" won't cause the work to appear in the "available online" filter. If the work has another item with a digitised location which *is* the work in question, we'll still add the filter.

Note: this is a breaking internal model change. I'll likely do a reindex once this is merged.