### PR TITLE
Add the 2021-08-09 pipeline

### DIFF
--- a/.wellcome_project
+++ b/.wellcome_project
@@ -85,12 +85,10 @@ catalogue_pipeline:
       name: Production
     - id: stage
       name: Staging
-    - id: "2021-07-06"
-      name: "2021-07-06"
-    - id: "2021-07-13"
-      name: "2021-07-13"
     - id: "2021-07-19"
       name: "2021-07-19"
+    - id: "2021-08-09"
+      name: "2021-08-09"
   image_repositories:
     - id: id_minter
       services:

--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -86,3 +86,93 @@ module "catalogue_pipeline_2021-07-19" {
 
   logging_cluster_id = local.logging_cluster_id
 }
+
+module "catalogue_pipeline_2021-08-09" {
+  source = "./stack"
+
+  pipeline_date = "2021-08-09"
+  release_label = "2021-08-09"
+
+  is_reindexing = true
+
+  # Boilerplate that shouldn't change between pipelines.
+
+  adapters = {
+    sierra = {
+      topics = [
+        local.sierra_merged_bibs_topic_arn,
+        local.sierra_merged_items_topic_arn,
+        local.sierra_merged_holdings_topic_arn,
+      ]
+      reindex_topic = local.sierra_reindexer_topic_arn
+    }
+
+    miro = {
+      topics = [
+        local.miro_updates_topic_arn,
+      ]
+      reindex_topic = local.miro_reindexer_topic_arn,
+    }
+
+    mets = {
+      topics = [
+        local.mets_adapter_topic_arn,
+      ],
+      reindex_topic = local.mets_reindexer_topic_arn,
+    }
+
+    calm = {
+      topics = [
+        local.calm_adapter_topic_arn,
+        local.calm_deletions_topic_arn,
+      ],
+      reindex_topic = local.calm_reindexer_topic_arn,
+    }
+    // we want to keep tei out of the prod pipeline for now,
+    // while me make sure that the data is good enough to present
+    // and while we extend the transformer to extract more of it.
+    tei = {
+      topics = [
+        //local.tei_adapter_topic_arn,
+      ],
+      reindex_topic = null //local.tei_reindexer_topic_arn,
+    }
+  }
+
+  vpc_id  = local.vpc_id
+  subnets = local.private_subnets
+
+  dlq_alarm_arn = local.dlq_alarm_arn
+
+  rds_cluster_id        = local.rds_cluster_id
+  rds_subnet_group_name = local.rds_subnet_group_name
+
+  # Security groups
+  rds_ids_access_security_group_id = local.rds_access_security_group_id
+  ec_privatelink_security_group_id = local.ec_platform_privatelink_security_group_id
+
+  traffic_filter_platform_vpce_id   = local.traffic_filter_platform_vpce_id
+  traffic_filter_catalogue_vpce_id  = local.traffic_filter_catalogue_vpce_id
+  traffic_filter_public_internet_id = local.traffic_filter_public_internet_id
+
+  # Adapter VHS
+  vhs_miro_read_policy   = local.vhs_miro_read_policy
+  vhs_sierra_read_policy = local.vhs_sierra_read_policy
+  vhs_calm_read_policy   = local.vhs_calm_read_policy
+
+  # Inferrer data
+  inferrer_model_data_bucket_name = aws_s3_bucket.inferrer_model_core_data.id
+
+  tei_adapter_bucket_name = local.tei_adapter_bucket_name
+
+  shared_logging_secrets = data.terraform_remote_state.shared_infra.outputs.shared_secrets_logging
+
+  storage_bucket_name = local.storage_bucket
+
+  providers = {
+    aws.catalogue = aws.catalogue
+  }
+
+  logging_cluster_id = local.logging_cluster_id
+}
+

--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -128,14 +128,18 @@ module "catalogue_pipeline_2021-08-09" {
       ],
       reindex_topic = local.calm_reindexer_topic_arn,
     }
-    // we want to keep tei out of the prod pipeline for now,
-    // while me make sure that the data is good enough to present
-    // and while we extend the transformer to extract more of it.
+    # we want to keep tei out of the prod pipeline for now,
+    # while me make sure that the data is good enough to present
+    # and while we extend the transformer to extract more of it.
+    #
+    # Note: we have to supply a real topic ARN here, not just 'null',
+    # or the module gets confused.  For now we just create a dummy topic
+    # that will never receive messages.
     tei = {
       topics = [
-        //local.tei_adapter_topic_arn,
+        # local.tei_adapter_topic_arn,
       ],
-      reindex_topic = null //local.tei_reindexer_topic_arn,
+      reindex_topic = aws_sns_topic.tei_transformer_donotuse.arn,  # local.tei_reindexer_topic_arn,
     }
   }
 
@@ -176,3 +180,8 @@ module "catalogue_pipeline_2021-08-09" {
   logging_cluster_id = local.logging_cluster_id
 }
 
+# This topic isn't meant to be used -- it's just so we have an empty topic
+# for the arguments in the "stack" module (see above).
+resource "aws_sns_topic" "tei_transformer_donotuse" {
+  name = "tei_transformer_donotuse"
+}

--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -139,7 +139,7 @@ module "catalogue_pipeline_2021-08-09" {
       topics = [
         # local.tei_adapter_topic_arn,
       ],
-      reindex_topic = aws_sns_topic.tei_transformer_donotuse.arn,  # local.tei_reindexer_topic_arn,
+      reindex_topic = aws_sns_topic.tei_transformer_donotuse.arn, # local.tei_reindexer_topic_arn,
     }
   }
 

--- a/pipeline/terraform/stack/elastic_pipeline.tf
+++ b/pipeline/terraform/stack/elastic_pipeline.tf
@@ -5,11 +5,16 @@ locals {
   es_memory = var.is_reindexing ? "58g" : "15g"
 }
 
+data "ec_stack" "latest" {
+  version_regex = "latest"
+  region        = "eu-west-1"
+}
+
 resource "ec_deployment" "pipeline" {
   name = "pipeline-${var.pipeline_date}"
 
   region                 = "eu-west-1"
-  version                = "7.12.1"
+  version                = data.ec_stack.latest.version
   deployment_template_id = "aws-io-optimized-v2"
 
   traffic_filter = [

--- a/pipeline/terraform/stack/provider.tf
+++ b/pipeline/terraform/stack/provider.tf
@@ -1,15 +1,14 @@
-# Although we've declared the provider at the top level, we need to redeclare it in
-# the module. Otherwise, Terraform defaults to "hashicorp/{provider}"
-# See https://github.com/hashicorp/terraform/issues/25172#issuecomment-641284286
 terraform {
   required_providers {
+    aws = {
+      source = "hashicorp/aws"
+
+      configuration_aliases = [aws.catalogue]
+    }
+
     ec = {
       source  = "elastic/ec"
       version = "0.2.1"
     }
   }
-}
-
-provider "aws" {
-  alias = "catalogue"
 }


### PR DESCRIPTION
This brings in the following data changes:

* Fix encoding issues in the Calm data (#1777)
* About 560k Sierra records will be skipped entirely, because they were deleted/suppressed pre-catalogue and so have never had a public URL on wc.org/works (#1780)
* Fixed multi-line physical description on Sierra records (#1784)
* Open ranges on production dates; no more "1729–1999" (#1794)
* Digital items won't be marked as available online if 856 indicator 2 is 2 (#1795)
* More items will have fully mapped access data, and no more linking out to wellcomelibrary.org if we can't map the access data (#1797, #1799)
