### PR TITLE
Don't allow an infinite loop in the Sierra transformer

### DIFF
--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -322,7 +322,6 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           rulesForRequestingResult,
           Some(LocationType.ClosedStores))
           if isOnHold(holdCount, rulesForRequestingResult) =>
-
         val inferredItemData = itemData.copy(
           holdCount = Some(0),
           fixedFields = itemData.fixedFields ++ Map(
@@ -333,7 +332,8 @@ object SierraItemAccess extends SierraQueryOps with Logging {
               display = "Available"))
         )
 
-        val rulesForRequestingResult = SierraRulesForRequesting(inferredItemData)
+        val rulesForRequestingResult = SierraRulesForRequesting(
+          inferredItemData)
 
         // Make sure we only recurse here once, not infinitely many times.
         assert(!rulesForRequestingResult.isInstanceOf[NotRequestable.OnHold])

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -616,6 +616,41 @@ class SierraItemAccessTest
           )
       }
 
+      it("can't be requested when an item is on hold for a loan rule") {
+        val itemData = createSierraItemDataWith(
+          holdCount = Some(1),
+          fixedFields = Map(
+            "79" -> FixedField(
+              label = "LOCATION",
+              value = "sgeph",
+              display = "Closed stores ephemera"),
+            "87" -> FixedField(label = "LOANRULE", value = "5"),
+            "88" -> FixedField(
+              label = "STATUS",
+              value = "-",
+              display = "Available"),
+            "108" -> FixedField(
+              label = "OPACMSG",
+              value = "f",
+              display = "Online request"),
+          )
+        )
+
+        val (ac, _) = getItemAccess(
+          bibStatus = None,
+          location = Some(LocationType.ClosedStores),
+          itemData = itemData
+        )
+
+        ac shouldBe
+          AccessCondition(
+            method = AccessMethod.OnlineRequest,
+            status = Some(AccessStatus.TemporarilyUnavailable),
+            note = Some(
+              "Item is in use by another reader. Please ask at Enquiry Desk.")
+          )
+      }
+
       it("can't be requested when a manual request item is on hold for somebody else") {
         val itemData = createSierraItemDataWith(
           holdCount = Some(1),


### PR DESCRIPTION
Oops.

In the Sierra transformer, when we try to look up the correct access method for an item that's currently on hold, it was possible to enter an infinite loop that would blow up the transformer. This is bad. This patch makes us not do that.

I could do a more extensive refactor to make this more impossible, but for now I wanted to get something that works.