### PR TITLE
Keep tweaking the item access data

### DIFF
--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -314,7 +314,7 @@ object SierraItemAccess extends SierraQueryOps with Logging {
       // It is possible for an item to have a non-zero hold count but still be available
       // for requesting, e.g. some of our long-lived test holds didn't get cleared properly.
       // If an item seems to be stuck on a non-zero hold count, ask somebody to check Sierra.
-      case (None, Some(holdCount), _, _, _, Some(LocationType.ClosedStores))
+      case (_, Some(holdCount), _, _, _, Some(LocationType.ClosedStores))
           if holdCount > 0 =>
         AccessCondition(
           method = AccessMethod.NotRequestable,
@@ -324,7 +324,7 @@ object SierraItemAccess extends SierraQueryOps with Logging {
         )
 
       case (
-          None,
+          _,
           _,
           _,
           _,

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -90,10 +90,10 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           Some(OpacMsg.OnlineRequest),
           Requestable,
           Some(LocationType.ClosedStores))
-          if bibStatus.isEmpty || bibStatus.contains(AccessStatus.Open) =>
+          if bibStatus.isEmpty || bibStatus.contains(AccessStatus.Open) || bibStatus.contains(AccessStatus.OpenWithAdvisory) =>
         AccessCondition(
           method = AccessMethod.OnlineRequest,
-          status = AccessStatus.Open
+          status = bibStatus.getOrElse(AccessStatus.Open)
         )
 
       // Note: it is possible for individual items within a restricted bib to be available

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -90,7 +90,8 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           Some(OpacMsg.OnlineRequest),
           Requestable,
           Some(LocationType.ClosedStores))
-          if bibStatus.isEmpty || bibStatus.contains(AccessStatus.Open) || bibStatus.contains(AccessStatus.OpenWithAdvisory) =>
+          if bibStatus.isEmpty || bibStatus.contains(AccessStatus.Open) || bibStatus
+            .contains(AccessStatus.OpenWithAdvisory) =>
         AccessCondition(
           method = AccessMethod.OnlineRequest,
           status = bibStatus.getOrElse(AccessStatus.Open)

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -80,6 +80,36 @@ class SierraItemAccessTest
               status = AccessStatus.Open)
         }
 
+        it("if it has no restrictions and the bib is open with advisory") {
+          val itemData = createSierraItemDataWith(
+            fixedFields = Map(
+              "79" -> FixedField(
+                label = "LOCATION",
+                value = "scmac",
+                display = "Closed stores Arch. & MSS"),
+              "88" -> FixedField(
+                label = "STATUS",
+                value = "-",
+                display = "Available"),
+              "108" -> FixedField(
+                label = "OPACMSG",
+                value = "f",
+                display = "Online request"),
+            )
+          )
+
+          val (ac, _) = getItemAccess(
+            bibStatus = Some(AccessStatus.OpenWithAdvisory),
+            location = Some(LocationType.ClosedStores),
+            itemData = itemData
+          )
+
+          ac shouldBe
+            AccessCondition(
+              method = AccessMethod.OnlineRequest,
+              status = AccessStatus.OpenWithAdvisory)
+        }
+
         it("if it's restricted") {
           val itemData = createSierraItemDataWith(
             fixedFields = Map(

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -583,8 +583,8 @@ class SierraItemAccessTest
       }
     }
 
-    describe("that's on hold") {
-      it("can't be requested when another reader has placed a hold") {
+    describe("that's on hold can't be requested") {
+      it("when another reader has placed a hold") {
         val itemData = createSierraItemDataWith(
           holdCount = Some(1),
           fixedFields = Map(
@@ -618,7 +618,7 @@ class SierraItemAccessTest
           )
       }
 
-      it("can't be requested when an item is on hold for a loan rule") {
+      it("when an item is on hold for a loan rule") {
         val itemData = createSierraItemDataWith(
           holdCount = Some(1),
           fixedFields = Map(
@@ -653,7 +653,7 @@ class SierraItemAccessTest
           )
       }
 
-      it("can't be requested when a manual request item is on hold for somebody else") {
+      it("when a manual request item is on hold for somebody else") {
         val itemData = createSierraItemDataWith(
           holdCount = Some(1),
           fixedFields = Map(
@@ -691,7 +691,7 @@ class SierraItemAccessTest
           )
       }
 
-      it("can't be requested when it's on the hold shelf for another reader") {
+      it("when it's on the hold shelf for another reader") {
         val itemData = createSierraItemDataWith(
           holdCount = Some(1),
           fixedFields = Map(
@@ -712,6 +712,41 @@ class SierraItemAccessTest
 
         val (ac, _) = getItemAccess(
           bibStatus = None,
+          location = Some(LocationType.ClosedStores),
+          itemData = itemData
+        )
+
+        ac shouldBe
+          AccessCondition(
+            method = AccessMethod.NotRequestable,
+            status = Some(AccessStatus.TemporarilyUnavailable),
+            note = Some(
+              "Item is in use by another reader. Please ask at Enquiry Desk.")
+          )
+      }
+
+      it("if there's a status on the bib") {
+        // This is based on b32204887 / i19379778, as retrieved 13 August 2021
+        val itemData = createSierraItemDataWith(
+          holdCount = Some(1),
+          fixedFields = Map(
+            "79" -> FixedField(
+              label = "scmac",
+              value = "swms4",
+              display = "Closed stores Arch. & MSS"),
+            "88" -> FixedField(
+              label = "STATUS",
+              value = "!",
+              display = "On holdshelf"),
+            "108" -> FixedField(
+              label = "OPACMSG",
+              value = "a",
+              display = "By appointment"),
+          )
+        )
+
+        val (ac, _) = getItemAccess(
+          bibStatus = Some(AccessStatus.ByAppointment),
           location = Some(LocationType.ClosedStores),
           itemData = itemData
         )

--- a/pipeline/transformer/transformer_sierra/SierraLiveDataTransformerTest.scala.txt
+++ b/pipeline/transformer/transformer_sierra/SierraLiveDataTransformerTest.scala.txt
@@ -17,8 +17,8 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.sts.StsClient
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest
 import weco.catalogue.source_model.sierra.SierraTransformable
-import weco.catalogue.source_model.sierra.identifiers.SierraBibNumber
 import weco.json.JsonUtil._
+import weco.sierra.models.identifiers.SierraBibNumber
 import weco.storage.dynamo.DynamoConfig
 import weco.storage.s3.{S3ObjectLocation, S3ObjectLocationPrefix}
 import weco.storage.store.dynamo.{DynamoHashStore, DynamoHybridStore}


### PR DESCRIPTION
Now I can create a spreadsheet showing me which items haven't been mapped correctly (https://github.com/wellcomecollection/catalogue-api/pull/226), I can pull some of the low-hanging fruit.

This fixes the access data on items where:

* The item is on hold and bib field 506 has a non-empty access status
* The item is available for online requesting, and bib 506 has open-for-advisory

In both cases the bib status in 506 would trip us up.