### PR TITLE
Halve the size of the inferrer tasks, back to one capacity provider

### DIFF
--- a/pipeline/terraform/stack/branch/service_image_inferrer.tf
+++ b/pipeline/terraform/stack/branch/service_image_inferrer.tf
@@ -9,12 +9,40 @@ locals {
   shared_storage_name      = "shared_storage"
   shared_storage_path      = "/data"
 
-  total_cpu           = 8192
-  total_memory        = 15463
-  manager_memory      = 2048
-  manager_cpu         = 1024
-  aspect_ratio_cpu    = 2048
-  aspect_ratio_memory = 2048
+  base_total_cpu           = 8192
+  base_total_memory        = 15463
+  base_manager_memory      = 2048
+  base_manager_cpu         = 1024
+  base_aspect_ratio_cpu    = 2048
+  base_aspect_ratio_memory = 2048
+
+  # When we're not reindexing, we halve the size of these tasks, because
+  # they won't be getting as many updates.
+  #
+  # Note: while we're running the TEI on/TEI off pipeline, we run c5.2xlarge
+  # instances when not reindexing, so we can run 2 tasks per instance.
+  # This avoids some weird issues we've seen where an instance starts
+  # but ECS is unable to place tasks anywhere.
+  #
+  # The problem:
+  #
+  #   - image update arrives
+  #   - both tei-on and tei-off want to start an inferrer = 2 tasks
+  #   - for some reason, the tasks consistently don't start
+  #
+  # We're hoping that using the same capacity provider and allowing
+  # 2 tasks per instance will fix this issue.
+  #
+  # Once we're no longer running a split TEI pipeline, we should be able
+  # to reduce the size of instances when we're not reindexing.
+  #
+  total_cpu           = var.is_reindexing ? local.base_total_cpu           : floor(local.base_total_cpu / 2)
+  total_memory        = var.is_reindexing ? local.base_total_memory        : floor(local.base_total_memory / 2)
+  manager_memory      = var.is_reindexing ? local.base_manager_memory      : floor(local.base_manager_memory / 2)
+  manager_cpu         = var.is_reindexing ? local.base_manager_cpu         : floor(local.base_manager_cpu / 2)
+  aspect_ratio_cpu    = var.is_reindexing ? local.base_aspect_ratio_cpu    : floor(local.base_aspect_ratio_cpu / 2)
+  aspect_ratio_memory = var.is_reindexing ? local.base_aspect_ratio_memory : floor(local.base_aspect_ratio_memory / 2)
+
   inferrer_cpu        = floor(0.5 * (local.total_cpu - local.manager_cpu - local.aspect_ratio_cpu))
   inferrer_memory     = floor(0.5 * (local.total_memory - local.manager_memory - local.aspect_ratio_memory))
 }

--- a/pipeline/terraform/stack/branch/service_image_inferrer.tf
+++ b/pipeline/terraform/stack/branch/service_image_inferrer.tf
@@ -36,15 +36,15 @@ locals {
   # Once we're no longer running a split TEI pipeline, we should be able
   # to reduce the size of instances when we're not reindexing.
   #
-  total_cpu           = var.is_reindexing ? local.base_total_cpu           : floor(local.base_total_cpu / 2)
-  total_memory        = var.is_reindexing ? local.base_total_memory        : floor(local.base_total_memory / 2)
-  manager_memory      = var.is_reindexing ? local.base_manager_memory      : floor(local.base_manager_memory / 2)
-  manager_cpu         = var.is_reindexing ? local.base_manager_cpu         : floor(local.base_manager_cpu / 2)
-  aspect_ratio_cpu    = var.is_reindexing ? local.base_aspect_ratio_cpu    : floor(local.base_aspect_ratio_cpu / 2)
+  total_cpu           = var.is_reindexing ? local.base_total_cpu : floor(local.base_total_cpu / 2)
+  total_memory        = var.is_reindexing ? local.base_total_memory : floor(local.base_total_memory / 2)
+  manager_memory      = var.is_reindexing ? local.base_manager_memory : floor(local.base_manager_memory / 2)
+  manager_cpu         = var.is_reindexing ? local.base_manager_cpu : floor(local.base_manager_cpu / 2)
+  aspect_ratio_cpu    = var.is_reindexing ? local.base_aspect_ratio_cpu : floor(local.base_aspect_ratio_cpu / 2)
   aspect_ratio_memory = var.is_reindexing ? local.base_aspect_ratio_memory : floor(local.base_aspect_ratio_memory / 2)
 
-  inferrer_cpu        = floor(0.5 * (local.total_cpu - local.manager_cpu - local.aspect_ratio_cpu))
-  inferrer_memory     = floor(0.5 * (local.total_memory - local.manager_memory - local.aspect_ratio_memory))
+  inferrer_cpu    = floor(0.5 * (local.total_cpu - local.manager_cpu - local.aspect_ratio_cpu))
+  inferrer_memory = floor(0.5 * (local.total_memory - local.manager_memory - local.aspect_ratio_memory))
 }
 
 module "image_inferrer_queue" {

--- a/pipeline/terraform/stack/cluster.tf
+++ b/pipeline/terraform/stack/cluster.tf
@@ -1,12 +1,12 @@
 resource "aws_ecs_cluster" "cluster" {
   name               = local.namespace_hyphen
-  capacity_providers = [module.inference_capacity_provider_tei_off.name, module.inference_capacity_provider_tei_on.name]
+  capacity_providers = [module.inference_capacity_provider.name]
 }
 
-module "inference_capacity_provider_tei_on" {
+module "inference_capacity_provider" {
   source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/ec2_capacity_provider?ref=v3.5.1"
 
-  name = "${local.namespace_hyphen}_inferrer-tei-on"
+  name = "${local.namespace_hyphen}_inferrer"
 
   // Setting this variable from aws_ecs_cluster.cluster.name creates a cycle
   // The cluster name is required for the instance user data script
@@ -14,28 +14,7 @@ module "inference_capacity_provider_tei_on" {
   cluster_name = local.namespace_hyphen
 
   instance_type           = "c5.2xlarge"
-  max_instances           = 6
-  use_spot_purchasing     = true
-  scaling_action_cooldown = 240
-
-  subnets = var.subnets
-  security_group_ids = [
-    aws_security_group.service_egress.id,
-  ]
-}
-
-module "inference_capacity_provider_tei_off" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/ec2_capacity_provider?ref=v3.5.1"
-
-  name = "${local.namespace_hyphen}_inferrer-tei-off"
-
-  // Setting this variable from aws_ecs_cluster.cluster.name creates a cycle
-  // The cluster name is required for the instance user data script
-  // This is a known issue https://github.com/terraform-providers/terraform-provider-aws/issues/12739
-  cluster_name = local.namespace_hyphen
-
-  instance_type           = "c5.2xlarge"
-  max_instances           = 6
+  max_instances           = var.is_reindexing ? 6 : 1
   use_spot_purchasing     = true
   scaling_action_cooldown = 240
 

--- a/pipeline/terraform/stack/tei_off_branch.tf
+++ b/pipeline/terraform/stack/tei_off_branch.tf
@@ -43,8 +43,7 @@ module "tei_off_branch" {
   pipeline_storage_es_service_secrets = local.pipeline_storage_es_service_secrets
   service_egress_security_group_id    = aws_security_group.service_egress.id
 
-
-  inference_capacity_provider_name = module.inference_capacity_provider_tei_off.name
+  inference_capacity_provider_name = module.inference_capacity_provider.name
 
   pipeline_date                 = var.pipeline_date
   pipeline_storage_port         = local.pipeline_storage_port

--- a/pipeline/terraform/stack/tei_on_branch.tf
+++ b/pipeline/terraform/stack/tei_on_branch.tf
@@ -42,8 +42,7 @@ module "tei_on_branch" {
   pipeline_storage_es_service_secrets = local.pipeline_storage_es_service_secrets
   service_egress_security_group_id    = aws_security_group.service_egress.id
 
-
-  inference_capacity_provider_name = module.inference_capacity_provider_tei_on.name
+  inference_capacity_provider_name = module.inference_capacity_provider.name
 
   pipeline_date                 = var.pipeline_date
   pipeline_storage_port         = local.pipeline_storage_port


### PR DESCRIPTION
Another fix for https://github.com/wellcomecollection/platform/issues/5292