### PR TITLE
Add more implicit encoders/decoders to speed up the compilation of internal model

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/Implicits.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/Implicits.scala
@@ -4,6 +4,7 @@ import io.circe.generic.extras.semiauto._
 import io.circe._
 import weco.catalogue.internal_model.identifiers._
 import weco.catalogue.internal_model.image._
+import weco.catalogue.internal_model.languages.Language
 import weco.catalogue.internal_model.locations.{
   AccessCondition,
   DigitalLocation,
@@ -37,6 +38,7 @@ object Implicits {
   implicit val _decIdentifierType: Decoder[IdentifierType] = IdentifierType.identifierTypeDecoder
   implicit val _decSourceIdentifier: Decoder[SourceIdentifier] = deriveConfiguredDecoder
   implicit val _decCanonicalId: Decoder[CanonicalId] = deriveConfiguredDecoder
+  implicit val _decReferenceNumber: Decoder[ReferenceNumber] = deriveConfiguredDecoder
 
   implicit val _decIdStateIdentified: Decoder[IdState.Identified] = deriveConfiguredDecoder
   implicit val _decIdStateIdentifiable: Decoder[IdState.Identifiable] = deriveConfiguredDecoder
@@ -44,6 +46,8 @@ object Implicits {
   implicit val _decIdStateMinted: Decoder[IdState.Minted] = deriveConfiguredDecoder
 
   implicit val _dec05: Decoder[InstantRange] = deriveConfiguredDecoder
+
+  implicit val _decLanguage: Decoder[Language] = deriveConfiguredDecoder
 
   implicit val _decLicense: Decoder[License] = License.licenseDecoder
   implicit val _decPhysicalLocationType: Decoder[PhysicalLocationType] = LocationType.physicalLocationTypeDecoder
@@ -55,10 +59,11 @@ object Implicits {
     deriveConfiguredDecoder
   implicit val _decLocation: Decoder[Location] = deriveConfiguredDecoder
 
-  implicit val _dec11: Decoder[MergeCandidate[IdState.Identifiable]] =
+  implicit val _decMergeCandidateIdentifiable: Decoder[MergeCandidate[IdState.Identifiable]] =
     deriveConfiguredDecoder
-  implicit val _dec12: Decoder[MergeCandidate[IdState.Identified]] =
+  implicit val _decMergeCandidateIdentified: Decoder[MergeCandidate[IdState.Identified]] =
     deriveConfiguredDecoder
+
   implicit val _dec13: Decoder[MatcherResult] = deriveConfiguredDecoder
   implicit val _dec14: Decoder[Person[IdState.Unminted]] =
     deriveConfiguredDecoder
@@ -78,7 +83,10 @@ object Implicits {
     deriveConfiguredDecoder
   implicit val _dec23: Decoder[AbstractAgent[IdState.Minted]] =
     deriveConfiguredDecoder
-  implicit val _dec24: Decoder[Place[IdState.Unminted]] =
+
+  implicit val _decPlaceMinted: Decoder[Place[IdState.Minted]] =
+    deriveConfiguredDecoder
+  implicit val _decPlaceUnminted: Decoder[Place[IdState.Unminted]] =
     deriveConfiguredDecoder
 
   implicit val _decPeriodMinted: Decoder[Period[IdState.Minted]] = deriveConfiguredDecoder
@@ -230,6 +238,7 @@ object Implicits {
   implicit val _encIdentifierType: Encoder[IdentifierType] = IdentifierType.identifierTypeEncoder
   implicit val _encSourceIdentifier: Encoder[SourceIdentifier] = deriveConfiguredEncoder
   implicit val _encCanonicalId: Encoder[CanonicalId] = deriveConfiguredEncoder
+  implicit val _envReferenceNumber: Encoder[ReferenceNumber] = deriveConfiguredEncoder
 
   implicit val _encIdStateIdentified: Encoder[IdState.Identified] = deriveConfiguredEncoder
   implicit val _encIdStateIdentifiable: Encoder[IdState.Identifiable] = deriveConfiguredEncoder
@@ -237,6 +246,8 @@ object Implicits {
   implicit val _encIdStateMinted: Encoder[IdState.Minted] = deriveConfiguredEncoder
 
   implicit val _enc05: Encoder[InstantRange] = deriveConfiguredEncoder
+
+  implicit val _encLanguage: Encoder[Language] = deriveConfiguredEncoder
 
   implicit val _encLicense: Encoder[License] = License.licenseEncoder
   implicit val _encPhysicalLocationType: Encoder[PhysicalLocationType] = LocationType.physicalLocationTypeEncoder
@@ -248,11 +259,11 @@ object Implicits {
     deriveConfiguredEncoder
   implicit val _encLocation: Encoder[Location] = deriveConfiguredEncoder
 
-  implicit val _enc11
-    : Encoder[MergeCandidate[ImageData[IdState.Identifiable]]] =
+  implicit val _encMergeCandidateIdentifiable: Encoder[MergeCandidate[IdState.Identifiable]] =
     deriveConfiguredEncoder
-  implicit val _enc12: Encoder[MergeCandidate[ImageData[IdState.Identified]]] =
+  implicit val _encMergeCandidateIdentified: Encoder[MergeCandidate[IdState.Identified]] =
     deriveConfiguredEncoder
+  
   implicit val _enc13: Encoder[MatcherResult] = deriveConfiguredEncoder
   implicit val _enc14: Encoder[Person[IdState.Unminted]] =
     deriveConfiguredEncoder
@@ -272,7 +283,10 @@ object Implicits {
     deriveConfiguredEncoder
   implicit val _enc23: Encoder[AbstractAgent[IdState.Minted]] =
     deriveConfiguredEncoder
-  implicit val _enc24: Encoder[Place[IdState.Unminted]] =
+
+  implicit val _encPlaceMinted: Encoder[Place[IdState.Minted]] =
+    deriveConfiguredEncoder
+  implicit val _encPlaceUnminted: Encoder[Place[IdState.Unminted]] =
     deriveConfiguredEncoder
 
   implicit val _encPeriodMinted: Encoder[Period[IdState.Minted]] = deriveConfiguredEncoder

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/Implicits.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/Implicits.scala
@@ -103,38 +103,64 @@ object Implicits {
     deriveConfiguredDecoder
   implicit val _dec46: Decoder[WorkData[DataState.Identified]] =
     deriveConfiguredDecoder
-  implicit val _dec47: Decoder[Work.Visible[WorkState.Source]] =
+    
+  // TODO: WorkState decoders?
+  
+  implicit val _decWorkVisibleSource: Decoder[Work.Visible[WorkState.Source]] =
     deriveConfiguredDecoder
-  implicit val _dec48: Decoder[Work.Visible[WorkState.Merged]] =
+  implicit val _decWorkVisibleMerged: Decoder[Work.Visible[WorkState.Merged]] =
     deriveConfiguredDecoder
-  implicit val _dec49: Decoder[Work.Visible[WorkState.Denormalised]] =
+  implicit val _decWorkVisibleDenormalised: Decoder[Work.Visible[WorkState.Denormalised]] =
     deriveConfiguredDecoder
-  implicit val _dec50: Decoder[Work.Visible[WorkState.Identified]] =
+  implicit val _decWorkVisibleIdentified: Decoder[Work.Visible[WorkState.Identified]] =
     deriveConfiguredDecoder
-  implicit val _dec51: Decoder[Work.Invisible[WorkState.Source]] =
+  implicit val _decWorkVisibleIndexed: Decoder[Work.Visible[WorkState.Indexed]] =
     deriveConfiguredDecoder
-  implicit val _dec52: Decoder[Work.Invisible[WorkState.Merged]] =
+  
+  implicit val _decWorkInvisibleSource: Decoder[Work.Invisible[WorkState.Source]] =
     deriveConfiguredDecoder
-  implicit val _dec53: Decoder[Work.Invisible[WorkState.Denormalised]] =
+  implicit val _decWorkInvisibleMerged: Decoder[Work.Invisible[WorkState.Merged]] =
     deriveConfiguredDecoder
-  implicit val _dec54: Decoder[Work.Invisible[WorkState.Identified]] =
+  implicit val _decWorkInvisibleDenormalised: Decoder[Work.Invisible[WorkState.Denormalised]] =
     deriveConfiguredDecoder
-  implicit val _dec55: Decoder[Work.Redirected[WorkState.Source]] =
+  implicit val _decWorkInvisibleIdentified: Decoder[Work.Invisible[WorkState.Identified]] =
     deriveConfiguredDecoder
-  implicit val _dec56: Decoder[Work.Redirected[WorkState.Merged]] =
+  implicit val _decWorkInvisibleIndexed: Decoder[Work.Invisible[WorkState.Indexed]] =
     deriveConfiguredDecoder
-  implicit val _dec57: Decoder[Work.Redirected[WorkState.Denormalised]] =
+  
+  implicit val _decWorkRedirectedSource: Decoder[Work.Redirected[WorkState.Source]] =
     deriveConfiguredDecoder
-  implicit val _dec58: Decoder[Work.Redirected[WorkState.Identified]] =
+  implicit val _decWorkRedirectedMerged: Decoder[Work.Redirected[WorkState.Merged]] =
     deriveConfiguredDecoder
-  implicit val _dec59: Decoder[Work[WorkState.Source]] =
+  implicit val _decWorkRedirectedDenormalised: Decoder[Work.Redirected[WorkState.Denormalised]] =
     deriveConfiguredDecoder
-  implicit val _dec60: Decoder[Work[WorkState.Merged]] =
+  implicit val _decWorkRedirectedIdentified: Decoder[Work.Redirected[WorkState.Identified]] =
     deriveConfiguredDecoder
-  implicit val _dec61: Decoder[Work[WorkState.Denormalised]] =
+  implicit val _decWorkRedirectedIndexed: Decoder[Work.Redirected[WorkState.Indexed]] =
     deriveConfiguredDecoder
-  implicit val _dec62: Decoder[Work[WorkState.Identified]] =
+
+  implicit val _decWorkDeletedSource: Decoder[Work.Deleted[WorkState.Source]] =
     deriveConfiguredDecoder
+  implicit val _decWorkDeletedMerged: Decoder[Work.Deleted[WorkState.Merged]] =
+    deriveConfiguredDecoder
+  implicit val _decWorkDeletedDenormalised: Decoder[Work.Deleted[WorkState.Denormalised]] =
+    deriveConfiguredDecoder
+  implicit val _decWorkDeletedIdentified: Decoder[Work.Deleted[WorkState.Identified]] =
+    deriveConfiguredDecoder
+  implicit val _decWorkDeletedIndexed: Decoder[Work.Deleted[WorkState.Indexed]] =
+    deriveConfiguredDecoder
+  
+  implicit val _decWorkSource: Decoder[Work[WorkState.Source]] =
+    deriveConfiguredDecoder
+  implicit val _decWorkMerged: Decoder[Work[WorkState.Merged]] =
+    deriveConfiguredDecoder
+  implicit val _decWorkDenormalised: Decoder[Work[WorkState.Denormalised]] =
+    deriveConfiguredDecoder
+  implicit val _decWorkIdentified: Decoder[Work[WorkState.Identified]] =
+    deriveConfiguredDecoder
+  implicit val _decWorkIndexed: Decoder[Work[WorkState.Indexed]] =
+    deriveConfiguredDecoder
+    
   implicit val _dec63: Decoder[ParentWorks] =
     deriveConfiguredDecoder
   implicit val _dec64: Decoder[ImageSource] =
@@ -144,14 +170,6 @@ object Implicits {
   implicit val _dec66: Decoder[Image[ImageState.Augmented]] =
     deriveConfiguredDecoder
   implicit val _dec67: Decoder[Image[ImageState.Indexed]] =
-    deriveConfiguredDecoder
-  implicit val _dec68: Decoder[Work[WorkState.Indexed]] =
-    deriveConfiguredDecoder
-  implicit val _dec69: Decoder[Work.Visible[WorkState.Indexed]] =
-    deriveConfiguredDecoder
-  implicit val _dec70: Decoder[Work.Invisible[WorkState.Indexed]] =
-    deriveConfiguredDecoder
-  implicit val _dec71: Decoder[Work.Redirected[WorkState.Indexed]] =
     deriveConfiguredDecoder
 
   implicit val _enc00: Encoder[AccessCondition] = deriveConfiguredEncoder
@@ -231,38 +249,62 @@ object Implicits {
     deriveConfiguredEncoder
   implicit val _enc46: Encoder[WorkData[DataState.Identified]] =
     deriveConfiguredEncoder
-  implicit val _enc47: Encoder[Work.Visible[WorkState.Source]] =
+
+  implicit val _encWorkVisibleSource: Encoder[Work.Visible[WorkState.Source]] =
     deriveConfiguredEncoder
-  implicit val _enc48: Encoder[Work.Visible[WorkState.Merged]] =
+  implicit val _encWorkVisibleMerged: Encoder[Work.Visible[WorkState.Merged]] =
     deriveConfiguredEncoder
-  implicit val _enc49: Encoder[Work.Visible[WorkState.Denormalised]] =
+  implicit val _encWorkVisibleDenormalised: Encoder[Work.Visible[WorkState.Denormalised]] =
     deriveConfiguredEncoder
-  implicit val _enc50: Encoder[Work.Visible[WorkState.Identified]] =
+  implicit val _encWorkVisibleIdentified: Encoder[Work.Visible[WorkState.Identified]] =
     deriveConfiguredEncoder
-  implicit val _enc51: Encoder[Work.Invisible[WorkState.Source]] =
+  implicit val _encWorkVisibleIndexed: Encoder[Work.Visible[WorkState.Indexed]] =
     deriveConfiguredEncoder
-  implicit val _enc52: Encoder[Work.Invisible[WorkState.Merged]] =
+
+  implicit val _encWorkInvisibleSource: Encoder[Work.Invisible[WorkState.Source]] =
     deriveConfiguredEncoder
-  implicit val _enc53: Encoder[Work.Invisible[WorkState.Denormalised]] =
+  implicit val _encWorkInvisibleMerged: Encoder[Work.Invisible[WorkState.Merged]] =
     deriveConfiguredEncoder
-  implicit val _enc54: Encoder[Work.Invisible[WorkState.Identified]] =
+  implicit val _encWorkInvisibleDenormalised: Encoder[Work.Invisible[WorkState.Denormalised]] =
     deriveConfiguredEncoder
-  implicit val _enc55: Encoder[Work.Redirected[WorkState.Source]] =
+  implicit val _encWorkInvisibleIdentified: Encoder[Work.Invisible[WorkState.Identified]] =
     deriveConfiguredEncoder
-  implicit val _enc56: Encoder[Work.Redirected[WorkState.Merged]] =
+  implicit val _encWorkInvisibleIndexed: Encoder[Work.Invisible[WorkState.Indexed]] =
     deriveConfiguredEncoder
-  implicit val _enc57: Encoder[Work.Redirected[WorkState.Denormalised]] =
+
+  implicit val _encWorkRedirectedSource: Encoder[Work.Redirected[WorkState.Source]] =
     deriveConfiguredEncoder
-  implicit val _enc58: Encoder[Work.Redirected[WorkState.Identified]] =
+  implicit val _encWorkRedirectedMerged: Encoder[Work.Redirected[WorkState.Merged]] =
     deriveConfiguredEncoder
-  implicit val _enc59: Encoder[Work[WorkState.Source]] =
+  implicit val _encWorkRedirectedDenormalised: Encoder[Work.Redirected[WorkState.Denormalised]] =
     deriveConfiguredEncoder
-  implicit val _enc60: Encoder[Work[WorkState.Merged]] =
+  implicit val _encWorkRedirectedIdentified: Encoder[Work.Redirected[WorkState.Identified]] =
     deriveConfiguredEncoder
-  implicit val _enc61: Encoder[Work[WorkState.Denormalised]] =
+  implicit val _encWorkRedirectedIndexed: Encoder[Work.Redirected[WorkState.Indexed]] =
     deriveConfiguredEncoder
-  implicit val _enc62: Encoder[Work[WorkState.Identified]] =
+
+  implicit val _encWorkDeletedSource: Encoder[Work.Deleted[WorkState.Source]] =
     deriveConfiguredEncoder
+  implicit val _encWorkDeletedMerged: Encoder[Work.Deleted[WorkState.Merged]] =
+    deriveConfiguredEncoder
+  implicit val _encWorkDeletedDenormalised: Encoder[Work.Deleted[WorkState.Denormalised]] =
+    deriveConfiguredEncoder
+  implicit val _encWorkDeletedIdentified: Encoder[Work.Deleted[WorkState.Identified]] =
+    deriveConfiguredEncoder
+  implicit val _encWorkDeletedIndexed: Encoder[Work.Deleted[WorkState.Indexed]] =
+    deriveConfiguredEncoder
+
+  implicit val _encWorkSource: Encoder[Work[WorkState.Source]] =
+    deriveConfiguredEncoder
+  implicit val _encWorkMerged: Encoder[Work[WorkState.Merged]] =
+    deriveConfiguredEncoder
+  implicit val _encWorkDenormalised: Encoder[Work[WorkState.Denormalised]] =
+    deriveConfiguredEncoder
+  implicit val _encWorkIdentified: Encoder[Work[WorkState.Identified]] =
+    deriveConfiguredEncoder
+  implicit val _encWorkIndexed: Encoder[Work[WorkState.Indexed]] =
+    deriveConfiguredEncoder
+  
   implicit val _enc63: Encoder[ParentWorks] =
     deriveConfiguredEncoder
   implicit val _enc64: Encoder[ImageSource] =
@@ -272,13 +314,5 @@ object Implicits {
   implicit val _enc66: Encoder[Image[ImageState.Augmented]] =
     deriveConfiguredEncoder
   implicit val _enc67: Encoder[Image[ImageState.Indexed]] =
-    deriveConfiguredEncoder
-  implicit val _enc68: Encoder[Work[WorkState.Indexed]] =
-    deriveConfiguredEncoder
-  implicit val _enc69: Encoder[Work.Visible[WorkState.Indexed]] =
-    deriveConfiguredEncoder
-  implicit val _enc70: Encoder[Work.Invisible[WorkState.Indexed]] =
-    deriveConfiguredEncoder
-  implicit val _enc71: Encoder[Work.Redirected[WorkState.Indexed]] =
     deriveConfiguredEncoder
 }

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/Implicits.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/Implicits.scala
@@ -7,7 +7,9 @@ import weco.catalogue.internal_model.image._
 import weco.catalogue.internal_model.locations.{
   AccessCondition,
   DigitalLocation,
+  License,
   Location,
+  LocationType,
   PhysicalLocation
 }
 import weco.catalogue.internal_model.matcher.MatcherResult
@@ -33,14 +35,21 @@ object Implicits {
   implicit val _decSourceIdentifier: Decoder[SourceIdentifier] = deriveConfiguredDecoder
   implicit val _decCanonicalId: Decoder[CanonicalId] = deriveConfiguredDecoder
 
-  implicit val _dec03: Decoder[IdState.Unminted] = deriveConfiguredDecoder
-  implicit val _dec04: Decoder[IdState.Minted] = deriveConfiguredDecoder
+  implicit val _decIdStateIdentified: Decoder[IdState.Identified] = deriveConfiguredDecoder
+  implicit val _decIdStateIdentifiable: Decoder[IdState.Identifiable] = deriveConfiguredDecoder
+  implicit val _decIdStateUnminted: Decoder[IdState.Unminted] = deriveConfiguredDecoder
+  implicit val _decIdStateMinted: Decoder[IdState.Minted] = deriveConfiguredDecoder
+
   implicit val _dec05: Decoder[InstantRange] = deriveConfiguredDecoder
-  implicit val _dec06: Decoder[DigitalLocation] =
+  
+  implicit val _decLicense: Decoder[License] = deriveConfiguredDecoder
+  implicit val _decLocationType: Decoder[LocationType] = deriveConfiguredDecoder
+  implicit val _decDigitalLocation: Decoder[DigitalLocation] =
     deriveConfiguredDecoder
-  implicit val _dec07: Decoder[PhysicalLocation] =
+  implicit val _decPhysicalLocation: Decoder[PhysicalLocation] =
     deriveConfiguredDecoder
-  implicit val _dec08: Decoder[Location] = deriveConfiguredDecoder
+  implicit val _decLocation: Decoder[Location] = deriveConfiguredDecoder
+
   implicit val _dec11: Decoder[MergeCandidate[IdState.Identifiable]] =
     deriveConfiguredDecoder
   implicit val _dec12: Decoder[MergeCandidate[IdState.Identified]] =
@@ -96,10 +105,6 @@ object Implicits {
     deriveConfiguredDecoder
   implicit val _dec41: Decoder[Contributor[IdState.Minted]] =
     deriveConfiguredDecoder
-  implicit val _dec42: Decoder[ImageData[IdState.Identifiable]] =
-    deriveConfiguredDecoder
-  implicit val _dec43: Decoder[ImageData[IdState.Identified]] =
-    deriveConfiguredDecoder
 
   implicit val _decFormat: Decoder[Format] = deriveConfiguredDecoder
   implicit val _decHoldings: Decoder[Holdings] = deriveConfiguredDecoder
@@ -111,7 +116,16 @@ object Implicits {
 
   implicit val _decDerivedWorkData: Decoder[DerivedWorkData] =
     deriveConfiguredDecoder
-  
+  implicit val _decInferredData: Decoder[InferredData] =
+    deriveConfiguredDecoder
+  implicit val _decDerivedImageData: Decoder[DerivedImageData] =
+    deriveConfiguredDecoder
+
+  implicit val _decImageDataIdentifiable: Decoder[ImageData[IdState.Identifiable]] =
+    deriveConfiguredDecoder
+  implicit val _decImageDataIdentified: Decoder[ImageData[IdState.Identified]] =
+    deriveConfiguredDecoder
+
   implicit val _dec45: Decoder[WorkData[DataState.Unidentified]] =
     deriveConfiguredDecoder
   implicit val _dec46: Decoder[WorkData[DataState.Identified]] =
@@ -205,14 +219,21 @@ object Implicits {
   implicit val _encSourceIdentifier: Encoder[SourceIdentifier] = deriveConfiguredEncoder
   implicit val _encCanonicalId: Encoder[CanonicalId] = deriveConfiguredEncoder
 
-  implicit val _enc03: Encoder[IdState.Unminted] = deriveConfiguredEncoder
-  implicit val _enc04: Encoder[IdState.Minted] = deriveConfiguredEncoder
+  implicit val _encIdStateIdentified: Encoder[IdState.Identified] = deriveConfiguredEncoder
+  implicit val _encIdStateIdentifiable: Encoder[IdState.Identifiable] = deriveConfiguredEncoder
+  implicit val _encIdStateUnminted: Encoder[IdState.Unminted] = deriveConfiguredEncoder
+  implicit val _encIdStateMinted: Encoder[IdState.Minted] = deriveConfiguredEncoder
+  
   implicit val _enc05: Encoder[InstantRange] = deriveConfiguredEncoder
-  implicit val _enc06: Encoder[DigitalLocation] =
+
+  implicit val _encLicense: Encoder[License] = deriveConfiguredEncoder
+  implicit val _encLocationType: Encoder[LocationType] = deriveConfiguredEncoder
+  implicit val _encDigitalLocation: Encoder[DigitalLocation] =
     deriveConfiguredEncoder
-  implicit val _enc07: Encoder[PhysicalLocation] =
+  implicit val _encPhysicalLocation: Encoder[PhysicalLocation] =
     deriveConfiguredEncoder
-  implicit val _enc08: Encoder[Location] = deriveConfiguredEncoder
+  implicit val _encLocation: Encoder[Location] = deriveConfiguredEncoder
+  
   implicit val _enc11
     : Encoder[MergeCandidate[ImageData[IdState.Identifiable]]] =
     deriveConfiguredEncoder
@@ -269,10 +290,6 @@ object Implicits {
     deriveConfiguredEncoder
   implicit val _enc41: Encoder[Contributor[IdState.Minted]] =
     deriveConfiguredEncoder
-  implicit val _enc42: Encoder[ImageData[IdState.Identifiable]] =
-    deriveConfiguredEncoder
-  implicit val _enc43: Encoder[ImageData[IdState.Identified]] =
-    deriveConfiguredEncoder
 
   implicit val _encFormat: Encoder[Format] = deriveConfiguredEncoder
   implicit val _encHoldings: Encoder[Holdings] = deriveConfiguredEncoder
@@ -282,7 +299,16 @@ object Implicits {
   implicit val _encRelation: Encoder[Relation] = deriveConfiguredEncoder
   implicit val _encRelations: Encoder[Relations] = deriveConfiguredEncoder
 
-  implicit val _encDerivedWorkData: Encoder[DerivedWorkData] =
+  implicit val _envDerivedWorkData: Encoder[DerivedWorkData] =
+    deriveConfiguredEncoder
+  implicit val _envInferredData: Encoder[InferredData] =
+    deriveConfiguredEncoder
+  implicit val _envDerivedImageData: Encoder[DerivedImageData] =
+    deriveConfiguredEncoder
+
+  implicit val _envImageDataIdentifiable: Encoder[ImageData[IdState.Identifiable]] =
+    deriveConfiguredEncoder
+  implicit val _envImageDataIdentified: Encoder[ImageData[IdState.Identified]] =
     deriveConfiguredEncoder
   
   implicit val _enc45: Encoder[WorkData[DataState.Unidentified]] =

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/Implicits.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/Implicits.scala
@@ -104,7 +104,16 @@ object Implicits {
   implicit val _dec46: Decoder[WorkData[DataState.Identified]] =
     deriveConfiguredDecoder
     
-  // TODO: WorkState decoders?
+  implicit val _decWorkStateSource: Decoder[WorkState.Source] =
+    deriveConfiguredDecoder
+  implicit val _decWorkStateMerged: Decoder[WorkState.Merged] =
+    deriveConfiguredDecoder
+  implicit val _decWorkStateDenormalised: Decoder[WorkState.Denormalised] =
+    deriveConfiguredDecoder
+  implicit val _decWorkStateIdentified: Decoder[WorkState.Identified] =
+    deriveConfiguredDecoder
+  implicit val _decWorkStateIndexed: Decoder[WorkState.Indexed] =
+    deriveConfiguredDecoder
   
   implicit val _decWorkVisibleSource: Decoder[Work.Visible[WorkState.Source]] =
     deriveConfiguredDecoder
@@ -250,6 +259,17 @@ object Implicits {
   implicit val _enc46: Encoder[WorkData[DataState.Identified]] =
     deriveConfiguredEncoder
 
+  implicit val _encWorkStateSource: Encoder[WorkState.Source] =
+    deriveConfiguredEncoder
+  implicit val _encWorkStateMerged: Encoder[WorkState.Merged] =
+    deriveConfiguredEncoder
+  implicit val _encWorkStateDenormalised: Encoder[WorkState.Denormalised] =
+    deriveConfiguredEncoder
+  implicit val _encWorkStateIdentified: Encoder[WorkState.Identified] =
+    deriveConfiguredEncoder
+  implicit val _encWorkStateIndexed: Encoder[WorkState.Indexed] =
+    deriveConfiguredEncoder
+  
   implicit val _encWorkVisibleSource: Encoder[Work.Visible[WorkState.Source]] =
     deriveConfiguredEncoder
   implicit val _encWorkVisibleMerged: Encoder[Work.Visible[WorkState.Merged]] =

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/Implicits.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/Implicits.scala
@@ -100,11 +100,17 @@ object Implicits {
     deriveConfiguredDecoder
   implicit val _dec43: Decoder[ImageData[IdState.Identified]] =
     deriveConfiguredDecoder
-    
+
+  implicit val _decFormat: Decoder[Format] = deriveConfiguredDecoder
+  implicit val _decHoldings: Decoder[Holdings] = deriveConfiguredDecoder
   implicit val _decWorkType: Decoder[WorkType] = deriveConfiguredDecoder
   implicit val _decCollectionPath: Decoder[CollectionPath] =
     deriveConfiguredDecoder
-  implicit val _decRelation: Decoder[Relation] = deriveConfiguredDecoder  
+  implicit val _decRelation: Decoder[Relation] = deriveConfiguredDecoder
+  implicit val _decRelations: Decoder[Relations] = deriveConfiguredDecoder
+
+  implicit val _decDerivedWorkData: Decoder[DerivedWorkData] =
+    deriveConfiguredDecoder
   
   implicit val _dec45: Decoder[WorkData[DataState.Unidentified]] =
     deriveConfiguredDecoder
@@ -268,10 +274,16 @@ object Implicits {
   implicit val _enc43: Encoder[ImageData[IdState.Identified]] =
     deriveConfiguredEncoder
 
+  implicit val _encFormat: Encoder[Format] = deriveConfiguredEncoder
+  implicit val _encHoldings: Encoder[Holdings] = deriveConfiguredEncoder
   implicit val _encWorkType: Encoder[WorkType] = deriveConfiguredEncoder
   implicit val _encCollectionPath: Encoder[CollectionPath] =
     deriveConfiguredEncoder
   implicit val _encRelation: Encoder[Relation] = deriveConfiguredEncoder
+  implicit val _encRelations: Encoder[Relations] = deriveConfiguredEncoder
+
+  implicit val _encDerivedWorkData: Encoder[DerivedWorkData] =
+    deriveConfiguredEncoder
   
   implicit val _enc45: Encoder[WorkData[DataState.Unidentified]] =
     deriveConfiguredEncoder

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/Implicits.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/Implicits.scala
@@ -41,7 +41,7 @@ object Implicits {
   implicit val _decIdStateMinted: Decoder[IdState.Minted] = deriveConfiguredDecoder
 
   implicit val _dec05: Decoder[InstantRange] = deriveConfiguredDecoder
-  
+
   implicit val _decLicense: Decoder[License] = deriveConfiguredDecoder
   implicit val _decLocationType: Decoder[LocationType] = deriveConfiguredDecoder
   implicit val _decDigitalLocation: Decoder[DigitalLocation] =
@@ -75,7 +75,10 @@ object Implicits {
     deriveConfiguredDecoder
   implicit val _dec24: Decoder[Place[IdState.Unminted]] =
     deriveConfiguredDecoder
-  implicit val _dec25: Decoder[Period[IdState.Minted]] = deriveConfiguredDecoder
+
+  implicit val _decPeriodMinted: Decoder[Period[IdState.Minted]] = deriveConfiguredDecoder
+  implicit val _decPeriodUnminted: Decoder[Period[IdState.Unminted]] = deriveConfiguredDecoder
+
   implicit val _dec26: Decoder[Concept[IdState.Unminted]] =
     deriveConfiguredDecoder
   implicit val _dec27: Decoder[Concept[IdState.Minted]] =
@@ -130,12 +133,12 @@ object Implicits {
     deriveConfiguredDecoder
   implicit val _dec46: Decoder[WorkData[DataState.Identified]] =
     deriveConfiguredDecoder
-    
+
   implicit val _decInvisibilityReason: Decoder[InvisibilityReason] =
     deriveConfiguredDecoder
   implicit val _decDeletedReason: Decoder[DeletedReason] =
     deriveConfiguredDecoder
-    
+
   implicit val _decWorkStateSource: Decoder[WorkState.Source] =
     deriveConfiguredDecoder
   implicit val _decWorkStateMerged: Decoder[WorkState.Merged] =
@@ -146,7 +149,7 @@ object Implicits {
     deriveConfiguredDecoder
   implicit val _decWorkStateIndexed: Decoder[WorkState.Indexed] =
     deriveConfiguredDecoder
-  
+
   implicit val _decWorkVisibleSource: Decoder[Work.Visible[WorkState.Source]] =
     deriveConfiguredDecoder
   implicit val _decWorkVisibleMerged: Decoder[Work.Visible[WorkState.Merged]] =
@@ -157,7 +160,7 @@ object Implicits {
     deriveConfiguredDecoder
   implicit val _decWorkVisibleIndexed: Decoder[Work.Visible[WorkState.Indexed]] =
     deriveConfiguredDecoder
-  
+
   implicit val _decWorkInvisibleSource: Decoder[Work.Invisible[WorkState.Source]] =
     deriveConfiguredDecoder
   implicit val _decWorkInvisibleMerged: Decoder[Work.Invisible[WorkState.Merged]] =
@@ -168,7 +171,7 @@ object Implicits {
     deriveConfiguredDecoder
   implicit val _decWorkInvisibleIndexed: Decoder[Work.Invisible[WorkState.Indexed]] =
     deriveConfiguredDecoder
-  
+
   implicit val _decWorkRedirectedSource: Decoder[Work.Redirected[WorkState.Source]] =
     deriveConfiguredDecoder
   implicit val _decWorkRedirectedMerged: Decoder[Work.Redirected[WorkState.Merged]] =
@@ -190,7 +193,7 @@ object Implicits {
     deriveConfiguredDecoder
   implicit val _decWorkDeletedIndexed: Decoder[Work.Deleted[WorkState.Indexed]] =
     deriveConfiguredDecoder
-  
+
   implicit val _decWorkSource: Decoder[Work[WorkState.Source]] =
     deriveConfiguredDecoder
   implicit val _decWorkMerged: Decoder[Work[WorkState.Merged]] =
@@ -201,7 +204,7 @@ object Implicits {
     deriveConfiguredDecoder
   implicit val _decWorkIndexed: Decoder[Work[WorkState.Indexed]] =
     deriveConfiguredDecoder
-    
+
   implicit val _dec63: Decoder[ParentWorks] =
     deriveConfiguredDecoder
   implicit val _dec64: Decoder[ImageSource] =
@@ -223,7 +226,7 @@ object Implicits {
   implicit val _encIdStateIdentifiable: Encoder[IdState.Identifiable] = deriveConfiguredEncoder
   implicit val _encIdStateUnminted: Encoder[IdState.Unminted] = deriveConfiguredEncoder
   implicit val _encIdStateMinted: Encoder[IdState.Minted] = deriveConfiguredEncoder
-  
+
   implicit val _enc05: Encoder[InstantRange] = deriveConfiguredEncoder
 
   implicit val _encLicense: Encoder[License] = deriveConfiguredEncoder
@@ -233,7 +236,7 @@ object Implicits {
   implicit val _encPhysicalLocation: Encoder[PhysicalLocation] =
     deriveConfiguredEncoder
   implicit val _encLocation: Encoder[Location] = deriveConfiguredEncoder
-  
+
   implicit val _enc11
     : Encoder[MergeCandidate[ImageData[IdState.Identifiable]]] =
     deriveConfiguredEncoder
@@ -260,7 +263,10 @@ object Implicits {
     deriveConfiguredEncoder
   implicit val _enc24: Encoder[Place[IdState.Unminted]] =
     deriveConfiguredEncoder
-  implicit val _enc25: Encoder[Period[IdState.Minted]] = deriveConfiguredEncoder
+
+  implicit val _encPeriodMinted: Encoder[Period[IdState.Minted]] = deriveConfiguredEncoder
+  implicit val _encPeriodUnminted: Encoder[Period[IdState.Unminted]] = deriveConfiguredEncoder
+
   implicit val _enc26: Encoder[Concept[IdState.Unminted]] =
     deriveConfiguredEncoder
   implicit val _enc27: Encoder[Concept[IdState.Minted]] =
@@ -310,7 +316,7 @@ object Implicits {
     deriveConfiguredEncoder
   implicit val _envImageDataIdentified: Encoder[ImageData[IdState.Identified]] =
     deriveConfiguredEncoder
-  
+
   implicit val _enc45: Encoder[WorkData[DataState.Unidentified]] =
     deriveConfiguredEncoder
   implicit val _enc46: Encoder[WorkData[DataState.Identified]] =
@@ -320,7 +326,7 @@ object Implicits {
     deriveConfiguredEncoder
   implicit val _encDeletedReason: Encoder[DeletedReason] =
     deriveConfiguredEncoder
-  
+
   implicit val _encWorkStateSource: Encoder[WorkState.Source] =
     deriveConfiguredEncoder
   implicit val _encWorkStateMerged: Encoder[WorkState.Merged] =
@@ -331,7 +337,7 @@ object Implicits {
     deriveConfiguredEncoder
   implicit val _encWorkStateIndexed: Encoder[WorkState.Indexed] =
     deriveConfiguredEncoder
-  
+
   implicit val _encWorkVisibleSource: Encoder[Work.Visible[WorkState.Source]] =
     deriveConfiguredEncoder
   implicit val _encWorkVisibleMerged: Encoder[Work.Visible[WorkState.Merged]] =
@@ -386,7 +392,7 @@ object Implicits {
     deriveConfiguredEncoder
   implicit val _encWorkIndexed: Encoder[Work[WorkState.Indexed]] =
     deriveConfiguredEncoder
-  
+
   implicit val _enc63: Encoder[ParentWorks] =
     deriveConfiguredEncoder
   implicit val _enc64: Encoder[ImageSource] =

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/Implicits.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/Implicits.scala
@@ -37,8 +37,8 @@ object Implicits {
 
   implicit val _decIdentifierType: Decoder[IdentifierType] = IdentifierType.identifierTypeDecoder
   implicit val _decSourceIdentifier: Decoder[SourceIdentifier] = deriveConfiguredDecoder
-  implicit val _decCanonicalId: Decoder[CanonicalId] = deriveConfiguredDecoder
-  implicit val _decReferenceNumber: Decoder[ReferenceNumber] = deriveConfiguredDecoder
+  implicit val _decCanonicalId: Decoder[CanonicalId] = CanonicalId.decoder
+  implicit val _decReferenceNumber: Decoder[ReferenceNumber] = ReferenceNumber.decoder
 
   implicit val _decIdStateIdentified: Decoder[IdState.Identified] = deriveConfiguredDecoder
   implicit val _decIdStateIdentifiable: Decoder[IdState.Identifiable] = deriveConfiguredDecoder
@@ -237,8 +237,8 @@ object Implicits {
 
   implicit val _encIdentifierType: Encoder[IdentifierType] = IdentifierType.identifierTypeEncoder
   implicit val _encSourceIdentifier: Encoder[SourceIdentifier] = deriveConfiguredEncoder
-  implicit val _encCanonicalId: Encoder[CanonicalId] = deriveConfiguredEncoder
-  implicit val _envReferenceNumber: Encoder[ReferenceNumber] = deriveConfiguredEncoder
+  implicit val _encCanonicalId: Encoder[CanonicalId] = CanonicalId.encoder
+  implicit val _envReferenceNumber: Encoder[ReferenceNumber] = ReferenceNumber.encoder
 
   implicit val _encIdStateIdentified: Encoder[IdState.Identified] = deriveConfiguredEncoder
   implicit val _encIdStateIdentifiable: Encoder[IdState.Identifiable] = deriveConfiguredEncoder

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/Implicits.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/Implicits.scala
@@ -100,8 +100,12 @@ object Implicits {
     deriveConfiguredDecoder
   implicit val _dec43: Decoder[ImageData[IdState.Identified]] =
     deriveConfiguredDecoder
-  implicit val _dec44: Decoder[CollectionPath] =
+    
+  implicit val _decWorkType: Decoder[WorkType] = deriveConfiguredDecoder
+  implicit val _decCollectionPath: Decoder[CollectionPath] =
     deriveConfiguredDecoder
+  implicit val _decRelation: Decoder[Relation] = deriveConfiguredDecoder  
+  
   implicit val _dec45: Decoder[WorkData[DataState.Unidentified]] =
     deriveConfiguredDecoder
   implicit val _dec46: Decoder[WorkData[DataState.Identified]] =
@@ -258,8 +262,12 @@ object Implicits {
     deriveConfiguredEncoder
   implicit val _enc43: Encoder[ImageData[IdState.Identified]] =
     deriveConfiguredEncoder
-  implicit val _enc44: Encoder[CollectionPath] =
+
+  implicit val _encWorkType: Encoder[WorkType] = deriveConfiguredEncoder
+  implicit val _encCollectionPath: Encoder[CollectionPath] =
     deriveConfiguredEncoder
+  implicit val _encRelation: Encoder[Relation] = deriveConfiguredEncoder
+  
   implicit val _enc45: Encoder[WorkData[DataState.Unidentified]] =
     deriveConfiguredEncoder
   implicit val _enc46: Encoder[WorkData[DataState.Identified]] =

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/Implicits.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/Implicits.scala
@@ -32,8 +32,8 @@ object Implicits {
   // then WorkData, then the other images and works due to the order of
   // dependencies (thus preventing duplicate work)
 
-  implicit val _dec00: Decoder[AccessCondition] = deriveConfiguredDecoder
-  implicit val _dec01: Decoder[Note] = deriveConfiguredDecoder
+  implicit val _decAccessCondition: Decoder[AccessCondition] = deriveConfiguredDecoder
+  implicit val _decNote: Decoder[Note] = deriveConfiguredDecoder
 
   implicit val _decIdentifierType: Decoder[IdentifierType] = IdentifierType.identifierTypeDecoder
   implicit val _decSourceIdentifier: Decoder[SourceIdentifier] = deriveConfiguredDecoder
@@ -44,8 +44,6 @@ object Implicits {
   implicit val _decIdStateIdentifiable: Decoder[IdState.Identifiable] = deriveConfiguredDecoder
   implicit val _decIdStateUnminted: Decoder[IdState.Unminted] = deriveConfiguredDecoder
   implicit val _decIdStateMinted: Decoder[IdState.Minted] = deriveConfiguredDecoder
-
-  implicit val _dec05: Decoder[InstantRange] = deriveConfiguredDecoder
 
   implicit val _decLanguage: Decoder[Language] = deriveConfiguredDecoder
 
@@ -64,63 +62,81 @@ object Implicits {
   implicit val _decMergeCandidateIdentified: Decoder[MergeCandidate[IdState.Identified]] =
     deriveConfiguredDecoder
 
-  implicit val _dec13: Decoder[MatcherResult] = deriveConfiguredDecoder
-  implicit val _dec14: Decoder[Person[IdState.Unminted]] =
+  implicit val _decAgentUnminted: Decoder[Agent[IdState.Unminted]] =
     deriveConfiguredDecoder
-  implicit val _dec15: Decoder[Person[IdState.Minted]] = deriveConfiguredDecoder
-  implicit val _dec16: Decoder[Meeting[IdState.Unminted]] =
+  implicit val _decAgentMinted: Decoder[Agent[IdState.Minted]] = deriveConfiguredDecoder
+  implicit val _decMeetingUnminted: Decoder[Meeting[IdState.Unminted]] =
     deriveConfiguredDecoder
-  implicit val _dec17: Decoder[Meeting[IdState.Minted]] =
+  implicit val _decMeetingMinted: Decoder[Meeting[IdState.Minted]] =
     deriveConfiguredDecoder
-  implicit val _dec18: Decoder[Organisation[IdState.Unminted]] =
+  implicit val _decOrganisationUnminted: Decoder[Organisation[IdState.Unminted]] =
     deriveConfiguredDecoder
-  implicit val _dec19: Decoder[Organisation[IdState.Minted]] =
+  implicit val _decOrganisationMinted: Decoder[Organisation[IdState.Minted]] =
     deriveConfiguredDecoder
-  implicit val _dec20: Decoder[Agent[IdState.Unminted]] =
+  implicit val _decPersonUnminted: Decoder[Person[IdState.Unminted]] =
     deriveConfiguredDecoder
-  implicit val _dec21: Decoder[Agent[IdState.Minted]] = deriveConfiguredDecoder
-  implicit val _dec22: Decoder[AbstractAgent[IdState.Unminted]] =
+  implicit val _decPersonMinted: Decoder[Person[IdState.Minted]] = deriveConfiguredDecoder
+
+  // The four classes above (Agent, Meeting, Organisation, Person) are the
+  // implementations of AbstractAgent.  We deliberately wait until we have those
+  // decoders before creating these two decoders.
+  implicit val _decAbstractAgentUnminted: Decoder[AbstractAgent[IdState.Unminted]] =
     deriveConfiguredDecoder
-  implicit val _dec23: Decoder[AbstractAgent[IdState.Minted]] =
+  implicit val _decAbstractAgentMinted: Decoder[AbstractAgent[IdState.Minted]] =
     deriveConfiguredDecoder
 
-  implicit val _decPlaceMinted: Decoder[Place[IdState.Minted]] =
+  implicit val _decConceptUnminted: Decoder[Concept[IdState.Unminted]] =
     deriveConfiguredDecoder
+  implicit val _decConceptMinted: Decoder[Concept[IdState.Minted]] =
+    deriveConfiguredDecoder
+
+  implicit val _decInstantRange: Decoder[InstantRange] = deriveConfiguredDecoder
+  implicit val _decPeriodUnminted: Decoder[Period[IdState.Unminted]] = deriveConfiguredDecoder
+  implicit val _decPeriodMinted: Decoder[Period[IdState.Minted]] = deriveConfiguredDecoder
+
   implicit val _decPlaceUnminted: Decoder[Place[IdState.Unminted]] =
     deriveConfiguredDecoder
+  implicit val _decPlaceMinted: Decoder[Place[IdState.Minted]] =
+    deriveConfiguredDecoder
 
-  implicit val _decPeriodMinted: Decoder[Period[IdState.Minted]] = deriveConfiguredDecoder
-  implicit val _decPeriodUnminted: Decoder[Period[IdState.Unminted]] = deriveConfiguredDecoder
+  // The classes above (Concept, Period, Place) are the implementations of
+  // AbstractConcept.  We deliberately wait until we have those decoders
+  // before creating these two decoders.
+  implicit val _decAbstractConceptUnminted: Decoder[AbstractConcept[IdState.Unminted]] =
+  deriveConfiguredDecoder
+  implicit val _decAbstractConceptMinted: Decoder[AbstractConcept[IdState.Minted]] =
+    deriveConfiguredDecoder
 
-  implicit val _dec26: Decoder[Concept[IdState.Unminted]] =
+  // A ProductionEvent uses AbstractAgent, Concept, Period and Place.
+  implicit val _decProductionEventUnminted: Decoder[ProductionEvent[IdState.Unminted]] =
     deriveConfiguredDecoder
-  implicit val _dec27: Decoder[Concept[IdState.Minted]] =
+  implicit val _decProductionEventMinted: Decoder[ProductionEvent[IdState.Minted]] =
     deriveConfiguredDecoder
-  implicit val _dec28: Decoder[AbstractConcept[IdState.Unminted]] =
+    
+  // An AbstractRootConcept is one of AbstractAgent and AbstractConcept
+  implicit val _decAbstractRootConceptUnminted: Decoder[AbstractRootConcept[IdState.Unminted]] =
     deriveConfiguredDecoder
-  implicit val _dec29: Decoder[AbstractConcept[IdState.Minted]] =
+  implicit val _decAbstractRootConceptMinted: Decoder[AbstractRootConcept[IdState.Minted]] =
     deriveConfiguredDecoder
-  implicit val _dec30: Decoder[AbstractRootConcept[IdState.Unminted]] =
+
+  // Contributor, Genre, and Subject all use a mixture of AbstractAgent,
+  // AbstractConcept and AbstractRootConcept.
+  implicit val _decContributorUnminted: Decoder[Contributor[IdState.Unminted]] =
+  deriveConfiguredDecoder
+  implicit val _decContributorMinted: Decoder[Contributor[IdState.Minted]] =
     deriveConfiguredDecoder
-  implicit val _dec31: Decoder[AbstractRootConcept[IdState.Minted]] =
+  implicit val _decGenreUnminted: Decoder[Genre[IdState.Unminted]] =
     deriveConfiguredDecoder
-  implicit val _dec32: Decoder[Genre[IdState.Unminted]] =
+  implicit val _decGenreMinted: Decoder[Genre[IdState.Minted]] = deriveConfiguredDecoder
+  implicit val _decSubjectUnminted: Decoder[Subject[IdState.Unminted]] =
     deriveConfiguredDecoder
-  implicit val _dec33: Decoder[Genre[IdState.Minted]] = deriveConfiguredDecoder
-  implicit val _dec34: Decoder[Subject[IdState.Unminted]] =
+  implicit val _decSubjectMinted: Decoder[Subject[IdState.Minted]] =
     deriveConfiguredDecoder
-  implicit val _dec35: Decoder[Subject[IdState.Minted]] =
-    deriveConfiguredDecoder
-  implicit val _dec36: Decoder[ProductionEvent[IdState.Unminted]] =
-    deriveConfiguredDecoder
-  implicit val _dec37: Decoder[ProductionEvent[IdState.Minted]] =
-    deriveConfiguredDecoder
-  implicit val _dec38: Decoder[Item[IdState.Unminted]] = deriveConfiguredDecoder
-  implicit val _dec39: Decoder[Item[IdState.Minted]] = deriveConfiguredDecoder
-  implicit val _dec40: Decoder[Contributor[IdState.Unminted]] =
-    deriveConfiguredDecoder
-  implicit val _dec41: Decoder[Contributor[IdState.Minted]] =
-    deriveConfiguredDecoder
+
+  implicit val _decMergeCandidate: Decoder[MatcherResult] = deriveConfiguredDecoder
+  
+  implicit val _decItemUnminted: Decoder[Item[IdState.Unminted]] = deriveConfiguredDecoder
+  implicit val _decItemMinted: Decoder[Item[IdState.Minted]] = deriveConfiguredDecoder
 
   implicit val _decFormat: Decoder[Format] = Format.formatDecoder
   implicit val _decHoldings: Decoder[Holdings] = deriveConfiguredDecoder
@@ -221,19 +237,19 @@ object Implicits {
   implicit val _decWorkIndexed: Decoder[Work[WorkState.Indexed]] =
     deriveConfiguredDecoder
 
-  implicit val _dec63: Decoder[ParentWorks] =
+  implicit val _decParentWorks: Decoder[ParentWorks] =
     deriveConfiguredDecoder
-  implicit val _dec64: Decoder[ImageSource] =
+  implicit val _decImageSource: Decoder[ImageSource] =
     deriveConfiguredDecoder
-  implicit val _dec65: Decoder[Image[ImageState.Initial]] =
+  implicit val _decImageInitial: Decoder[Image[ImageState.Initial]] =
     deriveConfiguredDecoder
-  implicit val _dec66: Decoder[Image[ImageState.Augmented]] =
+  implicit val _decImageAugmented: Decoder[Image[ImageState.Augmented]] =
     deriveConfiguredDecoder
-  implicit val _dec67: Decoder[Image[ImageState.Indexed]] =
+  implicit val _decImageIndexed: Decoder[Image[ImageState.Indexed]] =
     deriveConfiguredDecoder
 
-  implicit val _enc00: Encoder[AccessCondition] = deriveConfiguredEncoder
-  implicit val _enc01: Encoder[Note] = deriveConfiguredEncoder
+  implicit val _encAccessCondition: Encoder[AccessCondition] = deriveConfiguredEncoder
+  implicit val _encNote: Encoder[Note] = deriveConfiguredEncoder
 
   implicit val _encIdentifierType: Encoder[IdentifierType] = IdentifierType.identifierTypeEncoder
   implicit val _encSourceIdentifier: Encoder[SourceIdentifier] = deriveConfiguredEncoder
@@ -244,8 +260,6 @@ object Implicits {
   implicit val _encIdStateIdentifiable: Encoder[IdState.Identifiable] = deriveConfiguredEncoder
   implicit val _encIdStateUnminted: Encoder[IdState.Unminted] = deriveConfiguredEncoder
   implicit val _encIdStateMinted: Encoder[IdState.Minted] = deriveConfiguredEncoder
-
-  implicit val _enc05: Encoder[InstantRange] = deriveConfiguredEncoder
 
   implicit val _encLanguage: Encoder[Language] = deriveConfiguredEncoder
 
@@ -263,64 +277,82 @@ object Implicits {
     deriveConfiguredEncoder
   implicit val _encMergeCandidateIdentified: Encoder[MergeCandidate[IdState.Identified]] =
     deriveConfiguredEncoder
-  
-  implicit val _enc13: Encoder[MatcherResult] = deriveConfiguredEncoder
-  implicit val _enc14: Encoder[Person[IdState.Unminted]] =
+
+  implicit val _encAgentUnminted: Encoder[Agent[IdState.Unminted]] =
     deriveConfiguredEncoder
-  implicit val _enc15: Encoder[Person[IdState.Minted]] = deriveConfiguredEncoder
-  implicit val _enc16: Encoder[Meeting[IdState.Unminted]] =
+  implicit val _encAgentMinted: Encoder[Agent[IdState.Minted]] = deriveConfiguredEncoder
+  implicit val _encMeetingUnminted: Encoder[Meeting[IdState.Unminted]] =
     deriveConfiguredEncoder
-  implicit val _enc17: Encoder[Meeting[IdState.Minted]] =
+  implicit val _encMeetingMinted: Encoder[Meeting[IdState.Minted]] =
     deriveConfiguredEncoder
-  implicit val _enc18: Encoder[Organisation[IdState.Unminted]] =
+  implicit val _encOrganisationUnminted: Encoder[Organisation[IdState.Unminted]] =
     deriveConfiguredEncoder
-  implicit val _enc19: Encoder[Organisation[IdState.Minted]] =
+  implicit val _encOrganisationMinted: Encoder[Organisation[IdState.Minted]] =
     deriveConfiguredEncoder
-  implicit val _enc20: Encoder[Agent[IdState.Unminted]] =
+  implicit val _encPersonUnminted: Encoder[Person[IdState.Unminted]] =
     deriveConfiguredEncoder
-  implicit val _enc21: Encoder[Agent[IdState.Minted]] = deriveConfiguredEncoder
-  implicit val _enc22: Encoder[AbstractAgent[IdState.Unminted]] =
-    deriveConfiguredEncoder
-  implicit val _enc23: Encoder[AbstractAgent[IdState.Minted]] =
+  implicit val _encPersonMinted: Encoder[Person[IdState.Minted]] = deriveConfiguredEncoder
+
+  // The four classes above (Agent, Meeting, Organisation, Person) are the
+  // implementations of AbstractAgent.  We deliberately wait until we have those
+  // Encoders before creating these two Encoders.
+  implicit val _encAbstractAgentUnminted: Encoder[AbstractAgent[IdState.Unminted]] =
+  deriveConfiguredEncoder
+  implicit val _encAbstractAgentMinted: Encoder[AbstractAgent[IdState.Minted]] =
     deriveConfiguredEncoder
 
-  implicit val _encPlaceMinted: Encoder[Place[IdState.Minted]] =
+  implicit val _encConceptUnminted: Encoder[Concept[IdState.Unminted]] =
     deriveConfiguredEncoder
+  implicit val _encConceptMinted: Encoder[Concept[IdState.Minted]] =
+    deriveConfiguredEncoder
+
+  implicit val _encInstantRange: Encoder[InstantRange] = deriveConfiguredEncoder
+  implicit val _encPeriodUnminted: Encoder[Period[IdState.Unminted]] = deriveConfiguredEncoder
+  implicit val _encPeriodMinted: Encoder[Period[IdState.Minted]] = deriveConfiguredEncoder
+
   implicit val _encPlaceUnminted: Encoder[Place[IdState.Unminted]] =
     deriveConfiguredEncoder
+  implicit val _encPlaceMinted: Encoder[Place[IdState.Minted]] =
+    deriveConfiguredEncoder
 
-  implicit val _encPeriodMinted: Encoder[Period[IdState.Minted]] = deriveConfiguredEncoder
-  implicit val _encPeriodUnminted: Encoder[Period[IdState.Unminted]] = deriveConfiguredEncoder
+  // The classes above (Concept, Period, Place) are the implementations of
+  // AbstractConcept.  We deliberately wait until we have those Encoders
+  // before creating these two Encoders.
+  implicit val _encAbstractConceptUnminted: Encoder[AbstractConcept[IdState.Unminted]] =
+  deriveConfiguredEncoder
+  implicit val _encAbstractConceptMinted: Encoder[AbstractConcept[IdState.Minted]] =
+    deriveConfiguredEncoder
 
-  implicit val _enc26: Encoder[Concept[IdState.Unminted]] =
+  // A ProductionEvent uses AbstractAgent, Concept, Period and Place.
+  implicit val _encProductionEventUnminted: Encoder[ProductionEvent[IdState.Unminted]] =
     deriveConfiguredEncoder
-  implicit val _enc27: Encoder[Concept[IdState.Minted]] =
+  implicit val _encProductionEventMinted: Encoder[ProductionEvent[IdState.Minted]] =
     deriveConfiguredEncoder
-  implicit val _enc28: Encoder[AbstractConcept[IdState.Unminted]] =
+
+  // An AbstractRootConcept is one of AbstractAgent and AbstractConcept
+  implicit val _encAbstractRootConceptUnminted: Encoder[AbstractRootConcept[IdState.Unminted]] =
     deriveConfiguredEncoder
-  implicit val _enc29: Encoder[AbstractConcept[IdState.Minted]] =
+  implicit val _encAbstractRootConceptMinted: Encoder[AbstractRootConcept[IdState.Minted]] =
     deriveConfiguredEncoder
-  implicit val _enc30: Encoder[AbstractRootConcept[IdState.Unminted]] =
+
+  // Contributor, Genre, and Subject all use a mixture of AbstractAgent,
+  // AbstractConcept and AbstractRootConcept.
+  implicit val _encContributorUnminted: Encoder[Contributor[IdState.Unminted]] =
+  deriveConfiguredEncoder
+  implicit val _encContributorMinted: Encoder[Contributor[IdState.Minted]] =
     deriveConfiguredEncoder
-  implicit val _enc31: Encoder[AbstractRootConcept[IdState.Minted]] =
+  implicit val _encGenreUnminted: Encoder[Genre[IdState.Unminted]] =
     deriveConfiguredEncoder
-  implicit val _enc32: Encoder[Genre[IdState.Unminted]] =
+  implicit val _encGenreMinted: Encoder[Genre[IdState.Minted]] = deriveConfiguredEncoder
+  implicit val _encSubjectUnminted: Encoder[Subject[IdState.Unminted]] =
     deriveConfiguredEncoder
-  implicit val _enc33: Encoder[Genre[IdState.Minted]] = deriveConfiguredEncoder
-  implicit val _enc34: Encoder[Subject[IdState.Unminted]] =
+  implicit val _encSubjectMinted: Encoder[Subject[IdState.Minted]] =
     deriveConfiguredEncoder
-  implicit val _enc35: Encoder[Subject[IdState.Minted]] =
-    deriveConfiguredEncoder
-  implicit val _enc36: Encoder[ProductionEvent[IdState.Unminted]] =
-    deriveConfiguredEncoder
-  implicit val _enc37: Encoder[ProductionEvent[IdState.Minted]] =
-    deriveConfiguredEncoder
-  implicit val _enc38: Encoder[Item[IdState.Unminted]] = deriveConfiguredEncoder
-  implicit val _enc39: Encoder[Item[IdState.Minted]] = deriveConfiguredEncoder
-  implicit val _enc40: Encoder[Contributor[IdState.Unminted]] =
-    deriveConfiguredEncoder
-  implicit val _enc41: Encoder[Contributor[IdState.Minted]] =
-    deriveConfiguredEncoder
+
+  implicit val _encMergeCandidate: Encoder[MatcherResult] = deriveConfiguredEncoder
+
+  implicit val _encItemUnminted: Encoder[Item[IdState.Unminted]] = deriveConfiguredEncoder
+  implicit val _encItemMinted: Encoder[Item[IdState.Minted]] = deriveConfiguredEncoder
 
   implicit val _encFormat: Encoder[Format] = Format.formatEncoder
   implicit val _encHoldings: Encoder[Holdings] = deriveConfiguredEncoder
@@ -342,9 +374,9 @@ object Implicits {
   implicit val _envImageDataIdentified: Encoder[ImageData[IdState.Identified]] =
     deriveConfiguredEncoder
 
-  implicit val _enc45: Encoder[WorkData[DataState.Unidentified]] =
+  implicit val _encWorkDataUnidentified: Encoder[WorkData[DataState.Unidentified]] =
     deriveConfiguredEncoder
-  implicit val _enc46: Encoder[WorkData[DataState.Identified]] =
+  implicit val _envWorkDataIdentified: Encoder[WorkData[DataState.Identified]] =
     deriveConfiguredEncoder
 
   implicit val _encInvisibilityReason: Encoder[InvisibilityReason] =
@@ -421,14 +453,14 @@ object Implicits {
   implicit val _encWorkIndexed: Encoder[Work[WorkState.Indexed]] =
     deriveConfiguredEncoder
 
-  implicit val _enc63: Encoder[ParentWorks] =
+  implicit val _encParentWorks: Encoder[ParentWorks] =
     deriveConfiguredEncoder
-  implicit val _enc64: Encoder[ImageSource] =
+  implicit val _encImageSource: Encoder[ImageSource] =
     deriveConfiguredEncoder
-  implicit val _enc65: Encoder[Image[ImageState.Initial]] =
+  implicit val _encImageInitial: Encoder[Image[ImageState.Initial]] =
     deriveConfiguredEncoder
-  implicit val _enc66: Encoder[Image[ImageState.Augmented]] =
+  implicit val _encImageAugmented: Encoder[Image[ImageState.Augmented]] =
     deriveConfiguredEncoder
-  implicit val _enc67: Encoder[Image[ImageState.Indexed]] =
+  implicit val _encImageIndexed: Encoder[Image[ImageState.Indexed]] =
     deriveConfiguredEncoder
 }

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/Implicits.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/Implicits.scala
@@ -111,6 +111,11 @@ object Implicits {
   implicit val _dec46: Decoder[WorkData[DataState.Identified]] =
     deriveConfiguredDecoder
     
+  implicit val _decInvisibilityReason: Decoder[InvisibilityReason] =
+    deriveConfiguredDecoder
+  implicit val _decDeletedReason: Decoder[DeletedReason] =
+    deriveConfiguredDecoder
+    
   implicit val _decWorkStateSource: Decoder[WorkState.Source] =
     deriveConfiguredDecoder
   implicit val _decWorkStateMerged: Decoder[WorkState.Merged] =
@@ -273,6 +278,11 @@ object Implicits {
   implicit val _enc46: Encoder[WorkData[DataState.Identified]] =
     deriveConfiguredEncoder
 
+  implicit val _encInvisibilityReason: Encoder[InvisibilityReason] =
+    deriveConfiguredEncoder
+  implicit val _encDeletedReason: Encoder[DeletedReason] =
+    deriveConfiguredEncoder
+  
   implicit val _encWorkStateSource: Encoder[WorkState.Source] =
     deriveConfiguredEncoder
   implicit val _encWorkStateMerged: Encoder[WorkState.Merged] =

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/Implicits.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/Implicits.scala
@@ -29,7 +29,10 @@ object Implicits {
 
   implicit val _dec00: Decoder[AccessCondition] = deriveConfiguredDecoder
   implicit val _dec01: Decoder[Note] = deriveConfiguredDecoder
-  implicit val _dec02: Decoder[SourceIdentifier] = deriveConfiguredDecoder
+
+  implicit val _decSourceIdentifier: Decoder[SourceIdentifier] = deriveConfiguredDecoder
+  implicit val _decCanonicalId: Decoder[CanonicalId] = deriveConfiguredDecoder
+
   implicit val _dec03: Decoder[IdState.Unminted] = deriveConfiguredDecoder
   implicit val _dec04: Decoder[IdState.Minted] = deriveConfiguredDecoder
   implicit val _dec05: Decoder[InstantRange] = deriveConfiguredDecoder
@@ -183,7 +186,10 @@ object Implicits {
 
   implicit val _enc00: Encoder[AccessCondition] = deriveConfiguredEncoder
   implicit val _enc01: Encoder[Note] = deriveConfiguredEncoder
-  implicit val _enc02: Encoder[SourceIdentifier] = deriveConfiguredEncoder
+
+  implicit val _encSourceIdentifier: Encoder[SourceIdentifier] = deriveConfiguredEncoder
+  implicit val _encCanonicalId: Encoder[CanonicalId] = deriveConfiguredEncoder
+
   implicit val _enc03: Encoder[IdState.Unminted] = deriveConfiguredEncoder
   implicit val _enc04: Encoder[IdState.Minted] = deriveConfiguredEncoder
   implicit val _enc05: Encoder[InstantRange] = deriveConfiguredEncoder

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/Implicits.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/Implicits.scala
@@ -7,10 +7,12 @@ import weco.catalogue.internal_model.image._
 import weco.catalogue.internal_model.locations.{
   AccessCondition,
   DigitalLocation,
+  DigitalLocationType,
   License,
   Location,
   LocationType,
-  PhysicalLocation
+  PhysicalLocation,
+  PhysicalLocationType
 }
 import weco.catalogue.internal_model.matcher.MatcherResult
 import weco.catalogue.internal_model.work._
@@ -32,6 +34,7 @@ object Implicits {
   implicit val _dec00: Decoder[AccessCondition] = deriveConfiguredDecoder
   implicit val _dec01: Decoder[Note] = deriveConfiguredDecoder
 
+  implicit val _decIdentifierType: Decoder[IdentifierType] = IdentifierType.identifierTypeDecoder
   implicit val _decSourceIdentifier: Decoder[SourceIdentifier] = deriveConfiguredDecoder
   implicit val _decCanonicalId: Decoder[CanonicalId] = deriveConfiguredDecoder
 
@@ -42,8 +45,10 @@ object Implicits {
 
   implicit val _dec05: Decoder[InstantRange] = deriveConfiguredDecoder
 
-  implicit val _decLicense: Decoder[License] = deriveConfiguredDecoder
-  implicit val _decLocationType: Decoder[LocationType] = deriveConfiguredDecoder
+  implicit val _decLicense: Decoder[License] = License.licenseDecoder
+  implicit val _decPhysicalLocationType: Decoder[PhysicalLocationType] = LocationType.physicalLocationTypeDecoder
+  implicit val _decDigitalLocationType: Decoder[DigitalLocationType] = LocationType.digitalLocationTypeDecoder
+  implicit val _decLocationType: Decoder[LocationType] = LocationType.locationTypeDecoder
   implicit val _decDigitalLocation: Decoder[DigitalLocation] =
     deriveConfiguredDecoder
   implicit val _decPhysicalLocation: Decoder[PhysicalLocation] =
@@ -109,9 +114,9 @@ object Implicits {
   implicit val _dec41: Decoder[Contributor[IdState.Minted]] =
     deriveConfiguredDecoder
 
-  implicit val _decFormat: Decoder[Format] = deriveConfiguredDecoder
+  implicit val _decFormat: Decoder[Format] = Format.formatDecoder
   implicit val _decHoldings: Decoder[Holdings] = deriveConfiguredDecoder
-  implicit val _decWorkType: Decoder[WorkType] = deriveConfiguredDecoder
+  implicit val _decWorkType: Decoder[WorkType] = WorkType.workTypeDecoder
   implicit val _decCollectionPath: Decoder[CollectionPath] =
     deriveConfiguredDecoder
   implicit val _decRelation: Decoder[Relation] = deriveConfiguredDecoder
@@ -138,6 +143,9 @@ object Implicits {
     deriveConfiguredDecoder
   implicit val _decDeletedReason: Decoder[DeletedReason] =
     deriveConfiguredDecoder
+
+  implicit val _decAvailability: Decoder[Availability] =
+    Availability.availabilityDecoder
 
   implicit val _decWorkStateSource: Decoder[WorkState.Source] =
     deriveConfiguredDecoder
@@ -219,6 +227,7 @@ object Implicits {
   implicit val _enc00: Encoder[AccessCondition] = deriveConfiguredEncoder
   implicit val _enc01: Encoder[Note] = deriveConfiguredEncoder
 
+  implicit val _encIdentifierType: Encoder[IdentifierType] = IdentifierType.identifierTypeEncoder
   implicit val _encSourceIdentifier: Encoder[SourceIdentifier] = deriveConfiguredEncoder
   implicit val _encCanonicalId: Encoder[CanonicalId] = deriveConfiguredEncoder
 
@@ -229,8 +238,10 @@ object Implicits {
 
   implicit val _enc05: Encoder[InstantRange] = deriveConfiguredEncoder
 
-  implicit val _encLicense: Encoder[License] = deriveConfiguredEncoder
-  implicit val _encLocationType: Encoder[LocationType] = deriveConfiguredEncoder
+  implicit val _encLicense: Encoder[License] = License.licenseEncoder
+  implicit val _encPhysicalLocationType: Encoder[PhysicalLocationType] = LocationType.physicalLocationTypeEncoder
+  implicit val _encDigitalLocationType: Encoder[DigitalLocationType] = LocationType.digitalLocationTypeEncoder
+  implicit val _encLocationType: Encoder[LocationType] = LocationType.locationTypeEncoder
   implicit val _encDigitalLocation: Encoder[DigitalLocation] =
     deriveConfiguredEncoder
   implicit val _encPhysicalLocation: Encoder[PhysicalLocation] =
@@ -297,9 +308,9 @@ object Implicits {
   implicit val _enc41: Encoder[Contributor[IdState.Minted]] =
     deriveConfiguredEncoder
 
-  implicit val _encFormat: Encoder[Format] = deriveConfiguredEncoder
+  implicit val _encFormat: Encoder[Format] = Format.formatEncoder
   implicit val _encHoldings: Encoder[Holdings] = deriveConfiguredEncoder
-  implicit val _encWorkType: Encoder[WorkType] = deriveConfiguredEncoder
+  implicit val _encWorkType: Encoder[WorkType] = WorkType.workTypeEncoder
   implicit val _encCollectionPath: Encoder[CollectionPath] =
     deriveConfiguredEncoder
   implicit val _encRelation: Encoder[Relation] = deriveConfiguredEncoder
@@ -326,6 +337,9 @@ object Implicits {
     deriveConfiguredEncoder
   implicit val _encDeletedReason: Encoder[DeletedReason] =
     deriveConfiguredEncoder
+
+  implicit val _envAvailability: Encoder[Availability] =
+    Availability.availabilityEncoder
 
   implicit val _encWorkStateSource: Encoder[WorkState.Source] =
     deriveConfiguredEncoder

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/Implicits.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/Implicits.scala
@@ -32,55 +32,72 @@ object Implicits {
   // then WorkData, then the other images and works due to the order of
   // dependencies (thus preventing duplicate work)
 
-  implicit val _decAccessCondition: Decoder[AccessCondition] = deriveConfiguredDecoder
+  implicit val _decAccessCondition: Decoder[AccessCondition] =
+    deriveConfiguredDecoder
   implicit val _decNote: Decoder[Note] = deriveConfiguredDecoder
 
-  implicit val _decIdentifierType: Decoder[IdentifierType] = IdentifierType.identifierTypeDecoder
-  implicit val _decSourceIdentifier: Decoder[SourceIdentifier] = deriveConfiguredDecoder
+  implicit val _decIdentifierType: Decoder[IdentifierType] =
+    IdentifierType.identifierTypeDecoder
+  implicit val _decSourceIdentifier: Decoder[SourceIdentifier] =
+    deriveConfiguredDecoder
   implicit val _decCanonicalId: Decoder[CanonicalId] = CanonicalId.decoder
-  implicit val _decReferenceNumber: Decoder[ReferenceNumber] = ReferenceNumber.decoder
+  implicit val _decReferenceNumber: Decoder[ReferenceNumber] =
+    ReferenceNumber.decoder
 
-  implicit val _decIdStateIdentified: Decoder[IdState.Identified] = deriveConfiguredDecoder
-  implicit val _decIdStateIdentifiable: Decoder[IdState.Identifiable] = deriveConfiguredDecoder
-  implicit val _decIdStateUnminted: Decoder[IdState.Unminted] = deriveConfiguredDecoder
-  implicit val _decIdStateMinted: Decoder[IdState.Minted] = deriveConfiguredDecoder
+  implicit val _decIdStateIdentified: Decoder[IdState.Identified] =
+    deriveConfiguredDecoder
+  implicit val _decIdStateIdentifiable: Decoder[IdState.Identifiable] =
+    deriveConfiguredDecoder
+  implicit val _decIdStateUnminted: Decoder[IdState.Unminted] =
+    deriveConfiguredDecoder
+  implicit val _decIdStateMinted: Decoder[IdState.Minted] =
+    deriveConfiguredDecoder
 
   implicit val _decLanguage: Decoder[Language] = deriveConfiguredDecoder
 
   implicit val _decLicense: Decoder[License] = License.licenseDecoder
-  implicit val _decPhysicalLocationType: Decoder[PhysicalLocationType] = LocationType.physicalLocationTypeDecoder
-  implicit val _decDigitalLocationType: Decoder[DigitalLocationType] = LocationType.digitalLocationTypeDecoder
-  implicit val _decLocationType: Decoder[LocationType] = LocationType.locationTypeDecoder
+  implicit val _decPhysicalLocationType: Decoder[PhysicalLocationType] =
+    LocationType.physicalLocationTypeDecoder
+  implicit val _decDigitalLocationType: Decoder[DigitalLocationType] =
+    LocationType.digitalLocationTypeDecoder
+  implicit val _decLocationType: Decoder[LocationType] =
+    LocationType.locationTypeDecoder
   implicit val _decDigitalLocation: Decoder[DigitalLocation] =
     deriveConfiguredDecoder
   implicit val _decPhysicalLocation: Decoder[PhysicalLocation] =
     deriveConfiguredDecoder
   implicit val _decLocation: Decoder[Location] = deriveConfiguredDecoder
 
-  implicit val _decMergeCandidateIdentifiable: Decoder[MergeCandidate[IdState.Identifiable]] =
+  implicit val _decMergeCandidateIdentifiable
+    : Decoder[MergeCandidate[IdState.Identifiable]] =
     deriveConfiguredDecoder
-  implicit val _decMergeCandidateIdentified: Decoder[MergeCandidate[IdState.Identified]] =
+  implicit val _decMergeCandidateIdentified
+    : Decoder[MergeCandidate[IdState.Identified]] =
     deriveConfiguredDecoder
 
   implicit val _decAgentUnminted: Decoder[Agent[IdState.Unminted]] =
     deriveConfiguredDecoder
-  implicit val _decAgentMinted: Decoder[Agent[IdState.Minted]] = deriveConfiguredDecoder
+  implicit val _decAgentMinted: Decoder[Agent[IdState.Minted]] =
+    deriveConfiguredDecoder
   implicit val _decMeetingUnminted: Decoder[Meeting[IdState.Unminted]] =
     deriveConfiguredDecoder
   implicit val _decMeetingMinted: Decoder[Meeting[IdState.Minted]] =
     deriveConfiguredDecoder
-  implicit val _decOrganisationUnminted: Decoder[Organisation[IdState.Unminted]] =
+  implicit val _decOrganisationUnminted
+    : Decoder[Organisation[IdState.Unminted]] =
     deriveConfiguredDecoder
   implicit val _decOrganisationMinted: Decoder[Organisation[IdState.Minted]] =
     deriveConfiguredDecoder
   implicit val _decPersonUnminted: Decoder[Person[IdState.Unminted]] =
     deriveConfiguredDecoder
-  implicit val _decPersonMinted: Decoder[Person[IdState.Minted]] = deriveConfiguredDecoder
+  implicit val _decPersonMinted: Decoder[Person[IdState.Minted]] =
+    deriveConfiguredDecoder
 
   // The four classes above (Agent, Meeting, Organisation, Person) are the
   // implementations of AbstractAgent.  We deliberately wait until we have those
   // decoders before creating these two decoders.
-  implicit val _decAbstractAgentUnminted: Decoder[AbstractAgent[IdState.Unminted]] =
+  implicit val _decAbstractAgentUnminted
+    : Decoder[AbstractAgent[IdState.Unminted]] =
     deriveConfiguredDecoder
   implicit val _decAbstractAgentMinted: Decoder[AbstractAgent[IdState.Minted]] =
     deriveConfiguredDecoder
@@ -91,8 +108,10 @@ object Implicits {
     deriveConfiguredDecoder
 
   implicit val _decInstantRange: Decoder[InstantRange] = deriveConfiguredDecoder
-  implicit val _decPeriodUnminted: Decoder[Period[IdState.Unminted]] = deriveConfiguredDecoder
-  implicit val _decPeriodMinted: Decoder[Period[IdState.Minted]] = deriveConfiguredDecoder
+  implicit val _decPeriodUnminted: Decoder[Period[IdState.Unminted]] =
+    deriveConfiguredDecoder
+  implicit val _decPeriodMinted: Decoder[Period[IdState.Minted]] =
+    deriveConfiguredDecoder
 
   implicit val _decPlaceUnminted: Decoder[Place[IdState.Unminted]] =
     deriveConfiguredDecoder
@@ -102,41 +121,51 @@ object Implicits {
   // The classes above (Concept, Period, Place) are the implementations of
   // AbstractConcept.  We deliberately wait until we have those decoders
   // before creating these two decoders.
-  implicit val _decAbstractConceptUnminted: Decoder[AbstractConcept[IdState.Unminted]] =
-  deriveConfiguredDecoder
-  implicit val _decAbstractConceptMinted: Decoder[AbstractConcept[IdState.Minted]] =
+  implicit val _decAbstractConceptUnminted
+    : Decoder[AbstractConcept[IdState.Unminted]] =
+    deriveConfiguredDecoder
+  implicit val _decAbstractConceptMinted
+    : Decoder[AbstractConcept[IdState.Minted]] =
     deriveConfiguredDecoder
 
   // A ProductionEvent uses AbstractAgent, Concept, Period and Place.
-  implicit val _decProductionEventUnminted: Decoder[ProductionEvent[IdState.Unminted]] =
+  implicit val _decProductionEventUnminted
+    : Decoder[ProductionEvent[IdState.Unminted]] =
     deriveConfiguredDecoder
-  implicit val _decProductionEventMinted: Decoder[ProductionEvent[IdState.Minted]] =
+  implicit val _decProductionEventMinted
+    : Decoder[ProductionEvent[IdState.Minted]] =
     deriveConfiguredDecoder
-    
+
   // An AbstractRootConcept is one of AbstractAgent and AbstractConcept
-  implicit val _decAbstractRootConceptUnminted: Decoder[AbstractRootConcept[IdState.Unminted]] =
+  implicit val _decAbstractRootConceptUnminted
+    : Decoder[AbstractRootConcept[IdState.Unminted]] =
     deriveConfiguredDecoder
-  implicit val _decAbstractRootConceptMinted: Decoder[AbstractRootConcept[IdState.Minted]] =
+  implicit val _decAbstractRootConceptMinted
+    : Decoder[AbstractRootConcept[IdState.Minted]] =
     deriveConfiguredDecoder
 
   // Contributor, Genre, and Subject all use a mixture of AbstractAgent,
   // AbstractConcept and AbstractRootConcept.
   implicit val _decContributorUnminted: Decoder[Contributor[IdState.Unminted]] =
-  deriveConfiguredDecoder
+    deriveConfiguredDecoder
   implicit val _decContributorMinted: Decoder[Contributor[IdState.Minted]] =
     deriveConfiguredDecoder
   implicit val _decGenreUnminted: Decoder[Genre[IdState.Unminted]] =
     deriveConfiguredDecoder
-  implicit val _decGenreMinted: Decoder[Genre[IdState.Minted]] = deriveConfiguredDecoder
+  implicit val _decGenreMinted: Decoder[Genre[IdState.Minted]] =
+    deriveConfiguredDecoder
   implicit val _decSubjectUnminted: Decoder[Subject[IdState.Unminted]] =
     deriveConfiguredDecoder
   implicit val _decSubjectMinted: Decoder[Subject[IdState.Minted]] =
     deriveConfiguredDecoder
 
-  implicit val _decMergeCandidate: Decoder[MatcherResult] = deriveConfiguredDecoder
-  
-  implicit val _decItemUnminted: Decoder[Item[IdState.Unminted]] = deriveConfiguredDecoder
-  implicit val _decItemMinted: Decoder[Item[IdState.Minted]] = deriveConfiguredDecoder
+  implicit val _decMergeCandidate: Decoder[MatcherResult] =
+    deriveConfiguredDecoder
+
+  implicit val _decItemUnminted: Decoder[Item[IdState.Unminted]] =
+    deriveConfiguredDecoder
+  implicit val _decItemMinted: Decoder[Item[IdState.Minted]] =
+    deriveConfiguredDecoder
 
   implicit val _decFormat: Decoder[Format] = Format.formatDecoder
   implicit val _decHoldings: Decoder[Holdings] = deriveConfiguredDecoder
@@ -153,7 +182,8 @@ object Implicits {
   implicit val _decDerivedImageData: Decoder[DerivedImageData] =
     deriveConfiguredDecoder
 
-  implicit val _decImageDataIdentifiable: Decoder[ImageData[IdState.Identifiable]] =
+  implicit val _decImageDataIdentifiable
+    : Decoder[ImageData[IdState.Identifiable]] =
     deriveConfiguredDecoder
   implicit val _decImageDataIdentified: Decoder[ImageData[IdState.Identified]] =
     deriveConfiguredDecoder
@@ -186,44 +216,60 @@ object Implicits {
     deriveConfiguredDecoder
   implicit val _decWorkVisibleMerged: Decoder[Work.Visible[WorkState.Merged]] =
     deriveConfiguredDecoder
-  implicit val _decWorkVisibleDenormalised: Decoder[Work.Visible[WorkState.Denormalised]] =
+  implicit val _decWorkVisibleDenormalised
+    : Decoder[Work.Visible[WorkState.Denormalised]] =
     deriveConfiguredDecoder
-  implicit val _decWorkVisibleIdentified: Decoder[Work.Visible[WorkState.Identified]] =
+  implicit val _decWorkVisibleIdentified
+    : Decoder[Work.Visible[WorkState.Identified]] =
     deriveConfiguredDecoder
-  implicit val _decWorkVisibleIndexed: Decoder[Work.Visible[WorkState.Indexed]] =
-    deriveConfiguredDecoder
-
-  implicit val _decWorkInvisibleSource: Decoder[Work.Invisible[WorkState.Source]] =
-    deriveConfiguredDecoder
-  implicit val _decWorkInvisibleMerged: Decoder[Work.Invisible[WorkState.Merged]] =
-    deriveConfiguredDecoder
-  implicit val _decWorkInvisibleDenormalised: Decoder[Work.Invisible[WorkState.Denormalised]] =
-    deriveConfiguredDecoder
-  implicit val _decWorkInvisibleIdentified: Decoder[Work.Invisible[WorkState.Identified]] =
-    deriveConfiguredDecoder
-  implicit val _decWorkInvisibleIndexed: Decoder[Work.Invisible[WorkState.Indexed]] =
+  implicit val _decWorkVisibleIndexed
+    : Decoder[Work.Visible[WorkState.Indexed]] =
     deriveConfiguredDecoder
 
-  implicit val _decWorkRedirectedSource: Decoder[Work.Redirected[WorkState.Source]] =
+  implicit val _decWorkInvisibleSource
+    : Decoder[Work.Invisible[WorkState.Source]] =
     deriveConfiguredDecoder
-  implicit val _decWorkRedirectedMerged: Decoder[Work.Redirected[WorkState.Merged]] =
+  implicit val _decWorkInvisibleMerged
+    : Decoder[Work.Invisible[WorkState.Merged]] =
     deriveConfiguredDecoder
-  implicit val _decWorkRedirectedDenormalised: Decoder[Work.Redirected[WorkState.Denormalised]] =
+  implicit val _decWorkInvisibleDenormalised
+    : Decoder[Work.Invisible[WorkState.Denormalised]] =
     deriveConfiguredDecoder
-  implicit val _decWorkRedirectedIdentified: Decoder[Work.Redirected[WorkState.Identified]] =
+  implicit val _decWorkInvisibleIdentified
+    : Decoder[Work.Invisible[WorkState.Identified]] =
     deriveConfiguredDecoder
-  implicit val _decWorkRedirectedIndexed: Decoder[Work.Redirected[WorkState.Indexed]] =
+  implicit val _decWorkInvisibleIndexed
+    : Decoder[Work.Invisible[WorkState.Indexed]] =
+    deriveConfiguredDecoder
+
+  implicit val _decWorkRedirectedSource
+    : Decoder[Work.Redirected[WorkState.Source]] =
+    deriveConfiguredDecoder
+  implicit val _decWorkRedirectedMerged
+    : Decoder[Work.Redirected[WorkState.Merged]] =
+    deriveConfiguredDecoder
+  implicit val _decWorkRedirectedDenormalised
+    : Decoder[Work.Redirected[WorkState.Denormalised]] =
+    deriveConfiguredDecoder
+  implicit val _decWorkRedirectedIdentified
+    : Decoder[Work.Redirected[WorkState.Identified]] =
+    deriveConfiguredDecoder
+  implicit val _decWorkRedirectedIndexed
+    : Decoder[Work.Redirected[WorkState.Indexed]] =
     deriveConfiguredDecoder
 
   implicit val _decWorkDeletedSource: Decoder[Work.Deleted[WorkState.Source]] =
     deriveConfiguredDecoder
   implicit val _decWorkDeletedMerged: Decoder[Work.Deleted[WorkState.Merged]] =
     deriveConfiguredDecoder
-  implicit val _decWorkDeletedDenormalised: Decoder[Work.Deleted[WorkState.Denormalised]] =
+  implicit val _decWorkDeletedDenormalised
+    : Decoder[Work.Deleted[WorkState.Denormalised]] =
     deriveConfiguredDecoder
-  implicit val _decWorkDeletedIdentified: Decoder[Work.Deleted[WorkState.Identified]] =
+  implicit val _decWorkDeletedIdentified
+    : Decoder[Work.Deleted[WorkState.Identified]] =
     deriveConfiguredDecoder
-  implicit val _decWorkDeletedIndexed: Decoder[Work.Deleted[WorkState.Indexed]] =
+  implicit val _decWorkDeletedIndexed
+    : Decoder[Work.Deleted[WorkState.Indexed]] =
     deriveConfiguredDecoder
 
   implicit val _decWorkSource: Decoder[Work[WorkState.Source]] =
@@ -248,56 +294,73 @@ object Implicits {
   implicit val _decImageIndexed: Decoder[Image[ImageState.Indexed]] =
     deriveConfiguredDecoder
 
-  implicit val _encAccessCondition: Encoder[AccessCondition] = deriveConfiguredEncoder
+  implicit val _encAccessCondition: Encoder[AccessCondition] =
+    deriveConfiguredEncoder
   implicit val _encNote: Encoder[Note] = deriveConfiguredEncoder
 
-  implicit val _encIdentifierType: Encoder[IdentifierType] = IdentifierType.identifierTypeEncoder
-  implicit val _encSourceIdentifier: Encoder[SourceIdentifier] = deriveConfiguredEncoder
+  implicit val _encIdentifierType: Encoder[IdentifierType] =
+    IdentifierType.identifierTypeEncoder
+  implicit val _encSourceIdentifier: Encoder[SourceIdentifier] =
+    deriveConfiguredEncoder
   implicit val _encCanonicalId: Encoder[CanonicalId] = CanonicalId.encoder
-  implicit val _envReferenceNumber: Encoder[ReferenceNumber] = ReferenceNumber.encoder
+  implicit val _envReferenceNumber: Encoder[ReferenceNumber] =
+    ReferenceNumber.encoder
 
-  implicit val _encIdStateIdentified: Encoder[IdState.Identified] = deriveConfiguredEncoder
-  implicit val _encIdStateIdentifiable: Encoder[IdState.Identifiable] = deriveConfiguredEncoder
-  implicit val _encIdStateUnminted: Encoder[IdState.Unminted] = deriveConfiguredEncoder
-  implicit val _encIdStateMinted: Encoder[IdState.Minted] = deriveConfiguredEncoder
+  implicit val _encIdStateIdentified: Encoder[IdState.Identified] =
+    deriveConfiguredEncoder
+  implicit val _encIdStateIdentifiable: Encoder[IdState.Identifiable] =
+    deriveConfiguredEncoder
+  implicit val _encIdStateUnminted: Encoder[IdState.Unminted] =
+    deriveConfiguredEncoder
+  implicit val _encIdStateMinted: Encoder[IdState.Minted] =
+    deriveConfiguredEncoder
 
   implicit val _encLanguage: Encoder[Language] = deriveConfiguredEncoder
 
   implicit val _encLicense: Encoder[License] = License.licenseEncoder
-  implicit val _encPhysicalLocationType: Encoder[PhysicalLocationType] = LocationType.physicalLocationTypeEncoder
-  implicit val _encDigitalLocationType: Encoder[DigitalLocationType] = LocationType.digitalLocationTypeEncoder
-  implicit val _encLocationType: Encoder[LocationType] = LocationType.locationTypeEncoder
+  implicit val _encPhysicalLocationType: Encoder[PhysicalLocationType] =
+    LocationType.physicalLocationTypeEncoder
+  implicit val _encDigitalLocationType: Encoder[DigitalLocationType] =
+    LocationType.digitalLocationTypeEncoder
+  implicit val _encLocationType: Encoder[LocationType] =
+    LocationType.locationTypeEncoder
   implicit val _encDigitalLocation: Encoder[DigitalLocation] =
     deriveConfiguredEncoder
   implicit val _encPhysicalLocation: Encoder[PhysicalLocation] =
     deriveConfiguredEncoder
   implicit val _encLocation: Encoder[Location] = deriveConfiguredEncoder
 
-  implicit val _encMergeCandidateIdentifiable: Encoder[MergeCandidate[IdState.Identifiable]] =
+  implicit val _encMergeCandidateIdentifiable
+    : Encoder[MergeCandidate[IdState.Identifiable]] =
     deriveConfiguredEncoder
-  implicit val _encMergeCandidateIdentified: Encoder[MergeCandidate[IdState.Identified]] =
+  implicit val _encMergeCandidateIdentified
+    : Encoder[MergeCandidate[IdState.Identified]] =
     deriveConfiguredEncoder
 
   implicit val _encAgentUnminted: Encoder[Agent[IdState.Unminted]] =
     deriveConfiguredEncoder
-  implicit val _encAgentMinted: Encoder[Agent[IdState.Minted]] = deriveConfiguredEncoder
+  implicit val _encAgentMinted: Encoder[Agent[IdState.Minted]] =
+    deriveConfiguredEncoder
   implicit val _encMeetingUnminted: Encoder[Meeting[IdState.Unminted]] =
     deriveConfiguredEncoder
   implicit val _encMeetingMinted: Encoder[Meeting[IdState.Minted]] =
     deriveConfiguredEncoder
-  implicit val _encOrganisationUnminted: Encoder[Organisation[IdState.Unminted]] =
+  implicit val _encOrganisationUnminted
+    : Encoder[Organisation[IdState.Unminted]] =
     deriveConfiguredEncoder
   implicit val _encOrganisationMinted: Encoder[Organisation[IdState.Minted]] =
     deriveConfiguredEncoder
   implicit val _encPersonUnminted: Encoder[Person[IdState.Unminted]] =
     deriveConfiguredEncoder
-  implicit val _encPersonMinted: Encoder[Person[IdState.Minted]] = deriveConfiguredEncoder
+  implicit val _encPersonMinted: Encoder[Person[IdState.Minted]] =
+    deriveConfiguredEncoder
 
   // The four classes above (Agent, Meeting, Organisation, Person) are the
   // implementations of AbstractAgent.  We deliberately wait until we have those
   // Encoders before creating these two Encoders.
-  implicit val _encAbstractAgentUnminted: Encoder[AbstractAgent[IdState.Unminted]] =
-  deriveConfiguredEncoder
+  implicit val _encAbstractAgentUnminted
+    : Encoder[AbstractAgent[IdState.Unminted]] =
+    deriveConfiguredEncoder
   implicit val _encAbstractAgentMinted: Encoder[AbstractAgent[IdState.Minted]] =
     deriveConfiguredEncoder
 
@@ -307,8 +370,10 @@ object Implicits {
     deriveConfiguredEncoder
 
   implicit val _encInstantRange: Encoder[InstantRange] = deriveConfiguredEncoder
-  implicit val _encPeriodUnminted: Encoder[Period[IdState.Unminted]] = deriveConfiguredEncoder
-  implicit val _encPeriodMinted: Encoder[Period[IdState.Minted]] = deriveConfiguredEncoder
+  implicit val _encPeriodUnminted: Encoder[Period[IdState.Unminted]] =
+    deriveConfiguredEncoder
+  implicit val _encPeriodMinted: Encoder[Period[IdState.Minted]] =
+    deriveConfiguredEncoder
 
   implicit val _encPlaceUnminted: Encoder[Place[IdState.Unminted]] =
     deriveConfiguredEncoder
@@ -318,41 +383,51 @@ object Implicits {
   // The classes above (Concept, Period, Place) are the implementations of
   // AbstractConcept.  We deliberately wait until we have those Encoders
   // before creating these two Encoders.
-  implicit val _encAbstractConceptUnminted: Encoder[AbstractConcept[IdState.Unminted]] =
-  deriveConfiguredEncoder
-  implicit val _encAbstractConceptMinted: Encoder[AbstractConcept[IdState.Minted]] =
+  implicit val _encAbstractConceptUnminted
+    : Encoder[AbstractConcept[IdState.Unminted]] =
+    deriveConfiguredEncoder
+  implicit val _encAbstractConceptMinted
+    : Encoder[AbstractConcept[IdState.Minted]] =
     deriveConfiguredEncoder
 
   // A ProductionEvent uses AbstractAgent, Concept, Period and Place.
-  implicit val _encProductionEventUnminted: Encoder[ProductionEvent[IdState.Unminted]] =
+  implicit val _encProductionEventUnminted
+    : Encoder[ProductionEvent[IdState.Unminted]] =
     deriveConfiguredEncoder
-  implicit val _encProductionEventMinted: Encoder[ProductionEvent[IdState.Minted]] =
+  implicit val _encProductionEventMinted
+    : Encoder[ProductionEvent[IdState.Minted]] =
     deriveConfiguredEncoder
 
   // An AbstractRootConcept is one of AbstractAgent and AbstractConcept
-  implicit val _encAbstractRootConceptUnminted: Encoder[AbstractRootConcept[IdState.Unminted]] =
+  implicit val _encAbstractRootConceptUnminted
+    : Encoder[AbstractRootConcept[IdState.Unminted]] =
     deriveConfiguredEncoder
-  implicit val _encAbstractRootConceptMinted: Encoder[AbstractRootConcept[IdState.Minted]] =
+  implicit val _encAbstractRootConceptMinted
+    : Encoder[AbstractRootConcept[IdState.Minted]] =
     deriveConfiguredEncoder
 
   // Contributor, Genre, and Subject all use a mixture of AbstractAgent,
   // AbstractConcept and AbstractRootConcept.
   implicit val _encContributorUnminted: Encoder[Contributor[IdState.Unminted]] =
-  deriveConfiguredEncoder
+    deriveConfiguredEncoder
   implicit val _encContributorMinted: Encoder[Contributor[IdState.Minted]] =
     deriveConfiguredEncoder
   implicit val _encGenreUnminted: Encoder[Genre[IdState.Unminted]] =
     deriveConfiguredEncoder
-  implicit val _encGenreMinted: Encoder[Genre[IdState.Minted]] = deriveConfiguredEncoder
+  implicit val _encGenreMinted: Encoder[Genre[IdState.Minted]] =
+    deriveConfiguredEncoder
   implicit val _encSubjectUnminted: Encoder[Subject[IdState.Unminted]] =
     deriveConfiguredEncoder
   implicit val _encSubjectMinted: Encoder[Subject[IdState.Minted]] =
     deriveConfiguredEncoder
 
-  implicit val _encMergeCandidate: Encoder[MatcherResult] = deriveConfiguredEncoder
+  implicit val _encMergeCandidate: Encoder[MatcherResult] =
+    deriveConfiguredEncoder
 
-  implicit val _encItemUnminted: Encoder[Item[IdState.Unminted]] = deriveConfiguredEncoder
-  implicit val _encItemMinted: Encoder[Item[IdState.Minted]] = deriveConfiguredEncoder
+  implicit val _encItemUnminted: Encoder[Item[IdState.Unminted]] =
+    deriveConfiguredEncoder
+  implicit val _encItemMinted: Encoder[Item[IdState.Minted]] =
+    deriveConfiguredEncoder
 
   implicit val _encFormat: Encoder[Format] = Format.formatEncoder
   implicit val _encHoldings: Encoder[Holdings] = deriveConfiguredEncoder
@@ -369,12 +444,14 @@ object Implicits {
   implicit val _envDerivedImageData: Encoder[DerivedImageData] =
     deriveConfiguredEncoder
 
-  implicit val _envImageDataIdentifiable: Encoder[ImageData[IdState.Identifiable]] =
+  implicit val _envImageDataIdentifiable
+    : Encoder[ImageData[IdState.Identifiable]] =
     deriveConfiguredEncoder
   implicit val _envImageDataIdentified: Encoder[ImageData[IdState.Identified]] =
     deriveConfiguredEncoder
 
-  implicit val _encWorkDataUnidentified: Encoder[WorkData[DataState.Unidentified]] =
+  implicit val _encWorkDataUnidentified
+    : Encoder[WorkData[DataState.Unidentified]] =
     deriveConfiguredEncoder
   implicit val _envWorkDataIdentified: Encoder[WorkData[DataState.Identified]] =
     deriveConfiguredEncoder
@@ -402,44 +479,60 @@ object Implicits {
     deriveConfiguredEncoder
   implicit val _encWorkVisibleMerged: Encoder[Work.Visible[WorkState.Merged]] =
     deriveConfiguredEncoder
-  implicit val _encWorkVisibleDenormalised: Encoder[Work.Visible[WorkState.Denormalised]] =
+  implicit val _encWorkVisibleDenormalised
+    : Encoder[Work.Visible[WorkState.Denormalised]] =
     deriveConfiguredEncoder
-  implicit val _encWorkVisibleIdentified: Encoder[Work.Visible[WorkState.Identified]] =
+  implicit val _encWorkVisibleIdentified
+    : Encoder[Work.Visible[WorkState.Identified]] =
     deriveConfiguredEncoder
-  implicit val _encWorkVisibleIndexed: Encoder[Work.Visible[WorkState.Indexed]] =
-    deriveConfiguredEncoder
-
-  implicit val _encWorkInvisibleSource: Encoder[Work.Invisible[WorkState.Source]] =
-    deriveConfiguredEncoder
-  implicit val _encWorkInvisibleMerged: Encoder[Work.Invisible[WorkState.Merged]] =
-    deriveConfiguredEncoder
-  implicit val _encWorkInvisibleDenormalised: Encoder[Work.Invisible[WorkState.Denormalised]] =
-    deriveConfiguredEncoder
-  implicit val _encWorkInvisibleIdentified: Encoder[Work.Invisible[WorkState.Identified]] =
-    deriveConfiguredEncoder
-  implicit val _encWorkInvisibleIndexed: Encoder[Work.Invisible[WorkState.Indexed]] =
+  implicit val _encWorkVisibleIndexed
+    : Encoder[Work.Visible[WorkState.Indexed]] =
     deriveConfiguredEncoder
 
-  implicit val _encWorkRedirectedSource: Encoder[Work.Redirected[WorkState.Source]] =
+  implicit val _encWorkInvisibleSource
+    : Encoder[Work.Invisible[WorkState.Source]] =
     deriveConfiguredEncoder
-  implicit val _encWorkRedirectedMerged: Encoder[Work.Redirected[WorkState.Merged]] =
+  implicit val _encWorkInvisibleMerged
+    : Encoder[Work.Invisible[WorkState.Merged]] =
     deriveConfiguredEncoder
-  implicit val _encWorkRedirectedDenormalised: Encoder[Work.Redirected[WorkState.Denormalised]] =
+  implicit val _encWorkInvisibleDenormalised
+    : Encoder[Work.Invisible[WorkState.Denormalised]] =
     deriveConfiguredEncoder
-  implicit val _encWorkRedirectedIdentified: Encoder[Work.Redirected[WorkState.Identified]] =
+  implicit val _encWorkInvisibleIdentified
+    : Encoder[Work.Invisible[WorkState.Identified]] =
     deriveConfiguredEncoder
-  implicit val _encWorkRedirectedIndexed: Encoder[Work.Redirected[WorkState.Indexed]] =
+  implicit val _encWorkInvisibleIndexed
+    : Encoder[Work.Invisible[WorkState.Indexed]] =
+    deriveConfiguredEncoder
+
+  implicit val _encWorkRedirectedSource
+    : Encoder[Work.Redirected[WorkState.Source]] =
+    deriveConfiguredEncoder
+  implicit val _encWorkRedirectedMerged
+    : Encoder[Work.Redirected[WorkState.Merged]] =
+    deriveConfiguredEncoder
+  implicit val _encWorkRedirectedDenormalised
+    : Encoder[Work.Redirected[WorkState.Denormalised]] =
+    deriveConfiguredEncoder
+  implicit val _encWorkRedirectedIdentified
+    : Encoder[Work.Redirected[WorkState.Identified]] =
+    deriveConfiguredEncoder
+  implicit val _encWorkRedirectedIndexed
+    : Encoder[Work.Redirected[WorkState.Indexed]] =
     deriveConfiguredEncoder
 
   implicit val _encWorkDeletedSource: Encoder[Work.Deleted[WorkState.Source]] =
     deriveConfiguredEncoder
   implicit val _encWorkDeletedMerged: Encoder[Work.Deleted[WorkState.Merged]] =
     deriveConfiguredEncoder
-  implicit val _encWorkDeletedDenormalised: Encoder[Work.Deleted[WorkState.Denormalised]] =
+  implicit val _encWorkDeletedDenormalised
+    : Encoder[Work.Deleted[WorkState.Denormalised]] =
     deriveConfiguredEncoder
-  implicit val _encWorkDeletedIdentified: Encoder[Work.Deleted[WorkState.Identified]] =
+  implicit val _encWorkDeletedIdentified
+    : Encoder[Work.Deleted[WorkState.Identified]] =
     deriveConfiguredEncoder
-  implicit val _encWorkDeletedIndexed: Encoder[Work.Deleted[WorkState.Indexed]] =
+  implicit val _encWorkDeletedIndexed
+    : Encoder[Work.Deleted[WorkState.Indexed]] =
     deriveConfiguredEncoder
 
   implicit val _encWorkSource: Encoder[Work[WorkState.Source]] =

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/CollectionPath.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/CollectionPath.scala
@@ -7,14 +7,4 @@ package weco.catalogue.internal_model.work
 case class CollectionPath(
   path: String,
   label: Option[String] = None,
-) {
-
-  lazy val tokens: List[String] =
-    path.split("/").toList
-
-  lazy val depth: Int =
-    tokens.length
-
-  def isDescendent(other: CollectionPath): Boolean =
-    tokens.slice(0, other.depth) == other.tokens
-}
+)


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5298 I followed the instructions in the blog post linked at the top of `Implicits.scala`, identified the slowest parts, and added implicits for them. Unsurprisingly, implicit matching is still ~99% of our compilation time. It has a roughly 50% improvement:

Before:

```
Executed in  104.56 secs   fish           external
   usr time   72.90 millis   90.00 micros   72.81 millis
   sys time   87.06 millis  426.00 micros   86.63 millis
```

After:

```
Executed in   47.56 secs   fish           external
   usr time   63.90 millis   87.00 micros   63.81 millis
   sys time   78.13 millis  353.00 micros   77.77 millis
```

I'm at a point of diminishing returns – the last few changes made barely any dent in the compilation time.

I've uploaded the current flame graph here, so if anyone can see where I should make the next intervention, I can see if they make a difference: https://wellcome.slack.com/archives/C3TQSF63C/p1631533771051400