### PR TITLE
Ensure the METS adapter behaves idempotently

### DIFF
--- a/common/source_model/src/main/scala/weco/catalogue/source_model/mets/MetsSourceData.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/mets/MetsSourceData.scala
@@ -22,9 +22,35 @@ case class MetsFileWithImages(
 
   def manifestationLocations: List[S3ObjectLocation] =
     manifestations.map { root.asLocation(_) }
+
+  // We store these values in DynamoDB, which only supports second-level
+  // precision of Instant values.  We can treat two instances of this class
+  // as equal if their createdDates are at the same second.
+  override def equals(other: Any): Boolean =
+    other match {
+      case m: MetsFileWithImages if
+        m.root == root &&
+        m.filename == filename &&
+        m.manifestations == manifestations &&
+        m.createdDate.getEpochSecond == createdDate.getEpochSecond &&
+        m.version == version => true
+      case _ => false
+    }
 }
 
 case class DeletedMetsFile(
   createdDate: Instant,
   version: Int
-) extends MetsSourceData
+) extends MetsSourceData {
+
+  // We store these values in DynamoDB, which only supports second-level
+  // precision of Instant values.  We can treat two instances of this class
+  // as equal if their createdDates are at the same second.
+  override def equals(other: Any): Boolean =
+    other match {
+      case d: DeletedMetsFile if
+        d.createdDate.getEpochSecond == createdDate.getEpochSecond &&
+        d.version == version => true
+      case _ => false
+    }
+}

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/mets/MetsSourceData.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/mets/MetsSourceData.scala
@@ -28,12 +28,13 @@ case class MetsFileWithImages(
   // as equal if their createdDates are at the same second.
   override def equals(other: Any): Boolean =
     other match {
-      case m: MetsFileWithImages if
-        m.root == root &&
-        m.filename == filename &&
-        m.manifestations == manifestations &&
-        m.createdDate.getEpochSecond == createdDate.getEpochSecond &&
-        m.version == version => true
+      case m: MetsFileWithImages
+          if m.root == root &&
+            m.filename == filename &&
+            m.manifestations == manifestations &&
+            m.createdDate.getEpochSecond == createdDate.getEpochSecond &&
+            m.version == version =>
+        true
       case _ => false
     }
 }
@@ -48,9 +49,10 @@ case class DeletedMetsFile(
   // as equal if their createdDates are at the same second.
   override def equals(other: Any): Boolean =
     other match {
-      case d: DeletedMetsFile if
-        d.createdDate.getEpochSecond == createdDate.getEpochSecond &&
-        d.version == version => true
+      case d: DeletedMetsFile
+          if d.createdDate.getEpochSecond == createdDate.getEpochSecond &&
+            d.version == version =>
+        true
       case _ => false
     }
 }

--- a/mets_adapter/mets_adapter/docker-compose.yml
+++ b/mets_adapter/mets_adapter/docker-compose.yml
@@ -2,3 +2,7 @@ sqs:
   image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/s12v/elasticmq"
   ports:
     - "9324:9324"
+dynamodb:
+  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/peopleperhour/dynamodb"
+  ports:
+    - "45678:8000"

--- a/mets_adapter/mets_adapter/src/test/scala/weco/pipeline/mets_adapter/services/MetsAdapterWorkerServiceTest.scala
+++ b/mets_adapter/mets_adapter/src/test/scala/weco/pipeline/mets_adapter/services/MetsAdapterWorkerServiceTest.scala
@@ -69,7 +69,7 @@ class MetsAdapterWorkerServiceTest
 
   val expectedVersion = Version(externalIdentifier, version = 1)
 
-  val expectedData: MetsSourceData = createMetsSourceDataWith(
+  val expectedData = createMetsSourceDataWith(
     bucket = bag.location.bucket,
     path = bag.location.path,
     file = "mets.xml",
@@ -118,7 +118,7 @@ class MetsAdapterWorkerServiceTest
     // original timestamp.
     val createdDate = Instant.parse("2001-01-01T01:01:01.123456Z")
 
-    val expectedDataWithMilliseconds: MetsSourceData =
+    val expectedDataWithMilliseconds =
       expectedData.copy(createdDate = createdDate)
 
     val bagRetrieverWithMilliseconds =

--- a/mets_adapter/mets_adapter/src/test/scala/weco/pipeline/mets_adapter/services/MetsAdapterWorkerServiceTest.scala
+++ b/mets_adapter/mets_adapter/src/test/scala/weco/pipeline/mets_adapter/services/MetsAdapterWorkerServiceTest.scala
@@ -110,7 +110,9 @@ class MetsAdapterWorkerServiceTest
   it("can receive the same update twice") {
     // DynamoDB can only handle second-level precision, so if we get a bag that has
     // a millisecond-level timestamp, we need to handle the fact that the createdDate
-    // is going to be truncated.
+    // is going to be truncated.  In particular, we need to be able to double-send
+    // the message and not fail when the truncated timestamp is different from the
+    // original timestamp.
     val createdDate = Instant.parse("2001-01-01T01:01:01.123456Z")
 
     val expectedDataWithMilliseconds: MetsSourceData =

--- a/mets_adapter/mets_adapter/src/test/scala/weco/pipeline/mets_adapter/services/MetsAdapterWorkerServiceTest.scala
+++ b/mets_adapter/mets_adapter/src/test/scala/weco/pipeline/mets_adapter/services/MetsAdapterWorkerServiceTest.scala
@@ -105,7 +105,10 @@ class MetsAdapterWorkerServiceTest
   }
 
   override def createTable(table: DynamoFixtures.Table): DynamoFixtures.Table =
-    createTableWithHashKey(table, keyName = "id", keyType = ScalarAttributeType.S)
+    createTableWithHashKey(
+      table,
+      keyName = "id",
+      keyType = ScalarAttributeType.S)
 
   it("can receive the same update twice") {
     // DynamoDB can only handle second-level precision, so if we get a bag that has
@@ -146,8 +149,9 @@ class MetsAdapterWorkerServiceTest
 
             messageSender.messages should have size 2
 
-            messageSender.getMessages[Version[String, Int]]().distinct shouldBe Seq(
-              expectedVersion)
+            messageSender
+              .getMessages[Version[String, Int]]()
+              .distinct shouldBe Seq(expectedVersion)
             messageSender.getMessages[MetsSourcePayload].distinct shouldBe Seq(
               MetsSourcePayload(
                 id = expectedVersion.id,


### PR DESCRIPTION
Because DynamoDB only supports second-level precision of Instant values, if we get a bag with a millisecond-level createdDate, we can't store it in DynamoDB if we receive the notification twice -- it looks different to the already stored bag.

We used to handle this by catching a VersionAlreadyExistsError, but that swallows errors where DynamoDB has recorded different information.  This patch tweaks the equality methods on the associated classes so we'll only allow the double-write if the data in DynamoDB matches what we're trying to write (by leveraging the idempotence of VersionedStore.put()).