### PR TITLE
Use DynamoDB autoscaling when we're reindexing in a pipeline

### DIFF
--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -93,7 +93,7 @@ module "catalogue_pipeline_2021-08-09" {
   pipeline_date = "2021-08-09"
   release_label = "2021-08-09"
 
-  is_reindexing = true
+  is_reindexing = false
 
   # Boilerplate that shouldn't change between pipelines.
 

--- a/pipeline/terraform/modules/dynamodb_autoscaling/main.tf
+++ b/pipeline/terraform/modules/dynamodb_autoscaling/main.tf
@@ -27,7 +27,7 @@ resource "aws_appautoscaling_policy" "dynamodb_table_read_policy" {
   service_namespace  = aws_appautoscaling_target.read.service_namespace
 
   target_tracking_scaling_policy_configuration {
-    target_value       = 70
+    target_value = 70
 
     predefined_metric_specification {
       predefined_metric_type = "DynamoDBReadCapacityUtilization"
@@ -60,7 +60,7 @@ resource "aws_appautoscaling_policy" "dynamodb_table_write_policy" {
   service_namespace  = aws_appautoscaling_target.write.service_namespace
 
   target_tracking_scaling_policy_configuration {
-    target_value       = 70
+    target_value = 70
 
     predefined_metric_specification {
       predefined_metric_type = "DynamoDBWriteCapacityUtilization"

--- a/pipeline/terraform/modules/dynamodb_autoscaling/main.tf
+++ b/pipeline/terraform/modules/dynamodb_autoscaling/main.tf
@@ -1,0 +1,69 @@
+variable "table_name" {
+  type = string
+}
+
+variable "min_read_capacity" {
+  type    = number
+  default = 1
+}
+
+variable "max_read_capacity" {
+  type = number
+}
+
+resource "aws_appautoscaling_target" "read" {
+  max_capacity       = var.max_read_capacity
+  min_capacity       = var.min_read_capacity
+  resource_id        = "table/${var.table_name}"
+  scalable_dimension = "dynamodb:table:ReadCapacityUnits"
+  service_namespace  = "dynamodb"
+}
+
+resource "aws_appautoscaling_policy" "dynamodb_table_read_policy" {
+  name               = "DynamoDBReadCapacityUtilization:${aws_appautoscaling_target.read.resource_id}"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.read.resource_id
+  scalable_dimension = aws_appautoscaling_target.read.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.read.service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    target_value       = 70
+
+    predefined_metric_specification {
+      predefined_metric_type = "DynamoDBReadCapacityUtilization"
+    }
+  }
+}
+
+variable "min_write_capacity" {
+  type    = number
+  default = 1
+}
+
+variable "max_write_capacity" {
+  type = number
+}
+
+resource "aws_appautoscaling_target" "write" {
+  max_capacity       = var.max_write_capacity
+  min_capacity       = var.min_write_capacity
+  resource_id        = "table/${var.table_name}"
+  scalable_dimension = "dynamodb:table:WriteCapacityUnits"
+  service_namespace  = "dynamodb"
+}
+
+resource "aws_appautoscaling_policy" "dynamodb_table_write_policy" {
+  name               = "DynamoDBWriteCapacityUtilization:${aws_appautoscaling_target.write.resource_id}"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.write.resource_id
+  scalable_dimension = aws_appautoscaling_target.write.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.write.service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    target_value       = 70
+
+    predefined_metric_specification {
+      predefined_metric_type = "DynamoDBWriteCapacityUtilization"
+    }
+  }
+}

--- a/pipeline/terraform/stack/dynamo.tf
+++ b/pipeline/terraform/stack/dynamo.tf
@@ -13,17 +13,34 @@
 # https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/switching.capacitymode.html
 
 locals {
-  # These numbers were chosen by running a reindex and seeing when the
-  # matcher started throttling.
-  graph_table_billing_mode   = var.is_reindexing ? "PROVISIONED" : "PAY_PER_REQUEST"
-  graph_table_write_capacity = var.is_reindexing ? 1000 : null
-  graph_table_read_capacity  = var.is_reindexing ? 600 : null
+  graph_table_billing_mode = var.is_reindexing ? "PROVISIONED" : "PAY_PER_REQUEST"
+  lock_table_billing_mode  = var.is_reindexing ? "PROVISIONED" : "PAY_PER_REQUEST"
+}
 
-  # These numbers were chosen by running a reindex and seeing when the
-  # matcher started throttling.
-  lock_table_billing_mode   = var.is_reindexing ? "PROVISIONED" : "PAY_PER_REQUEST"
-  lock_table_write_capacity = var.is_reindexing ? 2000 : null
-  lock_table_read_capacity  = var.is_reindexing ? 1500 : null
+# These numbers were chosen by running a reindex and seeing when the
+# matcher started throttling.
+module "matcher_graph_table_autoscaling" {
+  source = "../modules/dynamodb_autoscaling"
+
+  count = var.is_reindexing ? 1 : 0
+
+  table_name = aws_dynamodb_table.matcher_graph_table.name
+
+  max_read_capacity  = 600
+  max_write_capacity = 1000
+}
+
+# These numbers were chosen by running a reindex and seeing when the
+# matcher started throttling.
+module "lock_table_autoscaling" {
+  source = "../modules/dynamodb_autoscaling"
+
+  count = var.is_reindexing ? 1 : 0
+
+  table_name = aws_dynamodb_table.matcher_lock_table.name
+
+  max_read_capacity  = 1500
+  max_write_capacity = 2000
 }
 
 # Graph table
@@ -46,20 +63,23 @@ resource "aws_dynamodb_table" "matcher_graph_table" {
   }
 
   billing_mode   = local.graph_table_billing_mode
-  write_capacity = local.graph_table_write_capacity
-  read_capacity  = local.graph_table_read_capacity
 
   global_secondary_index {
     name            = "work-sets-index"
     hash_key        = "componentId"
     projection_type = "ALL"
-
-    write_capacity = local.graph_table_write_capacity
-    read_capacity  = local.graph_table_read_capacity
   }
 
   tags = {
     Name = local.graph_table_name
+  }
+
+  lifecycle {
+    ignore_changes = [
+      global_secondary_index,
+      read_capacity,
+      write_capacity
+    ]
   }
 }
 
@@ -100,8 +120,6 @@ resource "aws_dynamodb_table" "matcher_lock_table" {
   hash_key = "id"
 
   billing_mode   = local.lock_table_billing_mode
-  write_capacity = local.lock_table_write_capacity
-  read_capacity  = local.lock_table_read_capacity
 
   attribute {
     name = "id"
@@ -117,9 +135,6 @@ resource "aws_dynamodb_table" "matcher_lock_table" {
     name            = "context-ids-index"
     hash_key        = "contextId"
     projection_type = "ALL"
-
-    write_capacity = local.lock_table_write_capacity
-    read_capacity  = local.lock_table_read_capacity
   }
 
   ttl {
@@ -129,6 +144,14 @@ resource "aws_dynamodb_table" "matcher_lock_table" {
 
   tags = {
     Name = local.lock_table_name
+  }
+
+  lifecycle {
+    ignore_changes = [
+      global_secondary_index,
+      read_capacity,
+      write_capacity
+    ]
   }
 }
 

--- a/pipeline/terraform/stack/dynamo.tf
+++ b/pipeline/terraform/stack/dynamo.tf
@@ -62,7 +62,7 @@ resource "aws_dynamodb_table" "matcher_graph_table" {
     type = "S"
   }
 
-  billing_mode   = local.graph_table_billing_mode
+  billing_mode = local.graph_table_billing_mode
 
   global_secondary_index {
     name            = "work-sets-index"
@@ -119,7 +119,7 @@ resource "aws_dynamodb_table" "matcher_lock_table" {
   name     = local.lock_table_name
   hash_key = "id"
 
-  billing_mode   = local.lock_table_billing_mode
+  billing_mode = local.lock_table_billing_mode
 
   attribute {
     name = "id"


### PR DESCRIPTION
So we'll get a big pile of provisioned capacity when everything goes through the matcher, but when we're waiting for the ingestor it'll scale away. 💸 💸 💸 