### PR TITLE
Fix a bug in merging Sierra works when the 776 $w is on the e-bib

### DIFF
--- a/pipeline/merger/src/main/scala/weco/pipeline/merger/models/Sources.scala
+++ b/pipeline/merger/src/main/scala/weco/pipeline/merger/models/Sources.scala
@@ -44,11 +44,13 @@ object Sources {
 
       case t if physicalSierra(t) =>
         sources
-          .filter { w => sierraWork(w) && allDigitalLocations(w) }
+          .filter { w =>
+            sierraWork(w) && allDigitalLocations(w)
+          }
           .find { w =>
             w.data.mergeCandidates.exists { mc =>
               mc.reason == "Physical/digitised Sierra work" &&
-                mc.id.canonicalId == target.state.canonicalId
+              mc.id.canonicalId == target.state.canonicalId
             }
           }
 

--- a/pipeline/merger/src/main/scala/weco/pipeline/merger/rules/OtherIdentifiersRule.scala
+++ b/pipeline/merger/src/main/scala/weco/pipeline/merger/rules/OtherIdentifiersRule.scala
@@ -114,10 +114,15 @@ object OtherIdentifiersRule extends FieldMergeRule with MergerLogging {
 
     val isDefinedForSource: WorkPredicate = sierraWork
 
+    // TODO: What if we don't get any matching source work?  Then we'd blat the
+    // otherIdentifiers already on the target work.  I can't think of a scenario
+    // in which it would happen in practice, so I can't test it, but noting in
+    // case we see this in future.
     def rule(target: Work.Visible[Identified],
              sources: NonEmptyList[Work[Identified]]): FieldData =
       findFirstLinkedDigitisedSierraWorkFor(target, sources.toList)
-        .map(target.data.otherIdentifiers ++ _.identifiers)
+        .map { w =>
+          target.data.otherIdentifiers ++ w.identifiers }
         .getOrElse(Nil)
   }
 }

--- a/pipeline/merger/src/main/scala/weco/pipeline/merger/rules/OtherIdentifiersRule.scala
+++ b/pipeline/merger/src/main/scala/weco/pipeline/merger/rules/OtherIdentifiersRule.scala
@@ -122,7 +122,8 @@ object OtherIdentifiersRule extends FieldMergeRule with MergerLogging {
              sources: NonEmptyList[Work[Identified]]): FieldData =
       findFirstLinkedDigitisedSierraWorkFor(target, sources.toList)
         .map { w =>
-          target.data.otherIdentifiers ++ w.identifiers }
+          target.data.otherIdentifiers ++ w.identifiers
+        }
         .getOrElse(Nil)
   }
 }

--- a/pipeline/merger/src/main/scala/weco/pipeline/merger/rules/WorkPredicates.scala
+++ b/pipeline/merger/src/main/scala/weco/pipeline/merger/rules/WorkPredicates.scala
@@ -123,7 +123,7 @@ object WorkPredicates {
       }
     }
 
-  private def allDigitalLocations(work: Work[Identified]): Boolean =
+  def allDigitalLocations(work: Work[Identified]): Boolean =
     work.data.items.forall { item =>
       item.locations.forall {
         case _: DigitalLocation => true

--- a/pipeline/merger/src/test/scala/weco/pipeline/merger/models/SourcesTest.scala
+++ b/pipeline/merger/src/test/scala/weco/pipeline/merger/models/SourcesTest.scala
@@ -55,6 +55,32 @@ class SourcesTest
       result shouldBe Some(digitisedWork1)
     }
 
+    it("finds a matching work if the MergeCandidate is on the digitised work") {
+      // There are some bib/e-bib pairs where the 776 $w linking field is on the
+      // electronic bib, rather than the physical bib.  In this case, we still
+      // need to find to digitised work.
+      val physicalWork = sierraPhysicalIdentifiedWork()
+      val digitisedWork =
+        sierraDigitalIdentifiedWork()
+          .mergeCandidates(
+            List(
+              MergeCandidate(
+                id = IdState.Identified(
+                  sourceIdentifier = physicalWork.sourceIdentifier,
+                  canonicalId = physicalWork.state.canonicalId),
+                reason = "Physical/digitised Sierra work"
+              )
+            )
+          )
+
+      val result =
+        Sources.findFirstLinkedDigitisedSierraWorkFor(
+          physicalWork,
+          sources = Seq(digitisedWork))
+
+      result shouldBe Some(digitisedWork)
+    }
+
     it("skips a MergeCandidate with the right ID but wrong reason") {
       val digitisedWork = sierraDigitalIdentifiedWork()
 

--- a/pipeline/merger/src/test/scala/weco/pipeline/merger/services/PlatformMergerTest.scala
+++ b/pipeline/merger/src/test/scala/weco/pipeline/merger/services/PlatformMergerTest.scala
@@ -955,7 +955,8 @@ class PlatformMergerTest
     visibleWorks.head.data.items should contain(item)
   }
 
-  it("preserves the identifiers when it merges a Sierra bib, e-bib and METS work and the e-bib has the link") {
+  it(
+    "preserves the identifiers when it merges a Sierra bib, e-bib and METS work and the e-bib has the link") {
     // This test case is based on a real issue, when identifiers weren't being copied
     // across correctly and we were losing identifiers in the merging process.
 
@@ -1006,7 +1007,8 @@ class PlatformMergerTest
 
     val works = Seq(metsWork, electronicWork, physicalWork)
 
-    val redirectedWork = merger.merge(works)
+    val redirectedWork = merger
+      .merge(works)
       .mergedWorksWithTime(now)
       .collectFirst { case w: Work.Visible[Merged] => w }
       .get

--- a/pipeline/merger/src/test/scala/weco/pipeline/merger/services/PlatformMergerTest.scala
+++ b/pipeline/merger/src/test/scala/weco/pipeline/merger/services/PlatformMergerTest.scala
@@ -6,12 +6,7 @@ import org.scalatest.prop.TableDrivenPropertyChecks._
 import weco.catalogue.internal_model.work.WorkState.{Identified, Merged}
 import weco.catalogue.internal_model.work.WorkFsm._
 import weco.catalogue.internal_model.image.ParentWork._
-import weco.catalogue.internal_model.identifiers.{
-  CanonicalId,
-  IdState,
-  IdentifierType,
-  SourceIdentifier
-}
+import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.image.ParentWorks
 import weco.catalogue.internal_model.locations.{
   AccessCondition,
@@ -19,8 +14,7 @@ import weco.catalogue.internal_model.locations.{
   AccessStatus,
   DigitalLocation,
   License,
-  LocationType,
-  PhysicalLocation
+  LocationType
 }
 import weco.catalogue.internal_model.work.generators.SourceWorkGenerators
 import weco.catalogue.internal_model.work.{
@@ -961,81 +955,24 @@ class PlatformMergerTest
     visibleWorks.head.data.items should contain(item)
   }
 
-  it("preserves the identifiers when it merges a Sierra bib, e-bib and METS work") {
+  it("preserves the identifiers when it merges a Sierra bib, e-bib and METS work and the e-bib has the link") {
     // This test case is based on a real issue, when identifiers weren't being copied
     // across correctly and we were losing identifiers in the merging process.
 
     val physicalWork =
-      identifiedWork(
-        sourceIdentifier = SourceIdentifier(
-          identifierType = IdentifierType.SierraSystemNumber,
-          value = "b13456143",
-          ontologyType = "Work"
-        ),
-        canonicalId = CanonicalId("ym7pjfz2"),
-      )
+      sierraIdentifiedWork()
         .otherIdentifiers(
-          List(
-            SourceIdentifier(
-              identifierType = IdentifierType.SierraIdentifier,
-              value = "1345614",
-              ontologyType = "Work"
-            )
-          )
+          List(createSierraIdentifierSourceIdentifier)
         )
         .format(Format.Books)
-        .items(
-          List(
-            Item(
-              id = IdState.Identified(
-                canonicalId = CanonicalId("drmvgk97"),
-                sourceIdentifier = SourceIdentifier(
-                  identifierType = IdentifierType.SierraSystemNumber,
-                  value = "i13702543",
-                  ontologyType = "Item"
-                ),
-                otherIdentifiers = List(
-                  SourceIdentifier(
-                    identifierType = IdentifierType.SierraIdentifier,
-                    value = "1370254",
-                    ontologyType = "Item"
-                  )
-                )
-              ),
-              title = Some("Copy 1"),
-              locations = List(
-                PhysicalLocation(
-                  locationType = LocationType.OpenShelves,
-                  label = "Medical Collection",
-                  shelfmark = Some("Wm600 1905E47s"),
-                  accessConditions = List(AccessCondition(method = AccessMethod.OpenShelves))
-                )
-              )
-            ),
-          )
-        )
+        .items(List(createIdentifiedPhysicalItem))
 
     val electronicWork =
-      identifiedWork(
-        sourceIdentifier = SourceIdentifier(
-          identifierType = IdentifierType.SierraSystemNumber,
-          value = "b20442129",
-          ontologyType = "Work"
-        ),
-        canonicalId = CanonicalId("vvdua7tw")
-      )
+      sierraIdentifiedWork()
         .otherIdentifiers(
           List(
-            SourceIdentifier(
-              identifierType = IdentifierType.SierraIdentifier,
-              value = "2044212",
-              ontologyType = "Work"
-            ),
-            SourceIdentifier(
-              identifierType = IdentifierType.WellcomeDigcode,
-              value = "digsexology",
-              ontologyType = "Work"
-            )
+            createSierraIdentifierSourceIdentifier,
+            createDigcodeIdentifier("digsexology")
           )
         )
         .format(Format.Books)
@@ -1052,14 +989,7 @@ class PlatformMergerTest
         )
 
     val metsWork =
-      identifiedWork(
-        sourceIdentifier = SourceIdentifier(
-          identifierType = IdentifierType.METS,
-          value = "b20442129",
-          ontologyType = "Work"
-        ),
-        canonicalId = CanonicalId("gj9r47pm")
-      )
+      metsIdentifiedWork()
         .mergeCandidates(
           List(
             MergeCandidate(
@@ -1071,26 +1001,7 @@ class PlatformMergerTest
             )
           )
         )
-        .items(
-          List(
-            Item(
-              title = None,
-              locations = List(
-                DigitalLocation(
-                  locationType = LocationType.IIIFPresentationAPI,
-                  url = "https://iiif.wellcomecollection.org/presentation/v2/b20442129",
-                  license = Some(License.InCopyright),
-                  accessConditions = List(
-                    AccessCondition(
-                      method = AccessMethod.ViewOnline,
-                      status = AccessStatus.Open
-                    )
-                  )
-                )
-              )
-            )
-          )
-        )
+        .items(List(createDigitalItem))
         .invisible(List(InvisibilityReason.MetsWorksAreNotVisible))
 
     val works = Seq(metsWork, electronicWork, physicalWork)
@@ -1101,11 +1012,6 @@ class PlatformMergerTest
       .get
 
     redirectedWork.state.canonicalId shouldBe physicalWork.state.canonicalId
-
-    redirectedWork.identifiers should contain allOf(
-      physicalWork.identifiers,
-      electronicWork.identifiers,
-      metsWork.identifiers
-    )
+    redirectedWork.identifiers should contain theSameElementsAs (physicalWork.identifiers ++ electronicWork.identifiers)
   }
 }


### PR DESCRIPTION
## The problem

Some works are missing their identifiers. e.g. https://api.wellcomecollection.org/catalogue/v2/works/ym7pjfz2?include=identifiers:

```json
  "identifiers": [
    {
      "identifierType": {
        "id": "sierra-system-number",
        "label": "Sierra system number",
        "type": "IdentifierType"
      },
      "value": "b13456143",
      "type": "Identifier"
    }
  ],
```

This is a combination of a Sierra bib, e-bib and METS work – but it only has a single identifier. What's up with that?

## The cause

We use the 776 $w linking field to merge physical/digitised Sierra pairs, and we expect to see a 776 $w on the physical bib – but sometimes, as is the case here, that linking record is actually on the e-bib only. In this case, we'd drop all the identifiers on the work (and maybe some other stuff)

See
https://search.wellcomelibrary.org/iii/encore/record/C__Rb1345614?lang=eng
https://search.wellcomelibrary.org/iii/encore/record/C__Rb2044212?lang=eng

## The solution

Update the code that looks for the matching work in `Sources`, so if there are no merge candidates on the physical work, we look through the electronic works instead for the first match.