### PR TITLE
Add comments and tests to CollectionPathSorter

### DIFF
--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/ArchiveRelationsCache.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/ArchiveRelationsCache.scala
@@ -3,7 +3,7 @@ package weco.pipeline.relation_embedder
 import grizzled.slf4j.Logging
 import weco.catalogue.internal_model.work.WorkState.Merged
 import weco.catalogue.internal_model.work._
-import weco.pipeline.relation_embedder.models.{CollectionPathSorter, PathCollection}
+import weco.pipeline.relation_embedder.models.PathCollection
 
 class ArchiveRelationsCache(works: Map[String, RelationWork]) extends Logging {
 

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/ArchiveRelationsCache.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/ArchiveRelationsCache.scala
@@ -3,7 +3,7 @@ package weco.pipeline.relation_embedder
 import grizzled.slf4j.Logging
 import weco.catalogue.internal_model.work.WorkState.Merged
 import weco.catalogue.internal_model.work._
-import weco.pipeline.relation_embedder.models.PathCollection
+import weco.pipeline.relation_embedder.models.{CollectionPathSorter, PathCollection}
 
 class ArchiveRelationsCache(works: Map[String, RelationWork]) extends Logging {
 

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/models/CollectionPathSorter.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/models/CollectionPathSorter.scala
@@ -1,7 +1,7 @@
-package weco.pipeline.relation_embedder
+package weco.pipeline.relation_embedder.models
 
-import scala.util.Try
 import scala.annotation.tailrec
+import scala.util.Try
 
 object CollectionPathSorter {
   def sortPaths(paths: List[String]): List[String] =

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/models/CollectionPathSorter.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/models/CollectionPathSorter.scala
@@ -55,6 +55,9 @@ object CollectionPathSorter {
           case (Nil, Nil) => 0
 
           // Shorter lists sort higher, e.g. "A/B" sorts above "A/B/C".
+          //
+          // Also within a single path, shorter parts sort higher,
+          // e.g. "1" sorts above "1a"
           case (Nil, _) => -1
           case (_, Nil) => 1
 

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/models/CollectionPathSorter.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/models/CollectionPathSorter.scala
@@ -12,7 +12,8 @@ object CollectionPathSorter {
   type PathTokenPart = Either[Int, String]
 
   private def tokenizePath(path: String): TokenizedPath =
-    path.split("/")
+    path
+      .split("/")
       .map(parsePathToken)
       .toList
 
@@ -23,7 +24,9 @@ object CollectionPathSorter {
   // e.g. parsePathToken("ab1cd") = List(Right(ab), Left(1), Right(cd)
   //
   private def parsePathToken(s: String): PathToken =
-    """\d+|\D+""".r.findAllIn(s).toList
+    """\d+|\D+""".r
+      .findAllIn(s)
+      .toList
       .map { part =>
         Try(part.toInt) match {
           case Success(number) => Left(number)
@@ -45,9 +48,10 @@ object CollectionPathSorter {
         case (Right(strX), Right(strY))     => strX.compareTo(strY)
         case (Left(_), _)                   => -1
         case _                              => 1
-      }
+    }
 
-  def shorterPathsWinOrdering[T](perItemOrdering: Ordering[T]): Ordering[List[T]] =
+  def shorterPathsWinOrdering[T](
+    perItemOrdering: Ordering[T]): Ordering[List[T]] =
     new Ordering[List[T]] {
       @tailrec
       override def compare(x: List[T], y: List[T]): Int =

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/models/CollectionPathSorter.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/models/CollectionPathSorter.scala
@@ -31,18 +31,18 @@ object CollectionPathSorter {
         }
       }
 
-  // Note: when calling compare(a, b), the result sign has the following meaning:
+  // Note: when calling compare(x, y), the result sign has the following meaning:
   //
-  //    - negative if a < b
-  //    - positive if a > b
-  //    - zero otherwise (if a == b)
+  //    - negative if x < y
+  //    - positive if x > y
+  //    - zero otherwise (if x == y)
   //
 
   implicit val tokenizedPathOrdering: Ordering[TokenizedPath] =
     new Ordering[TokenizedPath] {
       @tailrec
-      override def compare(a: TokenizedPath, b: TokenizedPath): Int =
-        (a, b) match {
+      override def compare(x: TokenizedPath, y: TokenizedPath): Int =
+        (x, y) match {
           case (Nil, Nil) => 0
 
           // Shorter paths sort higher, e.g. "A/B" sorts above "A/B/C".

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/models/PathCollection.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/models/PathCollection.scala
@@ -1,7 +1,5 @@
 package weco.pipeline.relation_embedder.models
 
-import weco.pipeline.relation_embedder.CollectionPathSorter
-
 import scala.annotation.tailrec
 
 case class PathCollection(paths: Set[String]) {
@@ -73,7 +71,7 @@ case class PathCollection(paths: Set[String]) {
       val childPaths = parentMapping.collect {
         case (childPath, parentPath) if parentPath == p =>
           childPath
-      }.toList
+      }.toSet
 
       require(childPaths.forall(_.parent == p))
 
@@ -155,7 +153,7 @@ case class PathCollection(paths: Set[String]) {
     }
 
     CollectionPathSorter.sortPaths(
-      getKnownDescendents(childMapping.getOrElse(p, Nil))
+      getKnownDescendents(childMapping.getOrElse(p, Nil)).toSet
     )
   }
 

--- a/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/models/CollectionPathSorterTest.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/models/CollectionPathSorterTest.scala
@@ -24,6 +24,9 @@ class CollectionPathSorterTest extends AnyFunSpec with Matchers with TableDriven
       // Sort within runs of letters/numbers
       List("A/B/1", "A/B/2", "A/B/3"),
       List("A/B/a", "A/B/b", "A/B/c"),
+
+      // A suffix added after a letter
+      List("A/1", "A/1a", "A/1b", "A/2", "A/10a", "A/10b", "A/11a"),
     )
 
     forAll(testCases) { paths =>

--- a/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/models/CollectionPathSorterTest.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/models/CollectionPathSorterTest.scala
@@ -4,27 +4,25 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
 
-class CollectionPathSorterTest extends AnyFunSpec with Matchers with TableDrivenPropertyChecks {
+class CollectionPathSorterTest
+    extends AnyFunSpec
+    with Matchers
+    with TableDrivenPropertyChecks {
   it("handles simple cases") {
     val testCases = Table(
       "paths",
-
       // Within a common prefix, shorter paths sort higher
       List("A", "A/B"),
       List("A", "A/B", "A/B/C"),
-
       // But shorter paths may appear later than another path if they don't have
       // a common prefix
       List("A/B/C", "B"),
       List("A/B/C", "B", "B/1"),
-
       // Numbers sort higher than letters
       List("A/B/1", "A/B/A"),
-
       // Sort within runs of letters/numbers
       List("A/B/1", "A/B/2", "A/B/3"),
       List("A/B/a", "A/B/b", "A/B/c"),
-
       // A suffix added after a letter
       List("A/1", "A/1a", "A/1b", "A/2", "A/10a", "A/10b", "A/11a"),
     )

--- a/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/models/CollectionPathSorterTest.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/models/CollectionPathSorterTest.scala
@@ -17,6 +17,13 @@ class CollectionPathSorterTest extends AnyFunSpec with Matchers with TableDriven
       // a common prefix
       List("A/B/C", "B"),
       List("A/B/C", "B", "B/1"),
+
+      // Numbers sort higher than letters
+      List("A/B/1", "A/B/A"),
+
+      // Sort within runs of letters/numbers
+      List("A/B/1", "A/B/2", "A/B/3"),
+      List("A/B/a", "A/B/b", "A/B/c"),
     )
 
     forAll(testCases) { paths =>

--- a/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/models/CollectionPathSorterTest.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/models/CollectionPathSorterTest.scala
@@ -1,0 +1,28 @@
+package weco.pipeline.relation_embedder.models
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks
+
+class CollectionPathSorterTest extends AnyFunSpec with Matchers with TableDrivenPropertyChecks {
+  it("handles simple cases") {
+    val testCases = Table(
+      "paths",
+
+      // Within a common prefix, shorter paths sort higher
+      List("A", "A/B"),
+      List("A", "A/B", "A/B/C"),
+
+      // But shorter paths may appear later than another path if they don't have
+      // a common prefix
+      List("A/B/C", "B"),
+      List("A/B/C", "B", "B/1"),
+    )
+
+    forAll(testCases) { paths =>
+      // Pass in the list as a set so they don't pick up any implicit ordering
+      // from the test spec.
+      CollectionPathSorter.sortPaths(paths.toSet) shouldBe paths
+    }
+  }
+}


### PR DESCRIPTION
While trying to read the relation embedder code for wellcomecollection/platform#5270, I wasn't entirely clear what was going on in CollectionPathSorter – and it's only tested through its side effects.

This is less of a radical refactor than #1824; it's mostly just adding some comments and tests, tightening up the variable names, and rearranging the order of some functions to make similarities/distinctions more obvious.