### PR TITLE
Fix a flaky test in the deletion checker

### DIFF
--- a/calm_adapter/calm_deletion_checker/src/test/scala/weco/pipeline/calm_deletion_checker/DeletionCheckerWorkerServiceTest.scala
+++ b/calm_adapter/calm_deletion_checker/src/test/scala/weco/pipeline/calm_deletion_checker/DeletionCheckerWorkerServiceTest.scala
@@ -131,7 +131,10 @@ class DeletionCheckerWorkerServiceTest
     ) { apiClient =>
       withDynamoSourceVHS(storeRecords) {
         case (_, sourceTable, getRows) =>
-          withDeletionCheckerWorkerService(apiClient, sourceTable, visibilityTimeout = 1 second) {
+          withDeletionCheckerWorkerService(
+            apiClient,
+            sourceTable,
+            visibilityTimeout = 1 second) {
             case (QueuePair(queue, dlq), _) =>
               getRows().map(_.toPayload).foreach { payload =>
                 sendNotificationToSQS(queue, payload)
@@ -158,7 +161,10 @@ class DeletionCheckerWorkerServiceTest
     ) { apiClient =>
       withDynamoSourceVHS(storeRecords) {
         case (_, sourceTable, getRows) =>
-          withDeletionCheckerWorkerService(apiClient, sourceTable, visibilityTimeout = 1 second) {
+          withDeletionCheckerWorkerService(
+            apiClient,
+            sourceTable,
+            visibilityTimeout = 1 second) {
             case (QueuePair(queue, dlq), _) =>
               val storedPayloads = getRows().map(_.toPayload)
               val phantomPayloads = (1 to 3).map(_ => calmSourcePayload)

--- a/calm_adapter/calm_deletion_checker/src/test/scala/weco/pipeline/calm_deletion_checker/DeletionCheckerWorkerServiceTest.scala
+++ b/calm_adapter/calm_deletion_checker/src/test/scala/weco/pipeline/calm_deletion_checker/DeletionCheckerWorkerServiceTest.scala
@@ -131,7 +131,7 @@ class DeletionCheckerWorkerServiceTest
     ) { apiClient =>
       withDynamoSourceVHS(storeRecords) {
         case (_, sourceTable, getRows) =>
-          withDeletionCheckerWorkerService(apiClient, sourceTable) {
+          withDeletionCheckerWorkerService(apiClient, sourceTable, visibilityTimeout = 1 second) {
             case (QueuePair(queue, dlq), _) =>
               getRows().map(_.toPayload).foreach { payload =>
                 sendNotificationToSQS(queue, payload)
@@ -158,7 +158,7 @@ class DeletionCheckerWorkerServiceTest
     ) { apiClient =>
       withDynamoSourceVHS(storeRecords) {
         case (_, sourceTable, getRows) =>
-          withDeletionCheckerWorkerService(apiClient, sourceTable) {
+          withDeletionCheckerWorkerService(apiClient, sourceTable, visibilityTimeout = 1 second) {
             case (QueuePair(queue, dlq), _) =>
               val storedPayloads = getRows().map(_.toPayload)
               val phantomPayloads = (1 to 3).map(_ => calmSourcePayload)
@@ -185,10 +185,11 @@ class DeletionCheckerWorkerServiceTest
     apiClient: TestCalmApiClient,
     sourceTable: DynamoFixtures.Table,
     batchSize: Int = 10,
-    batchDuration: FiniteDuration = 100 milliseconds
+    batchDuration: FiniteDuration = 100 milliseconds,
+    visibilityTimeout: Duration = 5 seconds
   )(testWith: TestWith[(QueuePair, MemoryMessageSender), R]): R =
     withActorSystem { implicit actorSystem =>
-      withLocalSqsQueuePair() {
+      withLocalSqsQueuePair(visibilityTimeout = visibilityTimeout) {
         case queuePair @ QueuePair(queue, _) =>
           withSQSStream[NotificationMessage, R](queue) { stream =>
             implicit val ec: ExecutionContext = actorSystem.dispatcher


### PR DESCRIPTION
The test waits 15 seconds to complete, by default the queue has 3 retries and waits 5 seconds between retries, so it can be flaky in CI.

Reducing the wait to 1 second between retries should stop this test from being flaky in CI.

For https://github.com/wellcomecollection/platform/issues/5275