### PR TITLE
Code tidies in the relation embedder

### DIFF
--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/RelationEmbedderWorkerService.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/RelationEmbedderWorkerService.scala
@@ -45,7 +45,10 @@ class RelationEmbedderWorkerService[MsgDestination](
         relationsService
           .getRelationTree(batch)
           .runWith(Sink.seq)
-          .map(ArchiveRelationsCache(_))
+          .map { relationWorks =>
+            info(s"Received ${relationWorks.size} relations for tree ${batch.rootPath}")
+            ArchiveRelationsCache(relationWorks)
+          }
           .flatMap { relationsCache =>
             info(
               s"Built cache for tree ${batch.rootPath}, containing ${relationsCache.size} relations (${relationsCache.numParents} works map to parent works).")

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/RelationEmbedderWorkerService.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/RelationEmbedderWorkerService.scala
@@ -46,7 +46,8 @@ class RelationEmbedderWorkerService[MsgDestination](
           .getRelationTree(batch)
           .runWith(Sink.seq)
           .map { relationWorks =>
-            info(s"Received ${relationWorks.size} relations for tree ${batch.rootPath}")
+            info(
+              s"Received ${relationWorks.size} relations for tree ${batch.rootPath}")
             ArchiveRelationsCache(relationWorks)
           }
           .flatMap { relationsCache =>

--- a/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/RelationsServiceTest.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/RelationsServiceTest.scala
@@ -3,7 +3,6 @@ package weco.pipeline.relation_embedder
 import akka.actor.ActorSystem
 import akka.stream.scaladsl.Sink
 import com.sksamuel.elastic4s.Index
-import org.scalatest.Assertion
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.akka.fixtures.Akka
@@ -29,9 +28,6 @@ class RelationsServiceTest
       completeTreeScroll = completeTreeScroll,
       affectedWorksScroll = affectedWorksScroll
     )
-
-  def storeWorks(index: Index, works: List[Work[Merged]] = works): Assertion =
-    insertIntoElasticsearch(index, works: _*)
 
   /** The following tests use works within this tree:
     *
@@ -81,7 +77,7 @@ class RelationsServiceTest
 
     it("Retrieves all affected works when batch consists of a complete tree") {
       withLocalMergedWorksIndex { index =>
-        storeWorks(index)
+        insertIntoElasticsearch(index, works: _*)
         withActorSystem { implicit actorSystem =>
           val batch = Batch(rootPath = "A", List(Tree("A")))
           whenReady(queryAffectedWorks(service(index), batch)) {
@@ -93,7 +89,7 @@ class RelationsServiceTest
 
     it("Retrieves all affected works when batch consists of single node") {
       withLocalMergedWorksIndex { index =>
-        storeWorks(index)
+        insertIntoElasticsearch(index, works: _*)
         withActorSystem { implicit actorSystem =>
           val batch = Batch(rootPath = "A", List(Node("A/B")))
           whenReady(queryAffectedWorks(service(index), batch)) {
@@ -105,7 +101,7 @@ class RelationsServiceTest
 
     it("Retrieves all affected works when batch consists of a nodes children") {
       withLocalMergedWorksIndex { index =>
-        storeWorks(index)
+        insertIntoElasticsearch(index, works: _*)
         withActorSystem { implicit actorSystem =>
           val batch = Batch(rootPath = "A", List(Children("A/C")))
           whenReady(queryAffectedWorks(service(index), batch)) {
@@ -118,7 +114,7 @@ class RelationsServiceTest
     it(
       "Retrieves all affected works when batch consists of a nodes descendents") {
       withLocalMergedWorksIndex { index =>
-        storeWorks(index)
+        insertIntoElasticsearch(index, works: _*)
         withActorSystem { implicit actorSystem =>
           val batch = Batch(rootPath = "A", List(Descendents("A/C")))
           whenReady(queryAffectedWorks(service(index), batch)) {
@@ -136,7 +132,7 @@ class RelationsServiceTest
     it(
       "Retrieves all affected works when batch consists of a mixture of selectors") {
       withLocalMergedWorksIndex { index =>
-        storeWorks(index)
+        insertIntoElasticsearch(index, works: _*)
         withActorSystem { implicit actorSystem =>
           val batch = Batch(
             rootPath = "A",
@@ -160,7 +156,7 @@ class RelationsServiceTest
 
     it("Retrieves all affected works across multiple scroll pages") {
       withLocalMergedWorksIndex { index =>
-        storeWorks(index)
+        insertIntoElasticsearch(index, works: _*)
         withActorSystem { implicit actorSystem =>
           val batch = Batch(rootPath = "A", List(Tree("A")))
           whenReady(queryAffectedWorks(
@@ -175,7 +171,7 @@ class RelationsServiceTest
     it("Returns invisible works") {
       withLocalMergedWorksIndex { index =>
         val invisibleWork = work("A/C/X/5").invisible()
-        storeWorks(index, invisibleWork :: works)
+        insertIntoElasticsearch(index, invisibleWork :: works: _*)
         withActorSystem { implicit actorSystem =>
           val batch = Batch(
             rootPath = "A",
@@ -205,7 +201,7 @@ class RelationsServiceTest
     it("Retrieves all works in archive") {
       withLocalMergedWorksIndex { index =>
         withActorSystem { implicit actorSystem =>
-          storeWorks(index, works)
+          insertIntoElasticsearch(index, works: _*)
           whenReady(queryRelationTree(service(index), batch)) {
             _ should contain theSameElementsAs works.map(toRelationWork)
           }
@@ -216,7 +212,7 @@ class RelationsServiceTest
     it("Ignores works in other archvies") {
       withLocalMergedWorksIndex { index =>
         withActorSystem { implicit actorSystem =>
-          storeWorks(index, work("other/archive") :: works)
+          insertIntoElasticsearch(index, work("other/archive") :: works: _*)
           whenReady(queryRelationTree(service(index), batch)) {
             _ should contain theSameElementsAs works.map(toRelationWork)
           }
@@ -227,7 +223,7 @@ class RelationsServiceTest
     it("Ignores invisible works") {
       withLocalMergedWorksIndex { index =>
         withActorSystem { implicit actorSystem =>
-          storeWorks(index, work("A/Invisible").invisible() :: works)
+          insertIntoElasticsearch(index, work("A/Invisible").invisible() :: works: _*)
           whenReady(queryRelationTree(service(index), batch)) {
             _ should contain theSameElementsAs works.map(toRelationWork)
           }

--- a/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/RelationsServiceTest.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/RelationsServiceTest.scala
@@ -177,10 +177,7 @@ class RelationsServiceTest
             rootPath = "A",
             List(Children("A/C/X"), Descendents("A/C/X"), Node("A/C/X/5")))
           whenReady(queryAffectedWorks(service(index), batch)) {
-            _ should contain theSameElementsAs List(
-              work3,
-              work4,
-              invisibleWork)
+            _ should contain theSameElementsAs List(work3, work4, invisibleWork)
           }
         }
       }
@@ -223,7 +220,9 @@ class RelationsServiceTest
     it("Ignores invisible works") {
       withLocalMergedWorksIndex { index =>
         withActorSystem { implicit actorSystem =>
-          insertIntoElasticsearch(index, work("A/Invisible").invisible() :: works: _*)
+          insertIntoElasticsearch(
+            index,
+            work("A/Invisible").invisible() :: works: _*)
           whenReady(queryRelationTree(service(index), batch)) {
             _ should contain theSameElementsAs works.map(toRelationWork)
           }

--- a/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/RelationsServiceTest.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/RelationsServiceTest.scala
@@ -84,8 +84,8 @@ class RelationsServiceTest
         storeWorks(index)
         withActorSystem { implicit actorSystem =>
           val batch = Batch(rootPath = "A", List(Tree("A")))
-          whenReady(queryAffectedWorks(service(index), batch)) { result =>
-            result should contain theSameElementsAs works
+          whenReady(queryAffectedWorks(service(index), batch)) {
+            _ should contain theSameElementsAs works
           }
         }
       }
@@ -96,8 +96,8 @@ class RelationsServiceTest
         storeWorks(index)
         withActorSystem { implicit actorSystem =>
           val batch = Batch(rootPath = "A", List(Node("A/B")))
-          whenReady(queryAffectedWorks(service(index), batch)) { result =>
-            result should contain theSameElementsAs List(workB)
+          whenReady(queryAffectedWorks(service(index), batch)) {
+            _ should contain theSameElementsAs List(workB)
           }
         }
       }
@@ -108,8 +108,8 @@ class RelationsServiceTest
         storeWorks(index)
         withActorSystem { implicit actorSystem =>
           val batch = Batch(rootPath = "A", List(Children("A/C")))
-          whenReady(queryAffectedWorks(service(index), batch)) { result =>
-            result should contain theSameElementsAs List(workX, workY, workZ)
+          whenReady(queryAffectedWorks(service(index), batch)) {
+            _ should contain theSameElementsAs List(workX, workY, workZ)
           }
         }
       }
@@ -121,8 +121,8 @@ class RelationsServiceTest
         storeWorks(index)
         withActorSystem { implicit actorSystem =>
           val batch = Batch(rootPath = "A", List(Descendents("A/C")))
-          whenReady(queryAffectedWorks(service(index), batch)) { result =>
-            result should contain theSameElementsAs List(
+          whenReady(queryAffectedWorks(service(index), batch)) {
+            _ should contain theSameElementsAs List(
               workX,
               workY,
               workZ,
@@ -141,8 +141,8 @@ class RelationsServiceTest
           val batch = Batch(
             rootPath = "A",
             List(Node("A/E/2"), Descendents("A/C"), Children("A")))
-          whenReady(queryAffectedWorks(service(index), batch)) { result =>
-            result should contain theSameElementsAs List(
+          whenReady(queryAffectedWorks(service(index), batch)) {
+            _ should contain theSameElementsAs List(
               workB,
               workC,
               workE,
@@ -165,8 +165,8 @@ class RelationsServiceTest
           val batch = Batch(rootPath = "A", List(Tree("A")))
           whenReady(queryAffectedWorks(
             service(index, affectedWorksScroll = 3),
-            batch)) { result =>
-            result should contain theSameElementsAs works
+            batch)) {
+            _ should contain theSameElementsAs works
           }
         }
       }
@@ -180,8 +180,8 @@ class RelationsServiceTest
           val batch = Batch(
             rootPath = "A",
             List(Children("A/C/X"), Descendents("A/C/X"), Node("A/C/X/5")))
-          whenReady(queryAffectedWorks(service(index), batch)) { result =>
-            result should contain theSameElementsAs List(
+          whenReady(queryAffectedWorks(service(index), batch)) {
+            _ should contain theSameElementsAs List(
               work3,
               work4,
               invisibleWork)
@@ -206,9 +206,8 @@ class RelationsServiceTest
       withLocalMergedWorksIndex { index =>
         withActorSystem { implicit actorSystem =>
           storeWorks(index, works)
-          whenReady(queryRelationTree(service(index), batch)) { relationWorks =>
-            relationWorks should contain theSameElementsAs works.map(
-              toRelationWork)
+          whenReady(queryRelationTree(service(index), batch)) {
+            _ should contain theSameElementsAs works.map(toRelationWork)
           }
         }
       }
@@ -218,9 +217,8 @@ class RelationsServiceTest
       withLocalMergedWorksIndex { index =>
         withActorSystem { implicit actorSystem =>
           storeWorks(index, work("other/archive") :: works)
-          whenReady(queryRelationTree(service(index), batch)) { relationWorks =>
-            relationWorks should contain theSameElementsAs works.map(
-              toRelationWork)
+          whenReady(queryRelationTree(service(index), batch)) {
+            _ should contain theSameElementsAs works.map(toRelationWork)
           }
         }
       }
@@ -230,9 +228,8 @@ class RelationsServiceTest
       withLocalMergedWorksIndex { index =>
         withActorSystem { implicit actorSystem =>
           storeWorks(index, work("A/Invisible").invisible() :: works)
-          whenReady(queryRelationTree(service(index), batch)) { relationWorks =>
-            relationWorks should contain theSameElementsAs works.map(
-              toRelationWork)
+          whenReady(queryRelationTree(service(index), batch)) {
+            _ should contain theSameElementsAs works.map(toRelationWork)
           }
         }
       }


### PR DESCRIPTION
This is a bunch of no-op code tidies in aid of https://github.com/wellcomecollection/platform/issues/5273. This isn't changing any functionality, but it means the diff for the actual change should be a lot smaller and easier to follow.