### PR TITLE
Bump the flushInterval to make this test less flaky in CI

### DIFF
--- a/pipeline/relation_embedder/batcher/src/test/scala/weco/pipeline/batcher/BatcherWorkerServiceTest.scala
+++ b/pipeline/relation_embedder/batcher/src/test/scala/weco/pipeline/batcher/BatcherWorkerServiceTest.scala
@@ -134,7 +134,7 @@ class BatcherWorkerServiceTest
   def withWorkerService[R](visibilityTimeout: Duration = 5 seconds,
                            maxBatchSize: Int = 10,
                            brokenPaths: Set[String] = Set.empty,
-                           flushInterval: FiniteDuration = 100 milliseconds)(
+                           flushInterval: FiniteDuration = 250 milliseconds)(
     testWith: TestWith[(QueuePair, MemoryMessageSender), R]): R =
     withLocalSqsQueuePair(visibilityTimeout = visibilityTimeout) { queuePair =>
       withActorSystem { implicit actorSystem =>


### PR DESCRIPTION
Sometimes it sends two batches instead of one; I suspect because it can't quite process both messages in time.  Maybe bumping the interval will help?