### PR TITLE
Disable the image inferrer in the "tei-on" pipeline

### DIFF
--- a/pipeline/terraform/stack/branch/service_image_inferrer.tf
+++ b/pipeline/terraform/stack/branch/service_image_inferrer.tf
@@ -170,6 +170,9 @@ module "image_inferrer" {
   #
   # Disabling the image inferrer in the "tei-on" pipeline is a hack
   # to fix the image inferrer in the publicly visible pipeline.
+  # The "tei-off" inferrer gets exclusive use of the EC2 instance and is
+  # able to start correctly.
+  #
   # At some point it'd be nice to come back and sort this out properly,
   # by understanding exactly how we've misconfigured ECS/EC2, but I don't
   # have time to do that right now.

--- a/pipeline/terraform/stack/branch/service_image_inferrer.tf
+++ b/pipeline/terraform/stack/branch/service_image_inferrer.tf
@@ -158,7 +158,25 @@ module "image_inferrer" {
   # TODO: Now these images are served by DLCS, not Loris, can we increase
   # the max capacity?
   min_capacity = var.min_capacity
-  max_capacity = min(6, var.max_capacity)
+
+  # Note: this slightly arcane construction essentially says: if the
+  # namespace contains "tei-on", disable the image inferrer.
+  #
+  # This is because of some sort of weird interaction between the image
+  # inferrers and the EC2 capacity provider.  When an image update
+  # arrives in the pipeline, both inferrer services get desiredCapacity=1,
+  # the EC2 capacity provider starts 1 instance, and neither task is
+  # able to start running successfully.
+  #
+  # Disabling the image inferrer in the "tei-on" pipeline is a hack
+  # to fix the image inferrer in the publicly visible pipeline.
+  # At some point it'd be nice to come back and sort this out properly,
+  # by understanding exactly how we've misconfigured ECS/EC2, but I don't
+  # have time to do that right now.
+  #
+  # When we bin the split TEI on/off pipelines, delete everything
+  # before the colon.
+  max_capacity = length(regexall("tei-on", local.namespace)) > 0 ? 0 : min(6, var.max_capacity)
 
   scale_down_adjustment = var.scale_down_adjustment
   scale_up_adjustment   = min(1, var.scale_up_adjustment)


### PR DESCRIPTION
Something weird is happening here (see comment in the Terraform) that I don't care to debug properly right now.