### PR TITLE
Add an option to display the Miro image in the visual graph

### DIFF
--- a/pipeline/matcher/scripts/get_graph.py
+++ b/pipeline/matcher/scripts/get_graph.py
@@ -57,7 +57,7 @@ def add_miro_image(*, graph, canonical_id, miro_id):
             </table>
         >
         """.strip(),
-        _attributes={"shape": "box"}
+        _attributes={"shape": "box"},
     )
 
 
@@ -105,7 +105,9 @@ def main(index_date, work_id, emit_work_data, miro_images):
         source = source_type_labels.get(node["source_id_type"], node["source_id_type"])
 
         if source == "Miro" and miro_images:
-            add_miro_image(graph=graph, miro_id=node["source_id"], canonical_id=node["id"])
+            add_miro_image(
+                graph=graph, miro_id=node["source_id"], canonical_id=node["id"]
+            )
         else:
             graph.node(node["id"], label=fr"{source}\n{node['source_id']}")
 


### PR DESCRIPTION
This will make it easier to reason about what's going on in the graph, e.g. if a Miro image has been incorrectly linked to a Sierra record. An example:

<img width="552" alt="Screenshot 2021-08-23 at 12 21 31" src="https://user-images.githubusercontent.com/301220/130439183-1edacd24-f751-49c8-bbca-47c475ae48f3.png">

I've done this by hand a few times, but this is what computers are good for!

This is enabled by default, but there's a flag to disable it if you just want the pure-text graph.