### PR TITLE
Switch back to using OpenShelves as the access method

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessMethod.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessMethod.scala
@@ -13,8 +13,6 @@ object AccessMethod extends Enum[License] {
     "IDs for AccessMethod are not unique!"
   )
 
-  // This is kept for compatibility with the 2021-08-09 index, but is no longer
-  // set anywhere.  We should remove it after the next reindex.
   case object OpenShelves extends AccessMethod
 
   case object ViewOnline extends AccessMethod

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -145,7 +145,7 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           Some(OpacMsg.OpenShelves),
           NotRequestable.OnOpenShelves(_),
           Some(LocationType.OpenShelves)) =>
-        AccessCondition(method = AccessMethod.NotRequestable)
+        AccessCondition(method = AccessMethod.OpenShelves)
 
       // There are some items that are labelled "bound in above" or "contained in above".
       //

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -974,7 +974,7 @@ class SierraItemAccessTest
           itemData = itemData
         )
 
-        ac shouldBe AccessCondition(method = AccessMethod.NotRequestable)
+        ac shouldBe AccessCondition(method = AccessMethod.OpenShelves)
       }
 
       it("gets a display note") {


### PR DESCRIPTION
This PR means that any open shelves items will get `"method": "open-shelves"` in the API, rather than their current value of `"method": "not-requestable"`.

I'll deploy this into the prod pipeline then flush any affected works back through the pipeline.