### PR TITLE
Improve the readability and testing in the relation embedder

### DIFF
--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/ArchiveRelationsCache.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/ArchiveRelationsCache.scala
@@ -122,12 +122,13 @@ class ArchiveRelationsCache(works: Map[String, RelationWork]) extends Logging {
         )
     }
 
+  import weco.pipeline.relation_embedder.models.PathOps._
+
   private lazy val parentMapping: Map[String, String] =
     works
       .map {
         case (path, _) =>
-          val parent = tokenize(path).dropRight(1)
-          path -> Some(parent.mkString("/")).filter(works.contains)
+          path -> Some(path.parent).filter(works.contains)
       }
       .collect { case (path, Some(parentPath)) => path -> parentPath }
 
@@ -141,9 +142,6 @@ class ArchiveRelationsCache(works: Map[String, RelationWork]) extends Logging {
           }.toList
         )
     }
-
-  private def tokenize(path: String): List[String] =
-    path.split("/").toList
 }
 
 object ArchiveRelationsCache {

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/ArchiveRelationsCache.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/ArchiveRelationsCache.scala
@@ -33,6 +33,8 @@ class ArchiveRelationsCache(works: Map[String, RelationWork]) extends Logging {
         Relations.none
       }
 
+  private val paths: Set[String] = works.keySet
+
   // The availabilities of an archive's Relations are the union of
   // all of its descendants' availabilities, as well as its own
   def getAvailabilities(work: Work[Merged]): Set[Availability] =
@@ -92,9 +94,6 @@ class ArchiveRelationsCache(works: Map[String, RelationWork]) extends Logging {
         getAncestors(parentPath, relations(parentPath) :: accum)
     }
 
-  private def getNumChildren(path: String): Int =
-    childMapping.get(path).map(_.length).getOrElse(0)
-
   private def getNumDescendents(path: String): Int = {
     @tailrec
     def numDescendents(stack: List[String], accum: Int = 0): Int =
@@ -111,7 +110,7 @@ class ArchiveRelationsCache(works: Map[String, RelationWork]) extends Logging {
       case (path, work) =>
         path -> work.toRelation(
           depth = path.split("/").length - 1,
-          numChildren = getNumChildren(path),
+          numChildren = paths.childrenOf(path).length,
           numDescendents = getNumDescendents(path)
         )
     }

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/ArchiveRelationsCache.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/ArchiveRelationsCache.scala
@@ -80,7 +80,7 @@ class ArchiveRelationsCache(works: Map[String, RelationWork]) extends Logging {
   import weco.pipeline.relation_embedder.models.PathOps._
 
   private def getSiblings(path: String): (List[Relation], List[Relation]) = {
-    val (preceding, succeeding) = works.keySet.siblingsOf(path)
+    val (preceding, succeeding) = paths.siblingsOf(path)
 
     (preceding.map(relations), succeeding.map(relations))
   }

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/ArchiveRelationsCache.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/ArchiveRelationsCache.scala
@@ -71,13 +71,10 @@ class ArchiveRelationsCache(works: Map[String, RelationWork]) extends Logging {
 
   def numParents = parentMapping.size
 
-  private def getChildren(path: String): List[Relation] =
-    childMapping
-    // Relations might not exist in the cache if e.g. the work is not Visible
-      .getOrElse(path, default = Nil)
-      .map(relations)
-
   import weco.pipeline.relation_embedder.models.PathOps._
+
+  private def getChildren(path: String): List[Relation] =
+    paths.childrenOf(path).map(relations)
 
   private def getSiblings(path: String): (List[Relation], List[Relation]) = {
     val (preceding, succeeding) = paths.siblingsOf(path)

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/ArchiveRelationsCache.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/ArchiveRelationsCache.scala
@@ -128,15 +128,7 @@ class ArchiveRelationsCache(works: Map[String, RelationWork]) extends Logging {
     works.keySet.parentMapping
 
   private lazy val childMapping: Map[String, List[String]] =
-    works.map {
-      case (path, _) =>
-        path -> CollectionPathSorter.sortPaths(
-          parentMapping.collect {
-            case (childPath, parentPath) if parentPath == path =>
-              childPath
-          }.toList
-        )
-    }
+    works.keySet.childMapping
 }
 
 object ArchiveRelationsCache {

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/ArchiveRelationsCache.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/ArchiveRelationsCache.scala
@@ -125,12 +125,7 @@ class ArchiveRelationsCache(works: Map[String, RelationWork]) extends Logging {
   import weco.pipeline.relation_embedder.models.PathOps._
 
   private lazy val parentMapping: Map[String, String] =
-    works
-      .map {
-        case (path, _) =>
-          path -> Some(path.parent).filter(works.contains)
-      }
-      .collect { case (path, Some(parentPath)) => path -> parentPath }
+    works.keySet.parentMapping
 
   private lazy val childMapping: Map[String, List[String]] =
     works.map {

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/ArchiveRelationsCache.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/ArchiveRelationsCache.scala
@@ -94,24 +94,13 @@ class ArchiveRelationsCache(works: Map[String, RelationWork]) extends Logging {
         getAncestors(parentPath, relations(parentPath) :: accum)
     }
 
-  private def getNumDescendents(path: String): Int = {
-    @tailrec
-    def numDescendents(stack: List[String], accum: Int = 0): Int =
-      stack match {
-        case Nil => accum
-        case head :: tail =>
-          numDescendents(childMapping.getOrElse(head, Nil) ++ tail, 1 + accum)
-      }
-    numDescendents(childMapping.getOrElse(path, Nil))
-  }
-
   private lazy val relations: Map[String, Relation] =
     works.map {
       case (path, work) =>
         path -> work.toRelation(
           depth = path.split("/").length - 1,
           numChildren = paths.childrenOf(path).length,
-          numDescendents = getNumDescendents(path)
+          numDescendents = paths.descendentsOf(path).length
         )
     }
 

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/ArchiveRelationsCache.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/ArchiveRelationsCache.scala
@@ -36,19 +36,19 @@ class ArchiveRelationsCache(works: Map[String, RelationWork]) extends Logging {
   private val paths: Set[String] = works.keySet
 
   /** Find the availabilities of this Work.
-   *
-   * The availabilities of an archive's Relations are the union of all the
-   * availabilities of its descendents, as well as its own.
-   *
-   * Note that this only covers *known* descendents.  e.g. if the works have
-   * paths (A, A/B/1), then A will not inherit availabilities from A/B/1 --
-   * the intermediate path A/B is missing.
-   *
-   * This preserves the original behaviour of the relation embedder, but it's
-   * not clear if it's intentional -- it was a side effect of the implementation,
-   * not something that was explicitly tested.
-   *
-   */
+    *
+    * The availabilities of an archive's Relations are the union of all the
+    * availabilities of its descendents, as well as its own.
+    *
+    * Note that this only covers *known* descendents.  e.g. if the works have
+    * paths (A, A/B/1), then A will not inherit availabilities from A/B/1 --
+    * the intermediate path A/B is missing.
+    *
+    * This preserves the original behaviour of the relation embedder, but it's
+    * not clear if it's intentional -- it was a side effect of the implementation,
+    * not something that was explicitly tested.
+    *
+    */
   def getAvailabilities(work: Work[Merged]): Set[Availability] =
     work.data.collectionPath match {
       case Some(CollectionPath(workPath, _)) =>
@@ -66,7 +66,8 @@ class ArchiveRelationsCache(works: Map[String, RelationWork]) extends Logging {
       case _ =>
         assert(
           assertion = false,
-          message = s"Cannot get availabilities for work with empty collectionPath field: $work"
+          message =
+            s"Cannot get availabilities for work with empty collectionPath field: $work"
         )
         Set()
     }

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/ArchiveRelationsCache.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/ArchiveRelationsCache.scala
@@ -59,7 +59,7 @@ class ArchiveRelationsCache(works: Map[String, RelationWork]) extends Logging {
 
   def size = relations.size
 
-  def numParents = parentMapping.size
+  def numParents: Int = works.keySet.parentMapping.size
 
   private def getChildren(path: String): List[Relation] =
     paths.childrenOf(path).map(relations)
@@ -82,9 +82,6 @@ class ArchiveRelationsCache(works: Map[String, RelationWork]) extends Logging {
           numDescendents = paths.descendentsOf(path).length
         )
     }
-
-  private lazy val parentMapping: Map[String, String] =
-    works.keySet.parentMapping
 }
 
 object ArchiveRelationsCache {

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/ArchiveRelationsCache.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/ArchiveRelationsCache.scala
@@ -75,18 +75,12 @@ class ArchiveRelationsCache(works: Map[String, RelationWork]) extends Logging {
       .getOrElse(path, default = Nil)
       .map(relations)
 
+  import weco.pipeline.relation_embedder.models.PathOps._
+
   private def getSiblings(path: String): (List[Relation], List[Relation]) = {
-    val siblings = parentMapping
-      .get(path)
-      .map(childMapping)
-      .getOrElse(Nil)
-    siblings match {
-      case Nil => (Nil, Nil)
-      case siblings =>
-        val splitIdx = siblings.indexOf(path)
-        val (preceding, succeeding) = siblings.splitAt(splitIdx)
-        (preceding.map(relations), succeeding.tail.map(relations))
-    }
+    val (preceding, succeeding) = works.keySet.siblingsOf(path)
+
+    (preceding.map(relations), succeeding.map(relations))
   }
 
   @tailrec
@@ -121,8 +115,6 @@ class ArchiveRelationsCache(works: Map[String, RelationWork]) extends Logging {
           numDescendents = getNumDescendents(path)
         )
     }
-
-  import weco.pipeline.relation_embedder.models.PathOps._
 
   private lazy val parentMapping: Map[String, String] =
     works.keySet.parentMapping

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/ArchiveRelationsCache.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/ArchiveRelationsCache.scala
@@ -4,8 +4,6 @@ import grizzled.slf4j.Logging
 import weco.catalogue.internal_model.work.WorkState.Merged
 import weco.catalogue.internal_model.work._
 
-import scala.annotation.tailrec
-
 class ArchiveRelationsCache(works: Map[String, RelationWork]) extends Logging {
 
   def apply(work: Work[Merged]): Relations =
@@ -72,14 +70,8 @@ class ArchiveRelationsCache(works: Map[String, RelationWork]) extends Logging {
     (preceding.map(relations), succeeding.map(relations))
   }
 
-  @tailrec
-  private def getAncestors(path: String,
-                           accum: List[Relation] = Nil): List[Relation] =
-    parentMapping.get(path) match {
-      case None => accum
-      case Some(parentPath) =>
-        getAncestors(parentPath, relations(parentPath) :: accum)
-    }
+  private def getAncestors(path: String): List[Relation] =
+    paths.knownAncestorsOf(path).map(relations)
 
   private lazy val relations: Map[String, Relation] =
     works.map {

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/CollectionPathSorter.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/CollectionPathSorter.scala
@@ -3,14 +3,7 @@ package weco.pipeline.relation_embedder
 import scala.util.Try
 import scala.annotation.tailrec
 
-import weco.catalogue.internal_model.work.Work
-import weco.catalogue.internal_model.work.WorkState.Identified
-
 object CollectionPathSorter {
-
-  def sortWorks(works: List[Work[Identified]]): List[Work[Identified]] =
-    works.sortBy(tokenizePath)
-
   def sortPaths(paths: List[String]): List[String] =
     paths.sortBy(tokenizePath)
 
@@ -27,12 +20,6 @@ object CollectionPathSorter {
           Try(token.toInt).map(Left(_)).getOrElse(Right(token))
         }
     }
-
-  private def tokenizePath(work: Work[Identified]): Option[TokenizedPath] =
-    work.data.collectionPath
-      .map { collectionPath =>
-        tokenizePath(collectionPath.path)
-      }
 
   implicit val tokenizedPathOrdering: Ordering[TokenizedPath] =
     new Ordering[TokenizedPath] {

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/models/PathOps.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/models/PathOps.scala
@@ -15,4 +15,37 @@ object PathOps {
       parentParts.mkString("/")
     }
   }
+
+  implicit class CollectionOps(paths: Set[String]) {
+    /** Returns a list of paths in ``works`` whose parents are also in the
+     * list of works.
+     *
+     * e.g. if the works have paths
+     *
+     *      A/B
+     *      A/B/1
+     *      A/B/2
+     *      A/B/2/1
+     *      A/B/2/2
+     *      A/B/3/1
+     *
+     * then this would return
+     *
+     *      Map(
+     *        A/B/1 -> A/B,
+     *        A/B/2 -> A/B,
+     *        A/B/2/1 -> A/B/2,
+     *        A/B/2/2 -> A/B/2
+     *      )
+     *
+     * Notice that A/B and A/B/3/1 are missing, because their parents (A and A/B/3)
+     * are not in the list of works.
+     *
+     */
+    def parentMapping: Map[String, String] =
+      paths
+        .map { p => p -> p.parent }
+        .filter { case (_, parentPath) => paths.contains(parentPath) }
+        .toMap
+  }
 }

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/models/PathOps.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/models/PathOps.scala
@@ -21,97 +21,96 @@ object PathOps {
   }
 
   implicit class CollectionOps(paths: Set[String]) {
+
     /** Returns a list of paths in ``works`` whose parents are also in the
-     * list of works.
-     *
-     * e.g. if the works have paths
-     *
-     *      A/B
-     *      A/B/1
-     *      A/B/2
-     *      A/B/2/1
-     *      A/B/2/2
-     *      A/B/3/1
-     *
-     * then this would return
-     *
-     *      Map(
-     *        A/B/1 -> A/B,
-     *        A/B/2 -> A/B,
-     *        A/B/2/1 -> A/B/2,
-     *        A/B/2/2 -> A/B/2
-     *      )
-     *
-     * Notice that A/B and A/B/3/1 are missing, because their parents (A and A/B/3)
-     * are not in the list of works.
-     *
-     */
+      * list of works.
+      *
+      * e.g. if the works have paths
+      *
+      *      A/B
+      *      A/B/1
+      *      A/B/2
+      *      A/B/2/1
+      *      A/B/2/2
+      *      A/B/3/1
+      *
+      * then this would return
+      *
+      *      Map(
+      *        A/B/1 -> A/B,
+      *        A/B/2 -> A/B,
+      *        A/B/2/1 -> A/B/2,
+      *        A/B/2/2 -> A/B/2
+      *      )
+      *
+      * Notice that A/B and A/B/3/1 are missing, because their parents (A and A/B/3)
+      * are not in the list of works.
+      *
+      */
     def parentMapping: Map[String, String] =
       paths
-        .map { p => p -> p.parent }
+        .map { p =>
+          p -> p.parent
+        }
         .filter { case (_, parentPath) => paths.contains(parentPath) }
         .toMap
 
     /** Returns a list of paths in ``works``, and a list of their immediate children.
-     *
-     * e.g. if the works have paths
-     *
-     *      A/B
-     *      A/B/1
-     *      A/B/2
-     *      A/B/2/1
-     *      A/B/2/2
-     *      A/B/3/1
-     *
-     * then this would return
-     *
-     *      Map(
-     *        A/B -> List(A/B/1, A/B/2),
-     *        A/B/1 -> List(),
-     *        A/B/2 -> List(A/B/2/1, A/B/2/2),
-     *        A/B/2/1 -> List(),
-     *        A/B/2/2 -> List(),
-     *        A/B/3/1 -> List()
-     *      )
-     *
-     * Notice that although all of these are below A/B, it only lists A/B/1 and
-     * A/B/2 because those are the immediate children.
-     *
-     * The children are sorted in CollectionPath order.
-     *
-     */
+      *
+      * e.g. if the works have paths
+      *
+      *      A/B
+      *      A/B/1
+      *      A/B/2
+      *      A/B/2/1
+      *      A/B/2/2
+      *      A/B/3/1
+      *
+      * then this would return
+      *
+      *      Map(
+      *        A/B -> List(A/B/1, A/B/2),
+      *        A/B/1 -> List(),
+      *        A/B/2 -> List(A/B/2/1, A/B/2/2),
+      *        A/B/2/1 -> List(),
+      *        A/B/2/2 -> List(),
+      *        A/B/3/1 -> List()
+      *      )
+      *
+      * Notice that although all of these are below A/B, it only lists A/B/1 and
+      * A/B/2 because those are the immediate children.
+      *
+      * The children are sorted in CollectionPath order.
+      *
+      */
     def childMapping: Map[String, List[String]] =
-      paths
-        .map { p =>
-          val childPaths = parentMapping
-            .collect {
-              case (childPath, parentPath) if parentPath == p =>
-                childPath
-            }
-            .toList
+      paths.map { p =>
+        val childPaths = parentMapping.collect {
+          case (childPath, parentPath) if parentPath == p =>
+            childPath
+        }.toList
 
-          require(childPaths.forall(_.parent == p))
+        require(childPaths.forall(_.parent == p))
 
-          p -> CollectionPathSorter.sortPaths(childPaths)
-        }
-        .toMap
+        p -> CollectionPathSorter.sortPaths(childPaths)
+      }.toMap
 
     /** Returns the siblings of ``path``.
-     *
-     * The result is two lists: the before/after siblings when arranged in order.
-     *
-     * e.g. if the works have paths
-     *
-     *   A/B
-     *   A/B/1
-     *   A/B/2
-     *   A/B/3
-     *   A/B/3/1
-     *   A/B/4
-     *   A/B/4/1
-     *
-     * then the siblings of A/B/3 would be (A/B/1, A/B/2) and (A/B/4,)
-     */
+      *
+      * The result is two lists: the before/after siblings when arranged in order.
+      *
+      * e.g. if the works have paths
+      *
+      *   A/B
+      *   A/B/1
+      *   A/B/2
+      *   A/B/3
+      *   A/B/3/1
+      *   A/B/4
+      *   A/B/4/1
+      *
+      * then the siblings of A/B/3 would be (A/B/1, A/B/2) and (A/B/4,)
+      */
     def siblingsOf(p: String): (List[String], List[String]) = {
       val siblings = for {
         // The children of your parents are your siblings
@@ -157,7 +156,8 @@ object PathOps {
     def knownDescendentsOf(p: String): List[String] = {
 
       @tailrec
-      def getKnownDescendents(stack: List[String], accum: List[String] = Nil): List[String] = {
+      def getKnownDescendents(stack: List[String],
+                              accum: List[String] = Nil): List[String] = {
         stack match {
           case Nil => accum
           case head :: tail =>
@@ -194,10 +194,12 @@ object PathOps {
     def knownAncestorsOf(p: String): List[String] = {
 
       @tailrec
-      def getKnownAncestors(path: String, accum: List[String] = Nil): List[String] = {
+      def getKnownAncestors(path: String,
+                            accum: List[String] = Nil): List[String] = {
         parentMapping.get(path) match {
-          case None             => accum
-          case Some(parentPath) => getKnownAncestors(parentPath, parentPath :: accum)
+          case None => accum
+          case Some(parentPath) =>
+            getKnownAncestors(parentPath, parentPath :: accum)
         }
       }
 

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/models/PathOps.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/models/PathOps.scala
@@ -1,0 +1,18 @@
+package weco.pipeline.relation_embedder.models
+
+object PathOps {
+  implicit class StringOps(path: String) {
+
+    /** Returns the parent of an archive path -- everything before the
+      * final slash.
+      *
+      * e.g. the parent of PP/CRI/J/2/3 is PP/CRI/J/2
+      *
+      */
+    def parent: String = {
+      val parts = path.split("/").toList
+      val parentParts = parts.dropRight(1)
+      parentParts.mkString("/")
+    }
+  }
+}

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/models/PathOps.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/models/PathOps.scala
@@ -1,5 +1,7 @@
 package weco.pipeline.relation_embedder.models
 
+import weco.pipeline.relation_embedder.CollectionPathSorter
+
 object PathOps {
   implicit class StringOps(path: String) {
 
@@ -46,6 +48,50 @@ object PathOps {
       paths
         .map { p => p -> p.parent }
         .filter { case (_, parentPath) => paths.contains(parentPath) }
+        .toMap
+
+    /** Returns a list of paths in ``works``, and a list of their immediate children.
+     *
+     * e.g. if the works have paths
+     *
+     *      A/B
+     *      A/B/1
+     *      A/B/2
+     *      A/B/2/1
+     *      A/B/2/2
+     *      A/B/3/1
+     *
+     * then this would return
+     *
+     *      Map(
+     *        A/B -> List(A/B/1, A/B/2),
+     *        A/B/1 -> List(),
+     *        A/B/2 -> List(A/B/2/1, A/B/2/2),
+     *        A/B/2/1 -> List(),
+     *        A/B/2/2 -> List(),
+     *        A/B/3/1 -> List()
+     *      )
+     *
+     * Notice that although all of these are below A/B, it only lists A/B/1 and
+     * A/B/2 because those are the immediate children.
+     *
+     * The children are sorted in CollectionPath order.
+     *
+     */
+    def childMapping: Map[String, List[String]] =
+      paths
+        .map { p =>
+          val childPaths = parentMapping
+            .collect {
+              case (childPath, parentPath) if parentPath == p =>
+                childPath
+            }
+            .toList
+
+          require(childPaths.forall(_.parent == p))
+
+          p -> CollectionPathSorter.sortPaths(childPaths)
+        }
         .toMap
   }
 }

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/models/PathOps.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/models/PathOps.scala
@@ -93,5 +93,38 @@ object PathOps {
           p -> CollectionPathSorter.sortPaths(childPaths)
         }
         .toMap
+
+    /** Returns the siblings of ``path``.
+     *
+     * The result is two lists: the before/after siblings when arranged in order.
+     *
+     * e.g. if the works have paths
+     *
+     *   A/B
+     *   A/B/1
+     *   A/B/2
+     *   A/B/3
+     *   A/B/3/1
+     *   A/B/4
+     *   A/B/4/1
+     *
+     * then the siblings of A/B/3 would be (A/B/1, A/B/2) and (A/B/4,)
+     */
+    def siblingsOf(p: String): (List[String], List[String]) = {
+      val siblings = for {
+        // The children of your parents are your siblings
+        parent <- parentMapping.get(p)
+        childrenOfParent = childMapping(parent)
+
+        // Where does this path fall in the list of children?
+        index = childrenOfParent.indexOf(p)
+        (preceding, succeedingAndSelf) = childrenOfParent.splitAt(index)
+
+        // Remember to remove yourself from the list of children
+        succeeding = succeedingAndSelf.tail
+      } yield (preceding, succeeding)
+
+      siblings.getOrElse((List(), List()))
+    }
   }
 }

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/models/PathOps.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/models/PathOps.scala
@@ -16,6 +16,14 @@ object PathOps {
       val parentParts = parts.dropRight(1)
       parentParts.mkString("/")
     }
+
+    /** Returns true if the path is a descendent, false otherwise.
+      *
+      * For these purposes, a path is not a descendent of itself.
+      *
+      */
+    def isDescendentOf(possibleAncestorPath: String): Boolean =
+      path.startsWith(possibleAncestorPath + "/")
   }
 
   implicit class CollectionOps(paths: Set[String]) {
@@ -134,5 +142,15 @@ object PathOps {
       */
     def childrenOf(p: String): List[String] =
       childMapping.getOrElse(p, List())
+
+    /** Returns the descendents of ``path``.
+      *
+      * The result is a list, which may be empty if this path isn't in the set
+      * or it doesn't have any children.
+      *
+      */
+    def descendentsOf(p: String): List[String] =
+      CollectionPathSorter.sortPaths(paths.toList)
+        .filter { _.isDescendentOf(p) }
   }
 }

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/models/PathOps.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/models/PathOps.scala
@@ -126,5 +126,13 @@ object PathOps {
 
       siblings.getOrElse((List(), List()))
     }
+
+    /** Returns the children of ``path``.
+      *
+      * The result is a list, which may be empty if this path isn't in the set
+      * or it doesn't have any children.
+      */
+    def childrenOf(p: String): List[String] =
+      childMapping.getOrElse(p, List())
   }
 }

--- a/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/ArchiveRelationsCacheTest.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/ArchiveRelationsCacheTest.scala
@@ -141,7 +141,8 @@ class ArchiveRelationsCacheTest
         Seq(workB, workB11).map(toRelationWork)
       )
 
-      cacheWithDirectDescendents.getAvailabilities(workB) shouldBe Set(Availability.Online)
+      cacheWithDirectDescendents.getAvailabilities(workB) shouldBe Set(
+        Availability.Online)
       cacheWithoutDirectDescendents.getAvailabilities(workB) shouldBe empty
     }
   }

--- a/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/ArchiveRelationsCacheTest.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/ArchiveRelationsCacheTest.scala
@@ -113,6 +113,39 @@ class ArchiveRelationsCacheTest
     )
   }
 
+  describe("gets the availabilities for a work") {
+    val workA = work("a")
+    val work1 = work("a/1")
+    val workB = work("a/1/b")
+    val workB1 = work("a/1/b/1")
+    val workB11 = work("a/1/b/1/1", isAvailableOnline = true)
+    val workC = work("a/1/c", isAvailableOnline = true)
+
+    it("finds the availability on direct descendents") {
+      val relationsCache = ArchiveRelationsCache(
+        Seq(workA, work1, workB, workC).map(toRelationWork)
+      )
+
+      relationsCache.getAvailabilities(workA) shouldBe Set(Availability.Online)
+      relationsCache.getAvailabilities(work1) shouldBe Set(Availability.Online)
+      relationsCache.getAvailabilities(workB) shouldBe empty
+      relationsCache.getAvailabilities(workC) shouldBe Set(Availability.Online)
+    }
+
+    it("skips the availability on indirect descendents") {
+      val cacheWithDirectDescendents = ArchiveRelationsCache(
+        Seq(workB, workB1, workB11).map(toRelationWork)
+      )
+
+      val cacheWithoutDirectDescendents = ArchiveRelationsCache(
+        Seq(workB, workB11).map(toRelationWork)
+      )
+
+      cacheWithDirectDescendents.getAvailabilities(workB) shouldBe Set(Availability.Online)
+      cacheWithoutDirectDescendents.getAvailabilities(workB) shouldBe empty
+    }
+  }
+
   it("finds a work's availabilities") {
     val relationsCache = ArchiveRelationsCache(works)
 

--- a/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/models/PathOpsTest.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/models/PathOpsTest.scala
@@ -10,6 +10,18 @@ class PathOpsTest extends AnyFunSpec with Matchers {
     "PP/CRI/J/2/3".parent shouldBe "PP/CRI/J/2"
   }
 
+  it("tests for being a descendent") {
+    "PP/CRI/J/2/3".isDescendentOf("PP/CRI/J/2/3") shouldBe false
+
+    "PP/CRI/J/2/3".isDescendentOf("PP/CRI/J/2") shouldBe true
+    "PP/CRI/J/2/3".isDescendentOf("PP/CRI/J") shouldBe true
+    "PP/CRI/J/2/3".isDescendentOf("PP/CRI") shouldBe true
+
+    "PP/CRI/J/2/3".isDescendentOf("PP/CRI/I/1") shouldBe false
+
+    "PP/CRI/J/2/3".isDescendentOf("PP/CRI/J1") shouldBe false
+  }
+
   it("creates a parent mapping") {
     val paths = Set("A/B", "A/B/1", "A/B/2", "A/B/2/1", "A/B/2/2", "A/B/3/1")
 
@@ -48,5 +60,15 @@ class PathOpsTest extends AnyFunSpec with Matchers {
     paths.childrenOf("A/B/1") shouldBe empty
     paths.childrenOf("A/B/2") shouldBe List("A/B/2/2")
     paths.childrenOf("A/B/4/1") shouldBe empty
+  }
+
+  it("finds the descendents of a path") {
+    val paths = Set("A/B", "A/B/1", "A/B/2", "A/B/2/1", "A/B/2/2", "A/B/3", "A/B/3/1")
+
+    paths.descendentsOf("A/B") shouldBe List("A/B/1", "A/B/2", "A/B/2/1", "A/B/2/2", "A/B/3", "A/B/3/1")
+    paths.descendentsOf("A/B/2") shouldBe List("A/B/2/1", "A/B/2/2")
+    paths.descendentsOf("A/B/3/1") shouldBe empty
+
+    paths.descendentsOf("doesnotexist") shouldBe empty
   }
 }

--- a/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/models/PathOpsTest.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/models/PathOpsTest.scala
@@ -40,4 +40,13 @@ class PathOpsTest extends AnyFunSpec with Matchers {
 
     paths.siblingsOf("doesnotexist") shouldBe ((List(), List()))
   }
+
+  it("finds the children of a path") {
+    val paths = Set("A/B", "A/B/1", "A/B/2", "A/B/2/2", "A/B/3", "A/B/3/1", "A/B/4", "A/B/4/1")
+
+    paths.childrenOf("A/B") shouldBe List("A/B/1", "A/B/2", "A/B/3", "A/B/4")
+    paths.childrenOf("A/B/1") shouldBe empty
+    paths.childrenOf("A/B/2") shouldBe List("A/B/2/2")
+    paths.childrenOf("A/B/4/1") shouldBe empty
+  }
 }

--- a/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/models/PathOpsTest.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/models/PathOpsTest.scala
@@ -71,4 +71,15 @@ class PathOpsTest extends AnyFunSpec with Matchers {
 
     paths.descendentsOf("doesnotexist") shouldBe empty
   }
+
+  it("finds the known ancestors of a path") {
+    val paths = Set("A", "A/B", "A/B/1/2", "A/B/1/2/3", "A/B/1/2/2", "A/B/1/2/3/4")
+
+    paths.knownAncestorsOf("A") shouldBe List()
+    paths.knownAncestorsOf("A/B") shouldBe List("A")
+    paths.knownAncestorsOf("A/B/1/2") shouldBe List()
+    paths.knownAncestorsOf("A/B/1/2/3") shouldBe List("A/B/1/2")
+    paths.knownAncestorsOf("A/B/1/2/2") shouldBe List("A/B/1/2")
+    paths.knownAncestorsOf("A/B/1/2/3/4") shouldBe List("A/B/1/2", "A/B/1/2/3")
+  }
 }

--- a/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/models/PathOpsTest.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/models/PathOpsTest.scala
@@ -10,18 +10,6 @@ class PathOpsTest extends AnyFunSpec with Matchers {
     "PP/CRI/J/2/3".parent shouldBe "PP/CRI/J/2"
   }
 
-  it("tests for being a descendent") {
-    "PP/CRI/J/2/3".isDescendentOf("PP/CRI/J/2/3") shouldBe false
-
-    "PP/CRI/J/2/3".isDescendentOf("PP/CRI/J/2") shouldBe true
-    "PP/CRI/J/2/3".isDescendentOf("PP/CRI/J") shouldBe true
-    "PP/CRI/J/2/3".isDescendentOf("PP/CRI") shouldBe true
-
-    "PP/CRI/J/2/3".isDescendentOf("PP/CRI/I/1") shouldBe false
-
-    "PP/CRI/J/2/3".isDescendentOf("PP/CRI/J1") shouldBe false
-  }
-
   it("creates a parent mapping") {
     val paths = Set("A/B", "A/B/1", "A/B/2", "A/B/2/1", "A/B/2/2", "A/B/3/1")
 
@@ -62,14 +50,14 @@ class PathOpsTest extends AnyFunSpec with Matchers {
     paths.childrenOf("A/B/4/1") shouldBe empty
   }
 
-  it("finds the descendents of a path") {
-    val paths = Set("A/B", "A/B/1", "A/B/2", "A/B/2/1", "A/B/2/2", "A/B/3", "A/B/3/1")
+  it("finds the known descendents of a path") {
+    val paths = Set("A", "A/B", "A/B/1", "A/B/1/2/3", "A/B/1/2/2", "A/B/1/2/3/4", "A/B/1/2/3/5", "A/B/2")
 
-    paths.descendentsOf("A/B") shouldBe List("A/B/1", "A/B/2", "A/B/2/1", "A/B/2/2", "A/B/3", "A/B/3/1")
-    paths.descendentsOf("A/B/2") shouldBe List("A/B/2/1", "A/B/2/2")
-    paths.descendentsOf("A/B/3/1") shouldBe empty
+    paths.knownDescendentsOf("A") shouldBe List("A/B", "A/B/1", "A/B/2")
+    paths.knownDescendentsOf("A/B") shouldBe List("A/B/1", "A/B/2")
+    paths.knownDescendentsOf("A/B/1") shouldBe empty
 
-    paths.descendentsOf("doesnotexist") shouldBe empty
+    paths.knownDescendentsOf("A/B/1/2/3") shouldBe List("A/B/1/2/3/4", "A/B/1/2/3/5")
   }
 
   it("finds the known ancestors of a path") {

--- a/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/models/PathOpsTest.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/models/PathOpsTest.scala
@@ -13,7 +13,11 @@ class PathOpsTest extends AnyFunSpec with Matchers {
   it("creates a parent mapping") {
     val paths = Set("A/B", "A/B/1", "A/B/2", "A/B/2/1", "A/B/2/2", "A/B/3/1")
 
-    paths.parentMapping shouldBe Map("A/B/1" -> "A/B", "A/B/2" -> "A/B", "A/B/2/1" -> "A/B/2", "A/B/2/2" -> "A/B/2")
+    paths.parentMapping shouldBe Map(
+      "A/B/1" -> "A/B",
+      "A/B/2" -> "A/B",
+      "A/B/2/1" -> "A/B/2",
+      "A/B/2/2" -> "A/B/2")
   }
 
   it("creates a child mapping") {
@@ -30,11 +34,25 @@ class PathOpsTest extends AnyFunSpec with Matchers {
   }
 
   it("finds the siblings of a path") {
-    val paths = Set("A/B", "A/B/1", "A/B/2", "A/B/2/2", "A/B/3", "A/B/3/1", "A/B/4", "A/B/4/1")
+    val paths = Set(
+      "A/B",
+      "A/B/1",
+      "A/B/2",
+      "A/B/2/2",
+      "A/B/3",
+      "A/B/3/1",
+      "A/B/4",
+      "A/B/4/1")
 
-    paths.siblingsOf("A/B/1") shouldBe ((List(), List("A/B/2", "A/B/3", "A/B/4")))
+    paths.siblingsOf("A/B/1") shouldBe (
+      (
+        List(),
+        List("A/B/2", "A/B/3", "A/B/4")))
     paths.siblingsOf("A/B/3") shouldBe ((List("A/B/1", "A/B/2"), List("A/B/4")))
-    paths.siblingsOf("A/B/4") shouldBe ((List("A/B/1", "A/B/2", "A/B/3"), List()))
+    paths.siblingsOf("A/B/4") shouldBe (
+      (
+        List("A/B/1", "A/B/2", "A/B/3"),
+        List()))
 
     paths.siblingsOf("A/B/2/2") shouldBe ((List(), List()))
 
@@ -42,7 +60,15 @@ class PathOpsTest extends AnyFunSpec with Matchers {
   }
 
   it("finds the children of a path") {
-    val paths = Set("A/B", "A/B/1", "A/B/2", "A/B/2/2", "A/B/3", "A/B/3/1", "A/B/4", "A/B/4/1")
+    val paths = Set(
+      "A/B",
+      "A/B/1",
+      "A/B/2",
+      "A/B/2/2",
+      "A/B/3",
+      "A/B/3/1",
+      "A/B/4",
+      "A/B/4/1")
 
     paths.childrenOf("A/B") shouldBe List("A/B/1", "A/B/2", "A/B/3", "A/B/4")
     paths.childrenOf("A/B/1") shouldBe empty
@@ -51,17 +77,28 @@ class PathOpsTest extends AnyFunSpec with Matchers {
   }
 
   it("finds the known descendents of a path") {
-    val paths = Set("A", "A/B", "A/B/1", "A/B/1/2/3", "A/B/1/2/2", "A/B/1/2/3/4", "A/B/1/2/3/5", "A/B/2")
+    val paths = Set(
+      "A",
+      "A/B",
+      "A/B/1",
+      "A/B/1/2/3",
+      "A/B/1/2/2",
+      "A/B/1/2/3/4",
+      "A/B/1/2/3/5",
+      "A/B/2")
 
     paths.knownDescendentsOf("A") shouldBe List("A/B", "A/B/1", "A/B/2")
     paths.knownDescendentsOf("A/B") shouldBe List("A/B/1", "A/B/2")
     paths.knownDescendentsOf("A/B/1") shouldBe empty
 
-    paths.knownDescendentsOf("A/B/1/2/3") shouldBe List("A/B/1/2/3/4", "A/B/1/2/3/5")
+    paths.knownDescendentsOf("A/B/1/2/3") shouldBe List(
+      "A/B/1/2/3/4",
+      "A/B/1/2/3/5")
   }
 
   it("finds the known ancestors of a path") {
-    val paths = Set("A", "A/B", "A/B/1/2", "A/B/1/2/3", "A/B/1/2/2", "A/B/1/2/3/4")
+    val paths =
+      Set("A", "A/B", "A/B/1/2", "A/B/1/2/3", "A/B/1/2/2", "A/B/1/2/3/4")
 
     paths.knownAncestorsOf("A") shouldBe List()
     paths.knownAncestorsOf("A/B") shouldBe List("A")

--- a/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/models/PathOpsTest.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/models/PathOpsTest.scala
@@ -1,0 +1,12 @@
+package weco.pipeline.relation_embedder.models
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class PathOpsTest extends AnyFunSpec with Matchers {
+  import PathOps._
+
+  it("finds the parent of a path") {
+    "PP/CRI/J/2/3".parent shouldBe "PP/CRI/J/2"
+  }
+}

--- a/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/models/PathOpsTest.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/models/PathOpsTest.scala
@@ -15,4 +15,17 @@ class PathOpsTest extends AnyFunSpec with Matchers {
 
     paths.parentMapping shouldBe Map("A/B/1" -> "A/B", "A/B/2" -> "A/B", "A/B/2/1" -> "A/B/2", "A/B/2/2" -> "A/B/2")
   }
+
+  it("creates a child mapping") {
+    val paths = Set("A/B", "A/B/1", "A/B/2", "A/B/2/1", "A/B/2/2", "A/B/3/1")
+
+    paths.childMapping shouldBe Map(
+      "A/B" -> List("A/B/1", "A/B/2"),
+      "A/B/1" -> List(),
+      "A/B/2" -> List("A/B/2/1", "A/B/2/2"),
+      "A/B/2/1" -> List(),
+      "A/B/2/2" -> List(),
+      "A/B/3/1" -> List()
+    )
+  }
 }

--- a/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/models/PathOpsTest.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/models/PathOpsTest.scala
@@ -28,4 +28,16 @@ class PathOpsTest extends AnyFunSpec with Matchers {
       "A/B/3/1" -> List()
     )
   }
+
+  it("finds the siblings of a path") {
+    val paths = Set("A/B", "A/B/1", "A/B/2", "A/B/2/2", "A/B/3", "A/B/3/1", "A/B/4", "A/B/4/1")
+
+    paths.siblingsOf("A/B/1") shouldBe ((List(), List("A/B/2", "A/B/3", "A/B/4")))
+    paths.siblingsOf("A/B/3") shouldBe ((List("A/B/1", "A/B/2"), List("A/B/4")))
+    paths.siblingsOf("A/B/4") shouldBe ((List("A/B/1", "A/B/2", "A/B/3"), List()))
+
+    paths.siblingsOf("A/B/2/2") shouldBe ((List(), List()))
+
+    paths.siblingsOf("doesnotexist") shouldBe ((List(), List()))
+  }
 }

--- a/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/models/PathOpsTest.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/models/PathOpsTest.scala
@@ -9,4 +9,10 @@ class PathOpsTest extends AnyFunSpec with Matchers {
   it("finds the parent of a path") {
     "PP/CRI/J/2/3".parent shouldBe "PP/CRI/J/2"
   }
+
+  it("creates a parent mapping") {
+    val paths = Set("A/B", "A/B/1", "A/B/2", "A/B/2/1", "A/B/2/2", "A/B/3/1")
+
+    paths.parentMapping shouldBe Map("A/B/1" -> "A/B", "A/B/2" -> "A/B", "A/B/2/1" -> "A/B/2", "A/B/2/2" -> "A/B/2")
+  }
 }


### PR DESCRIPTION
While trying to read the relation embedder code for https://github.com/wellcomecollection/platform/issues/5270, I was struggling to follow what's going on in ArchiveRelationsCache.

There's a whole bunch of fairly gnarly code for manipulating strings – i.e., collection paths – mixed in with the logic for dealing with Works and Relations, and it's only tested through its side effects. This patch pulls the string handling functions into a new trait called `PathOps` which just deals with those operations, adds some proper testing around them, and in many places simplifies them.

The tests are only additive, so I believe the behaviour of the relation embedder is unchanged – but hopefully a bit easier to follow.

I'll follow this up with some better tests around the collection path sorting, before finally changing it for 5270.