### PR TITLE
Add a modifiedTime value to SierraTransformable

### DIFF
--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraTransformable.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraTransformable.scala
@@ -47,7 +47,8 @@ case class SierraTransformable(
   // to this transformable, but was later unlinked, the modified time will be
   // taken from the update that unlinked the record.
   private val records = Seq(maybeBibRecord).flatten ++ itemRecords.values ++ holdingsRecords.values ++ orderRecords.values
-  require(records.forall(_.modifiedDate.toEpochMilli <= modifiedTime.toEpochMilli))
+  require(
+    records.forall(_.modifiedDate.toEpochMilli <= modifiedTime.toEpochMilli))
 }
 
 object SierraTransformable {

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraTransformable.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraTransformable.scala
@@ -48,7 +48,9 @@ case class SierraTransformable(
   // taken from the update that unlinked the record.
   private val records = Seq(maybeBibRecord).flatten ++ itemRecords.values ++ holdingsRecords.values ++ orderRecords.values
   require(
-    records.forall(_.modifiedDate.toEpochMilli <= modifiedTime.toEpochMilli))
+    records.forall(_.modifiedDate.toEpochMilli <= modifiedTime.toEpochMilli),
+    "modifiedTime should be at least as late as all linked records"
+  )
 }
 
 object SierraTransformable {

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraTransformable.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraTransformable.scala
@@ -40,32 +40,4 @@ object SierraTransformable {
     SierraTransformable(
       sierraId = bibRecord.id,
       maybeBibRecord = Some(bibRecord))
-
-  def createNew(
-    sierraId: SierraBibNumber,
-    itemRecords: Seq[SierraItemRecord] = List(),
-    holdingsRecords: Seq[SierraHoldingsRecord] = List(),
-    orderRecords: Seq[SierraOrderRecord] = List()
-  ): SierraTransformable =
-    SierraTransformable(
-      sierraId = sierraId,
-      maybeBibRecord = None,
-      itemRecords = itemRecords.map { record => record.id -> record }.toMap,
-      holdingsRecords = holdingsRecords.map { record => record.id -> record }.toMap,
-      orderRecords = orderRecords.map { record => record.id -> record }.toMap,
-    )
-
-  def createNew2(
-    bibRecord: SierraBibRecord,
-    itemRecords: Seq[SierraItemRecord] = List(),
-    holdingsRecords: Seq[SierraHoldingsRecord] = List(),
-    orderRecords: Seq[SierraOrderRecord] = List()
-  ): SierraTransformable =
-    SierraTransformable(
-      sierraId = bibRecord.id,
-      maybeBibRecord = Some(bibRecord),
-      itemRecords = itemRecords.map { record => record.id -> record }.toMap,
-      holdingsRecords = holdingsRecords.map { record => record.id -> record }.toMap,
-      orderRecords = orderRecords.map { record => record.id -> record }.toMap,
-    )
 }

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraTransformable.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraTransformable.scala
@@ -9,6 +9,12 @@ import weco.sierra.models.identifiers.{
 
 import java.time.Instant
 
+/** @param modifiedTime Note: this parameter may not be the max of the modified
+  *                     times of all the included records.  In particular, if there's
+  *                     a record that used to be linked to this transformable, but was
+  *                     later unlinked, the modified time will be taken from the update
+  *                     that unlinked the record.
+  */
 case class SierraTransformable(
   sierraId: SierraBibNumber,
   maybeBibRecord: Option[SierraBibRecord] = None,

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraTransformable.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraTransformable.scala
@@ -13,7 +13,18 @@ case class SierraTransformable(
   itemRecords: Map[SierraItemNumber, SierraItemRecord] = Map(),
   holdingsRecords: Map[SierraHoldingsNumber, SierraHoldingsRecord] = Map(),
   orderRecords: Map[SierraOrderNumber, SierraOrderRecord] = Map()
-)
+) {
+  // Run some consistency checks on the identifiers.  If these identifiers don't match,
+  // it indicates some sort of programming error.
+  maybeBibRecord match {
+    case Some(bibRecord) => require(bibRecord.id == sierraId)
+    case _ => ()
+  }
+
+  itemRecords.foreach { case (id, record) => require(record.id == id) }
+  holdingsRecords.foreach { case (id, record) => require(record.id == id) }
+  orderRecords.foreach { case (id, record) => require(record.id == id) }
+}
 
 object SierraTransformable {
   def apply(bibRecord: SierraBibRecord): SierraTransformable =

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraTransformable.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraTransformable.scala
@@ -9,12 +9,6 @@ import weco.sierra.models.identifiers.{
 
 import java.time.Instant
 
-/** @param modifiedTime Note: this parameter may not be the max of the modified
-  *                     times of all the included records.  In particular, if there's
-  *                     a record that used to be linked to this transformable, but was
-  *                     later unlinked, the modified time will be taken from the update
-  *                     that unlinked the record.
-  */
 case class SierraTransformable(
   sierraId: SierraBibNumber,
   maybeBibRecord: Option[SierraBibRecord] = None,
@@ -45,6 +39,15 @@ case class SierraTransformable(
       require(record.id == id)
       require(record.bibIds.contains(sierraId))
   }
+
+  // Check the modifiedTime makes sense.
+  //
+  // Note: this parameter may not be the max of the modified times of all the
+  // included records.  In particular, if there's a record that used to be linked
+  // to this transformable, but was later unlinked, the modified time will be
+  // taken from the update that unlinked the record.
+  private val records = Seq(maybeBibRecord).flatten ++ itemRecords.values ++ holdingsRecords.values ++ orderRecords.values
+  require(records.forall(_.modifiedDate.toEpochMilli <= modifiedTime.toEpochMilli))
 }
 
 object SierraTransformable {

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraTransformable.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraTransformable.scala
@@ -7,12 +7,15 @@ import weco.sierra.models.identifiers.{
   SierraOrderNumber
 }
 
+import java.time.Instant
+
 case class SierraTransformable(
   sierraId: SierraBibNumber,
   maybeBibRecord: Option[SierraBibRecord] = None,
   itemRecords: Map[SierraItemNumber, SierraItemRecord] = Map(),
   holdingsRecords: Map[SierraHoldingsNumber, SierraHoldingsRecord] = Map(),
-  orderRecords: Map[SierraOrderNumber, SierraOrderRecord] = Map()
+  orderRecords: Map[SierraOrderNumber, SierraOrderRecord] = Map(),
+  modifiedTime: Instant
 ) {
   // Run some consistency checks on the identifiers.  If these identifiers don't match,
   // it indicates some sort of programming error.
@@ -42,5 +45,7 @@ object SierraTransformable {
   def apply(bibRecord: SierraBibRecord): SierraTransformable =
     SierraTransformable(
       sierraId = bibRecord.id,
-      maybeBibRecord = Some(bibRecord))
+      maybeBibRecord = Some(bibRecord),
+      modifiedTime = bibRecord.modifiedDate
+    )
 }

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraTransformable.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraTransformable.scala
@@ -18,20 +18,23 @@ case class SierraTransformable(
   // it indicates some sort of programming error.
   maybeBibRecord match {
     case Some(bibRecord) => require(bibRecord.id == sierraId)
-    case _ => ()
+    case _               => ()
   }
 
-  itemRecords.foreach { case (id, record) =>
-    require(record.id == id)
-    require(record.bibIds.contains(sierraId))
+  itemRecords.foreach {
+    case (id, record) =>
+      require(record.id == id)
+      require(record.bibIds.contains(sierraId))
   }
-  holdingsRecords.foreach { case (id, record) =>
-    require(record.id == id)
-    require(record.bibIds.contains(sierraId))
+  holdingsRecords.foreach {
+    case (id, record) =>
+      require(record.id == id)
+      require(record.bibIds.contains(sierraId))
   }
-  orderRecords.foreach { case (id, record) =>
-    require(record.id == id)
-    require(record.bibIds.contains(sierraId))
+  orderRecords.foreach {
+    case (id, record) =>
+      require(record.id == id)
+      require(record.bibIds.contains(sierraId))
   }
 }
 

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraTransformable.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraTransformable.scala
@@ -21,9 +21,18 @@ case class SierraTransformable(
     case _ => ()
   }
 
-  itemRecords.foreach { case (id, record) => require(record.id == id) }
-  holdingsRecords.foreach { case (id, record) => require(record.id == id) }
-  orderRecords.foreach { case (id, record) => require(record.id == id) }
+  itemRecords.foreach { case (id, record) =>
+    require(record.id == id)
+    require(record.bibIds.contains(sierraId))
+  }
+  holdingsRecords.foreach { case (id, record) =>
+    require(record.id == id)
+    require(record.bibIds.contains(sierraId))
+  }
+  orderRecords.foreach { case (id, record) =>
+    require(record.id == id)
+    require(record.bibIds.contains(sierraId))
+  }
 }
 
 object SierraTransformable {
@@ -31,4 +40,32 @@ object SierraTransformable {
     SierraTransformable(
       sierraId = bibRecord.id,
       maybeBibRecord = Some(bibRecord))
+
+  def createNew(
+    sierraId: SierraBibNumber,
+    itemRecords: Seq[SierraItemRecord] = List(),
+    holdingsRecords: Seq[SierraHoldingsRecord] = List(),
+    orderRecords: Seq[SierraOrderRecord] = List()
+  ): SierraTransformable =
+    SierraTransformable(
+      sierraId = sierraId,
+      maybeBibRecord = None,
+      itemRecords = itemRecords.map { record => record.id -> record }.toMap,
+      holdingsRecords = holdingsRecords.map { record => record.id -> record }.toMap,
+      orderRecords = orderRecords.map { record => record.id -> record }.toMap,
+    )
+
+  def createNew2(
+    bibRecord: SierraBibRecord,
+    itemRecords: Seq[SierraItemRecord] = List(),
+    holdingsRecords: Seq[SierraHoldingsRecord] = List(),
+    orderRecords: Seq[SierraOrderRecord] = List()
+  ): SierraTransformable =
+    SierraTransformable(
+      sierraId = bibRecord.id,
+      maybeBibRecord = Some(bibRecord),
+      itemRecords = itemRecords.map { record => record.id -> record }.toMap,
+      holdingsRecords = holdingsRecords.map { record => record.id -> record }.toMap,
+      orderRecords = orderRecords.map { record => record.id -> record }.toMap,
+    )
 }

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/generators/SierraRecordGenerators.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/generators/SierraRecordGenerators.scala
@@ -155,16 +155,16 @@ trait SierraRecordGenerators extends SierraIdentifierGenerators {
 
   def createSierraItemRecord: SierraItemRecord = createSierraItemRecordWith()
 
-  def createSierraTransformableWith(
-    sierraId: SierraBibNumber = createSierraBibNumber,
-    maybeBibRecord: Option[SierraBibRecord] = Some(createSierraBibRecord),
+  def createSierraTransformableStubWith(
+    bibId: SierraBibNumber,
+    maybeBibRecord: Option[SierraBibRecord] = None,
     itemRecords: Seq[SierraItemRecord] = List(),
     holdingsRecords: Seq[SierraHoldingsRecord] = List(),
     orderRecords: Seq[SierraOrderRecord] = List()
   ): SierraTransformable =
     SierraTransformable(
-      sierraId = sierraId,
-      maybeBibRecord = maybeBibRecord,
+      sierraId = bibId,
+      maybeBibRecord = None,
       itemRecords = itemRecords.map { record =>
         record.id -> record
       }.toMap,
@@ -176,6 +176,20 @@ trait SierraRecordGenerators extends SierraIdentifierGenerators {
       }.toMap
     )
 
+  def createSierraTransformableWith(
+    bibRecord: SierraBibRecord,
+    itemRecords: Seq[SierraItemRecord] = List(),
+    holdingsRecords: Seq[SierraHoldingsRecord] = List(),
+    orderRecords: Seq[SierraOrderRecord] = List()
+  ): SierraTransformable =
+    createSierraTransformableStubWith(
+      bibId = bibRecord.id,
+      maybeBibRecord = Some(bibRecord),
+      itemRecords = itemRecords,
+      holdingsRecords = holdingsRecords,
+      orderRecords = orderRecords
+    )
+
   def createSierraTransformable: SierraTransformable =
-    createSierraTransformableWith()
+    createSierraTransformableWith(bibRecord = createSierraBibRecord)
 }

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/generators/SierraRecordGenerators.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/generators/SierraRecordGenerators.scala
@@ -175,8 +175,9 @@ trait SierraRecordGenerators extends SierraIdentifierGenerators {
         record.id -> record
       }.toMap,
       modifiedTime = {
-        val times = (Seq(maybeBibRecord).flatten ++ itemRecords ++ holdingsRecords ++ orderRecords)
-          .map(_.modifiedDate)
+        val times =
+          (Seq(maybeBibRecord).flatten ++ itemRecords ++ holdingsRecords ++ orderRecords)
+            .map(_.modifiedDate)
 
         times match {
           case Nil => Instant.now()

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/generators/SierraRecordGenerators.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/generators/SierraRecordGenerators.scala
@@ -173,7 +173,16 @@ trait SierraRecordGenerators extends SierraIdentifierGenerators {
       }.toMap,
       orderRecords = orderRecords.map { record =>
         record.id -> record
-      }.toMap
+      }.toMap,
+      modifiedTime = {
+        val times = (Seq(maybeBibRecord).flatten ++ itemRecords ++ holdingsRecords ++ orderRecords)
+          .map(_.modifiedDate)
+
+        times match {
+          case Nil => Instant.now()
+          case _   => times.max
+        }
+      }
     )
 
   def createSierraTransformableWith(

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/generators/SierraRecordGenerators.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/generators/SierraRecordGenerators.scala
@@ -164,7 +164,7 @@ trait SierraRecordGenerators extends SierraIdentifierGenerators {
   ): SierraTransformable =
     SierraTransformable(
       sierraId = bibId,
-      maybeBibRecord = None,
+      maybeBibRecord = maybeBibRecord,
       itemRecords = itemRecords.map { record =>
         record.id -> record
       }.toMap,

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/SierraTransformableTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/SierraTransformableTest.scala
@@ -20,7 +20,9 @@ class SierraTransformableTest
     //
     // Then we'd have a SierraTransformable for b123 but no attached records.
     // Is that likely?  Hard to say, but we can handle it so we might as well.
-    SierraTransformable(sierraId = createSierraBibNumber, modifiedTime = Instant.now)
+    SierraTransformable(
+      sierraId = createSierraBibNumber,
+      modifiedTime = Instant.now)
   }
 
   it("allows creation from only a SierraBibRecord") {

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/SierraTransformableTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/SierraTransformableTest.scala
@@ -22,10 +22,12 @@ class SierraTransformableTest
   }
 
   it("allows looking up items by ID") {
+    val bibId = createSierraBibNumber
     val itemRecords = (0 to 3).map { _ =>
-      createSierraItemRecord
+      createSierraItemRecordWith(bibIds = List(bibId))
     }
-    val transformable = createSierraTransformableWith(
+    val transformable = createSierraTransformableStubWith(
+      bibId = bibId,
       itemRecords = itemRecords
     )
 

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/SierraTransformableTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/SierraTransformableTest.scala
@@ -5,13 +5,22 @@ import org.scalatest.matchers.should.Matchers
 import weco.catalogue.source_model.generators.SierraRecordGenerators
 import weco.sierra.models.identifiers.SierraItemNumber
 
+import java.time.Instant
+
 class SierraTransformableTest
     extends AnyFunSpec
     with Matchers
     with SierraRecordGenerators {
 
   it("allows creation of SierraTransformable with no data") {
-    SierraTransformable(sierraId = createSierraBibNumber)
+    // We need this for the case where:
+    //
+    //  1. We receive an item that links to a bib record b123
+    //  2. Later, we receive an update to the item that unlinks it
+    //
+    // Then we'd have a SierraTransformable for b123 but no attached records.
+    // Is that likely?  Hard to say, but we can handle it so we might as well.
+    SierraTransformable(sierraId = createSierraBibNumber, modifiedTime = Instant.now)
   }
 
   it("allows creation from only a SierraBibRecord") {

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/SierraTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/SierraTransformer.scala
@@ -48,7 +48,7 @@ class SierraTransformer(sierraTransformable: SierraTransformable, version: Int)
             state = Source(sourceIdentifier, Instant.EPOCH),
             version = version,
             data = WorkData(),
-            invisibilityReasons = List(SourceFieldMissing("bibData"))
+            invisibilityReasons = List(SourceFieldMissing("bibRecord"))
           )
         )
       }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/SierraTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/SierraTransformer.scala
@@ -69,7 +69,8 @@ class SierraTransformer(sierraTransformable: SierraTransformable, version: Int)
           throw e
       }
 
-  def workFromBibRecord(state: Source, bibRecord: SierraBibRecord): Try[Work[Source]] =
+  def workFromBibRecord(state: Source,
+                        bibRecord: SierraBibRecord): Try[Work[Source]] =
     fromJson[SierraBibData](bibRecord.data)
       .map { bibData =>
         if (bibData.deleted) {

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/SierraTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/SierraTransformer.scala
@@ -36,7 +36,12 @@ class SierraTransformer(sierraTransformable: SierraTransformable, version: Int)
     sierraTransformable.maybeBibRecord
       .map { bibRecord =>
         debug(s"Attempting to transform ${bibRecord.id.withCheckDigit}")
-        workFromBibRecord(bibRecord)
+
+        val state = Source(
+          sourceIdentifier = sourceIdentifier,
+          sourceModifiedTime = sierraTransformable.modifiedTime
+        )
+        workFromBibRecord(state, bibRecord)
       }
       .getOrElse {
         // A merged record can have both bibs and items.  If we only have
@@ -64,9 +69,7 @@ class SierraTransformer(sierraTransformable: SierraTransformable, version: Int)
           throw e
       }
 
-  def workFromBibRecord(bibRecord: SierraBibRecord): Try[Work[Source]] = {
-    val state = Source(sourceIdentifier, bibRecord.modifiedDate)
-
+  def workFromBibRecord(state: Source, bibRecord: SierraBibRecord): Try[Work[Source]] =
     fromJson[SierraBibData](bibRecord.data)
       .map { bibData =>
         if (bibData.deleted) {
@@ -103,7 +106,6 @@ class SierraTransformer(sierraTransformable: SierraTransformable, version: Int)
             invisibilityReasons = List(UnableToTransform(e.getMessage))
           )
       }
-  }
 
   def workDataFromBibData(bibId: SierraBibNumber, bibData: SierraBibData) =
     WorkData[DataState.Unidentified](

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/services/SierraTransformerWorkerTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/services/SierraTransformerWorkerTest.scala
@@ -43,7 +43,8 @@ class SierraTransformerWorkerTest
     implicit store: MemoryTypedStore[S3ObjectLocation, SierraTransformable])
     : SierraSourcePayload = {
     val transformable = createSierraTransformableWith(
-      sierraId = SierraBibNumber(id))
+      bibRecord = createSierraBibRecordWith(id = SierraBibNumber(id))
+    )
     val location = createS3ObjectLocation
 
     store.put(location)(transformable) shouldBe a[Right[_, _]]

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraTransformerTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraTransformerTest.scala
@@ -1134,10 +1134,9 @@ class SierraTransformerTest
     val id = createSierraBibNumber
 
     val transformable = createSierraTransformableWith(
-      bibRecord =
-        createSierraBibRecordWith(
-          id = id,
-          data = s"""
+      bibRecord = createSierraBibRecordWith(
+        id = id,
+        data = s"""
                |{
                |  "id": "$id",
                |  "fixedFields": {
@@ -1145,7 +1144,7 @@ class SierraTransformerTest
                |  }
                |}
                |""".stripMargin
-        ),
+      ),
       orderRecords = List(createSierraOrderRecordWith(bibIds = List(id)))
     )
 
@@ -1191,11 +1190,10 @@ class SierraTransformerTest
          |""".stripMargin
 
     val transformable = createSierraTransformableWith(
-      bibRecord =
-        SierraBibRecord(
-          id = bibId,
-          data = bibData,
-          modifiedDate = Instant.now()),
+      bibRecord = SierraBibRecord(
+        id = bibId,
+        data = bibData,
+        modifiedDate = Instant.now()),
       itemRecords = List(
         SierraItemRecord(
           id = itemId,

--- a/sierra_adapter/sierra_indexer/src/test/scala/weco/pipeline/sierra_indexer/SierraIndexerFeatureTest.scala
+++ b/sierra_adapter/sierra_indexer/src/test/scala/weco/pipeline/sierra_indexer/SierraIndexerFeatureTest.scala
@@ -46,10 +46,9 @@ class SierraIndexerFeatureTest
     }
 
     val transformable = createSierraTransformableWith(
-      bibRecord =
-        createSierraBibRecordWith(
-          id = bibId,
-          data = s"""
+      bibRecord = createSierraBibRecordWith(
+        id = bibId,
+        data = s"""
                |{
                |  "id" : "$bibId",
                |  "updatedDate" : "2013-12-12T13:56:07Z",
@@ -84,7 +83,7 @@ class SierraIndexerFeatureTest
                |  }
                |}
                |""".stripMargin
-        ),
+      ),
       itemRecords = itemIds.map { id =>
         createSierraItemRecordWith(id = id, bibIds = List(bibId))
       },
@@ -252,10 +251,9 @@ class SierraIndexerFeatureTest
     val bibId = createSierraBibNumber
 
     val transformable1 = createSierraTransformableWith(
-      bibRecord =
-        createSierraBibRecordWith(
-          id = bibId,
-          data = s"""
+      bibRecord = createSierraBibRecordWith(
+        id = bibId,
+        data = s"""
                     |{
                     |  "id" : "$bibId",
                     |  "updatedDate" : "2001-01-01T01:01:01Z",
@@ -274,16 +272,15 @@ class SierraIndexerFeatureTest
                     |  }
                     |}
                     |""".stripMargin
-        ),
+      ),
       itemRecords = List(),
       holdingsRecords = List(),
     )
 
     val transformable2 = createSierraTransformableWith(
-      bibRecord =
-        createSierraBibRecordWith(
-          id = bibId,
-          data = s"""
+      bibRecord = createSierraBibRecordWith(
+        id = bibId,
+        data = s"""
                     |{
                     |  "id" : "$bibId",
                     |  "updatedDate" : "2002-02-02T02:02:02Z",
@@ -302,7 +299,7 @@ class SierraIndexerFeatureTest
                     |  }
                     |}
                     |""".stripMargin
-        ),
+      ),
       itemRecords = List(),
       holdingsRecords = List(),
     )

--- a/sierra_adapter/sierra_indexer/src/test/scala/weco/pipeline/sierra_indexer/SierraIndexerFeatureTest.scala
+++ b/sierra_adapter/sierra_indexer/src/test/scala/weco/pipeline/sierra_indexer/SierraIndexerFeatureTest.scala
@@ -46,7 +46,7 @@ class SierraIndexerFeatureTest
     }
 
     val transformable = createSierraTransformableWith(
-      maybeBibRecord = Some(
+      bibRecord =
         createSierraBibRecordWith(
           id = bibId,
           data = s"""
@@ -84,16 +84,15 @@ class SierraIndexerFeatureTest
                |  }
                |}
                |""".stripMargin
-        )
-      ),
+        ),
       itemRecords = itemIds.map { id =>
-        createSierraItemRecordWith(id = id)
+        createSierraItemRecordWith(id = id, bibIds = List(bibId))
       },
       holdingsRecords = holdingsIds.map { id =>
-        createSierraHoldingsRecordWith(id = id)
+        createSierraHoldingsRecordWith(id = id, bibIds = List(bibId))
       },
       orderRecords = orderIds.map { id =>
-        createSierraOrderRecordWith(id = id)
+        createSierraOrderRecordWith(id = id, bibIds = List(bibId))
       }
     )
 
@@ -253,7 +252,7 @@ class SierraIndexerFeatureTest
     val bibId = createSierraBibNumber
 
     val transformable1 = createSierraTransformableWith(
-      maybeBibRecord = Some(
+      bibRecord =
         createSierraBibRecordWith(
           id = bibId,
           data = s"""
@@ -275,14 +274,13 @@ class SierraIndexerFeatureTest
                     |  }
                     |}
                     |""".stripMargin
-        )
-      ),
+        ),
       itemRecords = List(),
       holdingsRecords = List(),
     )
 
     val transformable2 = createSierraTransformableWith(
-      maybeBibRecord = Some(
+      bibRecord =
         createSierraBibRecordWith(
           id = bibId,
           data = s"""
@@ -304,8 +302,7 @@ class SierraIndexerFeatureTest
                     |  }
                     |}
                     |""".stripMargin
-        )
-      ),
+        ),
       itemRecords = List(),
       holdingsRecords = List(),
     )
@@ -472,10 +469,12 @@ class SierraIndexerFeatureTest
   it("indexes item records and their varFields/fixedFields") {
     val location = createS3ObjectLocation
 
+    val bibId = createSierraBibNumber
     val itemId1 = createSierraItemNumber
     val itemId2 = createSierraItemNumber
 
-    val transformable = createSierraTransformableWith(
+    val transformable = createSierraTransformableStubWith(
+      bibId = bibId,
       itemRecords = List(
         SierraItemRecord(
           id = itemId1,
@@ -499,7 +498,7 @@ class SierraIndexerFeatureTest
             |}
             |""".stripMargin,
           modifiedDate = Instant.now(),
-          bibIds = List()
+          bibIds = List(bibId)
         ),
         SierraItemRecord(
           id = itemId2,
@@ -532,7 +531,7 @@ class SierraIndexerFeatureTest
                     |}
                     |""".stripMargin,
           modifiedDate = Instant.now(),
-          bibIds = List()
+          bibIds = List(bibId)
         )
       )
     )
@@ -669,10 +668,12 @@ class SierraIndexerFeatureTest
   it("indexes holdings records and their varFields/fixedFields") {
     val location = createS3ObjectLocation
 
+    val bibId = createSierraBibNumber
     val holdingsId1 = createSierraHoldingsNumber
     val holdingsId2 = createSierraHoldingsNumber
 
-    val transformable = createSierraTransformableWith(
+    val transformable = createSierraTransformableStubWith(
+      bibId = bibId,
       holdingsRecords = List(
         SierraHoldingsRecord(
           id = holdingsId1,
@@ -696,7 +697,7 @@ class SierraIndexerFeatureTest
                     |}
                     |""".stripMargin,
           modifiedDate = Instant.now(),
-          bibIds = List()
+          bibIds = List(bibId)
         ),
         SierraHoldingsRecord(
           id = holdingsId2,
@@ -728,7 +729,7 @@ class SierraIndexerFeatureTest
                     |}
                     |""".stripMargin,
           modifiedDate = Instant.now(),
-          bibIds = List()
+          bibIds = List(bibId)
         )
       )
     )
@@ -865,10 +866,12 @@ class SierraIndexerFeatureTest
   it("indexes order records and their varFields/fixedFields") {
     val location = createS3ObjectLocation
 
+    val bibId = createSierraBibNumber
     val orderId1 = createSierraOrderNumber
     val orderId2 = createSierraOrderNumber
 
-    val transformable = createSierraTransformableWith(
+    val transformable = createSierraTransformableStubWith(
+      bibId = bibId,
       orderRecords = List(
         SierraOrderRecord(
           id = orderId1,
@@ -892,7 +895,7 @@ class SierraIndexerFeatureTest
                     |}
                     |""".stripMargin,
           modifiedDate = Instant.now(),
-          bibIds = List()
+          bibIds = List(bibId)
         ),
         SierraOrderRecord(
           id = orderId2,
@@ -924,7 +927,7 @@ class SierraIndexerFeatureTest
                     |}
                     |""".stripMargin,
           modifiedDate = Instant.now(),
-          bibIds = List()
+          bibIds = List(bibId)
         )
       )
     )
@@ -1062,9 +1065,7 @@ class SierraIndexerFeatureTest
     withIndices { indexPrefix =>
       val location = createS3ObjectLocation
 
-      val bibId = createSierraBibNumber
-
-      val transformable = createSierraTransformableWith(sierraId = bibId)
+      val transformable = createSierraTransformable
 
       val store = MemoryTypedStore[S3ObjectLocation, SierraTransformable](
         initialEntries = Map(location -> transformable)
@@ -1091,7 +1092,7 @@ class SierraIndexerFeatureTest
             sendNotificationToSQS(
               queue,
               SierraSourcePayload(
-                id = bibId.withoutCheckDigit,
+                id = transformable.sierraId.withoutCheckDigit,
                 location = location,
                 version = 1
               )

--- a/sierra_adapter/sierra_indexer/src/test/scala/weco/pipeline/sierra_indexer/services/WorkerTest.scala
+++ b/sierra_adapter/sierra_indexer/src/test/scala/weco/pipeline/sierra_indexer/services/WorkerTest.scala
@@ -25,10 +25,9 @@ class WorkerTest
       val bibId = createSierraBibNumber
 
       val transformable = createSierraTransformableWith(
-        bibRecord =
-          createSierraBibRecordWith(
-            id = bibId,
-            data = s"""
+        bibRecord = createSierraBibRecordWith(
+          id = bibId,
+          data = s"""
                  |{
                  |  "id" : "$bibId",
                  |  "updatedDate" : "2013-12-12T13:56:07Z",
@@ -53,7 +52,7 @@ class WorkerTest
                  |  ]
                  |}
                  |""".stripMargin
-          )
+        )
       )
 
       val store = MemoryTypedStore[S3ObjectLocation, SierraTransformable](
@@ -105,10 +104,9 @@ class WorkerTest
       // that one of the fields was a date -- preventing any non-date data
       // being indexed in future updates.
       val transformable = createSierraTransformableWith(
-        bibRecord =
-          createSierraBibRecordWith(
-            id = bibId,
-            data = s"""
+        bibRecord = createSierraBibRecordWith(
+          id = bibId,
+          data = s"""
                  |{
                  |  "id" : "$bibId",
                  |  "updatedDate" : "2013-12-12T13:56:07Z",
@@ -125,7 +123,7 @@ class WorkerTest
                  |  ]
                  |}
                  |""".stripMargin
-          )
+        )
       )
 
       val store = MemoryTypedStore[S3ObjectLocation, SierraTransformable](
@@ -172,10 +170,9 @@ class WorkerTest
       // that one of the fields was a date -- preventing any non-date data
       // being indexed in future updates.
       val transformable = createSierraTransformableWith(
-        bibRecord =
-          createSierraBibRecordWith(
-            id = bibId,
-            data = s"""
+        bibRecord = createSierraBibRecordWith(
+          id = bibId,
+          data = s"""
                  |{
                  |  "id" : "$bibId",
                  |  "updatedDate" : "2013-12-12T13:56:07Z",
@@ -192,7 +189,7 @@ class WorkerTest
                  |  }
                  |}
                  |""".stripMargin
-          )
+        )
       )
 
       val store = MemoryTypedStore[S3ObjectLocation, SierraTransformable](

--- a/sierra_adapter/sierra_indexer/src/test/scala/weco/pipeline/sierra_indexer/services/WorkerTest.scala
+++ b/sierra_adapter/sierra_indexer/src/test/scala/weco/pipeline/sierra_indexer/services/WorkerTest.scala
@@ -25,7 +25,7 @@ class WorkerTest
       val bibId = createSierraBibNumber
 
       val transformable = createSierraTransformableWith(
-        maybeBibRecord = Some(
+        bibRecord =
           createSierraBibRecordWith(
             id = bibId,
             data = s"""
@@ -54,7 +54,6 @@ class WorkerTest
                  |}
                  |""".stripMargin
           )
-        )
       )
 
       val store = MemoryTypedStore[S3ObjectLocation, SierraTransformable](
@@ -72,6 +71,7 @@ class WorkerTest
         )
         .await
 
+      // TODO: This should be a regular queue, not a DLQ pair
       withLocalSqsQueuePair() {
         case QueuePair(queue, dlq) =>
           withWorker(queue, store, indexPrefix) { worker =>
@@ -105,7 +105,7 @@ class WorkerTest
       // that one of the fields was a date -- preventing any non-date data
       // being indexed in future updates.
       val transformable = createSierraTransformableWith(
-        maybeBibRecord = Some(
+        bibRecord =
           createSierraBibRecordWith(
             id = bibId,
             data = s"""
@@ -126,7 +126,6 @@ class WorkerTest
                  |}
                  |""".stripMargin
           )
-        )
       )
 
       val store = MemoryTypedStore[S3ObjectLocation, SierraTransformable](
@@ -173,7 +172,7 @@ class WorkerTest
       // that one of the fields was a date -- preventing any non-date data
       // being indexed in future updates.
       val transformable = createSierraTransformableWith(
-        maybeBibRecord = Some(
+        bibRecord =
           createSierraBibRecordWith(
             id = bibId,
             data = s"""
@@ -194,7 +193,6 @@ class WorkerTest
                  |}
                  |""".stripMargin
           )
-        )
       )
 
       val store = MemoryTypedStore[S3ObjectLocation, SierraTransformable](

--- a/sierra_adapter/sierra_merger/src/main/scala/weco/pipeline/sierra_merger/models/TransformableOps.scala
+++ b/sierra_adapter/sierra_merger/src/main/scala/weco/pipeline/sierra_merger/models/TransformableOps.scala
@@ -30,13 +30,25 @@ object TransformableOps {
       implicit
       ops: TransformableOps[Record]
     ): Option[SierraTransformable] =
-      ops.add(t, r)
+      ops
+        .add(t, r)
+        .map { transformable =>
+          transformable.copy(
+            modifiedTime = Seq(transformable.modifiedTime, r.modifiedDate).max
+          )
+        }
 
     def remove[Record <: AbstractSierraRecord[_]](r: Record)(
       implicit
       ops: TransformableOps[Record]
     ): Option[SierraTransformable] =
-      ops.remove(t, r)
+      ops
+        .remove(t, r)
+        .map { transformable =>
+          transformable.copy(
+            modifiedTime = Seq(transformable.modifiedTime, r.modifiedDate).max
+          )
+        }
   }
 
   implicit val bibTransformableOps = new TransformableOps[SierraBibRecord] {
@@ -86,7 +98,7 @@ object TransformableOps {
 
     override def create(sierraId: SierraBibNumber,
                         record: Record): SierraTransformable = {
-      val t = SierraTransformable(sierraId = sierraId)
+      val t = SierraTransformable(sierraId = sierraId, modifiedTime = record.modifiedDate)
       val newRecords = Map(record.id -> record)
 
       setRecords(t, newRecords)

--- a/sierra_adapter/sierra_merger/src/main/scala/weco/pipeline/sierra_merger/models/TransformableOps.scala
+++ b/sierra_adapter/sierra_merger/src/main/scala/weco/pipeline/sierra_merger/models/TransformableOps.scala
@@ -67,14 +67,20 @@ object TransformableOps {
       }
 
       val isNewerData = transformable.maybeBibRecord match {
-        case Some(bibData) =>
-          bibRecord.modifiedDate.isAfter(bibData.modifiedDate) ||
-            bibRecord.modifiedDate == bibData.modifiedDate
+        case Some(existingBibRecord) =>
+          bibRecord.modifiedDate.isAfter(existingBibRecord.modifiedDate) ||
+            bibRecord.modifiedDate == existingBibRecord.modifiedDate
         case None => true
       }
 
       if (isNewerData) {
-        Some(transformable.copy(maybeBibRecord = Some(bibRecord)))
+        val modifiedTime = Seq(bibRecord.modifiedDate, transformable.modifiedTime).max
+        Some(
+          transformable.copy(
+            maybeBibRecord = Some(bibRecord),
+            modifiedTime = modifiedTime
+          )
+        )
       } else {
         None
       }
@@ -178,8 +184,14 @@ object TransformableOps {
       override def setRecords(
         t: SierraTransformable,
         itemRecords: Map[SierraItemNumber, SierraItemRecord])
-        : SierraTransformable =
-        t.copy(itemRecords = itemRecords)
+        : SierraTransformable = {
+        val modifiedTime = (itemRecords.values.map(_.modifiedDate).toSeq :+ t.modifiedTime).max
+
+        t.copy(
+          itemRecords = itemRecords,
+          modifiedTime = modifiedTime
+        )
+      }
     }
 
   implicit val holdingsTransformableOps =
@@ -194,8 +206,14 @@ object TransformableOps {
       override def setRecords(
         t: SierraTransformable,
         holdingsRecords: Map[SierraHoldingsNumber, SierraHoldingsRecord])
-        : SierraTransformable =
-        t.copy(holdingsRecords = holdingsRecords)
+        : SierraTransformable = {
+        val modifiedTime = (holdingsRecords.values.map(_.modifiedDate).toSeq :+ t.modifiedTime).max
+
+        t.copy(
+          holdingsRecords = holdingsRecords,
+          modifiedTime = modifiedTime
+        )
+      }
     }
 
   implicit val orderTransformableOps =
@@ -210,7 +228,13 @@ object TransformableOps {
       override def setRecords(
         t: SierraTransformable,
         orderRecords: Map[SierraOrderNumber, SierraOrderRecord])
-        : SierraTransformable =
-        t.copy(orderRecords = orderRecords)
+        : SierraTransformable = {
+        val modifiedTime = (orderRecords.values.map(_.modifiedDate).toSeq :+ t.modifiedTime).max
+
+        t.copy(
+          orderRecords = orderRecords,
+          modifiedTime = modifiedTime
+        )
+      }
     }
 }

--- a/sierra_adapter/sierra_merger/src/main/scala/weco/pipeline/sierra_merger/models/TransformableOps.scala
+++ b/sierra_adapter/sierra_merger/src/main/scala/weco/pipeline/sierra_merger/models/TransformableOps.scala
@@ -98,7 +98,9 @@ object TransformableOps {
 
     override def create(sierraId: SierraBibNumber,
                         record: Record): SierraTransformable = {
-      val t = SierraTransformable(sierraId = sierraId, modifiedTime = record.modifiedDate)
+      val t = SierraTransformable(
+        sierraId = sierraId,
+        modifiedTime = record.modifiedDate)
       val newRecords = Map(record.id -> record)
 
       setRecords(t, newRecords)

--- a/sierra_adapter/sierra_merger/src/main/scala/weco/pipeline/sierra_merger/models/TransformableOps.scala
+++ b/sierra_adapter/sierra_merger/src/main/scala/weco/pipeline/sierra_merger/models/TransformableOps.scala
@@ -74,7 +74,8 @@ object TransformableOps {
       }
 
       if (isNewerData) {
-        val modifiedTime = Seq(bibRecord.modifiedDate, transformable.modifiedTime).max
+        val modifiedTime =
+          Seq(bibRecord.modifiedDate, transformable.modifiedTime).max
         Some(
           transformable.copy(
             maybeBibRecord = Some(bibRecord),
@@ -185,7 +186,8 @@ object TransformableOps {
         t: SierraTransformable,
         itemRecords: Map[SierraItemNumber, SierraItemRecord])
         : SierraTransformable = {
-        val modifiedTime = (itemRecords.values.map(_.modifiedDate).toSeq :+ t.modifiedTime).max
+        val modifiedTime =
+          (itemRecords.values.map(_.modifiedDate).toSeq :+ t.modifiedTime).max
 
         t.copy(
           itemRecords = itemRecords,
@@ -207,7 +209,9 @@ object TransformableOps {
         t: SierraTransformable,
         holdingsRecords: Map[SierraHoldingsNumber, SierraHoldingsRecord])
         : SierraTransformable = {
-        val modifiedTime = (holdingsRecords.values.map(_.modifiedDate).toSeq :+ t.modifiedTime).max
+        val modifiedTime = (holdingsRecords.values
+          .map(_.modifiedDate)
+          .toSeq :+ t.modifiedTime).max
 
         t.copy(
           holdingsRecords = holdingsRecords,
@@ -229,7 +233,8 @@ object TransformableOps {
         t: SierraTransformable,
         orderRecords: Map[SierraOrderNumber, SierraOrderRecord])
         : SierraTransformable = {
-        val modifiedTime = (orderRecords.values.map(_.modifiedDate).toSeq :+ t.modifiedTime).max
+        val modifiedTime =
+          (orderRecords.values.map(_.modifiedDate).toSeq :+ t.modifiedTime).max
 
         t.copy(
           orderRecords = orderRecords,

--- a/sierra_adapter/sierra_merger/src/test/scala/weco/pipeline/sierra_merger/models/TransformableOpsTest.scala
+++ b/sierra_adapter/sierra_merger/src/test/scala/weco/pipeline/sierra_merger/models/TransformableOpsTest.scala
@@ -129,7 +129,8 @@ class TransformableOpsTest
         val result = sierraTransformable.add(newerRecord)
 
         result.get shouldBe sierraTransformable.copy(
-          itemRecords = Map(itemRecord.id -> newerRecord))
+          itemRecords = Map(itemRecord.id -> newerRecord),
+          modifiedTime = newerDate)
       }
 
       it("returns the record if you apply the same update more than once") {
@@ -230,7 +231,8 @@ class TransformableOpsTest
         )
 
         val expectedSierraTransformable = sierraTransformable.copy(
-          itemRecords = Map.empty
+          itemRecords = Map.empty,
+          modifiedTime = unlinkedItemRecord.modifiedDate
         )
 
         sierraTransformable
@@ -345,7 +347,8 @@ class TransformableOpsTest
         val result = sierraTransformable.add(newerRecord)
 
         result.get shouldBe sierraTransformable.copy(
-          holdingsRecords = Map(olderRecord.id -> newerRecord))
+          holdingsRecords = Map(olderRecord.id -> newerRecord),
+          modifiedTime = newerDate)
       }
 
       it("returns the same record if you apply the same update more than once") {
@@ -443,7 +446,8 @@ class TransformableOpsTest
         )
 
         val expectedSierraTransformable = sierraTransformable.copy(
-          holdingsRecords = Map.empty
+          holdingsRecords = Map.empty,
+          modifiedTime = unlinkedRecord.modifiedDate
         )
 
         sierraTransformable
@@ -558,7 +562,8 @@ class TransformableOpsTest
         val result = sierraTransformable.add(newerRecord)
 
         result.get shouldBe sierraTransformable.copy(
-          orderRecords = Map(olderRecord.id -> newerRecord))
+          orderRecords = Map(olderRecord.id -> newerRecord),
+          modifiedTime = newerDate)
       }
 
       it("returns the same record if you apply the same update more than once") {
@@ -656,7 +661,8 @@ class TransformableOpsTest
         )
 
         val expectedSierraTransformable = sierraTransformable.copy(
-          orderRecords = Map.empty
+          orderRecords = Map.empty,
+          modifiedTime = unlinkedRecord.modifiedDate
         )
 
         sierraTransformable

--- a/sierra_adapter/sierra_merger/src/test/scala/weco/pipeline/sierra_merger/models/TransformableOpsTest.scala
+++ b/sierra_adapter/sierra_merger/src/test/scala/weco/pipeline/sierra_merger/models/TransformableOpsTest.scala
@@ -15,9 +15,11 @@ class TransformableOpsTest
     describe("add") {
       it("merges data from a bibRecord when empty") {
         val bibRecord = createSierraBibRecord
-        val transformable = createSierraTransformableWith(
-          sierraId = bibRecord.id,
-          maybeBibRecord = None
+        val transformable = createSierraTransformableStubWith(
+          bibId = bibRecord.id,
+          itemRecords = List(
+            createSierraItemRecordWith(bibIds = List(bibRecord.id))
+          )
         )
 
         val newTransformable = transformable.add(bibRecord)
@@ -100,7 +102,7 @@ class TransformableOpsTest
         )
 
         val sierraTransformable =
-          createSierraTransformableWith(sierraId = bibId)
+          createSierraTransformableWith(bibRecord = createSierraBibRecordWith(id = bibId))
         val result = sierraTransformable.add(record)
 
         result.get.itemRecords shouldBe Map(record.id -> record)
@@ -113,8 +115,8 @@ class TransformableOpsTest
           bibIds = List(bibId)
         )
 
-        val sierraTransformable = createSierraTransformableWith(
-          sierraId = bibId,
+        val sierraTransformable = createSierraTransformableStubWith(
+          bibId = bibId,
           itemRecords = List(itemRecord)
         )
 
@@ -136,7 +138,7 @@ class TransformableOpsTest
         )
 
         val sierraTransformable =
-          createSierraTransformableWith(sierraId = bibId)
+          createSierraTransformableWith(bibRecord = createSierraBibRecordWith(id = bibId))
 
         val transformable1 = sierraTransformable.add(record)
         val transformable2 = transformable1.get.add(record)
@@ -152,7 +154,7 @@ class TransformableOpsTest
         )
 
         val sierraTransformable = createSierraTransformableWith(
-          sierraId = bibId,
+          bibRecord = createSierraBibRecordWith(id = bibId),
           itemRecords = List(itemRecord)
         )
 
@@ -174,7 +176,7 @@ class TransformableOpsTest
         )
 
         val sierraTransformable =
-          createSierraTransformableWith(sierraId = bibId)
+          createSierraTransformableWith(bibRecord = createSierraBibRecordWith(id = bibId))
         val result1 = sierraTransformable.add(record1)
         val result2 = result1.get.add(record2)
 
@@ -192,7 +194,7 @@ class TransformableOpsTest
         )
 
         val sierraTransformable =
-          createSierraTransformableWith(sierraId = bibId)
+          createSierraTransformableWith(bibRecord = createSierraBibRecordWith(id = bibId))
 
         val caught = intercept[RuntimeException] {
           sierraTransformable.add(record)
@@ -219,7 +221,7 @@ class TransformableOpsTest
         )
 
         val sierraTransformable = createSierraTransformableWith(
-          sierraId = bibId,
+          bibRecord = createSierraBibRecordWith(id = bibId),
           itemRecords = List(record)
         )
 
@@ -245,8 +247,8 @@ class TransformableOpsTest
           unlinkedBibIds = List(bibId)
         )
 
-        val sierraTransformable = createSierraTransformableWith(
-          sierraId = bibId,
+        val sierraTransformable = createSierraTransformableStubWith(
+          bibId = bibId,
           itemRecords = List(record)
         )
 
@@ -268,8 +270,8 @@ class TransformableOpsTest
           unlinkedBibIds = List(bibId)
         )
 
-        val sierraTransformable = createSierraTransformableWith(
-          sierraId = bibId,
+        val sierraTransformable = createSierraTransformableStubWith(
+          bibId = bibId,
           itemRecords = List(record)
         )
 
@@ -290,8 +292,8 @@ class TransformableOpsTest
           unlinkedBibIds = List(unrelatedBibId)
         )
 
-        val sierraTransformable = createSierraTransformableWith(
-          sierraId = bibId,
+        val sierraTransformable = createSierraTransformableStubWith(
+          bibId = bibId,
           itemRecords = List(record)
         )
 
@@ -313,7 +315,7 @@ class TransformableOpsTest
         )
 
         val sierraTransformable =
-          createSierraTransformableWith(sierraId = bibId)
+          createSierraTransformableStubWith(bibId = bibId)
         val result = sierraTransformable.add(record)
 
         result.get.holdingsRecords shouldBe Map(record.id -> record)
@@ -326,8 +328,8 @@ class TransformableOpsTest
           bibIds = List(bibId)
         )
 
-        val sierraTransformable = createSierraTransformableWith(
-          sierraId = bibId,
+        val sierraTransformable = createSierraTransformableStubWith(
+          bibId = bibId,
           holdingsRecords = List(olderRecord)
         )
 
@@ -349,7 +351,7 @@ class TransformableOpsTest
         )
 
         val sierraTransformable =
-          createSierraTransformableWith(sierraId = bibId)
+          createSierraTransformableStubWith(bibId = bibId)
 
         val transformable1 = sierraTransformable.add(record)
         val transformable2 = transformable1.get.add(record)
@@ -364,8 +366,8 @@ class TransformableOpsTest
           bibIds = List(bibId)
         )
 
-        val sierraTransformable = createSierraTransformableWith(
-          sierraId = bibId,
+        val sierraTransformable = createSierraTransformableStubWith(
+          bibId = bibId,
           holdingsRecords = List(newerRecord)
         )
 
@@ -387,7 +389,7 @@ class TransformableOpsTest
         )
 
         val sierraTransformable =
-          createSierraTransformableWith(sierraId = bibId)
+          createSierraTransformableStubWith(bibId = bibId)
         val result1 = sierraTransformable.add(record1)
         val result2 = result1.get.add(record2)
 
@@ -405,7 +407,7 @@ class TransformableOpsTest
         )
 
         val sierraTransformable =
-          createSierraTransformableWith(sierraId = bibId)
+          createSierraTransformableStubWith(bibId = bibId)
 
         val caught = intercept[RuntimeException] {
           sierraTransformable.add(record)
@@ -431,8 +433,8 @@ class TransformableOpsTest
           unlinkedBibIds = List(bibId)
         )
 
-        val sierraTransformable = createSierraTransformableWith(
-          sierraId = bibId,
+        val sierraTransformable = createSierraTransformableStubWith(
+          bibId = bibId,
           holdingsRecords = List(record)
         )
 
@@ -458,8 +460,8 @@ class TransformableOpsTest
           unlinkedBibIds = List(bibId)
         )
 
-        val sierraTransformable = createSierraTransformableWith(
-          sierraId = bibId,
+        val sierraTransformable = createSierraTransformableStubWith(
+          bibId = bibId,
           holdingsRecords = List(record)
         )
 
@@ -481,8 +483,8 @@ class TransformableOpsTest
           unlinkedBibIds = List(bibId)
         )
 
-        val sierraTransformable = createSierraTransformableWith(
-          sierraId = bibId,
+        val sierraTransformable = createSierraTransformableStubWith(
+          bibId = bibId,
           holdingsRecords = List(record)
         )
 
@@ -503,8 +505,8 @@ class TransformableOpsTest
           unlinkedBibIds = List(unrelatedBibId)
         )
 
-        val sierraTransformable = createSierraTransformableWith(
-          sierraId = bibId,
+        val sierraTransformable = createSierraTransformableStubWith(
+          bibId = bibId,
           holdingsRecords = List(record)
         )
 
@@ -526,7 +528,7 @@ class TransformableOpsTest
         )
 
         val sierraTransformable =
-          createSierraTransformableWith(sierraId = bibId)
+          createSierraTransformableStubWith(bibId = bibId)
         val result = sierraTransformable.add(record)
 
         result.get.orderRecords shouldBe Map(record.id -> record)
@@ -539,8 +541,8 @@ class TransformableOpsTest
           bibIds = List(bibId)
         )
 
-        val sierraTransformable = createSierraTransformableWith(
-          sierraId = bibId,
+        val sierraTransformable = createSierraTransformableStubWith(
+          bibId = bibId,
           orderRecords = List(olderRecord)
         )
 
@@ -562,7 +564,7 @@ class TransformableOpsTest
         )
 
         val sierraTransformable =
-          createSierraTransformableWith(sierraId = bibId)
+          createSierraTransformableStubWith(bibId = bibId)
 
         val transformable1 = sierraTransformable.add(record)
         val transformable2 = transformable1.get.add(record)
@@ -577,8 +579,8 @@ class TransformableOpsTest
           bibIds = List(bibId)
         )
 
-        val sierraTransformable = createSierraTransformableWith(
-          sierraId = bibId,
+        val sierraTransformable = createSierraTransformableStubWith(
+          bibId = bibId,
           orderRecords = List(newerRecord)
         )
 
@@ -600,7 +602,7 @@ class TransformableOpsTest
         )
 
         val sierraTransformable =
-          createSierraTransformableWith(sierraId = bibId)
+          createSierraTransformableStubWith(bibId = bibId)
         val result1 = sierraTransformable.add(record1)
         val result2 = result1.get.add(record2)
 
@@ -618,7 +620,7 @@ class TransformableOpsTest
         )
 
         val sierraTransformable =
-          createSierraTransformableWith(sierraId = bibId)
+          createSierraTransformableStubWith(bibId = bibId)
 
         val caught = intercept[RuntimeException] {
           sierraTransformable.add(record)
@@ -644,8 +646,8 @@ class TransformableOpsTest
           unlinkedBibIds = List(bibId)
         )
 
-        val sierraTransformable = createSierraTransformableWith(
-          sierraId = bibId,
+        val sierraTransformable = createSierraTransformableStubWith(
+          bibId = bibId,
           orderRecords = List(record)
         )
 
@@ -671,8 +673,8 @@ class TransformableOpsTest
           unlinkedBibIds = List(bibId)
         )
 
-        val sierraTransformable = createSierraTransformableWith(
-          sierraId = bibId,
+        val sierraTransformable = createSierraTransformableStubWith(
+          bibId = bibId,
           orderRecords = List(record)
         )
 
@@ -694,8 +696,8 @@ class TransformableOpsTest
           unlinkedBibIds = List(bibId)
         )
 
-        val sierraTransformable = createSierraTransformableWith(
-          sierraId = bibId,
+        val sierraTransformable = createSierraTransformableStubWith(
+          bibId = bibId,
           orderRecords = List(record)
         )
 
@@ -716,8 +718,8 @@ class TransformableOpsTest
           unlinkedBibIds = List(unrelatedBibId)
         )
 
-        val sierraTransformable = createSierraTransformableWith(
-          sierraId = bibId,
+        val sierraTransformable = createSierraTransformableStubWith(
+          bibId = bibId,
           orderRecords = List(record)
         )
 

--- a/sierra_adapter/sierra_merger/src/test/scala/weco/pipeline/sierra_merger/models/TransformableOpsTest.scala
+++ b/sierra_adapter/sierra_merger/src/test/scala/weco/pipeline/sierra_merger/models/TransformableOpsTest.scala
@@ -102,7 +102,8 @@ class TransformableOpsTest
         )
 
         val sierraTransformable =
-          createSierraTransformableWith(bibRecord = createSierraBibRecordWith(id = bibId))
+          createSierraTransformableWith(
+            bibRecord = createSierraBibRecordWith(id = bibId))
         val result = sierraTransformable.add(record)
 
         result.get.itemRecords shouldBe Map(record.id -> record)
@@ -138,7 +139,8 @@ class TransformableOpsTest
         )
 
         val sierraTransformable =
-          createSierraTransformableWith(bibRecord = createSierraBibRecordWith(id = bibId))
+          createSierraTransformableWith(
+            bibRecord = createSierraBibRecordWith(id = bibId))
 
         val transformable1 = sierraTransformable.add(record)
         val transformable2 = transformable1.get.add(record)
@@ -176,7 +178,8 @@ class TransformableOpsTest
         )
 
         val sierraTransformable =
-          createSierraTransformableWith(bibRecord = createSierraBibRecordWith(id = bibId))
+          createSierraTransformableWith(
+            bibRecord = createSierraBibRecordWith(id = bibId))
         val result1 = sierraTransformable.add(record1)
         val result2 = result1.get.add(record2)
 
@@ -194,7 +197,8 @@ class TransformableOpsTest
         )
 
         val sierraTransformable =
-          createSierraTransformableWith(bibRecord = createSierraBibRecordWith(id = bibId))
+          createSierraTransformableWith(
+            bibRecord = createSierraBibRecordWith(id = bibId))
 
         val caught = intercept[RuntimeException] {
           sierraTransformable.add(record)

--- a/sierra_adapter/sierra_merger/src/test/scala/weco/pipeline/sierra_merger/services/UpdaterTest.scala
+++ b/sierra_adapter/sierra_merger/src/test/scala/weco/pipeline/sierra_merger/services/UpdaterTest.scala
@@ -58,9 +58,8 @@ class UpdaterTest
       Version(bibId.withoutCheckDigit, 0))
 
     val expectedSierraTransformable =
-      createSierraTransformableWith(
-        sierraId = bibId,
-        maybeBibRecord = None,
+      createSierraTransformableStubWith(
+        bibId = bibId,
         itemRecords = List(newItemRecord)
       )
 
@@ -75,9 +74,8 @@ class UpdaterTest
       bibIds = List(bibId)
     )
 
-    val oldTransformable = createSierraTransformableWith(
-      sierraId = bibId,
-      maybeBibRecord = None,
+    val oldTransformable = createSierraTransformableStubWith(
+      bibId = bibId,
       itemRecords = List(itemRecord)
     )
 
@@ -117,15 +115,13 @@ class UpdaterTest
       bibIds = List(bibId1)
     )
 
-    val sierraTransformable1 = createSierraTransformableWith(
-      sierraId = bibId1,
-      maybeBibRecord = None,
+    val sierraTransformable1 = createSierraTransformableStubWith(
+      bibId = bibId1,
       itemRecords = List(itemRecord)
     )
 
-    val sierraTransformable2 = createSierraTransformableWith(
-      sierraId = bibId2,
-      maybeBibRecord = None
+    val sierraTransformable2 = createSierraTransformableStubWith(
+      bibId = bibId2
     )
 
     val sourceVHS = createSourceVHSWith(
@@ -173,18 +169,16 @@ class UpdaterTest
     val bibId2 = createSierraBibNumber
 
     val itemRecord = createSierraItemRecordWith(
-      bibIds = List(bibId1)
+      bibIds = List(bibId1, bibId2)
     )
 
-    val sierraTransformable1 = createSierraTransformableWith(
-      sierraId = bibId1,
-      maybeBibRecord = None,
+    val sierraTransformable1 = createSierraTransformableStubWith(
+      bibId = bibId1,
       itemRecords = List(itemRecord)
     )
 
-    val sierraTransformable2 = createSierraTransformableWith(
-      sierraId = bibId2,
-      maybeBibRecord = None,
+    val sierraTransformable2 = createSierraTransformableStubWith(
+      bibId = bibId2,
       itemRecords = List(itemRecord)
     )
 
@@ -235,12 +229,12 @@ class UpdaterTest
     )
 
     val sierraTransformable1 =
-      createSierraTransformableWith(
-        sierraId = bibId1,
+      createSierraTransformableStubWith(
+        bibId = bibId1,
         itemRecords = List(itemRecord))
 
     val sierraTransformable2 =
-      createSierraTransformableWith(sierraId = bibId2)
+      createSierraTransformableStubWith(bibId = bibId2)
 
     val sourceVHS = createSourceVHSWith(
       initialEntries = Map(
@@ -289,9 +283,8 @@ class UpdaterTest
       bibIds = List(bibId)
     )
 
-    val transformable = createSierraTransformableWith(
-      sierraId = bibId,
-      maybeBibRecord = None,
+    val transformable = createSierraTransformableStubWith(
+      bibId = bibId,
       itemRecords = List(itemRecord)
     )
 
@@ -336,10 +329,7 @@ class UpdaterTest
 
   it("adds an item to the record if the bibId exists but has no itemData") {
     val bibId = createSierraBibNumber
-    val transformable = createSierraTransformableWith(
-      sierraId = bibId,
-      maybeBibRecord = None
-    )
+    val transformable = createSierraTransformableStubWith(bibId = bibId)
 
     val sourceVHS = createSourceVHSWith(
       initialEntries = Map(
@@ -352,9 +342,8 @@ class UpdaterTest
       bibIds = List(bibId)
     )
 
-    val expectedTransformable = createSierraTransformableWith(
-      sierraId = bibId,
-      maybeBibRecord = None,
+    val expectedTransformable = createSierraTransformableStubWith(
+      bibId = bibId,
       itemRecords = List(itemRecord)
     )
 

--- a/sierra_adapter/sierra_merger/src/test/scala/weco/pipeline/sierra_merger/services/UpdaterTest.scala
+++ b/sierra_adapter/sierra_merger/src/test/scala/weco/pipeline/sierra_merger/services/UpdaterTest.scala
@@ -91,14 +91,15 @@ class UpdaterTest
       modifiedDate = newerDate
     )
     val expectedTransformable = oldTransformable.copy(
-      itemRecords = Map(itemRecord.id -> newItemRecord)
+      itemRecords = Map(itemRecord.id -> newItemRecord),
+      modifiedTime = newerDate
     )
 
     val result = updater.update(newItemRecord)
 
     result shouldBe a[Right[_, _]]
-    result.right.get.map { _.id } should contain theSameElementsAs (List(
-      Version(bibId.withoutCheckDigit, 1)))
+    result.right.get.map { _.id } should contain theSameElementsAs List(
+      Version(bibId.withoutCheckDigit, 1))
 
     assertStored(
       expectedTransformable.sierraId,
@@ -139,7 +140,8 @@ class UpdaterTest
     )
 
     val expectedTransformable1 = sierraTransformable1.copy(
-      itemRecords = Map.empty
+      itemRecords = Map.empty,
+      modifiedTime = unlinkItemRecord.modifiedDate
     )
 
     val expectedItemRecords = Map(
@@ -150,7 +152,8 @@ class UpdaterTest
       )
     )
     val expectedTransformable2 = sierraTransformable2.copy(
-      itemRecords = expectedItemRecords
+      itemRecords = expectedItemRecords,
+      modifiedTime = unlinkItemRecord.modifiedDate
     )
 
     val result = updater.update(unlinkItemRecord)
@@ -201,13 +204,15 @@ class UpdaterTest
     )
 
     val expectedTransformable1 = sierraTransformable1.copy(
-      itemRecords = Map.empty
+      itemRecords = Map.empty,
+      modifiedTime = unlinkItemRecord.modifiedDate
     )
 
     // In this situation the item was already linked to sierraTransformable2
     // but the modified date is updated in line with the item update
     val expectedTransformable2 = sierraTransformable2.copy(
-      itemRecords = expectedItemData
+      itemRecords = expectedItemData,
+      modifiedTime = unlinkItemRecord.modifiedDate
     )
 
     val result = updater.update(unlinkItemRecord)


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5286

1. Adds some runtime assertions that all the data in a SierraTransformable is internally consistent. This should already be true in the real pipeline; the tricky bit was getting all the tests to use sensible data.

2. The `modifiedTime` is the last modified time of any of the source records that are part of this SierraTransformable were modified, where previously it just used the modified time from the bib record. I'll backfill this field on all the existing Sierra records as a one-off migration, rather than absorbing the ongoing complexity of this being an optional field.
