### PR TITLE
Allow the Calm indexer to turn off when it's not in use

### DIFF
--- a/calm_adapter/terraform/indexer.tf
+++ b/calm_adapter/terraform/indexer.tf
@@ -17,6 +17,9 @@ module "calm_indexer" {
 
   image = local.calm_indexer_image
 
+  min_capacity = 0
+  max_capacity = 1
+
   env_vars = {
     sqs_queue_url     = module.calm_indexer_queue.url
     es_index          = "calm_catalog"

--- a/calm_adapter/terraform/provider.tf
+++ b/calm_adapter/terraform/provider.tf
@@ -5,6 +5,10 @@ provider "aws" {
     role_arn = "arn:aws:iam::760097843905:role/platform-developer"
   }
 
+  ignore_tags {
+    keys = ["deployment:label"]
+  }
+
   default_tags {
     tags = {
       TerraformConfigurationURL = "https://github.com/wellcomecollection/catalogue-pipeline/tree/main/calm_adapter/terraform"

--- a/infrastructure/modules/worker/variables.tf
+++ b/infrastructure/modules/worker/variables.tf
@@ -41,8 +41,7 @@ variable "desired_task_count" {
 }
 
 variable "min_capacity" {
-  type    = number
-  default = 1
+  type = number
 }
 
 variable "max_capacity" {


### PR DESCRIPTION
Spotted while debugging the Calm adapter auto-deployment.

I thought the default min capacity of the `worker` module was 0, but it was actually 1, so it would never scale all the way to zero. This patch allows the Calm indexer to scale down to 0, and removes the default value so we can't make the same mistake again – I've checked all the uses of the module, and everywhere else the min capacity is already explicitly set.

💸 