### PR TITLE
Don't log a warning if there's no access information

### DIFF
--- a/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/transformers/CalmTermsOfUse.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/transformers/CalmTermsOfUse.scala
@@ -79,8 +79,9 @@ object CalmTermsOfUse extends CalmRecordOps with Logging {
           if conditions.toLowerCase.contains("permission") & conditions.hasRestrictions =>
           Some(s"$conditions Restricted until ${restrictedUntil.format(displayFormat)}.")
 
-        // If the item only has an access status, there's nothing useful to put in the access terms.
-        case (None, Some(accessStatus), None, None) =>
+        // If the item only has an access status or there's no information at all, there's
+        // nothing useful to put in the access terms.
+        case (None, _, None, None) =>
           None
 
         // Otherwise, we create a TermsOfUse note that smushes together all the bits of

--- a/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/transformers/CalmTermsOfUseTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/transformers/CalmTermsOfUseTest.scala
@@ -117,6 +117,12 @@ class CalmTermsOfUseTest
     CalmTermsOfUse(record) shouldBe empty
   }
 
+  it("doesn't create a note for an item with no access information") {
+    val record = createCalmRecord
+
+    CalmTermsOfUse(record) shouldBe empty
+  }
+
   it("creates a note for an item with permission + restrictions") {
     val record = createCalmRecordWith(
       (


### PR DESCRIPTION
CalmTermsOfUse will log a warning if it doesn't know how to map the access information to create a TermsOfUse note.  If there aren't any access-related fields populated on the record, it logs this warning, which is unhelpful.  Don't do that!

It doesn't affect the data at all, just creates noise in the logs.