### PR TITLE
Add a modifiedTime to SierraTransformable

### DIFF
--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraTransformable.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraTransformable.scala
@@ -9,6 +9,12 @@ import weco.sierra.models.identifiers.{
 
 import java.time.Instant
 
+/** @param modifiedTime Note: this parameter may not be the max of the modified
+  *                     times of all the included records.  In particular, if there's
+  *                     a record that used to be linked to this transformable, but was
+  *                     later unlinked, the modified time will be taken from the update
+  *                     that unlinked the record.
+  */
 case class SierraTransformable(
   sierraId: SierraBibNumber,
   maybeBibRecord: Option[SierraBibRecord] = None,

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraTransformable.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/SierraTransformable.scala
@@ -7,12 +7,15 @@ import weco.sierra.models.identifiers.{
   SierraOrderNumber
 }
 
+import java.time.Instant
+
 case class SierraTransformable(
   sierraId: SierraBibNumber,
   maybeBibRecord: Option[SierraBibRecord] = None,
   itemRecords: Map[SierraItemNumber, SierraItemRecord] = Map(),
   holdingsRecords: Map[SierraHoldingsNumber, SierraHoldingsRecord] = Map(),
-  orderRecords: Map[SierraOrderNumber, SierraOrderRecord] = Map()
+  orderRecords: Map[SierraOrderNumber, SierraOrderRecord] = Map(),
+  modifiedTime: Instant
 ) {
   // Run some consistency checks on the identifiers.  If these identifiers don't match,
   // it indicates some sort of programming error.
@@ -42,5 +45,7 @@ object SierraTransformable {
   def apply(bibRecord: SierraBibRecord): SierraTransformable =
     SierraTransformable(
       sierraId = bibRecord.id,
-      maybeBibRecord = Some(bibRecord))
+      maybeBibRecord = Some(bibRecord),
+      modifiedTime = bibRecord.modifiedDate
+    )
 }

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/generators/SierraRecordGenerators.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/generators/SierraRecordGenerators.scala
@@ -173,7 +173,16 @@ trait SierraRecordGenerators extends SierraIdentifierGenerators {
       }.toMap,
       orderRecords = orderRecords.map { record =>
         record.id -> record
-      }.toMap
+      }.toMap,
+      modifiedTime = {
+        val times = (Seq(maybeBibRecord).flatten ++ itemRecords ++ holdingsRecords ++ orderRecords)
+          .map(_.modifiedDate)
+
+        times match {
+          case Nil => Instant.now()
+          case _   => times.max
+        }
+      }
     )
 
   def createSierraTransformableWith(

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/SierraTransformableTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/SierraTransformableTest.scala
@@ -5,13 +5,22 @@ import org.scalatest.matchers.should.Matchers
 import weco.catalogue.source_model.generators.SierraRecordGenerators
 import weco.sierra.models.identifiers.SierraItemNumber
 
+import java.time.Instant
+
 class SierraTransformableTest
     extends AnyFunSpec
     with Matchers
     with SierraRecordGenerators {
 
   it("allows creation of SierraTransformable with no data") {
-    SierraTransformable(sierraId = createSierraBibNumber)
+    // We need this for the case where:
+    //
+    //  1. We receive an item that links to a bib record b123
+    //  2. Later, we receive an update to the item that unlinks it
+    //
+    // Then we'd have a SierraTransformable for b123 but no attached records.
+    // Is that likely?  Hard to say, but we can handle it so we might as well.
+    SierraTransformable(sierraId = createSierraBibNumber, modifiedTime = Instant.now)
   }
 
   it("allows creation from only a SierraBibRecord") {

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/SierraTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/SierraTransformer.scala
@@ -36,7 +36,12 @@ class SierraTransformer(sierraTransformable: SierraTransformable, version: Int)
     sierraTransformable.maybeBibRecord
       .map { bibRecord =>
         debug(s"Attempting to transform ${bibRecord.id.withCheckDigit}")
-        workFromBibRecord(bibRecord)
+
+        val state = Source(
+          sourceIdentifier = sourceIdentifier,
+          sourceModifiedTime = sierraTransformable.modifiedTime
+        )
+        workFromBibRecord(state, bibRecord)
       }
       .getOrElse {
         // A merged record can have both bibs and items.  If we only have
@@ -64,9 +69,7 @@ class SierraTransformer(sierraTransformable: SierraTransformable, version: Int)
           throw e
       }
 
-  def workFromBibRecord(bibRecord: SierraBibRecord): Try[Work[Source]] = {
-    val state = Source(sourceIdentifier, bibRecord.modifiedDate)
-
+  def workFromBibRecord(state: Source, bibRecord: SierraBibRecord): Try[Work[Source]] =
     fromJson[SierraBibData](bibRecord.data)
       .map { bibData =>
         if (bibData.deleted) {
@@ -103,7 +106,6 @@ class SierraTransformer(sierraTransformable: SierraTransformable, version: Int)
             invisibilityReasons = List(UnableToTransform(e.getMessage))
           )
       }
-  }
 
   def workDataFromBibData(bibId: SierraBibNumber, bibData: SierraBibData) =
     WorkData[DataState.Unidentified](

--- a/sierra_adapter/sierra_merger/src/main/scala/weco/pipeline/sierra_merger/models/TransformableOps.scala
+++ b/sierra_adapter/sierra_merger/src/main/scala/weco/pipeline/sierra_merger/models/TransformableOps.scala
@@ -30,13 +30,25 @@ object TransformableOps {
       implicit
       ops: TransformableOps[Record]
     ): Option[SierraTransformable] =
-      ops.add(t, r)
+      ops
+        .add(t, r)
+        .map { transformable =>
+          transformable.copy(
+            modifiedTime = Seq(transformable.modifiedTime, r.modifiedDate).max
+          )
+        }
 
     def remove[Record <: AbstractSierraRecord[_]](r: Record)(
       implicit
       ops: TransformableOps[Record]
     ): Option[SierraTransformable] =
-      ops.remove(t, r)
+      ops
+        .remove(t, r)
+        .map { transformable =>
+          transformable.copy(
+            modifiedTime = Seq(transformable.modifiedTime, r.modifiedDate).max
+          )
+        }
   }
 
   implicit val bibTransformableOps = new TransformableOps[SierraBibRecord] {
@@ -86,7 +98,7 @@ object TransformableOps {
 
     override def create(sierraId: SierraBibNumber,
                         record: Record): SierraTransformable = {
-      val t = SierraTransformable(sierraId = sierraId)
+      val t = SierraTransformable(sierraId = sierraId, modifiedTime = record.modifiedDate)
       val newRecords = Map(record.id -> record)
 
       setRecords(t, newRecords)

--- a/sierra_adapter/sierra_merger/src/test/scala/weco/pipeline/sierra_merger/models/TransformableOpsTest.scala
+++ b/sierra_adapter/sierra_merger/src/test/scala/weco/pipeline/sierra_merger/models/TransformableOpsTest.scala
@@ -129,7 +129,8 @@ class TransformableOpsTest
         val result = sierraTransformable.add(newerRecord)
 
         result.get shouldBe sierraTransformable.copy(
-          itemRecords = Map(itemRecord.id -> newerRecord))
+          itemRecords = Map(itemRecord.id -> newerRecord),
+          modifiedTime = newerDate)
       }
 
       it("returns the record if you apply the same update more than once") {
@@ -230,7 +231,8 @@ class TransformableOpsTest
         )
 
         val expectedSierraTransformable = sierraTransformable.copy(
-          itemRecords = Map.empty
+          itemRecords = Map.empty,
+          modifiedTime = unlinkedItemRecord.modifiedDate
         )
 
         sierraTransformable
@@ -345,7 +347,8 @@ class TransformableOpsTest
         val result = sierraTransformable.add(newerRecord)
 
         result.get shouldBe sierraTransformable.copy(
-          holdingsRecords = Map(olderRecord.id -> newerRecord))
+          holdingsRecords = Map(olderRecord.id -> newerRecord),
+          modifiedTime = newerDate)
       }
 
       it("returns the same record if you apply the same update more than once") {
@@ -443,7 +446,8 @@ class TransformableOpsTest
         )
 
         val expectedSierraTransformable = sierraTransformable.copy(
-          holdingsRecords = Map.empty
+          holdingsRecords = Map.empty,
+          modifiedTime = unlinkedRecord.modifiedDate
         )
 
         sierraTransformable
@@ -558,7 +562,8 @@ class TransformableOpsTest
         val result = sierraTransformable.add(newerRecord)
 
         result.get shouldBe sierraTransformable.copy(
-          orderRecords = Map(olderRecord.id -> newerRecord))
+          orderRecords = Map(olderRecord.id -> newerRecord),
+          modifiedTime = newerDate)
       }
 
       it("returns the same record if you apply the same update more than once") {
@@ -656,7 +661,8 @@ class TransformableOpsTest
         )
 
         val expectedSierraTransformable = sierraTransformable.copy(
-          orderRecords = Map.empty
+          orderRecords = Map.empty,
+          modifiedTime = unlinkedRecord.modifiedDate
         )
 
         sierraTransformable

--- a/sierra_adapter/sierra_merger/src/test/scala/weco/pipeline/sierra_merger/services/UpdaterTest.scala
+++ b/sierra_adapter/sierra_merger/src/test/scala/weco/pipeline/sierra_merger/services/UpdaterTest.scala
@@ -91,14 +91,15 @@ class UpdaterTest
       modifiedDate = newerDate
     )
     val expectedTransformable = oldTransformable.copy(
-      itemRecords = Map(itemRecord.id -> newItemRecord)
+      itemRecords = Map(itemRecord.id -> newItemRecord),
+      modifiedTime = newerDate
     )
 
     val result = updater.update(newItemRecord)
 
     result shouldBe a[Right[_, _]]
-    result.right.get.map { _.id } should contain theSameElementsAs (List(
-      Version(bibId.withoutCheckDigit, 1)))
+    result.right.get.map { _.id } should contain theSameElementsAs List(
+      Version(bibId.withoutCheckDigit, 1))
 
     assertStored(
       expectedTransformable.sierraId,
@@ -139,7 +140,8 @@ class UpdaterTest
     )
 
     val expectedTransformable1 = sierraTransformable1.copy(
-      itemRecords = Map.empty
+      itemRecords = Map.empty,
+      modifiedTime = unlinkItemRecord.modifiedDate
     )
 
     val expectedItemRecords = Map(
@@ -150,7 +152,8 @@ class UpdaterTest
       )
     )
     val expectedTransformable2 = sierraTransformable2.copy(
-      itemRecords = expectedItemRecords
+      itemRecords = expectedItemRecords,
+      modifiedTime = unlinkItemRecord.modifiedDate
     )
 
     val result = updater.update(unlinkItemRecord)
@@ -201,13 +204,15 @@ class UpdaterTest
     )
 
     val expectedTransformable1 = sierraTransformable1.copy(
-      itemRecords = Map.empty
+      itemRecords = Map.empty,
+      modifiedTime = unlinkItemRecord.modifiedDate
     )
 
     // In this situation the item was already linked to sierraTransformable2
     // but the modified date is updated in line with the item update
     val expectedTransformable2 = sierraTransformable2.copy(
-      itemRecords = expectedItemData
+      itemRecords = expectedItemData,
+      modifiedTime = unlinkItemRecord.modifiedDate
     )
 
     val result = updater.update(unlinkItemRecord)


### PR DESCRIPTION
This field is the last modified time of any of the source records that are part of this SierraTransformable were modified, where previously it just used the modified time from the bib record.

Follows #1851, for wellcomecollection/platform#5286

I'll backfill this field on all the existing Sierra records as a one-off migration, rather than absorbing the ongoing complexity of this being an optional field.