### PR TITLE
Suppress 591 subfield $9 – don't show the barcode

### DIFF
--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraNotes.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraNotes.scala
@@ -37,10 +37,10 @@ object SierraNotes extends SierraDataTransformer with SierraQueryOps {
     "581" -> createNoteFromContents(PublicationsNote),
     "585" -> createNoteFromContents(ExhibitionsNote),
     "586" -> createNoteFromContents(AwardsNote),
-
     // 591 subfield ǂ9 contains barcodes that we don't want to show on /works.
-    "591" -> createNoteFromContents(GeneralNote, suppressedSubfields = Set("9")),
-
+    "591" -> createNoteFromContents(
+      GeneralNote,
+      suppressedSubfields = Set("9")),
     "593" -> createNoteFromContents(CopyrightNote),
   )
 
@@ -69,7 +69,8 @@ object SierraNotes extends SierraDataTransformer with SierraQueryOps {
     (varField: VarField) => {
       val contents =
         varField
-          .subfieldsWithoutTags((globallySuppressedSubfields ++ suppressedSubfields).toSeq: _*)
+          .subfieldsWithoutTags(
+            (globallySuppressedSubfields ++ suppressedSubfields).toSeq: _*)
           .contents
           .mkString(" ")
 

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraNotesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraNotesTest.scala
@@ -185,6 +185,25 @@ class SierraNotesTest
     SierraNotes(bibData) should contain theSameElementsAs notes
   }
 
+  it("skips 591 subfield ǂ9 (barcode)") {
+    val varFields = List(
+      VarField(
+        marcTag = "591",
+        subfields = List(
+          Subfield(tag = "z", content = "Copy 1."),
+          Subfield(tag = "e", content = "Note: The author's presentation inscription on verso of 2nd leaf."),
+          Subfield(tag = "9", content = "X8253")
+        )
+      )
+    )
+
+    val bibData = createSierraBibDataWith(varFields = varFields)
+
+    SierraNotes(bibData) should contain theSameElementsAs List(
+      GeneralNote("Copy 1. Note: The author's presentation inscription on verso of 2nd leaf.")
+    )
+  }
+
   def bibData(contents: List[(String, Note)]): SierraBibData =
     bibData(contents.map { case (tag, note) => (tag, note.content) }: _*)
 

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraNotesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraNotesTest.scala
@@ -191,7 +191,10 @@ class SierraNotesTest
         marcTag = "591",
         subfields = List(
           Subfield(tag = "z", content = "Copy 1."),
-          Subfield(tag = "e", content = "Note: The author's presentation inscription on verso of 2nd leaf."),
+          Subfield(
+            tag = "e",
+            content =
+              "Note: The author's presentation inscription on verso of 2nd leaf."),
           Subfield(tag = "9", content = "X8253")
         )
       )
@@ -200,7 +203,8 @@ class SierraNotesTest
     val bibData = createSierraBibDataWith(varFields = varFields)
 
     SierraNotes(bibData) should contain theSameElementsAs List(
-      GeneralNote("Copy 1. Note: The author's presentation inscription on verso of 2nd leaf.")
+      GeneralNote(
+        "Copy 1. Note: The author's presentation inscription on verso of 2nd leaf.")
     )
   }
 


### PR DESCRIPTION
Based on a report from Victoria in Slack: https://wellcome.slack.com/archives/C8X9YKM5X/p1630925994004400

For https://github.com/wellcomecollection/platform/issues/5285

Once this is reviewed, merged and deployed, I've got the list of affected works, so I'll reindex those works specifically to pick up the change.