### PR TITLE
Various pipeline fixes for CCR reliability

### DIFF
--- a/pipeline/terraform/locals.tf
+++ b/pipeline/terraform/locals.tf
@@ -55,4 +55,6 @@ locals {
   traffic_filter_public_internet_id = local.shared_infra["ec_public_internet_traffic_filter_id"]
 
   logging_cluster_id = data.terraform_remote_state.shared_infra.outputs.logging_cluster_id
+
+  api_ec_version = data.terraform_remote_state.catalogue_api.outputs.catalogue_api_ec_version
 }

--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -84,6 +84,8 @@ module "catalogue_pipeline_2021-08-16" {
 
   storage_bucket_name = local.storage_bucket
 
+  api_ec_version = local.api_ec_version
+
   providers = {
     aws.catalogue = aws.catalogue
   }

--- a/pipeline/terraform/stack/branch/service_image_inferrer.tf
+++ b/pipeline/terraform/stack/branch/service_image_inferrer.tf
@@ -159,27 +159,7 @@ module "image_inferrer" {
   # the max capacity?
   min_capacity = var.min_capacity
 
-  # Note: this slightly arcane construction essentially says: if the
-  # namespace contains "tei-on", disable the image inferrer.
-  #
-  # This is because of some sort of weird interaction between the image
-  # inferrers and the EC2 capacity provider.  When an image update
-  # arrives in the pipeline, both inferrer services get desiredCapacity=1,
-  # the EC2 capacity provider starts 1 instance, and neither task is
-  # able to start running successfully.
-  #
-  # Disabling the image inferrer in the "tei-on" pipeline is a hack
-  # to fix the image inferrer in the publicly visible pipeline.
-  # The "tei-off" inferrer gets exclusive use of the EC2 instance and is
-  # able to start correctly.
-  #
-  # At some point it'd be nice to come back and sort this out properly,
-  # by understanding exactly how we've misconfigured ECS/EC2, but I don't
-  # have time to do that right now.
-  #
-  # When we bin the split TEI on/off pipelines, delete everything
-  # before the colon.
-  max_capacity = length(regexall("tei-on", local.namespace)) > 0 ? 0 : min(6, var.max_capacity)
+  max_capacity = min(6, var.max_capacity)
 
   scale_down_adjustment = var.scale_down_adjustment
   scale_up_adjustment   = min(1, var.scale_up_adjustment)

--- a/pipeline/terraform/stack/branch/service_image_inferrer.tf
+++ b/pipeline/terraform/stack/branch/service_image_inferrer.tf
@@ -166,10 +166,6 @@ module "image_inferrer" {
 
   queue_read_policy = module.image_inferrer_queue.read_policy
 
-  depends_on = [
-    var.elasticsearch_users,
-  ]
-
   deployment_service_env  = var.release_label
   deployment_service_name = "image-inferrer-${local.tei_suffix}"
   shared_logging_secrets  = var.shared_logging_secrets

--- a/pipeline/terraform/stack/branch/service_ingestor_images.tf
+++ b/pipeline/terraform/stack/branch/service_ingestor_images.tf
@@ -79,10 +79,6 @@ module "ingestor_images" {
   deployment_service_env  = var.release_label
   deployment_service_name = "image-ingestor-${local.tei_suffix}"
 
-  depends_on = [
-    var.elasticsearch_users,
-  ]
-
   shared_logging_secrets = var.shared_logging_secrets
 }
 

--- a/pipeline/terraform/stack/branch/service_ingestor_works.tf
+++ b/pipeline/terraform/stack/branch/service_ingestor_works.tf
@@ -84,10 +84,6 @@ module "ingestor_works" {
 
   use_fargate_spot = true
 
-  depends_on = [
-    var.elasticsearch_users,
-  ]
-
   deployment_service_env  = var.release_label
   deployment_service_name = "work-ingestor-${local.tei_suffix}"
   shared_logging_secrets  = var.shared_logging_secrets

--- a/pipeline/terraform/stack/branch/service_merger.tf
+++ b/pipeline/terraform/stack/branch/service_merger.tf
@@ -55,10 +55,6 @@ module "merger" {
 
   queue_read_policy = module.merger_queue.read_policy
 
-  depends_on = [
-    var.elasticsearch_users,
-  ]
-
   deployment_service_env  = var.release_label
   deployment_service_name = "merger-${local.tei_suffix}"
   shared_logging_secrets  = var.shared_logging_secrets

--- a/pipeline/terraform/stack/branch/service_work_batcher.tf
+++ b/pipeline/terraform/stack/branch/service_work_batcher.tf
@@ -61,10 +61,6 @@ module "batcher" {
   cpu    = 1024
   memory = 2048
 
-  depends_on = [
-    var.elasticsearch_users,
-  ]
-
   deployment_service_env  = var.release_label
   deployment_service_name = "work-batcher"
 }

--- a/pipeline/terraform/stack/branch/service_work_relation_embedder.tf
+++ b/pipeline/terraform/stack/branch/service_work_relation_embedder.tf
@@ -57,10 +57,6 @@ module "relation_embedder" {
 
   use_fargate_spot = true
 
-  depends_on = [
-    var.elasticsearch_users,
-  ]
-
   deployment_service_env  = var.release_label
   deployment_service_name = "work-relation-embedder-${local.tei_suffix}"
   shared_logging_secrets  = var.shared_logging_secrets

--- a/pipeline/terraform/stack/branch/service_work_router.tf
+++ b/pipeline/terraform/stack/branch/service_work_router.tf
@@ -56,10 +56,6 @@ module "router" {
 
   use_fargate_spot = true
 
-  depends_on = [
-    var.elasticsearch_users,
-  ]
-
   deployment_service_env  = var.release_label
   deployment_service_name = "work-router-${local.tei_suffix}"
 }

--- a/pipeline/terraform/stack/branch/variables.tf
+++ b/pipeline/terraform/stack/branch/variables.tf
@@ -83,8 +83,7 @@ variable "dlq_alarm_arn" {}
 variable "release_label" {
   type = string
 }
-variable "elasticsearch_users" {
-}
+
 variable "es_works_merged_index" {
   type = string
 }

--- a/pipeline/terraform/stack/cluster.tf
+++ b/pipeline/terraform/stack/cluster.tf
@@ -1,12 +1,33 @@
 resource "aws_ecs_cluster" "cluster" {
   name               = local.namespace_hyphen
-  capacity_providers = [module.inference_capacity_provider.name]
+  capacity_providers = [module.inference_capacity_provider_tei_off.name,module.inference_capacity_provider_tei_on.name]
 }
 
-module "inference_capacity_provider" {
+module "inference_capacity_provider_tei_on" {
   source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/ec2_capacity_provider?ref=v3.5.1"
 
-  name = "${local.namespace_hyphen}_inference_capacity_provider"
+  name = "${local.namespace_hyphen}_inference_capacity_provider-tei-on"
+
+  // Setting this variable from aws_ecs_cluster.cluster.name creates a cycle
+  // The cluster name is required for the instance user data script
+  // This is a known issue https://github.com/terraform-providers/terraform-provider-aws/issues/12739
+  cluster_name = local.namespace_hyphen
+
+  instance_type           = "c5.2xlarge"
+  max_instances           = 6
+  use_spot_purchasing     = true
+  scaling_action_cooldown = 240
+
+  subnets = var.subnets
+  security_group_ids = [
+    aws_security_group.service_egress.id,
+  ]
+}
+
+module "inference_capacity_provider_tei_off" {
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/ec2_capacity_provider?ref=v3.5.1"
+
+  name = "${local.namespace_hyphen}_inference_capacity_provider-tei-off"
 
   // Setting this variable from aws_ecs_cluster.cluster.name creates a cycle
   // The cluster name is required for the instance user data script

--- a/pipeline/terraform/stack/cluster.tf
+++ b/pipeline/terraform/stack/cluster.tf
@@ -1,6 +1,6 @@
 resource "aws_ecs_cluster" "cluster" {
   name               = local.namespace_hyphen
-  capacity_providers = [module.inference_capacity_provider_tei_off.name,module.inference_capacity_provider_tei_on.name]
+  capacity_providers = [module.inference_capacity_provider_tei_off.name, module.inference_capacity_provider_tei_on.name]
 }
 
 module "inference_capacity_provider_tei_on" {

--- a/pipeline/terraform/stack/cluster.tf
+++ b/pipeline/terraform/stack/cluster.tf
@@ -6,7 +6,7 @@ resource "aws_ecs_cluster" "cluster" {
 module "inference_capacity_provider_tei_on" {
   source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/ec2_capacity_provider?ref=v3.5.1"
 
-  name = "${local.namespace_hyphen}_inference_capacity_provider-tei-on"
+  name = "${local.namespace_hyphen}_inferrer-tei-on"
 
   // Setting this variable from aws_ecs_cluster.cluster.name creates a cycle
   // The cluster name is required for the instance user data script
@@ -27,7 +27,7 @@ module "inference_capacity_provider_tei_on" {
 module "inference_capacity_provider_tei_off" {
   source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/ec2_capacity_provider?ref=v3.5.1"
 
-  name = "${local.namespace_hyphen}_inference_capacity_provider-tei-off"
+  name = "${local.namespace_hyphen}_inferrer-tei-off"
 
   // Setting this variable from aws_ecs_cluster.cluster.name creates a cycle
   // The cluster name is required for the instance user data script

--- a/pipeline/terraform/stack/elastic_pipeline.tf
+++ b/pipeline/terraform/stack/elastic_pipeline.tf
@@ -3,7 +3,7 @@ data "ec_deployment" "logging" {
 }
 
 locals {
-  es_memory = var.is_reindexing ? "58g" : "15g"
+  es_memory = var.is_reindexing ? "58g" : "8g"
 
   # When we're reindexing, this cluster isn't depended on for anything.
   # It's ephemeral data (and at 58GB of memory, expensive).

--- a/pipeline/terraform/stack/elastic_pipeline.tf
+++ b/pipeline/terraform/stack/elastic_pipeline.tf
@@ -5,16 +5,32 @@ locals {
   es_memory = var.is_reindexing ? "58g" : "15g"
 }
 
-data "ec_stack" "latest" {
-  version_regex = "latest"
-  region        = "eu-west-1"
-}
-
 resource "ec_deployment" "pipeline" {
   name = "pipeline-${var.pipeline_date}"
 
+  # Currently we do cross-cluster replication from the pipeline cluster
+  # to the API cluster.
+  #
+  # The Elasticsearch documentation is very clear [1]
+  #
+  #     The cluster containing follower indices must be running the same
+  #     or newer version of Elasticsearch as the remote cluster
+  #
+  # This even applies across patch versions, e.g. this configuration
+  # is no good:
+  #
+  #     pipeline = v7.14.1
+  #     api      = v7.14.0
+  #
+  # Using the same version as the API cluster means we'll never get CCR
+  # versioning in a muddle.  If you want a newer version, upgrade the
+  # API first.
+  #
+  # [1]: https://www.elastic.co/guide/en/elasticsearch/reference/current/xpack-ccr.html
+  #
+  version = var.api_ec_version
+
   region                 = "eu-west-1"
-  version                = data.ec_stack.latest.version
   deployment_template_id = "aws-io-optimized-v2"
 
   traffic_filter = [

--- a/pipeline/terraform/stack/service_id_minter.tf
+++ b/pipeline/terraform/stack/service_id_minter.tf
@@ -68,10 +68,6 @@ module "id_minter" {
 
   use_fargate_spot = true
 
-  depends_on = [
-    null_resource.elasticsearch_users,
-  ]
-
   deployment_service_env  = var.release_label
   deployment_service_name = "id-minter"
   shared_logging_secrets  = var.shared_logging_secrets

--- a/pipeline/terraform/stack/service_matcher.tf
+++ b/pipeline/terraform/stack/service_matcher.tf
@@ -83,10 +83,6 @@ module "matcher" {
 
   queue_read_policy = module.matcher_input_queue.read_policy
 
-  depends_on = [
-    null_resource.elasticsearch_users,
-  ]
-
   deployment_service_env  = var.release_label
   deployment_service_name = "matcher"
   shared_logging_secrets  = var.shared_logging_secrets

--- a/pipeline/terraform/stack/service_transformer_calm.tf
+++ b/pipeline/terraform/stack/service_transformer_calm.tf
@@ -44,10 +44,6 @@ module "calm_transformer" {
 
   queue_read_policy = module.calm_transformer_queue.read_policy
 
-  depends_on = [
-    null_resource.elasticsearch_users,
-  ]
-
   deployment_service_env  = var.release_label
   deployment_service_name = "calm-transformer"
   shared_logging_secrets  = var.shared_logging_secrets

--- a/pipeline/terraform/stack/service_transformer_mets.tf
+++ b/pipeline/terraform/stack/service_transformer_mets.tf
@@ -57,10 +57,6 @@ module "mets_transformer" {
 
   use_fargate_spot = true
 
-  depends_on = [
-    null_resource.elasticsearch_users,
-  ]
-
   deployment_service_env  = var.release_label
   deployment_service_name = "mets-transformer"
   shared_logging_secrets  = var.shared_logging_secrets

--- a/pipeline/terraform/stack/service_transformer_miro.tf
+++ b/pipeline/terraform/stack/service_transformer_miro.tf
@@ -47,10 +47,6 @@ module "miro_transformer" {
 
   queue_read_policy = module.miro_transformer_queue.read_policy
 
-  depends_on = [
-    null_resource.elasticsearch_users,
-  ]
-
   deployment_service_env  = var.release_label
   deployment_service_name = "miro-transformer"
   shared_logging_secrets  = var.shared_logging_secrets

--- a/pipeline/terraform/stack/service_transformer_sierra.tf
+++ b/pipeline/terraform/stack/service_transformer_sierra.tf
@@ -45,10 +45,6 @@ module "sierra_transformer" {
 
   queue_read_policy = module.sierra_transformer_queue.read_policy
 
-  depends_on = [
-    null_resource.elasticsearch_users,
-  ]
-
   deployment_service_env  = var.release_label
   deployment_service_name = "sierra-transformer"
   shared_logging_secrets  = var.shared_logging_secrets

--- a/pipeline/terraform/stack/service_transformer_tei.tf
+++ b/pipeline/terraform/stack/service_transformer_tei.tf
@@ -57,10 +57,6 @@ module "tei_transformer" {
 
   use_fargate_spot = true
 
-  depends_on = [
-    null_resource.elasticsearch_users,
-  ]
-
   deployment_service_env  = var.release_label
   deployment_service_name = "tei-transformer"
   shared_logging_secrets  = var.shared_logging_secrets

--- a/pipeline/terraform/stack/tei_off_branch.tf
+++ b/pipeline/terraform/stack/tei_off_branch.tf
@@ -45,7 +45,7 @@ module "tei_off_branch" {
   service_egress_security_group_id    = aws_security_group.service_egress.id
 
 
-  inference_capacity_provider_name = module.inference_capacity_provider.name
+  inference_capacity_provider_name = module.inference_capacity_provider_tei_off.name
 
   pipeline_date                 = var.pipeline_date
   pipeline_storage_port         = local.pipeline_storage_port

--- a/pipeline/terraform/stack/tei_off_branch.tf
+++ b/pipeline/terraform/stack/tei_off_branch.tf
@@ -39,7 +39,6 @@ module "tei_off_branch" {
   cluster_name                        = aws_ecs_cluster.cluster.name
   scale_down_adjustment               = local.scale_down_adjustment
   scale_up_adjustment                 = local.scale_up_adjustment
-  elasticsearch_users                 = null_resource.elasticsearch_users
   namespace_hyphen                    = local.namespace_hyphen
   pipeline_storage_es_service_secrets = local.pipeline_storage_es_service_secrets
   service_egress_security_group_id    = aws_security_group.service_egress.id

--- a/pipeline/terraform/stack/tei_on_branch.tf
+++ b/pipeline/terraform/stack/tei_on_branch.tf
@@ -38,7 +38,6 @@ module "tei_on_branch" {
   cluster_name                        = aws_ecs_cluster.cluster.name
   scale_down_adjustment               = local.scale_down_adjustment
   scale_up_adjustment                 = local.scale_up_adjustment
-  elasticsearch_users                 = null_resource.elasticsearch_users
   namespace_hyphen                    = local.namespace_hyphen
   pipeline_storage_es_service_secrets = local.pipeline_storage_es_service_secrets
   service_egress_security_group_id    = aws_security_group.service_egress.id

--- a/pipeline/terraform/stack/tei_on_branch.tf
+++ b/pipeline/terraform/stack/tei_on_branch.tf
@@ -44,7 +44,7 @@ module "tei_on_branch" {
   service_egress_security_group_id    = aws_security_group.service_egress.id
 
 
-  inference_capacity_provider_name = module.inference_capacity_provider.name
+  inference_capacity_provider_name = module.inference_capacity_provider_tei_on.name
 
   pipeline_date                 = var.pipeline_date
   pipeline_storage_port         = local.pipeline_storage_port

--- a/pipeline/terraform/stack/variables.tf
+++ b/pipeline/terraform/stack/variables.tf
@@ -2,6 +2,10 @@ variable "pipeline_date" {
   type = string
 }
 
+variable "api_ec_version" {
+  type = string
+}
+
 variable "min_capacity" {
   type    = number
   default = 0

--- a/pipeline/terraform/terraform.tf
+++ b/pipeline/terraform/terraform.tf
@@ -35,6 +35,17 @@ terraform {
   }
 }
 
+data "terraform_remote_state" "catalogue_api" {
+  backend = "s3"
+
+  config = {
+    role_arn = "arn:aws:iam::756629837203:role/catalogue-read_only"
+    bucket   = "wellcomecollection-catalogue-infra-delta"
+    key      = "terraform/catalogue/api/shared.tfstate"
+    region   = "eu-west-1"
+  }
+}
+
 data "terraform_remote_state" "catalogue_infra_critical" {
   backend = "s3"
 


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/platform/issues/5295, closes https://github.com/wellcomecollection/catalogue-pipeline/pull/1862

- Image inferrers now get dedicated capacity providers for TEI on/off (h/t @alicefuzier)
- We now get the version of Elasticsearch that the API is using, so we never step ahead of it. This means CCR can't get its versioning in a twist.
- We now run two, smaller Elasticsearch nodes in the pipeline cluster when we're not reindexing – for high availability and offset costs
- We no longer depend on the Elasticsearch cluster for all the pipeline resources. This is a "clever idea" I had when setting this up that means services won't be created before the relevant secrets are ready, but:
     1. It creates unreadable Terraform plans.
     2. If those secrets aren't ready, the services will just restart until they are. Not a big issue.