### PR TITLE
Don't use the bib data to create the item status

### DIFF
--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -11,7 +11,6 @@ import weco.catalogue.internal_model.locations.{
 import weco.catalogue.source_model.sierra.source.{OpacMsg, Status}
 import weco.sierra.models.SierraQueryOps
 import weco.sierra.models.data.SierraItemData
-import weco.sierra.models.identifiers.SierraBibNumber
 
 /** There are multiple sources of truth for item information in Sierra, and whether
   * a given item can be requested online.
@@ -30,13 +29,11 @@ import weco.sierra.models.identifiers.SierraBibNumber
   */
 object SierraItemAccess extends SierraQueryOps with Logging {
   def apply(
-    bibId: SierraBibNumber,
     bibStatus: Option[AccessStatus],
     location: Option[PhysicalLocationType],
     itemData: SierraItemData
   ): (AccessCondition, Option[String]) = {
     val accessCondition = createAccessCondition(
-      bibId = bibId,
       bibStatus = bibStatus,
       holdCount = itemData.holdCount,
       status = itemData.status,
@@ -69,7 +66,6 @@ object SierraItemAccess extends SierraQueryOps with Logging {
   }
 
   private def createAccessCondition(
-    bibId: SierraBibNumber,
     bibStatus: Option[AccessStatus],
     holdCount: Option[Int],
     status: Option[String],
@@ -342,11 +338,7 @@ object SierraItemAccess extends SierraQueryOps with Logging {
       // as unavailable for now.
       //
       // TODO: We should work with the Collections team to better handle any records
-      // that are hitting this branch.  Sending readers to Encore isn't a long-term
-      // solution.  Remove this link when Encore goes away.
-      //
-      // Note: once you remove the link, you can also remove the bibId passed into
-      // this apply() method.
+      // that are hitting this branch.
       case (bibStatus, holdCount, status, opacmsg, isRequestable, location) =>
         warn(
           s"Unable to assign access status for item ${itemData.id.withCheckDigit}: " +

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -1079,7 +1079,6 @@ class SierraItemAccessTest
     itemData: SierraItemData
   ): (AccessCondition, Option[String]) =
     SierraItemAccess(
-      bibId = createSierraBibNumber,
       bibStatus = bibStatus,
       location = location,
       itemData = itemData

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -11,7 +11,6 @@ import weco.catalogue.internal_model.locations.{
 }
 import weco.sierra.generators.SierraDataGenerators
 import weco.sierra.models.data.SierraItemData
-import weco.sierra.models.identifiers.SierraBibNumber
 import weco.sierra.models.marc.{FixedField, VarField}
 
 class SierraItemAccessTest
@@ -1047,7 +1046,6 @@ class SierraItemAccessTest
   }
 
   it("handles the case where we can't map the access data") {
-    val bibId = createSierraBibNumber
     val itemData = createSierraItemDataWith(
       fixedFields = Map(
         "79" -> FixedField(
@@ -1063,7 +1061,6 @@ class SierraItemAccessTest
     )
 
     val (ac, _) = getItemAccess(
-      bibId = bibId,
       bibStatus = None,
       location = Some(LocationType.ClosedStores),
       itemData = itemData
@@ -1077,13 +1074,12 @@ class SierraItemAccessTest
   }
 
   private def getItemAccess(
-    bibId: SierraBibNumber = createSierraBibNumber,
     bibStatus: Option[AccessStatus],
     location: Option[PhysicalLocationType],
     itemData: SierraItemData
   ): (AccessCondition, Option[String]) =
     SierraItemAccess(
-      bibId = bibId,
+      bibId = createSierraBibNumber,
       bibStatus = bibStatus,
       location = location,
       itemData = itemData

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -6,11 +6,9 @@ import weco.catalogue.internal_model.locations.{
   AccessCondition,
   AccessMethod,
   AccessStatus,
-  LocationType,
-  PhysicalLocationType
+  LocationType
 }
 import weco.sierra.generators.SierraDataGenerators
-import weco.sierra.models.data.SierraItemData
 import weco.sierra.models.marc.{FixedField, VarField}
 
 class SierraItemAccessTest
@@ -38,8 +36,7 @@ class SierraItemAccessTest
             )
           )
 
-          val (ac, _) = getItemAccess(
-            bibStatus = None,
+          val (ac, _) = SierraItemAccess(
             location = Some(LocationType.ClosedStores),
             itemData = itemData
           )
@@ -47,66 +44,6 @@ class SierraItemAccessTest
           ac shouldBe AccessCondition(
             method = AccessMethod.OnlineRequest,
             status = AccessStatus.Open)
-        }
-
-        it("if it has no restrictions and the bib is open") {
-          val itemData = createSierraItemDataWith(
-            fixedFields = Map(
-              "79" -> FixedField(
-                label = "LOCATION",
-                value = "scmwf",
-                display = "Closed stores A&MSS Well.Found."),
-              "88" -> FixedField(
-                label = "STATUS",
-                value = "-",
-                display = "Available"),
-              "108" -> FixedField(
-                label = "OPACMSG",
-                value = "f",
-                display = "Online request"),
-            )
-          )
-
-          val (ac, _) = getItemAccess(
-            bibStatus = Some(AccessStatus.Open),
-            location = Some(LocationType.ClosedStores),
-            itemData = itemData
-          )
-
-          ac shouldBe
-            AccessCondition(
-              method = AccessMethod.OnlineRequest,
-              status = AccessStatus.Open)
-        }
-
-        it("if it has no restrictions and the bib is open with advisory") {
-          val itemData = createSierraItemDataWith(
-            fixedFields = Map(
-              "79" -> FixedField(
-                label = "LOCATION",
-                value = "scmac",
-                display = "Closed stores Arch. & MSS"),
-              "88" -> FixedField(
-                label = "STATUS",
-                value = "-",
-                display = "Available"),
-              "108" -> FixedField(
-                label = "OPACMSG",
-                value = "f",
-                display = "Online request"),
-            )
-          )
-
-          val (ac, _) = getItemAccess(
-            bibStatus = Some(AccessStatus.OpenWithAdvisory),
-            location = Some(LocationType.ClosedStores),
-            itemData = itemData
-          )
-
-          ac shouldBe
-            AccessCondition(
-              method = AccessMethod.OnlineRequest,
-              status = AccessStatus.OpenWithAdvisory)
         }
 
         it("if it's restricted") {
@@ -127,8 +64,7 @@ class SierraItemAccessTest
             )
           )
 
-          val (ac, _) = getItemAccess(
-            bibStatus = Some(AccessStatus.Restricted),
+          val (ac, _) = SierraItemAccess(
             location = Some(LocationType.ClosedStores),
             itemData = itemData
           )
@@ -137,36 +73,6 @@ class SierraItemAccessTest
             AccessCondition(
               method = AccessMethod.OnlineRequest,
               status = AccessStatus.Restricted)
-        }
-
-        it("if the bib is restricted but the item is open") {
-          val itemData = createSierraItemDataWith(
-            fixedFields = Map(
-              "79" -> FixedField(
-                label = "LOCATION",
-                value = "scmac",
-                display = "Closed stores Arch. & MSS"),
-              "88" -> FixedField(
-                label = "STATUS",
-                value = "-",
-                display = "Available"),
-              "108" -> FixedField(
-                label = "OPACMSG",
-                value = "f",
-                display = "Online request"),
-            )
-          )
-
-          val (ac, _) = getItemAccess(
-            bibStatus = Some(AccessStatus.Restricted),
-            location = Some(LocationType.ClosedStores),
-            itemData = itemData
-          )
-
-          ac shouldBe
-            AccessCondition(
-              method = AccessMethod.OnlineRequest,
-              status = AccessStatus.Open)
         }
       }
 
@@ -193,8 +99,7 @@ class SierraItemAccessTest
             )
           )
 
-          val (ac, _) = getItemAccess(
-            bibStatus = None,
+          val (ac, _) = SierraItemAccess(
             location = Some(LocationType.ClosedStores),
             itemData = itemData
           )
@@ -220,8 +125,7 @@ class SierraItemAccessTest
             )
           )
 
-          val (ac, _) = getItemAccess(
-            bibStatus = None,
+          val (ac, _) = SierraItemAccess(
             location = None,
             itemData = itemData
           )
@@ -250,8 +154,7 @@ class SierraItemAccessTest
             )
           )
 
-          val (ac, _) = getItemAccess(
-            bibStatus = None,
+          val (ac, _) = SierraItemAccess(
             location = None,
             itemData = itemData
           )
@@ -280,8 +183,7 @@ class SierraItemAccessTest
             )
           )
 
-          val (ac, _) = getItemAccess(
-            bibStatus = Some(AccessStatus.Closed),
+          val (ac, _) = SierraItemAccess(
             location = Some(LocationType.ClosedStores),
             itemData = itemData
           )
@@ -291,36 +193,6 @@ class SierraItemAccessTest
               method = AccessMethod.NotRequestable,
               status = AccessStatus.Closed
             )
-        }
-
-        it("if the bib and the item are closed, and there's no location") {
-          val itemData = createSierraItemDataWith(
-            fixedFields = Map(
-              "79" -> FixedField(
-                label = "LOCATION",
-                value = "sc#ac",
-                display = "Unrequestable Arch. & MSS"),
-              "88" -> FixedField(
-                label = "STATUS",
-                value = "h",
-                display = "Closed"),
-              "108" -> FixedField(
-                label = "OPACMSG",
-                value = "u",
-                display = "Unavailable"),
-            )
-          )
-
-          val (ac, _) = getItemAccess(
-            bibStatus = Some(AccessStatus.Closed),
-            location = None,
-            itemData = itemData
-          )
-
-          ac shouldBe
-            AccessCondition(
-              method = AccessMethod.NotRequestable,
-              status = AccessStatus.Closed)
         }
 
         it("if the item is unavailable") {
@@ -341,38 +213,7 @@ class SierraItemAccessTest
             )
           )
 
-          val (ac, _) = getItemAccess(
-            bibStatus = None,
-            location = Some(LocationType.ClosedStores),
-            itemData = itemData
-          )
-
-          ac shouldBe
-            AccessCondition(
-              method = AccessMethod.NotRequestable,
-              status = AccessStatus.Unavailable)
-        }
-
-        it("if the item is unavailable and the bib is temporarily unavailable") {
-          val itemData = createSierraItemDataWith(
-            fixedFields = Map(
-              "79" -> FixedField(
-                label = "LOCATION",
-                value = "sc#ac",
-                display = "Unrequestable Arch. & MSS"),
-              "88" -> FixedField(
-                label = "STATUS",
-                value = "r",
-                display = "Unavailable"),
-              "108" -> FixedField(
-                label = "OPACMSG",
-                value = "u",
-                display = "Unavailable"),
-            )
-          )
-
-          val (ac, _) = getItemAccess(
-            bibStatus = Some(AccessStatus.TemporarilyUnavailable),
+          val (ac, _) = SierraItemAccess(
             location = Some(LocationType.ClosedStores),
             itemData = itemData
           )
@@ -401,8 +242,7 @@ class SierraItemAccessTest
             )
           )
 
-          val (ac, _) = getItemAccess(
-            bibStatus = None,
+          val (ac, _) = SierraItemAccess(
             location = Some(LocationType.ClosedStores),
             itemData = itemData
           )
@@ -441,8 +281,7 @@ class SierraItemAccessTest
             )
           )
 
-          val (ac, _) = getItemAccess(
-            bibStatus = None,
+          val (ac, _) = SierraItemAccess(
             location = Some(LocationType.ClosedStores),
             itemData = itemData
           )
@@ -456,7 +295,7 @@ class SierraItemAccessTest
             )
         }
 
-        it("if the bib and item are by appointment") {
+        it("if the item is by appointment") {
           val itemData = createSierraItemDataWith(
             fixedFields = Map(
               "79" -> FixedField(
@@ -474,8 +313,7 @@ class SierraItemAccessTest
             )
           )
 
-          val (ac, _) = getItemAccess(
-            bibStatus = Some(AccessStatus.ByAppointment),
+          val (ac, _) = SierraItemAccess(
             location = Some(LocationType.ClosedStores),
             itemData = itemData
           )
@@ -486,7 +324,7 @@ class SierraItemAccessTest
               status = AccessStatus.ByAppointment)
         }
 
-        it("if the bib and item need donor permission") {
+        it("if the item needs donor permission") {
           val itemData = createSierraItemDataWith(
             fixedFields = Map(
               "79" -> FixedField(
@@ -504,38 +342,7 @@ class SierraItemAccessTest
             )
           )
 
-          val (ac, _) = getItemAccess(
-            bibStatus = Some(AccessStatus.PermissionRequired),
-            location = Some(LocationType.ClosedStores),
-            itemData = itemData
-          )
-
-          ac shouldBe
-            AccessCondition(
-              method = AccessMethod.ManualRequest,
-              status = AccessStatus.PermissionRequired)
-        }
-
-        it("if the bib and item needs donor permission") {
-          val itemData = createSierraItemDataWith(
-            fixedFields = Map(
-              "79" -> FixedField(
-                label = "LOCATION",
-                value = "sicon",
-                display = "Closed stores Visual"),
-              "88" -> FixedField(
-                label = "STATUS",
-                value = "y",
-                display = "Permission required"),
-              "108" -> FixedField(
-                label = "OPACMSG",
-                value = "q",
-                display = "Donor permission"),
-            )
-          )
-
-          val (ac, _) = getItemAccess(
-            bibStatus = None,
+          val (ac, _) = SierraItemAccess(
             location = Some(LocationType.ClosedStores),
             itemData = itemData
           )
@@ -564,8 +371,7 @@ class SierraItemAccessTest
             )
           )
 
-          val (ac, _) = getItemAccess(
-            bibStatus = None,
+          val (ac, _) = SierraItemAccess(
             location = Some(LocationType.ClosedStores),
             itemData = itemData
           )
@@ -596,8 +402,7 @@ class SierraItemAccessTest
             )
           )
 
-          val (ac, _) = getItemAccess(
-            bibStatus = None,
+          val (ac, _) = SierraItemAccess(
             location = Some(LocationType.ClosedStores),
             itemData = itemData
           )
@@ -632,8 +437,7 @@ class SierraItemAccessTest
           )
         )
 
-        val (ac, _) = getItemAccess(
-          bibStatus = None,
+        val (ac, _) = SierraItemAccess(
           location = Some(LocationType.ClosedStores),
           itemData = itemData
         )
@@ -667,8 +471,7 @@ class SierraItemAccessTest
           )
         )
 
-        val (ac, _) = getItemAccess(
-          bibStatus = None,
+        val (ac, _) = SierraItemAccess(
           location = Some(LocationType.ClosedStores),
           itemData = itemData
         )
@@ -705,8 +508,7 @@ class SierraItemAccessTest
           )
         )
 
-        val (ac, _) = getItemAccess(
-          bibStatus = None,
+        val (ac, _) = SierraItemAccess(
           location = Some(LocationType.ClosedStores),
           itemData = itemData
         )
@@ -739,43 +541,7 @@ class SierraItemAccessTest
           )
         )
 
-        val (ac, _) = getItemAccess(
-          bibStatus = None,
-          location = Some(LocationType.ClosedStores),
-          itemData = itemData
-        )
-
-        ac shouldBe
-          AccessCondition(
-            method = AccessMethod.NotRequestable,
-            status = Some(AccessStatus.TemporarilyUnavailable),
-            note = Some(
-              "Item is in use by another reader. Please ask at Enquiry Desk.")
-          )
-      }
-
-      it("if there's a status on the bib") {
-        // This is based on b32204887 / i19379778, as retrieved 13 August 2021
-        val itemData = createSierraItemDataWith(
-          holdCount = Some(1),
-          fixedFields = Map(
-            "79" -> FixedField(
-              label = "scmac",
-              value = "swms4",
-              display = "Closed stores Arch. & MSS"),
-            "88" -> FixedField(
-              label = "STATUS",
-              value = "!",
-              display = "On holdshelf"),
-            "108" -> FixedField(
-              label = "OPACMSG",
-              value = "a",
-              display = "By appointment"),
-          )
-        )
-
-        val (ac, _) = getItemAccess(
-          bibStatus = Some(AccessStatus.ByAppointment),
+        val (ac, _) = SierraItemAccess(
           location = Some(LocationType.ClosedStores),
           itemData = itemData
         )
@@ -820,8 +586,7 @@ class SierraItemAccessTest
           )
         )
 
-        val (ac, note) = getItemAccess(
-          bibStatus = None,
+        val (ac, note) = SierraItemAccess(
           location = Some(LocationType.ClosedStores),
           itemData = itemData
         )
@@ -861,8 +626,7 @@ class SierraItemAccessTest
           )
         )
 
-        val (ac, note) = getItemAccess(
-          bibStatus = None,
+        val (ac, note) = SierraItemAccess(
           location = Some(LocationType.ClosedStores),
           itemData = itemData
         )
@@ -902,8 +666,7 @@ class SierraItemAccessTest
           )
         )
 
-        val (ac, _) = getItemAccess(
-          bibStatus = None,
+        val (ac, _) = SierraItemAccess(
           location = Some(LocationType.ClosedStores),
           itemData = itemData
         )
@@ -936,8 +699,7 @@ class SierraItemAccessTest
           )
         )
 
-        val (_, Some(note)) = getItemAccess(
-          bibStatus = None,
+        val (_, Some(note)) = SierraItemAccess(
           location = Some(LocationType.ClosedStores),
           itemData = itemData
         )
@@ -967,8 +729,7 @@ class SierraItemAccessTest
           )
         )
 
-        val (ac, _) = getItemAccess(
-          bibStatus = None,
+        val (ac, _) = SierraItemAccess(
           location = Some(LocationType.OpenShelves),
           itemData = itemData
         )
@@ -1001,8 +762,7 @@ class SierraItemAccessTest
           )
         )
 
-        val (ac, _) = getItemAccess(
-          bibStatus = None,
+        val (ac, _) = SierraItemAccess(
           location = Some(LocationType.OpenShelves),
           itemData = itemData
         )
@@ -1030,8 +790,7 @@ class SierraItemAccessTest
         )
       )
 
-      val (ac, _) = getItemAccess(
-        bibStatus = None,
+      val (ac, _) = SierraItemAccess(
         location = Some(LocationType.OpenShelves),
         itemData = itemData
       )
@@ -1060,8 +819,7 @@ class SierraItemAccessTest
       )
     )
 
-    val (ac, _) = getItemAccess(
-      bibStatus = None,
+    val (ac, _) = SierraItemAccess(
       location = Some(LocationType.ClosedStores),
       itemData = itemData
     )
@@ -1072,15 +830,4 @@ class SierraItemAccessTest
         s"""This item cannot be requested online. Please contact <a href="mailto:library@wellcomecollection.org">library@wellcomecollection.org</a> for more information.""")
     )
   }
-
-  private def getItemAccess(
-    bibStatus: Option[AccessStatus],
-    location: Option[PhysicalLocationType],
-    itemData: SierraItemData
-  ): (AccessCondition, Option[String]) =
-    SierraItemAccess(
-      bibStatus = bibStatus,
-      location = location,
-      itemData = itemData
-    )
 }

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/TransformerWorker.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/TransformerWorker.scala
@@ -32,8 +32,6 @@ case class TransformerError[SourceData, Key](t: Throwable,
   * - Runs it through a transformer and transforms the `SourceData` to `Work[Source]`
   * - Emits the message via `MessageSender` to SNS
   */
-class NewTransformerWorker
-
 trait TransformerWorker[Payload <: SourcePayload, SourceData, SenderDest]
     extends Logging {
   type Result[T] = Either[TransformerWorkerError, T]

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/TransformerWorker.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/TransformerWorker.scala
@@ -32,6 +32,8 @@ case class TransformerError[SourceData, Key](t: Throwable,
   * - Runs it through a transformer and transforms the `SourceData` to `Work[Source]`
   * - Emits the message via `MessageSender` to SNS
   */
+class NewTransformerWorker
+
 trait TransformerWorker[Payload <: SourcePayload, SourceData, SenderDest]
     extends Logging {
   type Result[T] = Either[TransformerWorkerError, T]

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraItems.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraItems.scala
@@ -48,12 +48,11 @@ object SierraItems
 
     SierraPhysicalItemOrder(
       bibId,
-      items = getPhysicalItems(bibId, visibleItems, bibData)
+      items = getPhysicalItems(visibleItems, bibData)
     )
   }
 
   private def getPhysicalItems(
-    bibId: SierraBibNumber,
     itemDataEntries: Seq[SierraItemData],
     bibData: SierraBibData): List[Item[IdState.Identifiable]] = {
 
@@ -101,7 +100,6 @@ object SierraItems
 
     val items = itemDataEntries.map { itemData =>
       transformItemData(
-        bibId = bibId,
         itemData = itemData,
         bibData = bibData,
         fallbackLocation = fallbackLocation
@@ -116,7 +114,6 @@ object SierraItems
   private type HasAutomatedTitle = Boolean
 
   private def transformItemData(
-    bibId: SierraBibNumber,
     itemData: SierraItemData,
     bibData: SierraBibData,
     fallbackLocation: Option[(PhysicalLocationType, String)]
@@ -125,7 +122,6 @@ object SierraItems
 
     val location =
       getPhysicalLocation(
-        bibNumber = bibId,
         itemData = itemData,
         bibData = bibData,
         fallbackLocation = fallbackLocation
@@ -136,9 +132,7 @@ object SierraItems
     val item = Item(
       title = title,
       note = getItemNote(
-        bibId = bibId,
         itemData = itemData,
-        bibData = bibData,
         location = location
       ),
       locations = List(location).flatten,
@@ -251,13 +245,9 @@ object SierraItems
     * discard it.
     */
   private def getItemNote(
-    bibId: SierraBibNumber,
     itemData: SierraItemData,
-    bibData: SierraBibData,
     location: Option[PhysicalLocation]): Option[String] = {
     val (_, note) = SierraItemAccess(
-      bibId = bibId,
-      bibStatus = SierraAccessStatus.forBib(bibId, bibData),
       location = location.map(_.locationType),
       itemData = itemData
     )

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraPhysicalLocation.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraPhysicalLocation.scala
@@ -6,11 +6,9 @@ import weco.catalogue.source_model.sierra.rules.{
   SierraPhysicalLocationType
 }
 import weco.sierra.models.data.{SierraBibData, SierraItemData}
-import weco.sierra.models.identifiers.SierraBibNumber
 
 trait SierraPhysicalLocation {
   def getPhysicalLocation(
-    bibNumber: SierraBibNumber,
     itemData: SierraItemData,
     bibData: SierraBibData,
     fallbackLocation: Option[(PhysicalLocationType, String)] = None)
@@ -42,7 +40,6 @@ trait SierraPhysicalLocation {
       }
 
       (accessCondition, _) = SierraItemAccess(
-        bibStatus = SierraAccessStatus.forBib(bibNumber, bibData),
         location = Some(locationType),
         itemData = itemData
       )

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraPhysicalLocation.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraPhysicalLocation.scala
@@ -42,7 +42,6 @@ trait SierraPhysicalLocation {
       }
 
       (accessCondition, _) = SierraItemAccess(
-        bibId = bibNumber,
         bibStatus = SierraAccessStatus.forBib(bibNumber, bibData),
         location = Some(locationType),
         itemData = itemData

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraPhysicalLocationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraPhysicalLocationTest.scala
@@ -22,7 +22,6 @@ class SierraPhysicalLocationTest
   private val transformer = new SierraPhysicalLocation {}
 
   describe("Physical locations") {
-    val bibId = createSierraBibNumber
     val bibData = createSierraBibData
 
     val itemData = createSierraItemDataWith(
@@ -57,7 +56,7 @@ class SierraPhysicalLocationTest
             status = AccessStatus.Open))
       )
 
-      transformer.getPhysicalLocation(bibId, itemData, bibData) shouldBe Some(
+      transformer.getPhysicalLocation(itemData, bibData) shouldBe Some(
         expectedLocation)
     }
 
@@ -67,7 +66,7 @@ class SierraPhysicalLocationTest
       )
 
       val location =
-        transformer.getPhysicalLocation(bibId, itemData, bibData).get
+        transformer.getPhysicalLocation(itemData, bibData).get
       location.label shouldBe "Folios"
     }
 
@@ -76,14 +75,14 @@ class SierraPhysicalLocationTest
         location = Some(SierraLocation("", ""))
       )
 
-      transformer.getPhysicalLocation(bibId, itemData, bibData) shouldBe None
+      transformer.getPhysicalLocation(itemData, bibData) shouldBe None
     }
 
     it("returns None if the location field only contains the string 'none'") {
       val itemData = createSierraItemDataWith(
         location = Some(SierraLocation("none", "none"))
       )
-      transformer.getPhysicalLocation(bibId, itemData, bibData) shouldBe None
+      transformer.getPhysicalLocation(itemData, bibData) shouldBe None
     }
 
     it("returns None if there is no location in the item data") {
@@ -91,7 +90,7 @@ class SierraPhysicalLocationTest
         location = None
       )
 
-      transformer.getPhysicalLocation(bibId, itemData, bibData) shouldBe None
+      transformer.getPhysicalLocation(itemData, bibData) shouldBe None
     }
 
     it("adds access conditions to the items") {
@@ -128,7 +127,7 @@ class SierraPhysicalLocationTest
       )
 
       val location =
-        transformer.getPhysicalLocation(bibId, itemData, bibData).get
+        transformer.getPhysicalLocation(itemData, bibData).get
       location.accessConditions shouldBe List(
         AccessCondition(
           method = AccessMethod.OnlineRequest,
@@ -151,7 +150,7 @@ class SierraPhysicalLocationTest
       )
 
       val location =
-        transformer.getPhysicalLocation(bibId, itemData, bibData).get
+        transformer.getPhysicalLocation(itemData, bibData).get
 
       location.shelfmark shouldBe Some("AX1234:Box 1")
     }
@@ -159,7 +158,6 @@ class SierraPhysicalLocationTest
     describe("uses fallback locations") {
       it("returns an empty location if location name is 'bound in above'") {
         val result = transformer.getPhysicalLocation(
-          bibNumber = createSierraBibNumber,
           bibData = createSierraBibData,
           itemData = createSierraItemDataWith(
             location = Some(SierraLocation("bwith", "bound in above"))
@@ -171,7 +169,6 @@ class SierraPhysicalLocationTest
 
       it("uses the fallback location if location name is 'bound in above'") {
         val result = transformer.getPhysicalLocation(
-          bibNumber = createSierraBibNumber,
           bibData = createSierraBibData,
           itemData = createSierraItemDataWith(
             location = Some(SierraLocation("bwith", "bound in above"))
@@ -187,7 +184,6 @@ class SierraPhysicalLocationTest
 
       it("returns an empty location if location name is 'contained in above'") {
         val result = transformer.getPhysicalLocation(
-          bibNumber = createSierraBibNumber,
           bibData = createSierraBibData,
           itemData = createSierraItemDataWith(
             location = Some(SierraLocation("cwith", "contained in above"))
@@ -199,7 +195,6 @@ class SierraPhysicalLocationTest
 
       it("uses the fallback location if location name is 'contained in above'") {
         val result = transformer.getPhysicalLocation(
-          bibNumber = createSierraBibNumber,
           bibData = createSierraBibData,
           itemData = createSierraItemDataWith(
             location = Some(SierraLocation("cwith", "contained in above"))
@@ -229,11 +224,7 @@ class SierraPhysicalLocationTest
 
       val location =
         transformer
-          .getPhysicalLocation(
-            bibNumber = bibId,
-            itemData = itemData,
-            bibData = bibData
-          )
+          .getPhysicalLocation(itemData = itemData, bibData = bibData)
           .get
 
       location.accessConditions shouldBe List(


### PR DESCRIPTION
Currently we get the item status in two ways:

* In the Catalogue API, we look at both the bib data and the item data.
* In the Items API, we just look at the item data. We skip fetching the bib data to avoid an extra request to Sierra.

This is because I had the “clever idea” of looking at them both, so we could spot the inconsistencies. Smart!

Unfortunately, this means we have two different code paths in play, which behave inconsistently, and the code wasn’t written to handle getting no bib data – so when you use the items API, a bunch of items get blatted with the _"I don't know what to do"_ generic message.

With agreement from Victoria, this removes all the bib-related code for getting the item status. We just use the item data, which means both APIs are using exactly the same code – so we shouldn't get any more inconsistencies.