### PR TITLE
Fix a flaky test in the batcher

### DIFF
--- a/pipeline/relation_embedder/batcher/src/test/scala/weco/pipeline/batcher/BatcherWorkerServiceTest.scala
+++ b/pipeline/relation_embedder/batcher/src/test/scala/weco/pipeline/batcher/BatcherWorkerServiceTest.scala
@@ -84,7 +84,7 @@ class BatcherWorkerServiceTest
   }
 
   it("sends the whole tree when batch consists of too many selectors") {
-    withWorkerService(3) {
+    withWorkerService(maxBatchSize = 3) {
       case (QueuePair(queue, dlq), msgSender) =>
         sendNotificationToSQS(queue = queue, body = "A/B")
         sendNotificationToSQS(queue = queue, body = "A/E/1")

--- a/pipeline/relation_embedder/batcher/src/test/scala/weco/pipeline/batcher/BatcherWorkerServiceTest.scala
+++ b/pipeline/relation_embedder/batcher/src/test/scala/weco/pipeline/batcher/BatcherWorkerServiceTest.scala
@@ -134,7 +134,7 @@ class BatcherWorkerServiceTest
   def withWorkerService[R](visibilityTimeout: Duration = 5 seconds,
                            maxBatchSize: Int = 10,
                            brokenPaths: Set[String] = Set.empty,
-                           flushInterval: FiniteDuration = 100 milliseconds)(
+                           flushInterval: FiniteDuration = 200 milliseconds)(
     testWith: TestWith[(QueuePair, MemoryMessageSender), R]): R =
     withLocalSqsQueuePair(visibilityTimeout = visibilityTimeout) { queuePair =>
       withActorSystem { implicit actorSystem =>


### PR DESCRIPTION
Sometimes in CI we see one of the batcher tests fail because the service sends two batches, instead of one.  You can reproduce this locally by cranking down the flushInterval until the batcher flushes the first message before the second is received.

Conversely, it seems like cranking the interval up will probably stop this test being flaky in CI.