### PR TITLE
Tweak the item access data again

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessMethod.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessMethod.scala
@@ -13,6 +13,8 @@ object AccessMethod extends Enum[License] {
     "IDs for AccessMethod are not unique!"
   )
 
+  // This is kept for compatibility with the 2021-08-09 index, but is no longer
+  // set anywhere.  We should remove it after the next reindex.
   case object OpenShelves extends AccessMethod
 
   case object ViewOnline extends AccessMethod

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -314,13 +314,8 @@ object SierraItemAccess extends SierraQueryOps with Logging {
       // It is possible for an item to have a non-zero hold count but still be available
       // for requesting, e.g. some of our long-lived test holds didn't get cleared properly.
       // If an item seems to be stuck on a non-zero hold count, ask somebody to check Sierra.
-      case (
-          None,
-          Some(holdCount),
-          _,
-          _,
-          _,
-          Some(LocationType.ClosedStores)) if holdCount > 0 =>
+      case (None, Some(holdCount), _, _, _, Some(LocationType.ClosedStores))
+          if holdCount > 0 =>
         AccessCondition(
           method = AccessMethod.NotRequestable,
           status = Some(AccessStatus.TemporarilyUnavailable),
@@ -329,12 +324,12 @@ object SierraItemAccess extends SierraQueryOps with Logging {
         )
 
       case (
-        None,
-        _,
-        _,
-        _,
-        NotRequestable.OnHold(_),
-        Some(LocationType.ClosedStores)) =>
+          None,
+          _,
+          _,
+          _,
+          NotRequestable.OnHold(_),
+          Some(LocationType.ClosedStores)) =>
         AccessCondition(
           method = AccessMethod.NotRequestable,
           status = Some(AccessStatus.TemporarilyUnavailable),

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -12,7 +12,6 @@ import weco.catalogue.source_model.sierra.source.{OpacMsg, Status}
 import weco.sierra.models.SierraQueryOps
 import weco.sierra.models.data.SierraItemData
 import weco.sierra.models.identifiers.SierraBibNumber
-import weco.sierra.models.marc.FixedField
 
 /** There are multiple sources of truth for item information in Sierra, and whether
   * a given item can be requested online.
@@ -94,7 +93,7 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           if bibStatus.isEmpty || bibStatus.contains(AccessStatus.Open) =>
         AccessCondition(
           method = AccessMethod.OnlineRequest,
-          status = bibStatus
+          status = AccessStatus.Open
         )
 
       // Note: it is possible for individual items within a restricted bib to be available
@@ -145,7 +144,7 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           Some(OpacMsg.OpenShelves),
           NotRequestable.OnOpenShelves(_),
           Some(LocationType.OpenShelves)) =>
-        AccessCondition(method = AccessMethod.OpenShelves)
+        AccessCondition(method = AccessMethod.NotRequestable)
 
       // There are some items that are labelled "bound in above" or "contained in above".
       //
@@ -305,50 +304,39 @@ object SierraItemAccess extends SierraQueryOps with Logging {
       // If an item is on hold for another reader, it can't be requested -- even
       // if it would ordinarily be requestable.
       //
-      // We try to work out what the access condition would have been before the item
-      // was on hold -- this allows us to preserve the original access method.
+      // Note that an item on hold goes through two stages:
       //
-      // e.g. if an item is usually an "online request" but is temporarily on hold for
-      // somebody else, we can show that it's an online request at other times.
+      //  1. A reader places a hold, but the item is still in the store.
+      //     The status is still "-" (Available)
+      //  2. A staff member collects the item from the store, and places it on the holdshelf
+      //     Then the status becomes "!" (On holdshelf)  This is reflected in the rules for requesting.
       //
+      // It is possible for an item to have a non-zero hold count but still be available
+      // for requesting, e.g. some of our long-lived test holds didn't get cleared properly.
+      // If an item seems to be stuck on a non-zero hold count, ask somebody to check Sierra.
       case (
           None,
-          holdCount,
+          Some(holdCount),
           _,
           _,
-          rulesForRequestingResult,
-          Some(LocationType.ClosedStores))
-          if isOnHold(holdCount, rulesForRequestingResult) =>
-        val inferredItemData = itemData.copy(
-          holdCount = Some(0),
-          fixedFields = itemData.fixedFields ++ Map(
-            "87" -> FixedField(label = "LOANRULE", value = "0"),
-            "88" -> FixedField(
-              label = "STATUS",
-              value = "-",
-              display = "Available"))
+          _,
+          Some(LocationType.ClosedStores)) if holdCount > 0 =>
+        AccessCondition(
+          method = AccessMethod.NotRequestable,
+          status = Some(AccessStatus.TemporarilyUnavailable),
+          note = Some(
+            "Item is in use by another reader. Please ask at Enquiry Desk.")
         )
 
-        val rulesForRequestingResult = SierraRulesForRequesting(
-          inferredItemData)
-
-        // Make sure we only recurse here once, not infinitely many times.
-        assert(!rulesForRequestingResult.isInstanceOf[NotRequestable.OnHold])
-        assert(!isOnHold(inferredItemData.holdCount, rulesForRequestingResult))
-
-        val originalAccessCondition =
-          createAccessCondition(
-            bibId = bibId,
-            bibStatus = bibStatus,
-            holdCount = Some(0),
-            status = Some(Status.Available),
-            opacmsg = inferredItemData.opacmsg,
-            rulesForRequestingResult = rulesForRequestingResult,
-            location = location,
-            itemData = inferredItemData
-          )
-
-        originalAccessCondition.copy(
+      case (
+        None,
+        _,
+        _,
+        _,
+        NotRequestable.OnHold(_),
+        Some(LocationType.ClosedStores)) =>
+        AccessCondition(
+          method = AccessMethod.NotRequestable,
           status = Some(AccessStatus.TemporarilyUnavailable),
           note = Some(
             "Item is in use by another reader. Please ask at Enquiry Desk.")
@@ -375,22 +363,6 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           note = Some(
             s"""This item cannot be requested online. Please contact <a href="mailto:library@wellcomecollection.org">library@wellcomecollection.org</a> for more information.""")
         )
-    }
-
-  // Note that an item on hold goes through two stages:
-  //
-  //  1. A reader places a hold, but the item is still in the store.
-  //     The status is still "-" (Available)
-  //  2. A staff member collects the item from the store, and places it on the holdshelf
-  //     Then the status becomes "!" (On holdshelf)  This is reflected in the rules for requesting.
-  //
-  private def isOnHold(
-    holdCount: Option[Int],
-    rulesForRequestingResult: RulesForRequestingResult): Boolean =
-    (holdCount, rulesForRequestingResult) match {
-      case (Some(holdCount), _) if holdCount > 0 => true
-      case (_, NotRequestable.OnHold(_))         => true
-      case _                                     => false
     }
 
   implicit class ItemDataAccessOps(itemData: SierraItemData) {

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -45,7 +45,7 @@ class SierraItemAccessTest
             itemData = itemData
           )
 
-          ac shouldBe AccessCondition(method = AccessMethod.OnlineRequest)
+          ac shouldBe AccessCondition(method = AccessMethod.OnlineRequest, status = AccessStatus.Open)
         }
 
         it("if it has no restrictions and the bib is open") {
@@ -609,7 +609,7 @@ class SierraItemAccessTest
 
         ac shouldBe
           AccessCondition(
-            method = AccessMethod.OnlineRequest,
+            method = AccessMethod.NotRequestable,
             status = Some(AccessStatus.TemporarilyUnavailable),
             note = Some(
               "Item is in use by another reader. Please ask at Enquiry Desk.")
@@ -644,7 +644,7 @@ class SierraItemAccessTest
 
         ac shouldBe
           AccessCondition(
-            method = AccessMethod.OnlineRequest,
+            method = AccessMethod.NotRequestable,
             status = Some(AccessStatus.TemporarilyUnavailable),
             note = Some(
               "Item is in use by another reader. Please ask at Enquiry Desk.")
@@ -682,7 +682,7 @@ class SierraItemAccessTest
 
         ac shouldBe
           AccessCondition(
-            method = AccessMethod.ManualRequest,
+            method = AccessMethod.NotRequestable,
             status = Some(AccessStatus.TemporarilyUnavailable),
             note = Some(
               "Item is in use by another reader. Please ask at Enquiry Desk.")
@@ -716,7 +716,7 @@ class SierraItemAccessTest
 
         ac shouldBe
           AccessCondition(
-            method = AccessMethod.OnlineRequest,
+            method = AccessMethod.NotRequestable,
             status = Some(AccessStatus.TemporarilyUnavailable),
             note = Some(
               "Item is in use by another reader. Please ask at Enquiry Desk.")
@@ -907,7 +907,7 @@ class SierraItemAccessTest
           itemData = itemData
         )
 
-        ac shouldBe AccessCondition(method = AccessMethod.OpenShelves)
+        ac shouldBe AccessCondition(method = AccessMethod.NotRequestable)
       }
 
       it("gets a display note") {
@@ -941,12 +941,8 @@ class SierraItemAccessTest
           itemData = itemData
         )
 
-        ac shouldBe
-          AccessCondition(
-            method = AccessMethod.OpenShelves,
-            note = Some(
-              "Shelved at the end of the Quick Ref. section with the oversize Quick Ref. books.")
-          )
+        ac.note shouldBe Some(
+          "Shelved at the end of the Quick Ref. section with the oversize Quick Ref. books.")
       }
     }
 

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -45,7 +45,9 @@ class SierraItemAccessTest
             itemData = itemData
           )
 
-          ac shouldBe AccessCondition(method = AccessMethod.OnlineRequest, status = AccessStatus.Open)
+          ac shouldBe AccessCondition(
+            method = AccessMethod.OnlineRequest,
+            status = AccessStatus.Open)
         }
 
         it("if it has no restrictions and the bib is open") {

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraItemsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraItemsTest.scala
@@ -11,6 +11,7 @@ import weco.catalogue.internal_model.identifiers.{
 import weco.catalogue.internal_model.locations.{
   AccessCondition,
   AccessMethod,
+  AccessStatus,
   LocationType,
   PhysicalLocation
 }
@@ -285,7 +286,7 @@ class SierraItemsTest
         locationType = LocationType.ClosedStores,
         label = LocationType.ClosedStores.label,
         accessConditions =
-          List(AccessCondition(method = AccessMethod.OnlineRequest))
+          List(AccessCondition(method = AccessMethod.OnlineRequest, status = AccessStatus.Open))
       )
     )
   }
@@ -380,7 +381,7 @@ class SierraItemsTest
           locationType = LocationType.ClosedStores,
           label = LocationType.ClosedStores.label,
           accessConditions =
-            List(AccessCondition(method = AccessMethod.OnlineRequest))
+            List(AccessCondition(method = AccessMethod.OnlineRequest, status = AccessStatus.Open))
         )
       ))
   }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraItemsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraItemsTest.scala
@@ -285,8 +285,10 @@ class SierraItemsTest
       PhysicalLocation(
         locationType = LocationType.ClosedStores,
         label = LocationType.ClosedStores.label,
-        accessConditions =
-          List(AccessCondition(method = AccessMethod.OnlineRequest, status = AccessStatus.Open))
+        accessConditions = List(
+          AccessCondition(
+            method = AccessMethod.OnlineRequest,
+            status = AccessStatus.Open))
       )
     )
   }
@@ -380,8 +382,10 @@ class SierraItemsTest
         PhysicalLocation(
           locationType = LocationType.ClosedStores,
           label = LocationType.ClosedStores.label,
-          accessConditions =
-            List(AccessCondition(method = AccessMethod.OnlineRequest, status = AccessStatus.Open))
+          accessConditions = List(
+            AccessCondition(
+              method = AccessMethod.OnlineRequest,
+              status = AccessStatus.Open))
         )
       ))
   }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraPhysicalLocationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraPhysicalLocationTest.scala
@@ -53,7 +53,7 @@ class SierraPhysicalLocationTest
         locationType = LocationType.ClosedStores,
         label = LocationType.ClosedStores.label,
         accessConditions =
-          List(AccessCondition(method = AccessMethod.OnlineRequest))
+          List(AccessCondition(method = AccessMethod.OnlineRequest, status = AccessStatus.Open))
       )
 
       transformer.getPhysicalLocation(bibId, itemData, bibData) shouldBe Some(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraPhysicalLocationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraPhysicalLocationTest.scala
@@ -52,8 +52,10 @@ class SierraPhysicalLocationTest
       val expectedLocation = PhysicalLocation(
         locationType = LocationType.ClosedStores,
         label = LocationType.ClosedStores.label,
-        accessConditions =
-          List(AccessCondition(method = AccessMethod.OnlineRequest, status = AccessStatus.Open))
+        accessConditions = List(
+          AccessCondition(
+            method = AccessMethod.OnlineRequest,
+            status = AccessStatus.Open))
       )
 
       transformer.getPhysicalLocation(bibId, itemData, bibData) shouldBe Some(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraTransformerTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraTransformerTest.scala
@@ -190,7 +190,7 @@ class SierraTransformerTest
           locationType = LocationType.ClosedStores,
           label = LocationType.ClosedStores.label,
           accessConditions =
-            List(AccessCondition(method = AccessMethod.OnlineRequest))
+            List(AccessCondition(method = AccessMethod.OnlineRequest, status = AccessStatus.Open))
         )
       )
     )

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraTransformerTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraTransformerTest.scala
@@ -189,8 +189,10 @@ class SierraTransformerTest
         PhysicalLocation(
           locationType = LocationType.ClosedStores,
           label = LocationType.ClosedStores.label,
-          accessConditions =
-            List(AccessCondition(method = AccessMethod.OnlineRequest, status = AccessStatus.Open))
+          accessConditions = List(
+            AccessCondition(
+              method = AccessMethod.OnlineRequest,
+              status = AccessStatus.Open))
         )
       )
     )


### PR DESCRIPTION
- Set the access status on items with method "Online request" and no status to "Open"
- Set the access method on items which are on hold to "Not requestable"
- Set the access method on open shelves items to "Not requestable"

For https://github.com/wellcomecollection/platform/issues/5262