### PR TITLE
Use the new per-account SQS DLQ alarm topic

### DIFF
--- a/calm_adapter/terraform/locals.tf
+++ b/calm_adapter/terraform/locals.tf
@@ -4,7 +4,7 @@ locals {
 
   infra_bucket           = data.terraform_remote_state.shared_infra.outputs.infra_bucket
   account_id             = data.aws_caller_identity.current.account_id
-  dlq_alarm_arn          = data.terraform_remote_state.shared_infra.outputs.dlq_alarm_arn
+  dlq_alarm_arn          = data.terraform_remote_state.monitoring.outputs.platform_dlq_alarm_topic_arn
   vpc_id                 = local.catalogue_vpcs["catalogue_vpc_delta_id"]
   private_subnets        = local.catalogue_vpcs["catalogue_vpc_delta_private_subnets"]
   shared_logging_secrets = data.terraform_remote_state.shared_infra.outputs.shared_secrets_logging

--- a/calm_adapter/terraform/terraform.tf
+++ b/calm_adapter/terraform/terraform.tf
@@ -9,6 +9,18 @@ terraform {
   }
 }
 
+data "terraform_remote_state" "monitoring" {
+  backend = "s3"
+
+  config = {
+    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+
+    bucket = "wellcomecollection-platform-infra"
+    key    = "terraform/monitoring.tfstate"
+    region = "eu-west-1"
+  }
+}
+
 data "terraform_remote_state" "shared_infra" {
   backend = "s3"
 

--- a/mets_adapter/terraform/locals.tf
+++ b/mets_adapter/terraform/locals.tf
@@ -12,7 +12,7 @@ locals {
   mets_adapter_table_name = aws_dynamodb_table.mets_adapter_table.id
 
   # Infra stuff
-  dlq_alarm_arn   = data.terraform_remote_state.shared_infra.outputs.dlq_alarm_arn
+  dlq_alarm_arn   = data.terraform_remote_state.monitoring.outputs.platform_dlq_alarm_topic_arn
   vpc_id          = local.catalogue_vpcs["catalogue_vpc_delta_id"]
   private_subnets = local.catalogue_vpcs["catalogue_vpc_delta_private_subnets"]
 }

--- a/mets_adapter/terraform/terraform.tf
+++ b/mets_adapter/terraform/terraform.tf
@@ -23,6 +23,18 @@ data "terraform_remote_state" "storage_service" {
   }
 }
 
+data "terraform_remote_state" "monitoring" {
+  backend = "s3"
+
+  config = {
+    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+
+    bucket = "wellcomecollection-platform-infra"
+    key    = "terraform/monitoring.tfstate"
+    region = "eu-west-1"
+  }
+}
+
 data "terraform_remote_state" "shared_infra" {
   backend = "s3"
 

--- a/pipeline/terraform/locals.tf
+++ b/pipeline/terraform/locals.tf
@@ -36,7 +36,7 @@ locals {
   calm_reindexer_topic_arn   = data.terraform_remote_state.reindexer.outputs.calm_reindexer_topic_arn
 
   # Infra stuff
-  dlq_alarm_arn   = data.terraform_remote_state.shared_infra.outputs.dlq_alarm_arn
+  dlq_alarm_arn   = data.terraform_remote_state.monitoring.outputs.platform_dlq_alarm_topic_arn
   vpc_id          = local.catalogue_vpcs["catalogue_vpc_delta_id"]
   private_subnets = local.catalogue_vpcs["catalogue_vpc_delta_private_subnets"]
 

--- a/pipeline/terraform/terraform.tf
+++ b/pipeline/terraform/terraform.tf
@@ -57,6 +57,18 @@ data "terraform_remote_state" "shared_infra" {
   }
 }
 
+data "terraform_remote_state" "monitoring" {
+  backend = "s3"
+
+  config = {
+    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+
+    bucket = "wellcomecollection-platform-infra"
+    key    = "terraform/monitoring.tfstate"
+    region = "eu-west-1"
+  }
+}
+
 data "terraform_remote_state" "accounts_catalogue" {
   backend = "s3"
 

--- a/reindexer/terraform/locals.tf
+++ b/reindexer/terraform/locals.tf
@@ -24,7 +24,7 @@ locals {
 
   vpc_id          = local.catalogue_vpcs["catalogue_vpc_delta_id"]
   private_subnets = local.catalogue_vpcs["catalogue_vpc_delta_private_subnets"]
-  dlq_alarm_arn   = data.terraform_remote_state.shared_infra.outputs.dlq_alarm_arn
+  dlq_alarm_arn   = data.terraform_remote_state.monitoring.outputs.platform_dlq_alarm_topic_arn
 
   reindex_worker_image = "${aws_ecr_repository.reindexer.repository_url}:env.${local.environment}"
 

--- a/reindexer/terraform/terraform.tf
+++ b/reindexer/terraform/terraform.tf
@@ -23,6 +23,18 @@ data "terraform_remote_state" "shared_infra" {
   }
 }
 
+data "terraform_remote_state" "monitoring" {
+  backend = "s3"
+
+  config = {
+    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+
+    bucket = "wellcomecollection-platform-infra"
+    key    = "terraform/monitoring.tfstate"
+    region = "eu-west-1"
+  }
+}
+
 data "terraform_remote_state" "accounts_catalogue" {
   backend = "s3"
 

--- a/sierra_adapter/terraform/locals.tf
+++ b/sierra_adapter/terraform/locals.tf
@@ -1,7 +1,7 @@
 locals {
   lambda_error_alarm_arn = data.terraform_remote_state.shared_infra.outputs.lambda_error_alarm_arn
 
-  dlq_alarm_arn = data.terraform_remote_state.shared_infra.outputs.dlq_alarm_arn
+  dlq_alarm_arn = data.terraform_remote_state.monitoring.outputs.platform_dlq_alarm_topic_arn
 
   vpc_id          = local.catalogue_vpcs["catalogue_vpc_delta_id"]
   private_subnets = local.catalogue_vpcs["catalogue_vpc_delta_private_subnets"]

--- a/sierra_adapter/terraform/terraform.tf
+++ b/sierra_adapter/terraform/terraform.tf
@@ -35,6 +35,18 @@ data "terraform_remote_state" "accounts_catalogue" {
   }
 }
 
+data "terraform_remote_state" "monitoring" {
+  backend = "s3"
+
+  config = {
+    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+
+    bucket = "wellcomecollection-platform-infra"
+    key    = "terraform/monitoring.tfstate"
+    region = "eu-west-1"
+  }
+}
+
 locals {
   catalogue_vpcs = data.terraform_remote_state.accounts_catalogue.outputs
 }

--- a/tei_adapter/terraform/locals.tf
+++ b/tei_adapter/terraform/locals.tf
@@ -3,7 +3,6 @@ locals {
   lambda_error_alarm_arn           = data.terraform_remote_state.shared_infra.outputs.lambda_error_alarm_arn
   namespace                        = "tei-adapter"
   release_label                    = "prod"
-  dlq_alarm_arn                    = data.terraform_remote_state.shared_infra.outputs.dlq_alarm_arn
   vpc_id                           = local.catalogue_vpcs["catalogue_vpc_delta_id"]
   private_subnets                  = local.catalogue_vpcs["catalogue_vpc_delta_private_subnets"]
   shared_logging_secrets           = data.terraform_remote_state.shared_infra.outputs.shared_secrets_logging
@@ -14,7 +13,10 @@ locals {
   rds_max_connections              = 45
   tei_id_extractor_max_connections = 5
   rds_lock_timeout_seconds         = 10 * 60
+
+  dlq_alarm_arn = data.terraform_remote_state.monitoring.outputs.platform_dlq_alarm_topic_arn
 }
+
 data "aws_ssm_parameter" "admin_cidr_ingress" {
   name = "/infra_critical/config/prod/admin_cidr_ingress"
 }

--- a/tei_adapter/terraform/terraform.tf
+++ b/tei_adapter/terraform/terraform.tf
@@ -33,6 +33,18 @@ data "terraform_remote_state" "accounts_catalogue" {
   }
 }
 
+data "terraform_remote_state" "monitoring" {
+  backend = "s3"
+
+  config = {
+    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+
+    bucket = "wellcomecollection-platform-infra"
+    key    = "terraform/monitoring.tfstate"
+    region = "eu-west-1"
+  }
+}
+
 locals {
   catalogue_vpcs = data.terraform_remote_state.accounts_catalogue.outputs
 }


### PR DESCRIPTION
This uses the new SQS DLQ alerting infra from wellcomecollection/platform-infrastructure#221

Because all the pipeline services run in the platform account, this isn't getting us any new functionality, just converting them to the new topic and alerting Lambda.

For wellcomecollection/platform#5245