### PR TITLE
Fix merger tei filtering

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/DeletedReason.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/DeletedReason.scala
@@ -5,4 +5,5 @@ sealed trait DeletedReason
 object DeletedReason {
   case class DeletedFromSource(info: String) extends DeletedReason
   case class SuppressedFromSource(info: String) extends DeletedReason
+  case object TeiDeletedInMerger extends DeletedReason
 }

--- a/pipeline/merger/src/main/scala/weco/pipeline/merger/Main.scala
+++ b/pipeline/merger/src/main/scala/weco/pipeline/merger/Main.scala
@@ -1,33 +1,24 @@
 package weco.pipeline.merger
 
-import scala.concurrent.ExecutionContext
 import akka.actor.ActorSystem
 import com.typesafe.config.Config
+import weco.catalogue.internal_model.Implicits._
+import weco.catalogue.internal_model.image.Image
+import weco.catalogue.internal_model.image.ImageState.Initial
 import weco.catalogue.internal_model.index.{ImagesIndexConfig, WorksIndexConfig}
+import weco.catalogue.internal_model.work.Work
+import weco.catalogue.internal_model.work.WorkState.{Identified, Merged}
+import weco.elasticsearch.typesafe.ElasticBuilder
 import weco.messaging.sns.NotificationMessage
 import weco.messaging.typesafe.{SNSBuilder, SQSBuilder}
-import weco.catalogue.internal_model.Implicits._
-import weco.elasticsearch.typesafe.ElasticBuilder
+import weco.pipeline.merger.services.{IdentifiedWorkLookup, MergerManager, MergerWorkerService}
+import weco.pipeline_storage.EitherIndexer
+import weco.pipeline_storage.typesafe.{ElasticIndexerBuilder, ElasticSourceRetrieverBuilder, PipelineStorageStreamBuilder}
 import weco.typesafe.WellcomeTypesafeApp
 import weco.typesafe.config.builders.AkkaBuilder
 import weco.typesafe.config.builders.EnrichConfig._
-import weco.catalogue.internal_model.work.WorkState.{Identified, Merged}
-import weco.catalogue.internal_model.image.Image
-import weco.catalogue.internal_model.image.ImageState.Initial
-import weco.catalogue.internal_model.work.Work
-import weco.pipeline.merger.services.{
-  IdentifiedWorkLookup,
-  MergerManager,
-  MergerWorkerService,
-  TeiOffMerger,
-  TeiOnMerger
-}
-import weco.pipeline_storage.EitherIndexer
-import weco.pipeline_storage.typesafe.{
-  ElasticIndexerBuilder,
-  ElasticSourceRetrieverBuilder,
-  PipelineStorageStreamBuilder
-}
+
+import scala.concurrent.ExecutionContext
 
 object Main extends WellcomeTypesafeApp {
   runWithConfig { config: Config =>
@@ -49,15 +40,10 @@ object Main extends WellcomeTypesafeApp {
     val toggleTeiOn =
       config.getBooleanOption("toggle.tei_on").getOrElse(false)
 
-    val mergerRules = if (toggleTeiOn) {
-      TeiOnMerger
-    } else {
-      TeiOffMerger
+    val mergerManager = toggleTeiOn match {
+      case true => MergerManager.teiOnMergerManager
+      case false     => MergerManager.teiOffMergerManager
     }
-
-    val mergerManager = new MergerManager(
-      mergerRules = mergerRules
-    )
 
     val workMsgSender =
       SNSBuilder.buildSNSMessageSender(

--- a/pipeline/merger/src/main/scala/weco/pipeline/merger/Main.scala
+++ b/pipeline/merger/src/main/scala/weco/pipeline/merger/Main.scala
@@ -11,9 +11,17 @@ import weco.catalogue.internal_model.work.WorkState.{Identified, Merged}
 import weco.elasticsearch.typesafe.ElasticBuilder
 import weco.messaging.sns.NotificationMessage
 import weco.messaging.typesafe.{SNSBuilder, SQSBuilder}
-import weco.pipeline.merger.services.{IdentifiedWorkLookup, MergerManager, MergerWorkerService}
+import weco.pipeline.merger.services.{
+  IdentifiedWorkLookup,
+  MergerManager,
+  MergerWorkerService
+}
 import weco.pipeline_storage.EitherIndexer
-import weco.pipeline_storage.typesafe.{ElasticIndexerBuilder, ElasticSourceRetrieverBuilder, PipelineStorageStreamBuilder}
+import weco.pipeline_storage.typesafe.{
+  ElasticIndexerBuilder,
+  ElasticSourceRetrieverBuilder,
+  PipelineStorageStreamBuilder
+}
 import weco.typesafe.WellcomeTypesafeApp
 import weco.typesafe.config.builders.AkkaBuilder
 import weco.typesafe.config.builders.EnrichConfig._
@@ -41,8 +49,8 @@ object Main extends WellcomeTypesafeApp {
       config.getBooleanOption("toggle.tei_on").getOrElse(false)
 
     val mergerManager = toggleTeiOn match {
-      case true => MergerManager.teiOnMergerManager
-      case false     => MergerManager.teiOffMergerManager
+      case true  => MergerManager.teiOnMergerManager
+      case false => MergerManager.teiOffMergerManager
     }
 
     val workMsgSender =

--- a/pipeline/merger/src/main/scala/weco/pipeline/merger/rules/WorkPredicates.scala
+++ b/pipeline/merger/src/main/scala/weco/pipeline/merger/rules/WorkPredicates.scala
@@ -29,7 +29,8 @@ object WorkPredicates {
   private val teiIdentified: WorkPredicate = identifierTypeId(
     IdentifierType.Tei
   )
-  private val isVisible: WorkPredicate = work => work.isInstanceOf[Work.Visible[_]]
+  private val isVisible: WorkPredicate = work =>
+    work.isInstanceOf[Work.Visible[_]]
   private val miroIdentified: WorkPredicate = identifierTypeId(
     IdentifierType.MiroImageNumber
   )

--- a/pipeline/merger/src/main/scala/weco/pipeline/merger/rules/WorkPredicates.scala
+++ b/pipeline/merger/src/main/scala/weco/pipeline/merger/rules/WorkPredicates.scala
@@ -29,6 +29,7 @@ object WorkPredicates {
   private val teiIdentified: WorkPredicate = identifierTypeId(
     IdentifierType.Tei
   )
+  private val isVisible: WorkPredicate = work => work.isInstanceOf[Work.Visible[_]]
   private val miroIdentified: WorkPredicate = identifierTypeId(
     IdentifierType.MiroImageNumber
   )
@@ -45,7 +46,8 @@ object WorkPredicates {
 
   val teiWork: WorkPredicate = satisfiesAll(
     teiIdentified,
-    zeroItem
+    zeroItem,
+    isVisible
   )
 
   /**

--- a/pipeline/merger/src/main/scala/weco/pipeline/merger/services/Merger.scala
+++ b/pipeline/merger/src/main/scala/weco/pipeline/merger/services/Merger.scala
@@ -8,7 +8,12 @@ import weco.catalogue.internal_model.work.WorkState.Identified
 import weco.catalogue.internal_model.work.{Work, WorkData, WorkState}
 import weco.pipeline.merger.logging.MergerLogging
 import weco.pipeline.merger.models
-import weco.pipeline.merger.models.{FieldMergeResult, ImageDataWithSource, MergeResult, MergerOutcome}
+import weco.pipeline.merger.models.{
+  FieldMergeResult,
+  ImageDataWithSource,
+  MergeResult,
+  MergerOutcome
+}
 import weco.pipeline.merger.rules._
 
 /*

--- a/pipeline/merger/src/main/scala/weco/pipeline/merger/services/MergerManager.scala
+++ b/pipeline/merger/src/main/scala/weco/pipeline/merger/services/MergerManager.scala
@@ -1,11 +1,12 @@
 package weco.pipeline.merger.services
 
-import weco.catalogue.internal_model.work.Work
+import weco.catalogue.internal_model.work.{DeletedReason, Work}
 import weco.catalogue.internal_model.work.WorkState.Identified
 import weco.pipeline.merger.models.MergerOutcome
+import weco.pipeline.merger.rules.WorkPredicates
 
-class MergerManager(mergerRules: Merger) {
-
+trait MergerManager {
+  val mergerRules: Merger
   /** Given a list of recorder work entries retrieved from VHS, and a
     * merging function, apply the function to these works.
     *
@@ -14,12 +15,36 @@ class MergerManager(mergerRules: Merger) {
     */
   def applyMerge(maybeWorks: Seq[Option[Work[Identified]]]): MergerOutcome = {
     val works = maybeWorks.flatten
-
+    val modifiedWorks = preMergeModify(works)
     if (works.size == maybeWorks.size) {
-      val result = mergerRules.merge(works)
-      assert(result.resultWorks.size == works.size)
+      val result = mergerRules.merge(modifiedWorks)
+      assert(result.resultWorks.size == modifiedWorks.size)
       result
     } else
-      MergerOutcome.passThrough(works)
+      MergerOutcome.passThrough(modifiedWorks)
   }
+
+  protected def preMergeModify(works: Seq[Work[Identified]]): Seq[Work[Identified]]
+}
+
+class TeiOffMergerManager(val mergerRules: Merger) extends MergerManager{
+  override protected def preMergeModify(works: Seq[Work[Identified]]): Seq[Work[Identified]] =
+    works.map( work =>
+      // In the default pipeline behaviour we want tei works to be filtered out
+      // until we're happy with the merging work.
+      if (WorkPredicates.teiWork(work)) {
+        Work.Deleted[Identified](version = work.version, state = work.state, deletedReason = DeletedReason.TeiDeletedInMerger)
+      }else {
+        work
+      }
+    )
+}
+class TeiOnMergerManager(val mergerRules: Merger) extends MergerManager{
+
+  override protected def preMergeModify(works: Seq[Work[Identified]]): Seq[Work[Identified]] = works
+}
+
+object MergerManager{
+  def teiOnMergerManager = new TeiOnMergerManager(PlatformMerger)
+  def teiOffMergerManager = new TeiOffMergerManager(PlatformMerger)
 }

--- a/pipeline/merger/src/main/scala/weco/pipeline/merger/services/MergerManager.scala
+++ b/pipeline/merger/src/main/scala/weco/pipeline/merger/services/MergerManager.scala
@@ -7,6 +7,7 @@ import weco.pipeline.merger.rules.WorkPredicates
 
 trait MergerManager {
   val mergerRules: Merger
+
   /** Given a list of recorder work entries retrieved from VHS, and a
     * merging function, apply the function to these works.
     *
@@ -24,27 +25,33 @@ trait MergerManager {
       MergerOutcome.passThrough(modifiedWorks)
   }
 
-  protected def preMergeModify(works: Seq[Work[Identified]]): Seq[Work[Identified]]
+  protected def preMergeModify(
+    works: Seq[Work[Identified]]): Seq[Work[Identified]]
 }
 
-class TeiOffMergerManager(val mergerRules: Merger) extends MergerManager{
-  override protected def preMergeModify(works: Seq[Work[Identified]]): Seq[Work[Identified]] =
-    works.map( work =>
-      // In the default pipeline behaviour we want tei works to be filtered out
-      // until we're happy with the merging work.
-      if (WorkPredicates.teiWork(work)) {
-        Work.Deleted[Identified](version = work.version, state = work.state, deletedReason = DeletedReason.TeiDeletedInMerger)
-      }else {
-        work
-      }
-    )
+class TeiOffMergerManager(val mergerRules: Merger) extends MergerManager {
+  override protected def preMergeModify(
+    works: Seq[Work[Identified]]): Seq[Work[Identified]] =
+    works.map(
+      work =>
+        // In the default pipeline behaviour we want tei works to be filtered out
+        // until we're happy with the merging work.
+        if (WorkPredicates.teiWork(work)) {
+          Work.Deleted[Identified](
+            version = work.version,
+            state = work.state,
+            deletedReason = DeletedReason.TeiDeletedInMerger)
+        } else {
+          work
+      })
 }
-class TeiOnMergerManager(val mergerRules: Merger) extends MergerManager{
+class TeiOnMergerManager(val mergerRules: Merger) extends MergerManager {
 
-  override protected def preMergeModify(works: Seq[Work[Identified]]): Seq[Work[Identified]] = works
+  override protected def preMergeModify(
+    works: Seq[Work[Identified]]): Seq[Work[Identified]] = works
 }
 
-object MergerManager{
+object MergerManager {
   def teiOnMergerManager = new TeiOnMergerManager(PlatformMerger)
   def teiOffMergerManager = new TeiOffMergerManager(PlatformMerger)
 }

--- a/pipeline/merger/src/test/scala/weco/pipeline/merger/MergerScenarioTest.scala
+++ b/pipeline/merger/src/test/scala/weco/pipeline/merger/MergerScenarioTest.scala
@@ -7,7 +7,7 @@ import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.work.generators.SourceWorkGenerators
 import weco.catalogue.internal_model.work.{Format, MergeCandidate}
 import weco.pipeline.merger.fixtures.FeatureTestSugar
-import weco.pipeline.merger.services.{PlatformMerger, TeiOffMerger}
+import weco.pipeline.merger.services.PlatformMerger
 
 class MergerScenarioTest
     extends AnyFeatureSpec
@@ -15,7 +15,7 @@ class MergerScenarioTest
     with Matchers
     with FeatureTestSugar
     with SourceWorkGenerators {
-  val merger: PlatformMerger = TeiOffMerger
+  val merger = PlatformMerger
 
   /*
    * We test field-level behaviour in the rule tests, and have to replicate it

--- a/pipeline/merger/src/test/scala/weco/pipeline/merger/fixtures/FeatureTestSugar.scala
+++ b/pipeline/merger/src/test/scala/weco/pipeline/merger/fixtures/FeatureTestSugar.scala
@@ -1,10 +1,10 @@
 package weco.pipeline.merger.fixtures
 
 import org.scalatest.matchers.{MatchResult, Matcher}
-import weco.catalogue.internal_model.work.WorkState.Identified
 import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.image.ImageData
 import weco.catalogue.internal_model.work.Work
+import weco.catalogue.internal_model.work.WorkState.Identified
 import weco.pipeline.merger.models.MergerOutcome
 
 trait FeatureTestSugar {
@@ -14,9 +14,8 @@ trait FeatureTestSugar {
         .find(_.sourceIdentifier == originalWork.sourceIdentifier)
         .get
 
-    def isMissing(work: Work[Identified]): Boolean =
-      !mergerOutcome.resultWorks.exists(
-        _.sourceIdentifier == work.sourceIdentifier)
+    def isDeleted(work: Work[Identified]): Boolean =
+      mergerOutcome.resultWorks.exists(w =>w.sourceIdentifier == work.sourceIdentifier && w.isInstanceOf[Work.Deleted[Identified]])
 
     def imageSourceIds: Seq[IdState.Identified] =
       mergerOutcome.imagesWithSources.map(_.source.id)

--- a/pipeline/merger/src/test/scala/weco/pipeline/merger/fixtures/FeatureTestSugar.scala
+++ b/pipeline/merger/src/test/scala/weco/pipeline/merger/fixtures/FeatureTestSugar.scala
@@ -15,7 +15,10 @@ trait FeatureTestSugar {
         .get
 
     def isDeleted(work: Work[Identified]): Boolean =
-      mergerOutcome.resultWorks.exists(w =>w.sourceIdentifier == work.sourceIdentifier && w.isInstanceOf[Work.Deleted[Identified]])
+      mergerOutcome.resultWorks.exists(
+        w =>
+          w.sourceIdentifier == work.sourceIdentifier && w
+            .isInstanceOf[Work.Deleted[Identified]])
 
     def imageSourceIds: Seq[IdState.Identified] =
       mergerOutcome.imagesWithSources.map(_.source.id)

--- a/pipeline/merger/src/test/scala/weco/pipeline/merger/fixtures/WorkerServiceFixture.scala
+++ b/pipeline/merger/src/test/scala/weco/pipeline/merger/fixtures/WorkerServiceFixture.scala
@@ -1,26 +1,22 @@
 package weco.pipeline.merger.fixtures
 
-import scala.collection.mutable
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import weco.catalogue.internal_model.image.Image
+import weco.catalogue.internal_model.image.ImageState.Initial
+import weco.catalogue.internal_model.work.Work
+import weco.catalogue.internal_model.work.WorkState.{Identified, Merged}
 import weco.fixtures.TestWith
 import weco.messaging.fixtures.SQS.Queue
 import weco.messaging.memory.MemoryMessageSender
 import weco.messaging.sns.NotificationMessage
 import weco.monitoring.Metrics
 import weco.monitoring.memory.MemoryMetrics
-import weco.catalogue.internal_model.work.WorkState.{Identified, Merged}
-import weco.catalogue.internal_model.image.Image
-import weco.catalogue.internal_model.image.ImageState.Initial
-import weco.catalogue.internal_model.work.Work
-import weco.pipeline.merger.services.{
-  IdentifiedWorkLookup,
-  MergerManager,
-  MergerWorkerService,
-  TeiOffMerger
-}
+import weco.pipeline.merger.services.{IdentifiedWorkLookup, MergerWorkerService, PlatformMerger, TeiOffMergerManager}
 import weco.pipeline_storage.fixtures.PipelineStorageStreamFixtures
 import weco.pipeline_storage.memory.{MemoryIndexer, MemoryRetriever}
+
+import scala.collection.mutable
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 trait WorkerServiceFixture extends PipelineStorageStreamFixtures {
 
@@ -39,7 +35,7 @@ trait WorkerServiceFixture extends PipelineStorageStreamFixtures {
         val workerService = new MergerWorkerService(
           msgStream = msgStream,
           sourceWorkLookup = new IdentifiedWorkLookup(retriever),
-          mergerManager = new MergerManager(TeiOffMerger),
+          mergerManager = new TeiOffMergerManager(PlatformMerger),
           workOrImageIndexer = new MemoryIndexer(index),
           workMsgSender = workSender,
           imageMsgSender = imageSender,

--- a/pipeline/merger/src/test/scala/weco/pipeline/merger/fixtures/WorkerServiceFixture.scala
+++ b/pipeline/merger/src/test/scala/weco/pipeline/merger/fixtures/WorkerServiceFixture.scala
@@ -10,7 +10,12 @@ import weco.messaging.memory.MemoryMessageSender
 import weco.messaging.sns.NotificationMessage
 import weco.monitoring.Metrics
 import weco.monitoring.memory.MemoryMetrics
-import weco.pipeline.merger.services.{IdentifiedWorkLookup, MergerWorkerService, PlatformMerger, TeiOffMergerManager}
+import weco.pipeline.merger.services.{
+  IdentifiedWorkLookup,
+  MergerWorkerService,
+  PlatformMerger,
+  TeiOffMergerManager
+}
 import weco.pipeline_storage.fixtures.PipelineStorageStreamFixtures
 import weco.pipeline_storage.memory.{MemoryIndexer, MemoryRetriever}
 

--- a/pipeline/merger/src/test/scala/weco/pipeline/merger/services/MergerManagerTest.scala
+++ b/pipeline/merger/src/test/scala/weco/pipeline/merger/services/MergerManagerTest.scala
@@ -93,6 +93,7 @@ class MergerManagerTest extends AnyFunSpec with Matchers with WorkGenerators {
   val mergerManager = new MergerManager {
     override val mergerRules: Merger = merger
 
-    override protected def preMergeModify(works: Seq[Work[Identified]]): Seq[Work[Identified]] = works
+    override protected def preMergeModify(
+      works: Seq[Work[Identified]]): Seq[Work[Identified]] = works
   }
 }

--- a/pipeline/merger/src/test/scala/weco/pipeline/merger/services/MergerManagerTest.scala
+++ b/pipeline/merger/src/test/scala/weco/pipeline/merger/services/MergerManagerTest.scala
@@ -53,7 +53,7 @@ class MergerManagerTest extends AnyFunSpec with Matchers with WorkGenerators {
       expectedWorks.map(_.transition[Merged](now))
   }
 
-  val mergerRules = new Merger {
+  val merger = new Merger {
 
     /** Make every work a redirect to the first work in the list, and leave
       * the first work intact.
@@ -90,5 +90,9 @@ class MergerManagerTest extends AnyFunSpec with Matchers with WorkGenerators {
       )
   }
 
-  val mergerManager = new MergerManager(mergerRules = mergerRules)
+  val mergerManager = new MergerManager {
+    override val mergerRules: Merger = merger
+
+    override protected def preMergeModify(works: Seq[Work[Identified]]): Seq[Work[Identified]] = works
+  }
 }

--- a/pipeline/merger/src/test/scala/weco/pipeline/merger/services/PlatformMergerTest.scala
+++ b/pipeline/merger/src/test/scala/weco/pipeline/merger/services/PlatformMergerTest.scala
@@ -99,7 +99,7 @@ class PlatformMergerTest
 
   val calmWork: Work.Visible[Identified] = calmIdentifiedWork()
 
-  private val merger = TeiOffMerger
+  private val merger = PlatformMerger
 
   it(
     "finds Calm || Sierra with physical item || Sierra work || Nothing as a target") {

--- a/pipeline/merger/src/test/scala/weco/pipeline/merger/services/TeiOffMergerScenarioTest.scala
+++ b/pipeline/merger/src/test/scala/weco/pipeline/merger/services/TeiOffMergerScenarioTest.scala
@@ -1,12 +1,20 @@
 package weco.pipeline.merger.services
 
+import org.scalatest.GivenWhenThen
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.matchers.should.Matchers
 import weco.catalogue.internal_model.work.Work
-import weco.pipeline.merger.MergerScenarioTest
+import weco.catalogue.internal_model.work.generators.SourceWorkGenerators
+import weco.pipeline.merger.fixtures.FeatureTestSugar
 
 // We should never really be adding to this test as it is just there to ensure we don't get TEI works
 // through the pipes until they are rich enough for us to want to present them to the public
-class TeiOffMergerScenarioTest extends MergerScenarioTest {
-  override val merger: PlatformMerger = TeiOffMerger
+class TeiOffMergerScenarioTest extends AnyFeatureSpec
+  with GivenWhenThen
+  with Matchers
+  with FeatureTestSugar
+  with SourceWorkGenerators {
+  val merger = MergerManager.teiOffMergerManager
 
   Scenario("A Tei is not merged with a Sierra digital and a sierra physical") {
     Given("a Tei, a Sierra physical record and a Sierra digital record")
@@ -16,7 +24,7 @@ class TeiOffMergerScenarioTest extends MergerScenarioTest {
     When("the works are merged")
     val sierraWorks = List(digitalSierra, physicalSierra)
     val works = sierraWorks :+ teiWork
-    val outcome = merger.merge(works)
+    val outcome = merger.applyMerge(works.map(Some(_)))
 
     Then("the digital Sierra is redirected to the physical sierra")
     outcome.getMerged(digitalSierra) should beRedirectedTo(physicalSierra)
@@ -31,7 +39,18 @@ class TeiOffMergerScenarioTest extends MergerScenarioTest {
     val teiWork = teiIdentifiedWork().title("A tei work")
 
     When("the tei work is merged")
-    val outcome = merger.merge(List(teiWork))
+    val outcome = merger.applyMerge(List(Some(teiWork)))
+
+    And("the tei work is deleted")
+    outcome.isDeleted(teiWork) shouldBe true
+  }
+
+  Scenario("A Tei work with a merge candidate not in the index becomes deleted") {
+    Given("a Tei")
+    val teiWork = teiIdentifiedWork().title("A tei work")
+    val otherWork = None
+    When("the tei work is merged")
+    val outcome = merger.applyMerge(List(Some(teiWork), otherWork))
 
     And("the tei work is deleted")
     outcome.isDeleted(teiWork) shouldBe true

--- a/pipeline/merger/src/test/scala/weco/pipeline/merger/services/TeiOffMergerScenarioTest.scala
+++ b/pipeline/merger/src/test/scala/weco/pipeline/merger/services/TeiOffMergerScenarioTest.scala
@@ -9,11 +9,12 @@ import weco.pipeline.merger.fixtures.FeatureTestSugar
 
 // We should never really be adding to this test as it is just there to ensure we don't get TEI works
 // through the pipes until they are rich enough for us to want to present them to the public
-class TeiOffMergerScenarioTest extends AnyFeatureSpec
-  with GivenWhenThen
-  with Matchers
-  with FeatureTestSugar
-  with SourceWorkGenerators {
+class TeiOffMergerScenarioTest
+    extends AnyFeatureSpec
+    with GivenWhenThen
+    with Matchers
+    with FeatureTestSugar
+    with SourceWorkGenerators {
   val merger = MergerManager.teiOffMergerManager
 
   Scenario("A Tei is not merged with a Sierra digital and a sierra physical") {

--- a/pipeline/merger/src/test/scala/weco/pipeline/merger/services/TeiOffMergerScenarioTest.scala
+++ b/pipeline/merger/src/test/scala/weco/pipeline/merger/services/TeiOffMergerScenarioTest.scala
@@ -23,7 +23,7 @@ class TeiOffMergerScenarioTest extends MergerScenarioTest {
     outcome.getMerged(physicalSierra) shouldBe a[Work.Visible[_]]
 
     And("the tei work is missing")
-    outcome.isMissing(teiWork) shouldBe true
+    outcome.isDeleted(teiWork) shouldBe true
   }
 
   Scenario("A Tei work becomes deleted") {
@@ -33,7 +33,7 @@ class TeiOffMergerScenarioTest extends MergerScenarioTest {
     When("the tei work is merged")
     val outcome = merger.merge(List(teiWork))
 
-    And("the tei work is missing")
-    outcome.isMissing(teiWork) shouldBe true
+    And("the tei work is deleted")
+    outcome.isDeleted(teiWork) shouldBe true
   }
 }

--- a/pipeline/merger/src/test/scala/weco/pipeline/merger/services/TeiOnMergerScenarioTest.scala
+++ b/pipeline/merger/src/test/scala/weco/pipeline/merger/services/TeiOnMergerScenarioTest.scala
@@ -9,11 +9,12 @@ import weco.pipeline.merger.fixtures.FeatureTestSugar
 
 // We'll eventually fold these tests into the base MergerScenarioTest
 // once the TEI works are rich enough for the public
-class TeiOnMergerScenarioTest extends AnyFeatureSpec
-  with GivenWhenThen
-  with Matchers
-  with FeatureTestSugar
-  with SourceWorkGenerators {
+class TeiOnMergerScenarioTest
+    extends AnyFeatureSpec
+    with GivenWhenThen
+    with Matchers
+    with FeatureTestSugar
+    with SourceWorkGenerators {
   val merger = MergerManager.teiOnMergerManager
 
   Scenario("A Tei and a Sierra digital and a sierra physical work are merged") {

--- a/pipeline/merger/src/test/scala/weco/pipeline/merger/services/TeiOnMergerScenarioTest.scala
+++ b/pipeline/merger/src/test/scala/weco/pipeline/merger/services/TeiOnMergerScenarioTest.scala
@@ -1,12 +1,20 @@
 package weco.pipeline.merger.services
 
+import org.scalatest.GivenWhenThen
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.matchers.should.Matchers
 import weco.catalogue.internal_model.identifiers.IdentifierType
-import weco.pipeline.merger.MergerScenarioTest
+import weco.catalogue.internal_model.work.generators.SourceWorkGenerators
+import weco.pipeline.merger.fixtures.FeatureTestSugar
 
 // We'll eventually fold these tests into the base MergerScenarioTest
 // once the TEI works are rich enough for the public
-class TeiOnMergerScenarioTest extends MergerScenarioTest {
-  override val merger = TeiOnMerger
+class TeiOnMergerScenarioTest extends AnyFeatureSpec
+  with GivenWhenThen
+  with Matchers
+  with FeatureTestSugar
+  with SourceWorkGenerators {
+  val merger = MergerManager.teiOnMergerManager
 
   Scenario("A Tei and a Sierra digital and a sierra physical work are merged") {
     Given("a Tei, a Sierra physical record and a Sierra digital record")
@@ -16,7 +24,7 @@ class TeiOnMergerScenarioTest extends MergerScenarioTest {
     When("the works are merged")
     val sierraWorks = List(digitalSierra, physicalSierra)
     val works = sierraWorks :+ teiWork
-    val outcome = merger.merge(works)
+    val outcome = merger.applyMerge(works.map(Some(_)))
 
     Then("the Sierra works are redirected to the tei")
     outcome.getMerged(digitalSierra) should beRedirectedTo(teiWork)
@@ -50,7 +58,7 @@ class TeiOnMergerScenarioTest extends MergerScenarioTest {
     val teiWork = teiIdentifiedWork().title("A tei work")
 
     When("the tei work is merged")
-    val outcome = merger.merge(List(teiWork))
+    val outcome = merger.applyMerge(List(Some(teiWork)))
 
     Then("the tei work should be a TEI work")
     outcome

--- a/pipeline/merger/src/test/scala/weco/pipeline/merger/services/TeiOnMergerTest.scala
+++ b/pipeline/merger/src/test/scala/weco/pipeline/merger/services/TeiOnMergerTest.scala
@@ -15,7 +15,7 @@ class TeiOnMergerTest
     with Matchers {
 
   it("merges a physical sierra with a tei") {
-    val merger = TeiOnMerger
+    val merger = PlatformMerger
     val physicalWork =
       sierraIdentifiedWork()
         .items(List(createIdentifiedPhysicalItem))


### PR DESCRIPTION
This pr does 2 things:
- Changes the merger to flip tei works to deleted in tei off mode, instead of quietly dropping the. This is useful for debugging so we can see that a work has been picked up and correctly handled but also it was causing messages to not be deleted from the queue and eventually sent to the dlq because we check that the messages we sed onwards are the same number of ids we receive 
- Pushes the filtering of tei earlier in the message processing so that we catch the passthrough case as well, which is the case that was letting some tei slip past 

This has been already deployed to the 2021-08-16 pipeline and it processed messages correctly