### PR TITLE
Add a title to works from the METS transformer

### DIFF
--- a/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/MetsData.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/MetsData.scala
@@ -50,6 +50,7 @@ case class DeletedMetsData(recordIdentifier: String) extends NewMetsData {
 
 case class InvisibleMetsData(
   recordIdentifier: String,
+  title: String,
   accessConditionDz: Option[String] = None,
   accessConditionStatus: Option[String] = None,
   accessConditionUsage: Option[String] = None,
@@ -79,6 +80,7 @@ case class InvisibleMetsData(
         version = version,
         state = Source(sourceIdentifier, modifiedTime),
         data = WorkData[DataState.Unidentified](
+          title = Some(title),
           items = List(item),
           mergeCandidates = List(mergeCandidate),
           thumbnail = thumbnail(sourceIdentifier.value, license, accessStatus),

--- a/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/MetsXml.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/MetsXml.scala
@@ -37,12 +37,38 @@ case class MetsXml(root: Elem) {
     */
   def recordIdentifier: Either[Exception, String] = {
     val identifierNodes =
-      (root \\ "dmdSec" \ "mdWrap" \\ "recordInfo" \ "recordIdentifier").toList
+      (root \\ "dmdSec" \ "mdWrap" \\ "recordInfo" \ "recordIdentifier").toList.distinct
     identifierNodes match {
-      case identifierNodes if identifierNodes.distinct.size == 1 =>
-        Right(identifierNodes.head.text)
+      case Seq(node) => Right(node.text)
       case _ =>
         Left(new Exception("Could not parse recordIdentifier from METS XML"))
+    }
+  }
+
+  /** The title is encoded in the METS.  For example:
+    *
+    * <mets:dmdSec ID="DMDLOG_0000">
+    *   <mets:mdWrap MDTYPE="MODS">
+    *     <mets:xmlData>
+    *       <mods:mods>
+    *         <mods:titleInfo>
+    *           <mods:title>Reduction and treatment of a fracture of the calcaneus</mods:title>
+    *         </mods:titleInfo>
+    *       </mods:mods>
+    *     </mets:xmlData>
+    *   </mets:mdWrap>
+    * </mets:dmdSec>
+    *
+    * The title is "Reduction and treatment of a fracture of the calcaneus"
+    */
+  def title: Either[Exception, String] = {
+    val titleNodes =
+      (root \\ "dmdSec" \ "mdWrap" \\ "titleInfo" \ "title").toList.distinct
+
+    titleNodes match {
+      case Seq(node) => Right(node.text)
+      case _ =>
+        Left(new Exception("Could not parse title from METS XML"))
     }
   }
 

--- a/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/MetsXmlTransformer.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/MetsXmlTransformer.scala
@@ -49,12 +49,14 @@ class MetsXmlTransformer(store: Readable[S3ObjectLocation, String])
     root: MetsXml): Result[InvisibleMetsData] =
     for {
       id <- root.recordIdentifier
+      title <- root.title
       accessConditionDz <- root.accessConditionDz
       accessConditionStatus <- root.accessConditionStatus
       accessConditionUsage <- root.accessConditionUsage
     } yield
       InvisibleMetsData(
         recordIdentifier = id,
+        title = title,
         accessConditionDz = accessConditionDz,
         accessConditionStatus = accessConditionStatus,
         accessConditionUsage = accessConditionUsage,
@@ -67,6 +69,7 @@ class MetsXmlTransformer(store: Readable[S3ObjectLocation, String])
     manifestations: List[S3ObjectLocation]): Result[InvisibleMetsData] =
     for {
       id <- root.recordIdentifier
+      title <- root.title
       firstManifestation <- getFirstManifestation(root, manifestations)
       accessConditionDz <- firstManifestation.accessConditionDz
       accessConditionStatus <- firstManifestation.accessConditionStatus
@@ -74,6 +77,7 @@ class MetsXmlTransformer(store: Readable[S3ObjectLocation, String])
     } yield
       InvisibleMetsData(
         recordIdentifier = id,
+        title = title,
         accessConditionDz = accessConditionDz,
         accessConditionStatus = accessConditionStatus,
         accessConditionUsage = accessConditionUsage,

--- a/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/generators/MetsDataGenerators.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/generators/MetsDataGenerators.scala
@@ -11,6 +11,7 @@ trait MetsDataGenerators extends SierraIdentifierGenerators {
 
   def createMetsDataWith(
     bibNumber: String = createBibNumberString,
+    title: String = randomAlphanumeric(),
     accessConditionDz: Option[String] = None,
     accessConditionStatus: Option[String] = None,
     accessConditionUsage: Option[String] = None,
@@ -18,6 +19,7 @@ trait MetsDataGenerators extends SierraIdentifierGenerators {
     titlePageId: Option[String] = None): InvisibleMetsData =
     InvisibleMetsData(
       recordIdentifier = bibNumber,
+      title = title,
       accessConditionDz = accessConditionDz,
       accessConditionStatus = accessConditionStatus,
       accessConditionUsage = accessConditionUsage,

--- a/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/generators/MetsGenerators.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/generators/MetsGenerators.scala
@@ -1,12 +1,14 @@
 package weco.pipeline.transformer.mets.generators
 
 import weco.catalogue.internal_model.locations.License
+import weco.fixtures.RandomGenerators
 
 import scala.xml.NodeSeq
 
-trait MetsGenerators {
+trait MetsGenerators extends RandomGenerators {
   def metsXmlWith(
     recordIdentifier: String,
+    title: String = randomAlphanumeric(),
     license: Option[License] = None,
     accessConditionStatus: Option[String] = None,
     accessConditionUsage: Option[String] = None,
@@ -18,6 +20,7 @@ trait MetsGenerators {
       {
       rootSection(
         recordIdentifier = recordIdentifier,
+        title = title,
         license = license,
         accessConditionStatus = accessConditionStatus,
         accessConditionUsage = accessConditionUsage
@@ -28,11 +31,12 @@ trait MetsGenerators {
       {structMap}
      </mets:mets>.toString()
 
-  def xmlWithManifestations(manifestations: List[(String, String, String)]) =
+  def xmlWithManifestations(manifestations: List[(String, String, String)], title: String = randomAlphanumeric()) =
     <mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:mods="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink">
       {
       rootSection(
         recordIdentifier = "b30246039",
+        title = title,
         license = None,
         accessConditionStatus = None,
         accessConditionUsage = None
@@ -54,6 +58,7 @@ trait MetsGenerators {
 
   def rootSection(
     recordIdentifier: String,
+    title: String,
     license: Option[License],
     accessConditionStatus: Option[String],
     accessConditionUsage: Option[String]
@@ -65,6 +70,9 @@ trait MetsGenerators {
             <mods:recordInfo>
               <mods:recordIdentifier source="gbv-ppn">{recordIdentifier}</mods:recordIdentifier>
             </mods:recordInfo>
+            <mods:titleInfo>
+              <mods:title>{title}</mods:title>
+            </mods:titleInfo>
             {
       license.fold(ifEmpty = NodeSeq.Empty) { l =>
         <mods:accessCondition type="dz">{l.id.toUpperCase}</mods:accessCondition>

--- a/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/generators/MetsGenerators.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/generators/MetsGenerators.scala
@@ -31,7 +31,8 @@ trait MetsGenerators extends RandomGenerators {
       {structMap}
      </mets:mets>.toString()
 
-  def xmlWithManifestations(manifestations: List[(String, String, String)], title: String = randomAlphanumeric()) =
+  def xmlWithManifestations(manifestations: List[(String, String, String)],
+                            title: String = randomAlphanumeric()) =
     <mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:mods="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink">
       {
       rootSection(

--- a/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformer/MetsDataTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformer/MetsDataTest.scala
@@ -25,11 +25,15 @@ class MetsDataTest
 
   it("creates a invisible work with an item and a license") {
     val bibNumber = createBibNumberString
+    val title = randomAlphanumeric()
+
     val metsData =
       createMetsDataWith(
         bibNumber = bibNumber,
+        title = title,
         accessConditionDz = Some("CC-BY-NC")
       )
+
     val version = 1
     val expectedSourceIdentifier = SourceIdentifier(
       identifierType = IdentifierType.METS,
@@ -53,6 +57,7 @@ class MetsDataTest
         version = version,
         state = Source(expectedSourceIdentifier, createdDate),
         data = WorkData[DataState.Unidentified](
+          title = Some(title),
           items = List(unidentifiableItem),
           mergeCandidates = List(
             MergeCandidate(
@@ -91,8 +96,10 @@ class MetsDataTest
 
   it("creates a invisible work with an item and no license") {
     val bibNumber = createBibNumberString
+    val title = randomAlphanumeric()
     val metsData = createMetsDataWith(
       bibNumber = bibNumber,
+      title = title,
       accessConditionDz = None
     )
     val version = 1
@@ -119,6 +126,7 @@ class MetsDataTest
         version = version,
         state = Source(expectedSourceIdentifier, createdDate),
         data = WorkData[DataState.Unidentified](
+          title = Some(title),
           items = List(unidentifiableItem),
           mergeCandidates = List(
             MergeCandidate(

--- a/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformer/MetsXmlTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformer/MetsXmlTest.scala
@@ -19,6 +19,10 @@ class MetsXmlTest
     MetsXml(xml).value.recordIdentifier shouldBe Right("b30246039")
   }
 
+  it("finds the title") {
+    MetsXml(xml).value.title shouldBe Right("[Report 1942] /")
+  }
+
   it("does not parse a mets if recordIdentifier is outside of dmdSec element") {
     MetsXml(xmlNodmdSec).recordIdentifier shouldBe a[Left[_, _]]
   }

--- a/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformer/MetsXmlTransformerTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformer/MetsXmlTransformerTest.scala
@@ -62,7 +62,8 @@ class MetsXmlTransformerTest
       manifestations = manifestations) shouldBe Right(
       InvisibleMetsData(
         recordIdentifier = "b22012692",
-        title = "Enciclopedia anatomica che comprende l'anatomia descrittiva, l'anatomia generale, l'anatomia patologica, la storia dello sviluppo e delle razze umane /",
+        title =
+          "Enciclopedia anatomica che comprende l'anatomia descrittiva, l'anatomia generale, l'anatomia patologica, la storia dello sviluppo e delle razze umane /",
         accessConditionDz = Some("PDM"),
         accessConditionStatus = Some("Open"),
         fileReferencesMapping = createFileReferences(2, "b22012692", Some(1)),
@@ -76,7 +77,8 @@ class MetsXmlTransformerTest
 
     val xml = xmlWithManifestations(
       title = title,
-      manifestations = List(("LOG_0001", "01", "first"), ("LOG_0002", "02", "second.xml"))
+      manifestations =
+        List(("LOG_0001", "01", "first"), ("LOG_0002", "02", "second.xml"))
     ).toString()
 
     val manifestations = Map(
@@ -88,9 +90,7 @@ class MetsXmlTransformerTest
           fileSec = fileSec("b30246039"),
           structMap = structMap)),
       "second.xml" -> Some(
-        metsXmlWith(
-          recordIdentifier = "b30246039",
-          title = title)),
+        metsXmlWith(recordIdentifier = "b30246039", title = title)),
     )
     transform(
       root = Some(xml),

--- a/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformer/MetsXmlTransformerTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformer/MetsXmlTransformerTest.scala
@@ -25,6 +25,7 @@ class MetsXmlTransformerTest
     transform(root = Some(xml), createdDate = Instant.now) shouldBe Right(
       InvisibleMetsData(
         recordIdentifier = "b30246039",
+        title = "[Report 1942] /",
         accessConditionDz = Some("CC-BY-NC"),
         accessConditionStatus = Some("Open"),
         accessConditionUsage = Some("Some terms"),
@@ -61,6 +62,7 @@ class MetsXmlTransformerTest
       manifestations = manifestations) shouldBe Right(
       InvisibleMetsData(
         recordIdentifier = "b22012692",
+        title = "Enciclopedia anatomica che comprende l'anatomia descrittiva, l'anatomia generale, l'anatomia patologica, la storia dello sviluppo e delle razze umane /",
         accessConditionDz = Some("PDM"),
         accessConditionStatus = Some("Open"),
         fileReferencesMapping = createFileReferences(2, "b22012692", Some(1)),
@@ -70,17 +72,25 @@ class MetsXmlTransformerTest
   }
 
   it("transforms METS XML with manifestations without .xml in the name") {
+    val title = "[Report 1942] /"
+
     val xml = xmlWithManifestations(
-      List(("LOG_0001", "01", "first"), ("LOG_0002", "02", "second.xml"))
+      title = title,
+      manifestations = List(("LOG_0001", "01", "first"), ("LOG_0002", "02", "second.xml"))
     ).toString()
+
     val manifestations = Map(
       "first.xml" -> Some(
         metsXmlWith(
-          "b30246039",
+          recordIdentifier = "b30246039",
+          title = title,
           license = Some(License.InCopyright),
           fileSec = fileSec("b30246039"),
           structMap = structMap)),
-      "second.xml" -> Some(metsXmlWith("b30246039")),
+      "second.xml" -> Some(
+        metsXmlWith(
+          recordIdentifier = "b30246039",
+          title = title)),
     )
     transform(
       root = Some(xml),
@@ -88,6 +98,7 @@ class MetsXmlTransformerTest
       manifestations = manifestations) shouldBe Right(
       InvisibleMetsData(
         recordIdentifier = "b30246039",
+        title = title,
         accessConditionDz = Some("INC"),
         accessConditionStatus = None,
         fileReferencesMapping = createFileReferences(2, "b30246039"),


### PR DESCRIPTION
Follows https://github.com/wellcomecollection/catalogue-pipeline/pull/1836, for https://github.com/wellcomecollection/platform/issues/5242

We assume the presence of a title in a bunch of places, including the design of the works pages – and indeed, the title will always be set on the WorkData for a visible Work – but this isn't enforced by the type system. We have `WorkData { title: Option[String] }` is because we don't set a title in the METS transformer. The reason we don't set a title in the METS transformer is that it'll be blatted in the merger – but there is a title in the METS files (and I checked every METS file to verify – yes, it really is there).

This PR updates the transformer to set a title on every METS work.

It **doesn't** update the internal model to assume the use of title – if we do that, we can't deploy it into the current pipeline, because the existing METS works without a title will break. My plan is:

* Get this patch reviewed, merged and deployed into the current pipeline
* Reindex just the METS works, so every METS work in the pipeline has a title
* Start enforcing a required title in internal model, and deploy that into the current pipeline