### PR TITLE
Further tweaks to the item access data

### DIFF
--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -356,7 +356,7 @@ object SierraItemAccess extends SierraQueryOps with Logging {
         AccessCondition(
           method = AccessMethod.NotRequestable,
           note = Some(
-            s"""Please check this item <a href="https://search.wellcomelibrary.org/iii/encore/record/C__Rb${bibId.withoutCheckDigit}?lang=eng">on the Wellcome Library website</a> for access information""")
+            s"""This item cannot be requested online. Please contact <a href="mailto:library@wellcomecollection.org">library@wellcomecollection.org</a> for more information.""")
         )
     }
   }

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -316,8 +316,8 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           _,
           _,
           rulesForRequestingResult,
-          Some(LocationType.ClosedStores)) if isOnHold(holdCount, rulesForRequestingResult) =>
-
+          Some(LocationType.ClosedStores))
+          if isOnHold(holdCount, rulesForRequestingResult) =>
         val originalAccessCondition =
           createAccessCondition(
             bibId = bibId,
@@ -325,7 +325,11 @@ object SierraItemAccess extends SierraQueryOps with Logging {
             location = location,
             itemData = itemData.copy(
               holdCount = Some(0),
-              fixedFields = itemData.fixedFields ++ Map("88" -> FixedField(label = "STATUS", value = "-", display = "Available"))
+              fixedFields = itemData.fixedFields ++ Map(
+                "88" -> FixedField(
+                  label = "STATUS",
+                  value = "-",
+                  display = "Available"))
             )
           )
 
@@ -366,7 +370,9 @@ object SierraItemAccess extends SierraQueryOps with Logging {
   //  2. A staff member collects the item from the store, and places it on the holdshelf
   //     Then the status becomes "!" (On holdshelf)  This is reflected in the rules for requesting.
   //
-  private def isOnHold(holdCount: Option[Int], rulesForRequestingResult: RulesForRequestingResult): Boolean =
+  private def isOnHold(
+    holdCount: Option[Int],
+    rulesForRequestingResult: RulesForRequestingResult): Boolean =
     (holdCount, rulesForRequestingResult) match {
       case (Some(holdCount), _) if holdCount > 0 => true
       case (_, NotRequestable.OnHold(_))         => true

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -10,6 +10,7 @@ import weco.catalogue.internal_model.locations.{
 }
 import weco.catalogue.source_model.sierra.SierraItemData
 import weco.catalogue.source_model.sierra.identifiers.SierraBibNumber
+import weco.catalogue.source_model.sierra.marc.FixedField
 import weco.catalogue.source_model.sierra.source.{
   OpacMsg,
   SierraQueryOps,
@@ -303,35 +304,32 @@ object SierraItemAccess extends SierraQueryOps with Logging {
       // If an item is on hold for another reader, it can't be requested -- even
       // if it would ordinarily be requestable.
       //
-      // Note that an item on hold goes through two stages:
-      //  1. A reader places a hold, but the item is still in the store.
-      //     The status is still "-" (Available)
-      //  2. A staff member collects the item from the store, and places it on the holdshelf
-      //     Then the status becomes "!" (On holdshelf)
+      // We try to work out what the access condition would have been before the item
+      // was on hold -- this allows us to preserve the original access method.
+      //
+      // e.g. if an item is usually an "online request" but is temporarily on hold for
+      // somebody else, we can show that it's an online request at other times.
       //
       case (
           None,
-          Some(holdCount),
+          holdCount,
           _,
           _,
-          Requestable,
-          Some(LocationType.ClosedStores)) if holdCount > 0 =>
-        AccessCondition(
-          method = AccessMethod.ManualRequest,
-          status = Some(AccessStatus.TemporarilyUnavailable),
-          note = Some(
-            "Item is in use by another reader. Please ask at Enquiry Desk.")
-        )
+          rulesForRequestingResult,
+          Some(LocationType.ClosedStores)) if isOnHold(holdCount, rulesForRequestingResult) =>
 
-      case (
-          None,
-          _,
-          _,
-          _,
-          NotRequestable.OnHold(_),
-          Some(LocationType.ClosedStores)) =>
-        AccessCondition(
-          method = AccessMethod.ManualRequest,
+        val originalAccessCondition =
+          createAccessCondition(
+            bibId = bibId,
+            bibStatus = bibStatus,
+            location = location,
+            itemData = itemData.copy(
+              holdCount = Some(0),
+              fixedFields = itemData.fixedFields ++ Map("88" -> FixedField(label = "STATUS", value = "-", display = "Available"))
+            )
+          )
+
+        originalAccessCondition.copy(
           status = Some(AccessStatus.TemporarilyUnavailable),
           note = Some(
             "Item is in use by another reader. Please ask at Enquiry Desk.")
@@ -360,6 +358,20 @@ object SierraItemAccess extends SierraQueryOps with Logging {
         )
     }
   }
+
+  // Note that an item on hold goes through two stages:
+  //
+  //  1. A reader places a hold, but the item is still in the store.
+  //     The status is still "-" (Available)
+  //  2. A staff member collects the item from the store, and places it on the holdshelf
+  //     Then the status becomes "!" (On holdshelf)  This is reflected in the rules for requesting.
+  //
+  private def isOnHold(holdCount: Option[Int], rulesForRequestingResult: RulesForRequestingResult): Boolean =
+    (holdCount, rulesForRequestingResult) match {
+      case (Some(holdCount), _) if holdCount > 0 => true
+      case (_, NotRequestable.OnHold(_))         => true
+      case _                                     => false
+    }
 
   implicit class ItemDataAccessOps(itemData: SierraItemData) {
     def status: Option[String] =

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -936,7 +936,7 @@ class SierraItemAccessTest
     ac shouldBe AccessCondition(
       method = AccessMethod.NotRequestable,
       note = Some(
-        s"""Please check this item <a href="https://search.wellcomelibrary.org/iii/encore/record/C__Rb${bibId.withoutCheckDigit}?lang=eng">on the Wellcome Library website</a> for access information""")
+        s"""This item cannot be requested online. Please contact <a href="mailto:library@wellcomecollection.org">library@wellcomecollection.org</a> for more information.""")
     )
   }
 

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -609,6 +609,44 @@ class SierraItemAccessTest
 
         ac shouldBe
           AccessCondition(
+            method = AccessMethod.OnlineRequest,
+            status = Some(AccessStatus.TemporarilyUnavailable),
+            note = Some(
+              "Item is in use by another reader. Please ask at Enquiry Desk.")
+          )
+      }
+
+      it("can't be requested when a manual request item is on hold for somebody else") {
+        val itemData = createSierraItemDataWith(
+          holdCount = Some(1),
+          fixedFields = Map(
+            "61" -> FixedField(
+              label = "I TYPE",
+              value = "4",
+              display = "serial"),
+            "79" -> FixedField(
+              label = "LOCATION",
+              value = "sgser",
+              display = "Closed stores journals"),
+            "88" -> FixedField(
+              label = "STATUS",
+              value = "-",
+              display = "Available"),
+            "108" -> FixedField(
+              label = "OPACMSG",
+              value = "n",
+              display = "Manual request"),
+          )
+        )
+
+        val (ac, _) = getItemAccess(
+          bibStatus = None,
+          location = Some(LocationType.ClosedStores),
+          itemData = itemData
+        )
+
+        ac shouldBe
+          AccessCondition(
             method = AccessMethod.ManualRequest,
             status = Some(AccessStatus.TemporarilyUnavailable),
             note = Some(
@@ -643,7 +681,7 @@ class SierraItemAccessTest
 
         ac shouldBe
           AccessCondition(
-            method = AccessMethod.ManualRequest,
+            method = AccessMethod.OnlineRequest,
             status = Some(AccessStatus.TemporarilyUnavailable),
             note = Some(
               "Item is in use by another reader. Please ask at Enquiry Desk.")

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraLocationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraLocationTest.scala
@@ -246,7 +246,7 @@ class SierraLocationTest
         AccessCondition(
           method = AccessMethod.NotRequestable,
           note = Some(
-            s"""Please check this item <a href="https://search.wellcomelibrary.org/iii/encore/record/C__Rb${bibId.withoutCheckDigit}?lang=eng">on the Wellcome Library website</a> for access information""")
+            s"""This item cannot be requested online. Please contact <a href="mailto:library@wellcomecollection.org">library@wellcomecollection.org</a> for more information.""")
         )
       )
     }


### PR DESCRIPTION
* If we can't map the item access, direct users to email us rather than linking them to wl.org. Closes https://github.com/wellcomecollection/platform/issues/5253. See https://wellcome.slack.com/archives/CUA669WHH/p1628248775037400?thread_ts=1628167556.018300&cid=CUA669WHH
* If the item is on hold, keep the original access method – don't map it to ManualRequest. See https://wellcome.slack.com/archives/C8X9YKM5X/p1628499354037400