### PR TITLE
Tweak the HttpClient in the METS adapter

### DIFF
--- a/mets_adapter/mets_adapter/src/main/scala/weco/pipeline/mets_adapter/Main.scala
+++ b/mets_adapter/mets_adapter/src/main/scala/weco/pipeline/mets_adapter/Main.scala
@@ -6,7 +6,7 @@ import akka.http.scaladsl.model.headers.BasicHttpCredentials
 import com.typesafe.config.Config
 import org.scanamo.generic.auto._
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
-import weco.http.client.{AkkaHttpClient, HttpGet, HttpPost}
+import weco.http.client.AkkaHttpClient
 import weco.messaging.typesafe.{SNSBuilder, SQSBuilder}
 import weco.pipeline.mets_adapter.http.StorageServiceOauthHttpClient
 import weco.pipeline.mets_adapter.services.{
@@ -33,12 +33,9 @@ object Main extends WellcomeTypesafeApp {
     implicit val dynamoClilent: DynamoDbClient =
       DynamoBuilder.buildDynamoClient
 
-    val client = new AkkaHttpClient() with HttpGet with HttpPost {
-      override val baseUri: Uri = Uri(config.requireString("bags.api.url"))
-    }
-
     val oauthClient = new StorageServiceOauthHttpClient(
-      underlying = client,
+      underlying = new AkkaHttpClient(),
+      baseUri = Uri(config.requireString("bags.api.url")),
       tokenUri = Uri(config.requireString("bags.oauth.url")),
       credentials = BasicHttpCredentials(
         config.requireString("bags.oauth.client_id"),

--- a/mets_adapter/mets_adapter/src/main/scala/weco/pipeline/mets_adapter/http/StorageServiceOauthHttpClient.scala
+++ b/mets_adapter/mets_adapter/src/main/scala/weco/pipeline/mets_adapter/http/StorageServiceOauthHttpClient.scala
@@ -9,7 +9,7 @@ import akka.http.scaladsl.model.headers.{
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.unmarshalling.{FromEntityUnmarshaller, Unmarshal}
 import weco.json.JsonUtil._
-import weco.http.client.{HttpClient, HttpGet, HttpPost, TokenExchange}
+import weco.http.client.{HttpClient, HttpGet, TokenExchange}
 import weco.http.json.CirceMarshalling
 
 import java.time.Instant
@@ -17,7 +17,8 @@ import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 
 class StorageServiceOauthHttpClient(
-  underlying: HttpClient with HttpGet with HttpPost,
+  underlying: HttpClient,
+  val baseUri: Uri,
   val tokenUri: Uri,
   val credentials: BasicHttpCredentials,
   val expiryGracePeriod: Duration = 60.seconds
@@ -27,7 +28,6 @@ class StorageServiceOauthHttpClient(
   val ec: ExecutionContext
 ) extends HttpClient
     with HttpGet
-    with HttpPost
     with TokenExchange[BasicHttpCredentials, OAuth2BearerToken] {
 
   implicit val um: FromEntityUnmarshaller[StorageServiceAccessToken] =
@@ -91,6 +91,4 @@ class StorageServiceOauthHttpClient(
 
       response <- underlying.singleRequest(authenticatedRequest)
     } yield response
-
-  override val baseUri: Uri = underlying.baseUri
 }

--- a/mets_adapter/mets_adapter/src/test/scala/weco/pipeline/mets_adapter/http/StorageServiceOauthHttpClientTest.scala
+++ b/mets_adapter/mets_adapter/src/test/scala/weco/pipeline/mets_adapter/http/StorageServiceOauthHttpClientTest.scala
@@ -11,7 +11,7 @@ import org.scalatest.concurrent.IntegrationPatience
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.akka.fixtures.Akka
-import weco.http.client.{HttpGet, HttpPost, MemoryHttpClient}
+import weco.http.client.MemoryHttpClient
 import weco.http.fixtures.HttpFixtures
 
 import scala.concurrent.duration._
@@ -154,15 +154,11 @@ class StorageServiceOauthHttpClientTest
       )
     )
 
-    val underlying = new MemoryHttpClient(responses) with HttpGet
-    with HttpPost {
-      override val baseUri: Uri = Uri("http://storage:1234")
-    }
-
     withActorSystem { implicit actorSystem =>
       val authClient = new StorageServiceOauthHttpClient(
-        underlying,
+        underlying = new MemoryHttpClient(responses),
         credentials = credentials,
+        baseUri = Uri("http://storage:1234"),
         tokenUri = Uri("http://storage:1234/token")
       )
 
@@ -237,14 +233,10 @@ class StorageServiceOauthHttpClientTest
       )
     )
 
-    val underlying = new MemoryHttpClient(responses) with HttpGet
-    with HttpPost {
-      override val baseUri: Uri = Uri("http://storage:1234")
-    }
-
     withActorSystem { implicit actorSystem =>
       val authClient = new StorageServiceOauthHttpClient(
-        underlying,
+        underlying = new MemoryHttpClient(responses),
+        baseUri = Uri("http://storage:1234"),
         tokenUri = Uri("http://storage:1234/token"),
         credentials = credentials,
         expiryGracePeriod = 3.seconds


### PR DESCRIPTION
It doesn't actually need the underlying client to have HttpGet or HttpPost.