### PR TITLE
Fix a bug where the METS transformer wasn't getting the title correctly

### DIFF
--- a/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/MetsXml.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/MetsXml.scala
@@ -45,33 +45,6 @@ case class MetsXml(root: Elem) {
     }
   }
 
-  /** The title is encoded in the METS.  For example:
-    *
-    * <mets:dmdSec ID="DMDLOG_0000">
-    *   <mets:mdWrap MDTYPE="MODS">
-    *     <mets:xmlData>
-    *       <mods:mods>
-    *         <mods:titleInfo>
-    *           <mods:title>Reduction and treatment of a fracture of the calcaneus</mods:title>
-    *         </mods:titleInfo>
-    *       </mods:mods>
-    *     </mets:xmlData>
-    *   </mets:mdWrap>
-    * </mets:dmdSec>
-    *
-    * The title is "Reduction and treatment of a fracture of the calcaneus"
-    */
-  def title: Either[Exception, String] = {
-    val titleNodes =
-      (root \\ "dmdSec" \ "mdWrap" \\ "titleInfo" \ "title").toList.distinct
-
-    titleNodes match {
-      case Seq(node) => Right(node.text)
-      case _ =>
-        Left(new Exception("Could not parse title from METS XML"))
-    }
-  }
-
   /** For licenses we are interested with the access condition with type `dz`.
     *  For example:
     *

--- a/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/MetsXmlTransformer.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/MetsXmlTransformer.scala
@@ -7,6 +7,7 @@ import weco.catalogue.source_model.mets.{
   MetsSourceData
 }
 import weco.pipeline.transformer.Transformer
+import weco.pipeline.transformer.mets.transformers.MetsTitle
 import weco.pipeline.transformer.result.Result
 import weco.storage.Identified
 import weco.storage.s3.S3ObjectLocation
@@ -49,7 +50,7 @@ class MetsXmlTransformer(store: Readable[S3ObjectLocation, String])
     root: MetsXml): Result[InvisibleMetsData] =
     for {
       id <- root.recordIdentifier
-      title <- root.title
+      title <- MetsTitle(root.root)
       accessConditionDz <- root.accessConditionDz
       accessConditionStatus <- root.accessConditionStatus
       accessConditionUsage <- root.accessConditionUsage
@@ -69,7 +70,7 @@ class MetsXmlTransformer(store: Readable[S3ObjectLocation, String])
     manifestations: List[S3ObjectLocation]): Result[InvisibleMetsData] =
     for {
       id <- root.recordIdentifier
-      title <- root.title
+      title <- MetsTitle(root.root)
       firstManifestation <- getFirstManifestation(root, manifestations)
       accessConditionDz <- firstManifestation.accessConditionDz
       accessConditionStatus <- firstManifestation.accessConditionStatus

--- a/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformers/MetsTitle.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformers/MetsTitle.scala
@@ -7,21 +7,21 @@ import scala.xml.Elem
 object MetsTitle {
 
   /** The title is encoded in the METS.  For example:
-   *
-   * <mets:dmdSec ID="DMDLOG_0000">
-   *   <mets:mdWrap MDTYPE="MODS">
-   *     <mets:xmlData>
-   *       <mods:mods>
-   *         <mods:titleInfo>
-   *           <mods:title>Reduction and treatment of a fracture of the calcaneus</mods:title>
-   *         </mods:titleInfo>
-   *       </mods:mods>
-   *     </mets:xmlData>
-   *   </mets:mdWrap>
-   * </mets:dmdSec>
-   *
-   * The title is "Reduction and treatment of a fracture of the calcaneus"
-   */
+    *
+    * <mets:dmdSec ID="DMDLOG_0000">
+    *   <mets:mdWrap MDTYPE="MODS">
+    *     <mets:xmlData>
+    *       <mods:mods>
+    *         <mods:titleInfo>
+    *           <mods:title>Reduction and treatment of a fracture of the calcaneus</mods:title>
+    *         </mods:titleInfo>
+    *       </mods:mods>
+    *     </mets:xmlData>
+    *   </mets:mdWrap>
+    * </mets:dmdSec>
+    *
+    * The title is "Reduction and treatment of a fracture of the calcaneus"
+    */
   def apply(root: Elem): Result[String] = {
     val titleNodes =
       (root \\ "dmdSec" \ "mdWrap" \\ "titleInfo" \ "title").toList.distinct

--- a/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformers/MetsTitle.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformers/MetsTitle.scala
@@ -1,0 +1,35 @@
+package weco.pipeline.transformer.mets.transformers
+
+import weco.pipeline.transformer.result.Result
+
+import scala.xml.Elem
+
+object MetsTitle {
+
+  /** The title is encoded in the METS.  For example:
+   *
+   * <mets:dmdSec ID="DMDLOG_0000">
+   *   <mets:mdWrap MDTYPE="MODS">
+   *     <mets:xmlData>
+   *       <mods:mods>
+   *         <mods:titleInfo>
+   *           <mods:title>Reduction and treatment of a fracture of the calcaneus</mods:title>
+   *         </mods:titleInfo>
+   *       </mods:mods>
+   *     </mets:xmlData>
+   *   </mets:mdWrap>
+   * </mets:dmdSec>
+   *
+   * The title is "Reduction and treatment of a fracture of the calcaneus"
+   */
+  def apply(root: Elem): Result[String] = {
+    val titleNodes =
+      (root \\ "dmdSec" \ "mdWrap" \\ "titleInfo" \ "title").toList.distinct
+
+    titleNodes match {
+      case Seq(node) => Right(node.text)
+      case _ =>
+        Left(new Throwable("Could not parse title from METS XML"))
+    }
+  }
+}

--- a/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformers/MetsTitle.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformers/MetsTitle.scala
@@ -27,9 +27,8 @@ object MetsTitle {
       (root \\ "dmdSec" \ "mdWrap" \\ "titleInfo" \ "title").toList.distinct
 
     titleNodes match {
-      case Seq(node) => Right(node.text)
-      case _ =>
-        Left(new Throwable("Could not parse title from METS XML"))
+      case Nil   => Left(new Throwable("Could not parse title from METS XML"))
+      case nodes => Right(nodes.map(_.text).mkString(" "))
     }
   }
 }

--- a/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformer/MetsXmlTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformer/MetsXmlTest.scala
@@ -19,10 +19,6 @@ class MetsXmlTest
     MetsXml(xml).value.recordIdentifier shouldBe Right("b30246039")
   }
 
-  it("finds the title") {
-    MetsXml(xml).value.title shouldBe Right("[Report 1942] /")
-  }
-
   it("does not parse a mets if recordIdentifier is outside of dmdSec element") {
     MetsXml(xmlNodmdSec).recordIdentifier shouldBe a[Left[_, _]]
   }

--- a/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformers/MetsTitleTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformers/MetsTitleTest.scala
@@ -1,0 +1,44 @@
+package weco.pipeline.transformer.mets.transformers
+
+import org.scalatest.EitherValues
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class MetsTitleTest extends AnyFunSpec with Matchers with EitherValues {
+  it("finds the title") {
+    val elem =
+      <mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:mods="http://www.loc.gov/mods/v3">
+        <mets:dmdSec ID="DMDLOG_0000">
+          <mets:mdWrap MDTYPE="MODS">
+            <mets:xmlData>
+              <mods:mods>
+                <mods:titleInfo>
+                  <mods:title>[Report 1942] /</mods:title>
+                </mods:titleInfo>
+              </mods:mods>
+            </mets:xmlData>
+          </mets:mdWrap>
+        </mets:dmdSec>
+      </mets:mets>
+
+    MetsTitle(elem).value shouldBe "[Report 1942] /"
+  }
+
+  it("fails if there is no mods:title element") {
+    val elem =
+      <mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:mods="http://www.loc.gov/mods/v3">
+        <mets:dmdSec ID="DMDLOG_0000">
+          <mets:mdWrap MDTYPE="MODS">
+            <mets:xmlData>
+              <mods:mods>
+                <mods:titleInfo>
+                </mods:titleInfo>
+              </mods:mods>
+            </mets:xmlData>
+          </mets:mdWrap>
+        </mets:dmdSec>
+      </mets:mets>
+
+    MetsTitle(elem).left.value.getMessage shouldBe "Could not parse title from METS XML"
+  }
+}

--- a/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformers/MetsTitleTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformers/MetsTitleTest.scala
@@ -41,4 +41,25 @@ class MetsTitleTest extends AnyFunSpec with Matchers with EitherValues {
 
     MetsTitle(elem).left.value.getMessage shouldBe "Could not parse title from METS XML"
   }
+
+  it("combines multiple instances of mods:title") {
+    val elem =
+      <mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:mods="http://www.loc.gov/mods/v3">
+        <mets:dmdSec ID="DMDLOG_0000">
+          <mets:mdWrap MDTYPE="MODS">
+            <mets:xmlData>
+              <mods:mods>
+                <mods:titleInfo>
+                  <mods:subTitle>sowie der Erzeugnisse der Fettindustrie</mods:subTitle>
+                  <mods:title>Analyse der Fette und Wachse :</mods:title>
+                  <mods:title>sowie der Erzeugnisse der Fettindustrie</mods:title>
+                </mods:titleInfo>
+              </mods:mods>
+            </mets:xmlData>
+          </mets:mdWrap>
+        </mets:dmdSec>
+      </mets:mets>
+
+    MetsTitle(elem).value shouldBe "Analyse der Fette und Wachse : sowie der Erzeugnisse der Fettindustrie"
+  }
 }


### PR DESCRIPTION
See the test for the example – turns out it can't handle the case where there are multiple `mods:title` elements.