### PR TITLE
Remove the VHS Miro migration table

### DIFF
--- a/infrastructure/critical/outputs.tf
+++ b/infrastructure/critical/outputs.tf
@@ -25,16 +25,3 @@ output "vhs_miro_table_name" {
 output "vhs_miro_assumable_read_role" {
   value = module.vhs_miro.assumable_read_role
 }
-
-# Miro Inventory Hybrid Store
-output "vhs_miro_inventory_read_policy" {
-  value = module.vhs_miro_migration.read_policy
-}
-
-output "vhs_miro_inventory_table_name" {
-  value = module.vhs_miro_migration.table_name
-}
-
-output "vhs_miro_inventory_assumable_read_role" {
-  value = module.vhs_miro_migration.assumable_read_role
-}

--- a/infrastructure/critical/vhs_miro_migration.tf
+++ b/infrastructure/critical/vhs_miro_migration.tf
@@ -1,6 +1,0 @@
-module "vhs_miro_migration" {
-  source = "./modules/vhs"
-  name   = "miro-migration"
-
-  read_principles = local.read_principles
-}


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5265, justification is on that ticket.

I haven't applied this yet; pending review.