### PR TITLE
Make the invisibilityReason a required value, rather than a list

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksIndexConfig.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksIndexConfig.scala
@@ -174,7 +174,7 @@ object WorksIndexConfig extends IndexConfigFields {
         search,
         keywordField("type"),
         data.withDynamic("false"),
-        objectField("invisibilityReasons")
+        objectField("invisibilityReason")
           .fields(keywordField("type"))
           .withDynamic("false"),
         objectField("deletedReason")

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Work.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Work.scala
@@ -41,8 +41,8 @@ sealed trait Work[State <: WorkState] {
         Work.Visible(version, outData, outState, redirectSources.map {
           transition.redirect
         })
-      case Work.Invisible(version, _, _, invisibilityReasons) =>
-        Work.Invisible(version, outData, outState, invisibilityReasons)
+      case Work.Invisible(version, _, _, invisibilityReason) =>
+        Work.Invisible(version, outData, outState, invisibilityReason)
       case Work.Deleted(version, _, deletedReason) =>
         Work.Deleted(version, outState, deletedReason)
       case Work.Redirected(version, redirectTarget, _) =>
@@ -72,7 +72,7 @@ object Work {
     version: Int,
     data: WorkData[State#WorkDataState],
     state: State,
-    invisibilityReasons: List[InvisibilityReason] = Nil,
+    invisibilityReason: InvisibilityReason,
   ) extends Work[State]
 
   case class Deleted[State <: WorkState](

--- a/common/internal_model/src/test/resources/WorksIndexConfig.json
+++ b/common/internal_model/src/test/resources/WorksIndexConfig.json
@@ -912,7 +912,7 @@
         },
         "dynamic" : "false"
       },
-      "invisibilityReasons" : {
+      "invisibilityReason" : {
         "type" : "object",
         "properties" : {
           "type" : {

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/generators/WorkGenerators.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/generators/WorkGenerators.scala
@@ -136,14 +136,12 @@ trait WorkGenerators
     work: Work.Visible[State]
   ) {
 
-    def invisible(
-      invisibilityReasons: List[InvisibilityReason] = Nil
-    ): Work.Invisible[State] =
+    def invisible(): Work.Invisible[State] =
       Work.Invisible[State](
         data = work.data,
         state = work.state,
         version = work.version,
-        invisibilityReasons = invisibilityReasons
+        invisibilityReason = InvisibilityReason.UnableToTransform("tests")
       )
 
     def deleted(

--- a/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/CalmTransformer.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/CalmTransformer.scala
@@ -112,8 +112,8 @@ object CalmTransformer
                 state = state,
                 version = version,
                 data = WorkData(),
-                invisibilityReasons =
-                  List(knownErrToUntransformableReason(knownErr))
+                invisibilityReason =
+                  knownErrToUntransformableReason(knownErr)
               )
             )
           case unknownStatus: UnknownAccessStatus =>
@@ -125,8 +125,8 @@ object CalmTransformer
                 state = state,
                 version = version,
                 data = WorkData(),
-                invisibilityReasons =
-                  List(InvalidValueInSourceField("Calm:AccessStatus"))
+                invisibilityReason =
+                  InvalidValueInSourceField("Calm:AccessStatus")
               )
             )
           case err: Exception => Left(err)

--- a/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/CalmTransformer.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/CalmTransformer.scala
@@ -112,8 +112,7 @@ object CalmTransformer
                 state = state,
                 version = version,
                 data = WorkData(),
-                invisibilityReason =
-                  knownErrToUntransformableReason(knownErr)
+                invisibilityReason = knownErrToUntransformableReason(knownErr)
               )
             )
           case unknownStatus: UnknownAccessStatus =>

--- a/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/MetsData.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/MetsData.scala
@@ -86,7 +86,7 @@ case class InvisibleMetsData(
           thumbnail = thumbnail(sourceIdentifier.value, license, accessStatus),
           imageData = imageData(version, license, accessStatus, location)
         ),
-        invisibilityReasons = List(MetsWorksAreNotVisible)
+        invisibilityReason = MetsWorksAreNotVisible
       )
     } yield work
 

--- a/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformer/MetsDataTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformer/MetsDataTest.scala
@@ -70,7 +70,7 @@ class MetsDataTest
             )
           )
         ),
-        invisibilityReasons = List(MetsWorksAreNotVisible)
+        invisibilityReason = MetsWorksAreNotVisible
       )
   }
 
@@ -139,7 +139,7 @@ class MetsDataTest
             )
           )
         ),
-        invisibilityReasons = List(MetsWorksAreNotVisible)
+        invisibilityReason = MetsWorksAreNotVisible
       )
   }
 

--- a/pipeline/transformer/transformer_miro/src/main/scala/weco/pipeline/transformer/miro/MiroRecordTransformer.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/weco/pipeline/transformer/miro/MiroRecordTransformer.scala
@@ -145,9 +145,7 @@ class MiroRecordTransformer
             state = state,
             version = version,
             data = WorkData(),
-            invisibilityReasons = List(
-              UnableToTransform(s"Miro: ${e.getMessage}")
-            )
+            invisibilityReason = UnableToTransform(s"Miro: ${e.getMessage}")
           )
       }
     }

--- a/pipeline/transformer/transformer_miro/src/test/scala/weco/pipeline/transformer/miro/transformers/MiroRecordTransformerTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/weco/pipeline/transformer/miro/transformers/MiroRecordTransformerTest.scala
@@ -291,9 +291,8 @@ class MiroRecordTransformerTest
         createMiroRecordWith(
           useRestrictions = None
         ),
-        invisibilityReasons = List(
+        invisibilityReason =
           UnableToTransform("Miro: Nothing in the image_use_restrictions field")
-        )
       )
     }
   }
@@ -392,7 +391,7 @@ class MiroRecordTransformerTest
   private def assertTransformReturnsInvisibleWork(
     miroRecord: MiroRecord,
     miroMetadata: MiroMetadata = MiroMetadata(isClearedForCatalogueAPI = true),
-    invisibilityReasons: List[InvisibilityReason]
+    invisibilityReason: InvisibilityReason
   ): Assertion = {
     val triedMaybeWork = transformer.transform(
       miroRecord = miroRecord,
@@ -412,7 +411,7 @@ class MiroRecordTransformerTest
       ),
       version = 1,
       data = WorkData(),
-      invisibilityReasons = invisibilityReasons
+      invisibilityReason = invisibilityReason
     )
   }
 

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/SierraTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/SierraTransformer.scala
@@ -48,7 +48,7 @@ class SierraTransformer(sierraTransformable: SierraTransformable, version: Int)
             state = Source(sourceIdentifier, Instant.EPOCH),
             version = version,
             data = WorkData(),
-            invisibilityReasons = List(SourceFieldMissing("bibData"))
+            invisibilityReason = SourceFieldMissing("bibData")
           )
         )
       }
@@ -100,7 +100,7 @@ class SierraTransformer(sierraTransformable: SierraTransformable, version: Int)
             state = state,
             version = version,
             data = WorkData(),
-            invisibilityReasons = List(UnableToTransform(e.getMessage))
+            invisibilityReason = UnableToTransform(e.getMessage)
           )
       }
   }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraTransformerTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraTransformerTest.scala
@@ -311,7 +311,7 @@ class SierraTransformerTest
     assertTransformReturnsInvisibleWork(
       maybeBibRecord = None,
       modifiedDate = Instant.EPOCH,
-      invisibilityReasons = List(SourceFieldMissing("bibData"))
+      invisibilityReasons = SourceFieldMissing("bibData")
     )
   }
 
@@ -320,7 +320,7 @@ class SierraTransformerTest
       maybeBibRecord = None,
       modifiedDate = Instant.EPOCH,
       itemRecords = List(createSierraItemRecord),
-      invisibilityReasons = List(SourceFieldMissing("bibData"))
+      invisibilityReasons = SourceFieldMissing("bibData")
     )
   }
 
@@ -958,7 +958,7 @@ class SierraTransformerTest
       maybeBibRecord = Some(bibRecord),
       modifiedDate = bibRecord.modifiedDate,
       invisibilityReasons =
-        List(UnableToTransform("Could not find field 245 to create title"))
+        UnableToTransform("Could not find field 245 to create title")
     )
   }
 
@@ -1331,7 +1331,7 @@ class SierraTransformerTest
     maybeBibRecord: Option[SierraBibRecord],
     modifiedDate: Instant,
     itemRecords: List[SierraItemRecord] = List(),
-    invisibilityReasons: List[InvisibilityReason]): Assertion = {
+    invisibilityReasons: InvisibilityReason): Assertion = {
     val id = createSierraBibNumber
 
     val sierraTransformable = createSierraTransformableWith(
@@ -1353,7 +1353,7 @@ class SierraTransformerTest
       ),
       version = 1,
       data = WorkData(),
-      invisibilityReasons = invisibilityReasons
+      invisibilityReason = invisibilityReason
     )
   }
 


### PR DESCRIPTION
Follows https://github.com/wellcomecollection/catalogue-pipeline/pull/1839, spotted while looking at https://github.com/wellcomecollection/platform/issues/5242

We always set exactly one invisibilityReason, let's reflect that in the model.

This is a backwards-incompatible change to internal model, so I'll hold off merging this until I'm ready to merge and deploy all the changes I want to make.