### PR TITLE
Two tweaks for contributor data in Sierra

### DIFF
--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraAgents.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraAgents.scala
@@ -98,7 +98,7 @@ trait SierraAgents extends SierraQueryOps {
 
   def getLabel(subfields: List[Subfield]): Option[String] =
     subfields.filter { s =>
-      List("a", "b", "c", "d", "t", "p", "n").contains(s.tag)
+      List("a", "b", "c", "d", "t", "p", "n", "q").contains(s.tag)
     } map (_.content) match {
       case Nil          => None
       case nonEmptyList => Some(nonEmptyList mkString " ")

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraContributors.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraContributors.scala
@@ -79,6 +79,14 @@ object SierraContributors
     subfields
       .withTag(subfieldTag)
       .contents
+      .map { role =>
+        // The contribution role in the raw MARC data sometimes includes a
+        // trailing full stop, because all the subfields are meant to be concatenated
+        // into a single sentence.
+        //
+        // This full stop doesn't make sense in a structured field, so remove it.
+        role.stripSuffix(".")
+      }
       .map(ContributionRole)
 
   private def withId(agent: AbstractAgent[IdState.Unminted],

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraContributorsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraContributorsTest.scala
@@ -202,6 +202,27 @@ class SierraContributorsTest
         expectedContributors = expectedContributors)
     }
 
+    it("gets the full form of a name from subfield ǂq") {
+      // This is based on b11941820
+      val varFields = List(
+        VarField(
+          marcTag = Some("700"),
+          subfields = List(
+            Subfield(tag = "a", content = "Faujas-de-St.-Fond,"),
+            Subfield(tag = "c", content = "cit."),
+            Subfield(tag = "q", content = "(Barthélemey),"),
+            Subfield(tag = "d", content = "1741-1819"),
+            Subfield(tag = "e", content = "dedicatee."),
+          )
+        )
+      )
+
+      val contributors = SierraContributors(createSierraBibDataWith(varFields = varFields))
+      contributors should have size 1
+
+      contributors.head.agent.label shouldBe "Faujas-de-St.-Fond, cit. (Barthélemey), 1741-1819"
+    }
+
     it("gets an identifier from subfield $$0") {
       val name = "Ivan the ivy"
       val lcshCode = "lcsh7101607"

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraContributorsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraContributorsTest.scala
@@ -217,7 +217,8 @@ class SierraContributorsTest
         )
       )
 
-      val contributors = SierraContributors(createSierraBibDataWith(varFields = varFields))
+      val contributors =
+        SierraContributors(createSierraBibDataWith(varFields = varFields))
       contributors should have size 1
 
       contributors.head.agent.label shouldBe "Faujas-de-St.-Fond, cit. (Barthélemey), 1741-1819"
@@ -782,10 +783,12 @@ class SierraContributorsTest
       ),
     )
 
-    val contributors = SierraContributors(createSierraBibDataWith(varFields = varFields))
+    val contributors =
+      SierraContributors(createSierraBibDataWith(varFields = varFields))
     contributors should have size 1
 
-    contributors.head.roles shouldBe List(ContributionRole("writer of introduction"))
+    contributors.head.roles shouldBe List(
+      ContributionRole("writer of introduction"))
   }
 
   private def transformAndCheckContributors(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraContributorsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraContributorsTest.scala
@@ -769,6 +769,25 @@ class SierraContributorsTest
     )
   }
 
+  it("removes trailing punctuation from the contribution role") {
+    // This is based on the MARC record for b28975005
+    val varFields = List(
+      createVarFieldWith(
+        marcTag = "700",
+        subfields = List(
+          Subfield(tag = "a", content = "Nurse, Paul,"),
+          Subfield(tag = "d", content = "1949-"),
+          Subfield(tag = "e", content = "writer of introduction."),
+        )
+      ),
+    )
+
+    val contributors = SierraContributors(createSierraBibDataWith(varFields = varFields))
+    contributors should have size 1
+
+    contributors.head.roles shouldBe List(ContributionRole("writer of introduction"))
+  }
+
   private def transformAndCheckContributors(
     varFields: List[VarField],
     expectedContributors: List[Contributor[IdState.Unminted]]


### PR DESCRIPTION
- Use subfield ǂq when constructing contributor labels (closes https://github.com/wellcomecollection/platform/issues/5263)
- Remove trailing punctuation in the list of contribution roles