### PR TITLE
Ditch the use of "version" on the Image-related classes

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/Implicits.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/Implicits.scala
@@ -284,7 +284,7 @@ object Implicits {
   implicit val _decWorkIndexed: Decoder[Work[WorkState.Indexed]] =
     deriveConfiguredDecoder
 
-  implicit val _decParentWorks: Decoder[ParentWorks] =
+  implicit val _decImageSourceParentWork: Decoder[ImageSource.ParentWork] =
     deriveConfiguredDecoder
   implicit val _decImageSource: Decoder[ImageSource] =
     deriveConfiguredDecoder
@@ -549,7 +549,7 @@ object Implicits {
   implicit val _encWorkIndexed: Encoder[Work[WorkState.Indexed]] =
     deriveConfiguredEncoder
 
-  implicit val _encParentWorks: Encoder[ParentWorks] =
+  implicit val _encImageSourceParentWork: Encoder[ImageSource.ParentWork] =
     deriveConfiguredEncoder
   implicit val _encImageSource: Encoder[ImageSource] =
     deriveConfiguredEncoder

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/image/DerivedImageData.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/image/DerivedImageData.scala
@@ -26,8 +26,7 @@ object DerivedImageData extends DerivedDataCommon {
 
   private def sourceContributorAgents(source: ImageSource): List[String] =
     source match {
-      case ParentWorks(canonicalWork, redirectedWork) =>
-        contributorAgentLabels(canonicalWork.data.contributors)
-      case _ => Nil
+      case ImageSource.ParentWork(_, data) => contributorAgentLabels(data.contributors)
+      case _                               => Nil
     }
 }

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/image/DerivedImageData.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/image/DerivedImageData.scala
@@ -26,7 +26,8 @@ object DerivedImageData extends DerivedDataCommon {
 
   private def sourceContributorAgents(source: ImageSource): List[String] =
     source match {
-      case ImageSource.ParentWork(_, data) => contributorAgentLabels(data.contributors)
-      case _                               => Nil
+      case ImageSource.ParentWork(_, data) =>
+        contributorAgentLabels(data.contributors)
+      case _ => Nil
     }
 }

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/image/Image.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/image/Image.scala
@@ -11,12 +11,10 @@ import java.time.Instant
 
 case class ImageData[+State](
   id: State,
-  version: Int,
   locations: List[DigitalLocation]
 ) extends HasId[State]
 
 case class Image[State <: ImageState](
-  version: Int,
   state: State,
   locations: List[DigitalLocation],
   source: ImageSource,
@@ -30,7 +28,6 @@ case class Image[State <: ImageState](
   ): Image[OutState] =
     Image[OutState](
       state = transition.state(this, args),
-      version = version,
       locations = locations,
       source = source,
       modifiedTime = modifiedTime

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/image/Image.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/image/Image.scala
@@ -75,7 +75,7 @@ object ImageState {
   case class Augmented(
     sourceIdentifier: SourceIdentifier,
     canonicalId: CanonicalId,
-    inferredData: Option[InferredData] = None
+    inferredData: Option[InferredData]
   ) extends ImageState {
     type TransitionArgs = Option[InferredData]
   }
@@ -83,7 +83,7 @@ object ImageState {
   case class Indexed(
     sourceIdentifier: SourceIdentifier,
     canonicalId: CanonicalId,
-    inferredData: Option[InferredData] = None,
+    inferredData: Option[InferredData],
     derivedData: DerivedImageData
   ) extends ImageState {
     type TransitionArgs = Unit

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/image/ImageSource.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/image/ImageSource.scala
@@ -5,53 +5,42 @@ import weco.catalogue.internal_model.work.{Work, WorkData, WorkState}
 
 sealed trait ImageSource {
   val id: IdState.Identified
-  val version: Int
 }
 
-case class ParentWorks(
-  canonicalWork: ParentWork,
-  redirectedWork: Option[ParentWork] = None
-) extends ImageSource {
-  override val id = canonicalWork.id
-  override val version =
-    canonicalWork.version + redirectedWork.map(_.version).getOrElse(0)
-}
+object ImageSource {
+  case class ParentWork(
+    id: IdState.Identified,
+    data: WorkData[DataState.Identified],
+  ) extends ImageSource
 
-case class ParentWork(
-  id: IdState.Identified,
-  data: WorkData[DataState.Identified],
-  version: Int,
-)
+  object ParentWork {
 
-object ParentWork {
+    // These parent works get attached to images.  In general we include all
+    // the WorkData fields, in case they're useful later -- but we deliberately
+    // omit the ImageData, because it's unnecessary and dramatically increases
+    // the size of an image.
+    //
+    // On one work with a lot of images, the size of the JSON for a single image
+    // in the images-initial index went from 3.3MB to 10KB.
 
-  // These parent works get attached to images.  In general we include all
-  // the WorkData fields, in case they're useful later -- but we deliberately
-  // omit the ImageData, because it's unnecessary and dramatically increases
-  // the size of an image.
-  //
-  // On one work with a lot of images, the size of the JSON for a single image
-  // in the images-initial index went from 3.3MB to 10KB.
+    implicit class MergedToParentWork(work: Work[WorkState.Merged]) {
+      def toParentWork: ParentWork =
+        ParentWork(
+          id = IdState
+            .Identified(work.state.canonicalId, work.state.sourceIdentifier),
+          data = work.data.copy(imageData = Nil)
+        )
+    }
 
-  implicit class MergedToParentWork(work: Work[WorkState.Merged]) {
-    def toParentWork: ParentWork =
-      ParentWork(
-        id = IdState
-          .Identified(work.state.canonicalId, work.state.sourceIdentifier),
-        data = work.data.copy(imageData = Nil),
-        version = work.version
-      )
-  }
-
-  implicit class IdentifiedToParentWork(work: Work[WorkState.Identified]) {
-    def toParentWork: ParentWork =
-      ParentWork(
-        id = IdState.Identified(
-          sourceIdentifier = work.state.sourceIdentifier,
-          canonicalId = work.state.canonicalId
-        ),
-        data = work.data.copy(imageData = Nil),
-        version = work.version
-      )
+    implicit class IdentifiedToParentWork(work: Work[WorkState.Identified]) {
+      def toParentWork: ParentWork =
+        ParentWork(
+          id = IdState.Identified(
+            sourceIdentifier = work.state.sourceIdentifier,
+            canonicalId = work.state.canonicalId
+          ),
+          data = work.data.copy(imageData = Nil)
+        )
+    }
   }
 }

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/ImagesIndexConfig.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/ImagesIndexConfig.scala
@@ -12,7 +12,7 @@ object ImagesIndexConfig extends IndexConfigFields {
   val initial = IndexConfig(emptyDynamicFalseMapping, analysis)
   val augmented = IndexConfig(emptyDynamicFalseMapping, analysis)
 
-  val ingested = IndexConfig(
+  val indexed = IndexConfig(
     {
       val inferredData = objectField("inferredData").fields(
         DenseVectorField("features1", dims = 2048),

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/ImagesIndexConfig.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/ImagesIndexConfig.scala
@@ -63,11 +63,7 @@ object ImagesIndexConfig extends IndexConfigFields {
           )
           .withDynamic("false")
 
-      val source = objectField("source").fields(
-        sourceWork("canonicalWork"),
-        sourceWork("redirectedWork"),
-        keywordField("type")
-      )
+      val source = sourceWork("source")
 
       val state = objectField("state")
         .fields(

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksIndexConfig.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksIndexConfig.scala
@@ -58,7 +58,7 @@ object WorksIndexConfig extends IndexConfigFields {
     )
   )
   val denormalised = WorksIndexConfig(Seq.empty)
-  val ingested = WorksIndexConfig(
+  val indexed = WorksIndexConfig(
     {
       val relationsPath = List("search.relations")
       val titlesAndContributorsPath = List("search.titlesAndContributors")

--- a/common/internal_model/src/test/resources/ImagesIndexConfig.json
+++ b/common/internal_model/src/test/resources/ImagesIndexConfig.json
@@ -173,712 +173,211 @@
       },
       "source" : {
         "type" : "object",
+        "dynamic" : "false",
         "properties" : {
-          "canonicalWork" : {
+          "id" : {
             "type" : "object",
             "properties" : {
-              "id" : {
+              "canonicalId" : {
+                "type" : "keyword",
+                "normalizer" : "lowercase_normalizer"
+              },
+              "sourceIdentifier" : {
                 "type" : "object",
+                "dynamic" : "false",
                 "properties" : {
-                  "canonicalId" : {
+                  "value" : {
                     "type" : "keyword",
                     "normalizer" : "lowercase_normalizer"
-                  },
-                  "sourceIdentifier" : {
-                    "type" : "object",
-                    "properties" : {
-                      "value" : {
-                        "type" : "keyword",
-                        "normalizer" : "lowercase_normalizer"
-                      }
-                    },
-                    "dynamic" : "false"
                   }
                 }
-              },
-              "data" : {
-                "type" : "object",
-                "properties" : {
-                  "otherIdentifiers" : {
-                    "type" : "object",
-                    "properties" : {
-                      "value" : {
-                        "type" : "keyword",
-                        "normalizer" : "lowercase_normalizer"
-                      }
-                    }
-                  },
-                  "title" : {
-                    "type" : "text",
-                    "fields" : {
-                      "keyword" : {
-                        "type" : "keyword",
-                        "normalizer" : "lowercase_normalizer"
-                      },
-                      "english" : {
-                        "type" : "text",
-                        "analyzer" : "english_analyzer"
-                      },
-                      "shingles" : {
-                        "type" : "text",
-                        "analyzer" : "shingle_asciifolding_analyzer"
-                      },
-                      "arabic" : {
-                        "type" : "text",
-                        "analyzer" : "arabic_analyzer"
-                      },
-                      "bengali" : {
-                        "type" : "text",
-                        "analyzer" : "bengali_analyzer"
-                      },
-                      "french" : {
-                        "type" : "text",
-                        "analyzer" : "french_analyzer"
-                      },
-                      "german" : {
-                        "type" : "text",
-                        "analyzer" : "german_analyzer"
-                      },
-                      "hindi" : {
-                        "type" : "text",
-                        "analyzer" : "hindi_analyzer"
-                      },
-                      "italian" : {
-                        "type" : "text",
-                        "analyzer" : "italian_analyzer"
-                      }
-                    }
-                  },
-                  "alternativeTitles" : {
-                    "type" : "text",
-                    "fields" : {
-                      "keyword" : {
-                        "type" : "keyword",
-                        "normalizer" : "lowercase_normalizer"
-                      },
-                      "english" : {
-                        "type" : "text",
-                        "analyzer" : "english_analyzer"
-                      },
-                      "shingles" : {
-                        "type" : "text",
-                        "analyzer" : "shingle_asciifolding_analyzer"
-                      },
-                      "arabic" : {
-                        "type" : "text",
-                        "analyzer" : "arabic_analyzer"
-                      },
-                      "bengali" : {
-                        "type" : "text",
-                        "analyzer" : "bengali_analyzer"
-                      },
-                      "french" : {
-                        "type" : "text",
-                        "analyzer" : "french_analyzer"
-                      },
-                      "german" : {
-                        "type" : "text",
-                        "analyzer" : "german_analyzer"
-                      },
-                      "hindi" : {
-                        "type" : "text",
-                        "analyzer" : "hindi_analyzer"
-                      },
-                      "italian" : {
-                        "type" : "text",
-                        "analyzer" : "italian_analyzer"
-                      }
-                    }
-                  },
-                  "description" : {
-                    "type" : "text",
-                    "fields" : {
-                      "english" : {
-                        "type" : "text",
-                        "analyzer" : "english_analyzer"
-                      },
-                      "shingles" : {
-                        "type" : "text",
-                        "analyzer" : "shingle_asciifolding_analyzer"
-                      },
-                      "arabic" : {
-                        "type" : "text",
-                        "analyzer" : "arabic_analyzer"
-                      },
-                      "bengali" : {
-                        "type" : "text",
-                        "analyzer" : "bengali_analyzer"
-                      },
-                      "french" : {
-                        "type" : "text",
-                        "analyzer" : "french_analyzer"
-                      },
-                      "german" : {
-                        "type" : "text",
-                        "analyzer" : "german_analyzer"
-                      },
-                      "hindi" : {
-                        "type" : "text",
-                        "analyzer" : "hindi_analyzer"
-                      },
-                      "italian" : {
-                        "type" : "text",
-                        "analyzer" : "italian_analyzer"
-                      }
-                    }
-                  },
-                  "physicalDescription" : {
-                    "type" : "text",
-                    "fields" : {
-                      "keyword" : {
-                        "type" : "keyword"
-                      },
-                      "english" : {
-                        "type" : "text",
-                        "analyzer" : "english"
-                      }
-                    }
-                  },
-                  "lettering" : {
-                    "type" : "text",
-                    "fields" : {
-                      "english" : {
-                        "type" : "text",
-                        "analyzer" : "english_analyzer"
-                      },
-                      "shingles" : {
-                        "type" : "text",
-                        "analyzer" : "shingle_asciifolding_analyzer"
-                      },
-                      "arabic" : {
-                        "type" : "text",
-                        "analyzer" : "arabic_analyzer"
-                      },
-                      "bengali" : {
-                        "type" : "text",
-                        "analyzer" : "bengali_analyzer"
-                      },
-                      "french" : {
-                        "type" : "text",
-                        "analyzer" : "french_analyzer"
-                      },
-                      "german" : {
-                        "type" : "text",
-                        "analyzer" : "german_analyzer"
-                      },
-                      "hindi" : {
-                        "type" : "text",
-                        "analyzer" : "hindi_analyzer"
-                      },
-                      "italian" : {
-                        "type" : "text",
-                        "analyzer" : "italian_analyzer"
-                      }
-                    }
-                  },
-                  "contributors" : {
-                    "type" : "object",
-                    "properties" : {
-                      "agent" : {
-                        "type" : "object",
-                        "properties" : {
-                          "label" : {
-                            "type" : "text",
-                            "analyzer" : "asciifolding_analyzer",
-                            "fields" : {
-                              "keyword" : {
-                                "type" : "keyword"
-                              },
-                              "lowercaseKeyword" : {
-                                "type" : "keyword",
-                                "normalizer" : "lowercase_normalizer"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "subjects" : {
-                    "type" : "object",
-                    "properties" : {
-                      "concepts" : {
-                        "type" : "object",
-                        "properties" : {
-                          "label" : {
-                            "type" : "text",
-                            "analyzer" : "asciifolding_analyzer",
-                            "fields" : {
-                              "keyword" : {
-                                "type" : "keyword"
-                              },
-                              "lowercaseKeyword" : {
-                                "type" : "keyword",
-                                "normalizer" : "lowercase_normalizer"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "genres" : {
-                    "type" : "object",
-                    "properties" : {
-                      "label" : {
-                        "type" : "text",
-                        "analyzer" : "asciifolding_analyzer",
-                        "fields" : {
-                          "keyword" : {
-                            "type" : "keyword"
-                          },
-                          "lowercaseKeyword" : {
-                            "type" : "keyword",
-                            "normalizer" : "lowercase_normalizer"
-                          }
-                        }
-                      },
-                      "concepts" : {
-                        "type" : "object",
-                        "properties" : {
-                          "label" : {
-                            "type" : "text",
-                            "analyzer" : "asciifolding_analyzer",
-                            "fields" : {
-                              "keyword" : {
-                                "type" : "keyword"
-                              },
-                              "lowercaseKeyword" : {
-                                "type" : "keyword",
-                                "normalizer" : "lowercase_normalizer"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "production" : {
-                    "type" : "object",
-                    "properties" : {
-                      "places" : {
-                        "type" : "object",
-                        "properties" : {
-                          "label" : {
-                            "type" : "text",
-                            "analyzer" : "asciifolding_analyzer",
-                            "fields" : {
-                              "keyword" : {
-                                "type" : "keyword"
-                              },
-                              "lowercaseKeyword" : {
-                                "type" : "keyword",
-                                "normalizer" : "lowercase_normalizer"
-                              }
-                            }
-                          }
-                        }
-                      },
-                      "agents" : {
-                        "type" : "object",
-                        "properties" : {
-                          "label" : {
-                            "type" : "text",
-                            "analyzer" : "asciifolding_analyzer",
-                            "fields" : {
-                              "keyword" : {
-                                "type" : "keyword"
-                              },
-                              "lowercaseKeyword" : {
-                                "type" : "keyword",
-                                "normalizer" : "lowercase_normalizer"
-                              }
-                            }
-                          }
-                        }
-                      },
-                      "dates" : {
-                        "type" : "object",
-                        "properties" : {
-                          "label" : {
-                            "type" : "text",
-                            "analyzer" : "asciifolding_analyzer",
-                            "fields" : {
-                              "keyword" : {
-                                "type" : "keyword"
-                              },
-                              "lowercaseKeyword" : {
-                                "type" : "keyword",
-                                "normalizer" : "lowercase_normalizer"
-                              }
-                            }
-                          }
-                        }
-                      },
-                      "function" : {
-                        "type" : "object",
-                        "properties" : {
-                          "label" : {
-                            "type" : "text",
-                            "analyzer" : "asciifolding_analyzer",
-                            "fields" : {
-                              "keyword" : {
-                                "type" : "keyword"
-                              },
-                              "lowercaseKeyword" : {
-                                "type" : "keyword",
-                                "normalizer" : "lowercase_normalizer"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "languages" : {
-                    "type" : "object",
-                    "properties" : {
-                      "label" : {
-                        "type" : "text",
-                        "analyzer" : "asciifolding_analyzer",
-                        "fields" : {
-                          "keyword" : {
-                            "type" : "keyword"
-                          },
-                          "lowercaseKeyword" : {
-                            "type" : "keyword",
-                            "normalizer" : "lowercase_normalizer"
-                          }
-                        }
-                      },
-                      "id" : {
-                        "type" : "keyword"
-                      }
-                    }
-                  },
-                  "edition" : {
-                    "type" : "text"
-                  },
-                  "notes" : {
-                    "type" : "object",
-                    "properties" : {
-                      "content" : {
-                        "type" : "text",
-                        "fields" : {
-                          "english" : {
-                            "type" : "text",
-                            "analyzer" : "english_analyzer"
-                          },
-                          "shingles" : {
-                            "type" : "text",
-                            "analyzer" : "shingle_asciifolding_analyzer"
-                          },
-                          "arabic" : {
-                            "type" : "text",
-                            "analyzer" : "arabic_analyzer"
-                          },
-                          "bengali" : {
-                            "type" : "text",
-                            "analyzer" : "bengali_analyzer"
-                          },
-                          "french" : {
-                            "type" : "text",
-                            "analyzer" : "french_analyzer"
-                          },
-                          "german" : {
-                            "type" : "text",
-                            "analyzer" : "german_analyzer"
-                          },
-                          "hindi" : {
-                            "type" : "text",
-                            "analyzer" : "hindi_analyzer"
-                          },
-                          "italian" : {
-                            "type" : "text",
-                            "analyzer" : "italian_analyzer"
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "collectionPath" : {
-                    "type" : "object",
-                    "properties" : {
-                      "label" : {
-                        "type" : "text",
-                        "analyzer" : "asciifolding_analyzer",
-                        "fields" : {
-                          "keyword" : {
-                            "type" : "keyword"
-                          },
-                          "lowercaseKeyword" : {
-                            "type" : "keyword",
-                            "normalizer" : "lowercase_normalizer"
-                          }
-                        }
-                      },
-                      "path" : {
-                        "type" : "text"
-                      }
-                    }
-                  }
-                }
-              },
-              "type" : {
-                "type" : "keyword"
               }
-            },
-            "dynamic" : "false"
+            }
           },
-          "redirectedWork" : {
+          "data" : {
             "type" : "object",
             "properties" : {
-              "id" : {
+              "otherIdentifiers" : {
                 "type" : "object",
                 "properties" : {
-                  "canonicalId" : {
+                  "value" : {
+                    "type" : "keyword",
+                    "normalizer" : "lowercase_normalizer"
+                  }
+                }
+              },
+              "title" : {
+                "type" : "text",
+                "fields" : {
+                  "keyword" : {
                     "type" : "keyword",
                     "normalizer" : "lowercase_normalizer"
                   },
-                  "sourceIdentifier" : {
-                    "type" : "object",
-                    "properties" : {
-                      "value" : {
-                        "type" : "keyword",
-                        "normalizer" : "lowercase_normalizer"
-                      }
-                    },
-                    "dynamic" : "false"
+                  "english" : {
+                    "type" : "text",
+                    "analyzer" : "english_analyzer"
+                  },
+                  "shingles" : {
+                    "type" : "text",
+                    "analyzer" : "shingle_asciifolding_analyzer"
+                  },
+                  "arabic" : {
+                    "type" : "text",
+                    "analyzer" : "arabic_analyzer"
+                  },
+                  "bengali" : {
+                    "type" : "text",
+                    "analyzer" : "bengali_analyzer"
+                  },
+                  "french" : {
+                    "type" : "text",
+                    "analyzer" : "french_analyzer"
+                  },
+                  "german" : {
+                    "type" : "text",
+                    "analyzer" : "german_analyzer"
+                  },
+                  "hindi" : {
+                    "type" : "text",
+                    "analyzer" : "hindi_analyzer"
+                  },
+                  "italian" : {
+                    "type" : "text",
+                    "analyzer" : "italian_analyzer"
                   }
                 }
               },
-              "data" : {
+              "alternativeTitles" : {
+                "type" : "text",
+                "fields" : {
+                  "keyword" : {
+                    "type" : "keyword",
+                    "normalizer" : "lowercase_normalizer"
+                  },
+                  "english" : {
+                    "type" : "text",
+                    "analyzer" : "english_analyzer"
+                  },
+                  "shingles" : {
+                    "type" : "text",
+                    "analyzer" : "shingle_asciifolding_analyzer"
+                  },
+                  "arabic" : {
+                    "type" : "text",
+                    "analyzer" : "arabic_analyzer"
+                  },
+                  "bengali" : {
+                    "type" : "text",
+                    "analyzer" : "bengali_analyzer"
+                  },
+                  "french" : {
+                    "type" : "text",
+                    "analyzer" : "french_analyzer"
+                  },
+                  "german" : {
+                    "type" : "text",
+                    "analyzer" : "german_analyzer"
+                  },
+                  "hindi" : {
+                    "type" : "text",
+                    "analyzer" : "hindi_analyzer"
+                  },
+                  "italian" : {
+                    "type" : "text",
+                    "analyzer" : "italian_analyzer"
+                  }
+                }
+              },
+              "description" : {
+                "type" : "text",
+                "fields" : {
+                  "english" : {
+                    "type" : "text",
+                    "analyzer" : "english_analyzer"
+                  },
+                  "shingles" : {
+                    "type" : "text",
+                    "analyzer" : "shingle_asciifolding_analyzer"
+                  },
+                  "arabic" : {
+                    "type" : "text",
+                    "analyzer" : "arabic_analyzer"
+                  },
+                  "bengali" : {
+                    "type" : "text",
+                    "analyzer" : "bengali_analyzer"
+                  },
+                  "french" : {
+                    "type" : "text",
+                    "analyzer" : "french_analyzer"
+                  },
+                  "german" : {
+                    "type" : "text",
+                    "analyzer" : "german_analyzer"
+                  },
+                  "hindi" : {
+                    "type" : "text",
+                    "analyzer" : "hindi_analyzer"
+                  },
+                  "italian" : {
+                    "type" : "text",
+                    "analyzer" : "italian_analyzer"
+                  }
+                }
+              },
+              "physicalDescription" : {
+                "type" : "text",
+                "fields" : {
+                  "keyword" : {
+                    "type" : "keyword"
+                  },
+                  "english" : {
+                    "type" : "text",
+                    "analyzer" : "english"
+                  }
+                }
+              },
+              "lettering" : {
+                "type" : "text",
+                "fields" : {
+                  "english" : {
+                    "type" : "text",
+                    "analyzer" : "english_analyzer"
+                  },
+                  "shingles" : {
+                    "type" : "text",
+                    "analyzer" : "shingle_asciifolding_analyzer"
+                  },
+                  "arabic" : {
+                    "type" : "text",
+                    "analyzer" : "arabic_analyzer"
+                  },
+                  "bengali" : {
+                    "type" : "text",
+                    "analyzer" : "bengali_analyzer"
+                  },
+                  "french" : {
+                    "type" : "text",
+                    "analyzer" : "french_analyzer"
+                  },
+                  "german" : {
+                    "type" : "text",
+                    "analyzer" : "german_analyzer"
+                  },
+                  "hindi" : {
+                    "type" : "text",
+                    "analyzer" : "hindi_analyzer"
+                  },
+                  "italian" : {
+                    "type" : "text",
+                    "analyzer" : "italian_analyzer"
+                  }
+                }
+              },
+              "contributors" : {
                 "type" : "object",
                 "properties" : {
-                  "otherIdentifiers" : {
-                    "type" : "object",
-                    "properties" : {
-                      "value" : {
-                        "type" : "keyword",
-                        "normalizer" : "lowercase_normalizer"
-                      }
-                    }
-                  },
-                  "title" : {
-                    "type" : "text",
-                    "fields" : {
-                      "keyword" : {
-                        "type" : "keyword",
-                        "normalizer" : "lowercase_normalizer"
-                      },
-                      "english" : {
-                        "type" : "text",
-                        "analyzer" : "english_analyzer"
-                      },
-                      "shingles" : {
-                        "type" : "text",
-                        "analyzer" : "shingle_asciifolding_analyzer"
-                      },
-                      "arabic" : {
-                        "type" : "text",
-                        "analyzer" : "arabic_analyzer"
-                      },
-                      "bengali" : {
-                        "type" : "text",
-                        "analyzer" : "bengali_analyzer"
-                      },
-                      "french" : {
-                        "type" : "text",
-                        "analyzer" : "french_analyzer"
-                      },
-                      "german" : {
-                        "type" : "text",
-                        "analyzer" : "german_analyzer"
-                      },
-                      "hindi" : {
-                        "type" : "text",
-                        "analyzer" : "hindi_analyzer"
-                      },
-                      "italian" : {
-                        "type" : "text",
-                        "analyzer" : "italian_analyzer"
-                      }
-                    }
-                  },
-                  "alternativeTitles" : {
-                    "type" : "text",
-                    "fields" : {
-                      "keyword" : {
-                        "type" : "keyword",
-                        "normalizer" : "lowercase_normalizer"
-                      },
-                      "english" : {
-                        "type" : "text",
-                        "analyzer" : "english_analyzer"
-                      },
-                      "shingles" : {
-                        "type" : "text",
-                        "analyzer" : "shingle_asciifolding_analyzer"
-                      },
-                      "arabic" : {
-                        "type" : "text",
-                        "analyzer" : "arabic_analyzer"
-                      },
-                      "bengali" : {
-                        "type" : "text",
-                        "analyzer" : "bengali_analyzer"
-                      },
-                      "french" : {
-                        "type" : "text",
-                        "analyzer" : "french_analyzer"
-                      },
-                      "german" : {
-                        "type" : "text",
-                        "analyzer" : "german_analyzer"
-                      },
-                      "hindi" : {
-                        "type" : "text",
-                        "analyzer" : "hindi_analyzer"
-                      },
-                      "italian" : {
-                        "type" : "text",
-                        "analyzer" : "italian_analyzer"
-                      }
-                    }
-                  },
-                  "description" : {
-                    "type" : "text",
-                    "fields" : {
-                      "english" : {
-                        "type" : "text",
-                        "analyzer" : "english_analyzer"
-                      },
-                      "shingles" : {
-                        "type" : "text",
-                        "analyzer" : "shingle_asciifolding_analyzer"
-                      },
-                      "arabic" : {
-                        "type" : "text",
-                        "analyzer" : "arabic_analyzer"
-                      },
-                      "bengali" : {
-                        "type" : "text",
-                        "analyzer" : "bengali_analyzer"
-                      },
-                      "french" : {
-                        "type" : "text",
-                        "analyzer" : "french_analyzer"
-                      },
-                      "german" : {
-                        "type" : "text",
-                        "analyzer" : "german_analyzer"
-                      },
-                      "hindi" : {
-                        "type" : "text",
-                        "analyzer" : "hindi_analyzer"
-                      },
-                      "italian" : {
-                        "type" : "text",
-                        "analyzer" : "italian_analyzer"
-                      }
-                    }
-                  },
-                  "physicalDescription" : {
-                    "type" : "text",
-                    "fields" : {
-                      "keyword" : {
-                        "type" : "keyword"
-                      },
-                      "english" : {
-                        "type" : "text",
-                        "analyzer" : "english"
-                      }
-                    }
-                  },
-                  "lettering" : {
-                    "type" : "text",
-                    "fields" : {
-                      "english" : {
-                        "type" : "text",
-                        "analyzer" : "english_analyzer"
-                      },
-                      "shingles" : {
-                        "type" : "text",
-                        "analyzer" : "shingle_asciifolding_analyzer"
-                      },
-                      "arabic" : {
-                        "type" : "text",
-                        "analyzer" : "arabic_analyzer"
-                      },
-                      "bengali" : {
-                        "type" : "text",
-                        "analyzer" : "bengali_analyzer"
-                      },
-                      "french" : {
-                        "type" : "text",
-                        "analyzer" : "french_analyzer"
-                      },
-                      "german" : {
-                        "type" : "text",
-                        "analyzer" : "german_analyzer"
-                      },
-                      "hindi" : {
-                        "type" : "text",
-                        "analyzer" : "hindi_analyzer"
-                      },
-                      "italian" : {
-                        "type" : "text",
-                        "analyzer" : "italian_analyzer"
-                      }
-                    }
-                  },
-                  "contributors" : {
-                    "type" : "object",
-                    "properties" : {
-                      "agent" : {
-                        "type" : "object",
-                        "properties" : {
-                          "label" : {
-                            "type" : "text",
-                            "analyzer" : "asciifolding_analyzer",
-                            "fields" : {
-                              "keyword" : {
-                                "type" : "keyword"
-                              },
-                              "lowercaseKeyword" : {
-                                "type" : "keyword",
-                                "normalizer" : "lowercase_normalizer"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "subjects" : {
-                    "type" : "object",
-                    "properties" : {
-                      "concepts" : {
-                        "type" : "object",
-                        "properties" : {
-                          "label" : {
-                            "type" : "text",
-                            "analyzer" : "asciifolding_analyzer",
-                            "fields" : {
-                              "keyword" : {
-                                "type" : "keyword"
-                              },
-                              "lowercaseKeyword" : {
-                                "type" : "keyword",
-                                "normalizer" : "lowercase_normalizer"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "genres" : {
+                  "agent" : {
                     "type" : "object",
                     "properties" : {
                       "label" : {
@@ -893,198 +392,235 @@
                             "normalizer" : "lowercase_normalizer"
                           }
                         }
-                      },
-                      "concepts" : {
-                        "type" : "object",
-                        "properties" : {
-                          "label" : {
-                            "type" : "text",
-                            "analyzer" : "asciifolding_analyzer",
-                            "fields" : {
-                              "keyword" : {
-                                "type" : "keyword"
-                              },
-                              "lowercaseKeyword" : {
-                                "type" : "keyword",
-                                "normalizer" : "lowercase_normalizer"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "production" : {
-                    "type" : "object",
-                    "properties" : {
-                      "places" : {
-                        "type" : "object",
-                        "properties" : {
-                          "label" : {
-                            "type" : "text",
-                            "analyzer" : "asciifolding_analyzer",
-                            "fields" : {
-                              "keyword" : {
-                                "type" : "keyword"
-                              },
-                              "lowercaseKeyword" : {
-                                "type" : "keyword",
-                                "normalizer" : "lowercase_normalizer"
-                              }
-                            }
-                          }
-                        }
-                      },
-                      "agents" : {
-                        "type" : "object",
-                        "properties" : {
-                          "label" : {
-                            "type" : "text",
-                            "analyzer" : "asciifolding_analyzer",
-                            "fields" : {
-                              "keyword" : {
-                                "type" : "keyword"
-                              },
-                              "lowercaseKeyword" : {
-                                "type" : "keyword",
-                                "normalizer" : "lowercase_normalizer"
-                              }
-                            }
-                          }
-                        }
-                      },
-                      "dates" : {
-                        "type" : "object",
-                        "properties" : {
-                          "label" : {
-                            "type" : "text",
-                            "analyzer" : "asciifolding_analyzer",
-                            "fields" : {
-                              "keyword" : {
-                                "type" : "keyword"
-                              },
-                              "lowercaseKeyword" : {
-                                "type" : "keyword",
-                                "normalizer" : "lowercase_normalizer"
-                              }
-                            }
-                          }
-                        }
-                      },
-                      "function" : {
-                        "type" : "object",
-                        "properties" : {
-                          "label" : {
-                            "type" : "text",
-                            "analyzer" : "asciifolding_analyzer",
-                            "fields" : {
-                              "keyword" : {
-                                "type" : "keyword"
-                              },
-                              "lowercaseKeyword" : {
-                                "type" : "keyword",
-                                "normalizer" : "lowercase_normalizer"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "languages" : {
-                    "type" : "object",
-                    "properties" : {
-                      "label" : {
-                        "type" : "text",
-                        "analyzer" : "asciifolding_analyzer",
-                        "fields" : {
-                          "keyword" : {
-                            "type" : "keyword"
-                          },
-                          "lowercaseKeyword" : {
-                            "type" : "keyword",
-                            "normalizer" : "lowercase_normalizer"
-                          }
-                        }
-                      },
-                      "id" : {
-                        "type" : "keyword"
-                      }
-                    }
-                  },
-                  "edition" : {
-                    "type" : "text"
-                  },
-                  "notes" : {
-                    "type" : "object",
-                    "properties" : {
-                      "content" : {
-                        "type" : "text",
-                        "fields" : {
-                          "english" : {
-                            "type" : "text",
-                            "analyzer" : "english_analyzer"
-                          },
-                          "shingles" : {
-                            "type" : "text",
-                            "analyzer" : "shingle_asciifolding_analyzer"
-                          },
-                          "arabic" : {
-                            "type" : "text",
-                            "analyzer" : "arabic_analyzer"
-                          },
-                          "bengali" : {
-                            "type" : "text",
-                            "analyzer" : "bengali_analyzer"
-                          },
-                          "french" : {
-                            "type" : "text",
-                            "analyzer" : "french_analyzer"
-                          },
-                          "german" : {
-                            "type" : "text",
-                            "analyzer" : "german_analyzer"
-                          },
-                          "hindi" : {
-                            "type" : "text",
-                            "analyzer" : "hindi_analyzer"
-                          },
-                          "italian" : {
-                            "type" : "text",
-                            "analyzer" : "italian_analyzer"
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "collectionPath" : {
-                    "type" : "object",
-                    "properties" : {
-                      "label" : {
-                        "type" : "text",
-                        "analyzer" : "asciifolding_analyzer",
-                        "fields" : {
-                          "keyword" : {
-                            "type" : "keyword"
-                          },
-                          "lowercaseKeyword" : {
-                            "type" : "keyword",
-                            "normalizer" : "lowercase_normalizer"
-                          }
-                        }
-                      },
-                      "path" : {
-                        "type" : "text"
                       }
                     }
                   }
                 }
               },
-              "type" : {
-                "type" : "keyword"
+              "subjects" : {
+                "type" : "object",
+                "properties" : {
+                  "concepts" : {
+                    "type" : "object",
+                    "properties" : {
+                      "label" : {
+                        "type" : "text",
+                        "analyzer" : "asciifolding_analyzer",
+                        "fields" : {
+                          "keyword" : {
+                            "type" : "keyword"
+                          },
+                          "lowercaseKeyword" : {
+                            "type" : "keyword",
+                            "normalizer" : "lowercase_normalizer"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "genres" : {
+                "type" : "object",
+                "properties" : {
+                  "label" : {
+                    "type" : "text",
+                    "analyzer" : "asciifolding_analyzer",
+                    "fields" : {
+                      "keyword" : {
+                        "type" : "keyword"
+                      },
+                      "lowercaseKeyword" : {
+                        "type" : "keyword",
+                        "normalizer" : "lowercase_normalizer"
+                      }
+                    }
+                  },
+                  "concepts" : {
+                    "type" : "object",
+                    "properties" : {
+                      "label" : {
+                        "type" : "text",
+                        "analyzer" : "asciifolding_analyzer",
+                        "fields" : {
+                          "keyword" : {
+                            "type" : "keyword"
+                          },
+                          "lowercaseKeyword" : {
+                            "type" : "keyword",
+                            "normalizer" : "lowercase_normalizer"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "production" : {
+                "type" : "object",
+                "properties" : {
+                  "places" : {
+                    "type" : "object",
+                    "properties" : {
+                      "label" : {
+                        "type" : "text",
+                        "analyzer" : "asciifolding_analyzer",
+                        "fields" : {
+                          "keyword" : {
+                            "type" : "keyword"
+                          },
+                          "lowercaseKeyword" : {
+                            "type" : "keyword",
+                            "normalizer" : "lowercase_normalizer"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "agents" : {
+                    "type" : "object",
+                    "properties" : {
+                      "label" : {
+                        "type" : "text",
+                        "analyzer" : "asciifolding_analyzer",
+                        "fields" : {
+                          "keyword" : {
+                            "type" : "keyword"
+                          },
+                          "lowercaseKeyword" : {
+                            "type" : "keyword",
+                            "normalizer" : "lowercase_normalizer"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "dates" : {
+                    "type" : "object",
+                    "properties" : {
+                      "label" : {
+                        "type" : "text",
+                        "analyzer" : "asciifolding_analyzer",
+                        "fields" : {
+                          "keyword" : {
+                            "type" : "keyword"
+                          },
+                          "lowercaseKeyword" : {
+                            "type" : "keyword",
+                            "normalizer" : "lowercase_normalizer"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "function" : {
+                    "type" : "object",
+                    "properties" : {
+                      "label" : {
+                        "type" : "text",
+                        "analyzer" : "asciifolding_analyzer",
+                        "fields" : {
+                          "keyword" : {
+                            "type" : "keyword"
+                          },
+                          "lowercaseKeyword" : {
+                            "type" : "keyword",
+                            "normalizer" : "lowercase_normalizer"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "languages" : {
+                "type" : "object",
+                "properties" : {
+                  "label" : {
+                    "type" : "text",
+                    "analyzer" : "asciifolding_analyzer",
+                    "fields" : {
+                      "keyword" : {
+                        "type" : "keyword"
+                      },
+                      "lowercaseKeyword" : {
+                        "type" : "keyword",
+                        "normalizer" : "lowercase_normalizer"
+                      }
+                    }
+                  },
+                  "id" : {
+                    "type" : "keyword"
+                  }
+                }
+              },
+              "edition" : {
+                "type" : "text"
+              },
+              "notes" : {
+                "type" : "object",
+                "properties" : {
+                  "content" : {
+                    "type" : "text",
+                    "fields" : {
+                      "english" : {
+                        "type" : "text",
+                        "analyzer" : "english_analyzer"
+                      },
+                      "shingles" : {
+                        "type" : "text",
+                        "analyzer" : "shingle_asciifolding_analyzer"
+                      },
+                      "arabic" : {
+                        "type" : "text",
+                        "analyzer" : "arabic_analyzer"
+                      },
+                      "bengali" : {
+                        "type" : "text",
+                        "analyzer" : "bengali_analyzer"
+                      },
+                      "french" : {
+                        "type" : "text",
+                        "analyzer" : "french_analyzer"
+                      },
+                      "german" : {
+                        "type" : "text",
+                        "analyzer" : "german_analyzer"
+                      },
+                      "hindi" : {
+                        "type" : "text",
+                        "analyzer" : "hindi_analyzer"
+                      },
+                      "italian" : {
+                        "type" : "text",
+                        "analyzer" : "italian_analyzer"
+                      }
+                    }
+                  }
+                }
+              },
+              "collectionPath" : {
+                "type" : "object",
+                "properties" : {
+                  "label" : {
+                    "type" : "text",
+                    "analyzer" : "asciifolding_analyzer",
+                    "fields" : {
+                      "keyword" : {
+                        "type" : "keyword"
+                      },
+                      "lowercaseKeyword" : {
+                        "type" : "keyword",
+                        "normalizer" : "lowercase_normalizer"
+                      }
+                    }
+                  },
+                  "path" : {
+                    "type" : "text"
+                  }
+                }
               }
-            },
-            "dynamic" : "false"
+            }
           },
           "type" : {
             "type" : "keyword"

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/generators/ImageGenerators.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/generators/ImageGenerators.scala
@@ -31,7 +31,6 @@ trait ImageGenerators
 
   def createImageDataWith(
     locations: List[DigitalLocation] = List(createImageLocation),
-    version: Int = 1,
     identifierValue: String = randomAlphanumeric(10),
     identifierType: IdentifierType = IdentifierType.MiroImageNumber
   ): ImageData[IdState.Identifiable] =
@@ -42,7 +41,6 @@ trait ImageGenerators
           value = identifierValue
         )
       ),
-      version = version,
       locations = locations
     )
 
@@ -112,7 +110,6 @@ trait ImageGenerators
       modifiedTime: Instant = instantInLast30Days,
       parentWork: ImageSource.ParentWork = mergedWork().toParentWork
     ): Image[ImageState.Initial] = Image[ImageState.Initial](
-      version = imageData.version,
       locations = imageData.locations,
       modifiedTime = modifiedTime,
       source = parentWork,

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/generators/ImageGenerators.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/generators/ImageGenerators.scala
@@ -5,8 +5,7 @@ import weco.catalogue.internal_model.identifiers.{
   IdState,
   IdentifierType
 }
-import weco.catalogue.internal_model.image
-import weco.catalogue.internal_model.image.ParentWork._
+import weco.catalogue.internal_model.image.ImageSource.ParentWork._
 import weco.catalogue.internal_model.image.ImageState.{Indexed, Initial}
 import weco.catalogue.internal_model.image._
 import weco.catalogue.internal_model.locations.{
@@ -69,26 +68,21 @@ trait ImageGenerators
 
     def toAugmentedImageWith(
       inferredData: Option[InferredData] = createInferredData,
-      parentWork: Work[WorkState.Identified] = sierraIdentifiedWork(),
-      redirectedWork: Option[Work[WorkState.Identified]] = Some(
-        sierraIdentifiedWork())): Image[ImageState.Augmented] =
+      parentWork: Work[WorkState.Identified] = sierraIdentifiedWork()): Image[ImageState.Augmented] =
       imageData.toIdentified
         .toAugmentedImageWith(
           inferredData = inferredData,
-          parentWork = parentWork,
-          redirectedWork = redirectedWork)
+          parentWork = parentWork)
 
     def toIndexedImageWith(
       canonicalId: CanonicalId = createCanonicalId,
       parentWork: Work[WorkState.Identified] = identifiedWork(),
-      redirectedWork: Option[Work[WorkState.Identified]] = None,
       inferredData: Option[InferredData] = createInferredData)
       : Image[ImageState.Indexed] =
       imageData
         .toIdentifiedWith(canonicalId = canonicalId)
         .toIndexedImageWith(
           parentWork = parentWork,
-          redirectedWork = redirectedWork,
           inferredData = inferredData
         )
 
@@ -116,15 +110,12 @@ trait ImageGenerators
     imageData: ImageData[IdState.Identified]) {
     def toInitialImageWith(
       modifiedTime: Instant = instantInLast30Days,
-      parentWorks: ParentWorks = ParentWorks(
-        canonicalWork = mergedWork().toParentWork,
-        redirectedWork = None
-      )
+      parentWork: ImageSource.ParentWork = mergedWork().toParentWork
     ): Image[ImageState.Initial] = Image[ImageState.Initial](
       version = imageData.version,
       locations = imageData.locations,
       modifiedTime = modifiedTime,
-      source = parentWorks,
+      source = parentWork,
       state = ImageState.Initial(
         sourceIdentifier = imageData.id.sourceIdentifier,
         canonicalId = imageData.id.canonicalId
@@ -133,27 +124,19 @@ trait ImageGenerators
 
     def toAugmentedImageWith(
       inferredData: Option[InferredData] = createInferredData,
-      parentWork: Work[WorkState.Identified] = sierraIdentifiedWork(),
-      redirectedWork: Option[Work[WorkState.Identified]] = Some(
-        sierraIdentifiedWork())
+      parentWork: Work[WorkState.Identified] = sierraIdentifiedWork()
     ): Image[ImageState.Augmented] =
       imageData
-        .toInitialImageWith(
-          parentWorks = image.ParentWorks(
-            canonicalWork = parentWork.toParentWork,
-            redirectedWork = redirectedWork.map(_.toParentWork))
-        )
+        .toInitialImageWith(parentWork = parentWork.toParentWork)
         .transition[ImageState.Augmented](inferredData)
 
     def toIndexedImageWith(
       parentWork: Work[WorkState.Identified] = identifiedWork(),
-      redirectedWork: Option[Work[WorkState.Identified]] = None,
       inferredData: Option[InferredData] = createInferredData)
       : Image[ImageState.Indexed] =
       imageData
         .toAugmentedImageWith(
           parentWork = parentWork,
-          redirectedWork = redirectedWork,
           inferredData = inferredData
         )
         .transition[ImageState.Indexed]()

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/generators/ImageGenerators.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/generators/ImageGenerators.scala
@@ -66,17 +66,18 @@ trait ImageGenerators
 
     def toAugmentedImageWith(
       inferredData: Option[InferredData] = createInferredData,
-      parentWork: Work[WorkState.Identified] = sierraIdentifiedWork()): Image[ImageState.Augmented] =
+      parentWork: Work[WorkState.Identified] = sierraIdentifiedWork())
+      : Image[ImageState.Augmented] =
       imageData.toIdentified
         .toAugmentedImageWith(
           inferredData = inferredData,
           parentWork = parentWork)
 
-    def toIndexedImageWith(
-      canonicalId: CanonicalId = createCanonicalId,
-      parentWork: Work[WorkState.Identified] = identifiedWork(),
-      inferredData: Option[InferredData] = createInferredData)
-      : Image[ImageState.Indexed] =
+    def toIndexedImageWith(canonicalId: CanonicalId = createCanonicalId,
+                           parentWork: Work[WorkState.Identified] =
+                             identifiedWork(),
+                           inferredData: Option[InferredData] =
+                             createInferredData): Image[ImageState.Indexed] =
       imageData
         .toIdentifiedWith(canonicalId = canonicalId)
         .toIndexedImageWith(
@@ -127,10 +128,10 @@ trait ImageGenerators
         .toInitialImageWith(parentWork = parentWork.toParentWork)
         .transition[ImageState.Augmented](inferredData)
 
-    def toIndexedImageWith(
-      parentWork: Work[WorkState.Identified] = identifiedWork(),
-      inferredData: Option[InferredData] = createInferredData)
-      : Image[ImageState.Indexed] =
+    def toIndexedImageWith(parentWork: Work[WorkState.Identified] =
+                             identifiedWork(),
+                           inferredData: Option[InferredData] =
+                             createInferredData): Image[ImageState.Indexed] =
       imageData
         .toAugmentedImageWith(
           parentWork = parentWork,

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/image/DerivedImageDataTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/image/DerivedImageDataTest.scala
@@ -3,7 +3,7 @@ package weco.catalogue.internal_model.image
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.catalogue.internal_model.generators.ImageGenerators
-import weco.catalogue.internal_model.work.{Contributor, Organisation, Person}
+import weco.catalogue.internal_model.work.{Contributor, Organisation}
 
 class DerivedImageDataTest
     extends AnyFunSpec
@@ -33,11 +33,6 @@ class DerivedImageDataTest
     val image = createImageData.toAugmentedImageWith(
       parentWork = identifiedWork().contributors(
         List(Contributor(Organisation("Planet Express"), roles = Nil))
-      ),
-      redirectedWork = Some(
-        identifiedWork().contributors(
-          List(Contributor(Person("Zaphod Beeblebrox"), roles = Nil))
-        )
       )
     )
     val derivedImageData = DerivedImageData(image)

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/image/ParentWorkTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/image/ParentWorkTest.scala
@@ -5,7 +5,7 @@ import org.scalatest.matchers.should.Matchers
 import weco.catalogue.internal_model.generators.ImageGenerators
 
 class ParentWorkTest extends AnyFunSpec with Matchers with ImageGenerators {
-  import ParentWork._
+  import ImageSource.ParentWork._
 
   describe("toParentWork") {
     it("removes the imageData from a merged work") {

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/index/IndexFixtures.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/index/IndexFixtures.scala
@@ -19,9 +19,8 @@ import weco.catalogue.internal_model.work.{Work, WorkState}
 trait IndexFixtures extends ElasticsearchFixtures { this: Suite =>
 
   def withLocalWorksIndex[R](testWith: TestWith[Index, R]): R =
-    withLocalElasticsearchIndex[R](config = WorksIndexConfig.indexed) {
-      index =>
-        testWith(index)
+    withLocalElasticsearchIndex[R](config = WorksIndexConfig.indexed) { index =>
+      testWith(index)
     }
 
   def withLocalIdentifiedWorksIndex[R](testWith: TestWith[Index, R]): R =

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/index/IndexFixtures.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/index/IndexFixtures.scala
@@ -19,7 +19,7 @@ import weco.catalogue.internal_model.work.{Work, WorkState}
 trait IndexFixtures extends ElasticsearchFixtures { this: Suite =>
 
   def withLocalWorksIndex[R](testWith: TestWith[Index, R]): R =
-    withLocalElasticsearchIndex[R](config = WorksIndexConfig.ingested) {
+    withLocalElasticsearchIndex[R](config = WorksIndexConfig.indexed) {
       index =>
         testWith(index)
     }
@@ -53,7 +53,7 @@ trait IndexFixtures extends ElasticsearchFixtures { this: Suite =>
     }
 
   def withLocalImagesIndex[R](testWith: TestWith[Index, R]): R =
-    withLocalElasticsearchIndex[R](config = ImagesIndexConfig.ingested) {
+    withLocalElasticsearchIndex[R](config = ImagesIndexConfig.indexed) {
       index =>
         testWith(index)
     }

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/index/IndexFixtures.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/index/IndexFixtures.scala
@@ -124,7 +124,7 @@ trait IndexFixtures extends ElasticsearchFixtures { this: Suite =>
           val jsonDoc = toJson(image).get
 
           indexInto(index.name)
-            .version(image.version)
+            .version(image.modifiedTime.toEpochMilli)
             .versionType(ExternalGte)
             .id(image.id)
             .doc(jsonDoc)

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/index/SearchIndexConfigJsonTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/index/SearchIndexConfigJsonTest.scala
@@ -37,8 +37,8 @@ class SearchIndexConfigJsonTest
       CreateIndexContentBuilder(
         CreateIndexRequest(
           "works",
-          analysis = Some(WorksIndexConfig.ingested.analysis),
-          mapping = Some(WorksIndexConfig.ingested.mapping.meta(Map()))
+          analysis = Some(WorksIndexConfig.indexed.analysis),
+          mapping = Some(WorksIndexConfig.indexed.mapping.meta(Map()))
         )
       ).value)
 
@@ -56,8 +56,8 @@ class SearchIndexConfigJsonTest
       CreateIndexContentBuilder(
         CreateIndexRequest(
           "images",
-          analysis = Some(ImagesIndexConfig.ingested.analysis),
-          mapping = Some(ImagesIndexConfig.ingested.mapping.meta(Map()))
+          analysis = Some(ImagesIndexConfig.indexed.analysis),
+          mapping = Some(ImagesIndexConfig.indexed.mapping.meta(Map()))
         )
       ).value)
 

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/index/WorksIndexConfigTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/index/WorksIndexConfigTest.scala
@@ -82,7 +82,7 @@ class WorksIndexConfigTest
     }
 
     it("WorkState.Indexed") {
-      withLocalIndex(WorksIndexConfig.ingested) { implicit index =>
+      withLocalIndex(WorksIndexConfig.indexed) { implicit index =>
         forAll { indexedWork: Work[WorkState.Indexed] =>
           assertWorkCanBeIndexed(indexedWork)
         }

--- a/common/pipeline_storage/src/test/scala/weco/pipeline_storage/ImageIndexableTest.scala
+++ b/common/pipeline_storage/src/test/scala/weco/pipeline_storage/ImageIndexableTest.scala
@@ -106,7 +106,7 @@ class ImageIndexableTest
                    Seq[Image[ImageState.Indexed]]],
     ingestedImage: Image[ImageState.Indexed],
     index: Index): Seq[Assertion] = {
-    result.isRight shouldBe true
+    result shouldBe a[Right[_, _]]
     assertElasticsearchEventuallyHasImage(index, ingestedImage)
   }
 

--- a/common/pipeline_storage/src/test/scala/weco/pipeline_storage/ImageIndexableTest.scala
+++ b/common/pipeline_storage/src/test/scala/weco/pipeline_storage/ImageIndexableTest.scala
@@ -47,9 +47,9 @@ class ImageIndexableTest
           )
 
           whenReady(insertFuture) { result =>
-            assertIngestedImageIs(
+            assertIndexedImageIs(
               result = result,
-              ingestedImage = updatedModifiedTimeImage,
+              indexedImage = updatedModifiedTimeImage,
               index = index
             )
           }
@@ -69,9 +69,9 @@ class ImageIndexableTest
           )
 
           whenReady(insertFuture) { result =>
-            assertIngestedImageIs(
+            assertIndexedImageIs(
               result = result,
-              ingestedImage = originalImage,
+              indexedImage = originalImage,
               index = index
             )
           }
@@ -91,9 +91,9 @@ class ImageIndexableTest
           )
 
           whenReady(insertFuture) { result =>
-            assertIngestedImageIs(
+            assertIndexedImageIs(
               result = result,
-              ingestedImage = updatedLocationImage,
+              indexedImage = updatedLocationImage,
               index = index
             )
           }
@@ -101,13 +101,13 @@ class ImageIndexableTest
     }
   }
 
-  private def assertIngestedImageIs(
+  private def assertIndexedImageIs(
     result: Either[Seq[Image[ImageState.Indexed]],
                    Seq[Image[ImageState.Indexed]]],
-    ingestedImage: Image[ImageState.Indexed],
+    indexedImage: Image[ImageState.Indexed],
     index: Index): Seq[Assertion] = {
     result shouldBe a[Right[_, _]]
-    assertElasticsearchEventuallyHasImage(index, ingestedImage)
+    assertElasticsearchEventuallyHasImage(index, indexedImage)
   }
 
   private def withImagesIndexAndIndexer[R](
@@ -116,7 +116,7 @@ class ImageIndexableTest
       val indexer = new ElasticIndexer[Image[ImageState.Indexed]](
         elasticClient,
         index,
-        ImagesIndexConfig.ingested)
+        ImagesIndexConfig.indexed)
       testWith((index, indexer))
     }
 }

--- a/common/pipeline_storage/src/test/scala/weco/pipeline_storage/fixtures/ElasticIndexerFixtures.scala
+++ b/common/pipeline_storage/src/test/scala/weco/pipeline_storage/fixtures/ElasticIndexerFixtures.scala
@@ -29,9 +29,9 @@ trait ElasticIndexerFixtures extends ElasticsearchFixtures {
 
   def indexInOrder[T](indexer: ElasticIndexer[T])(documents: T*)(
     implicit ec: ExecutionContext): Future[Either[Seq[T], Seq[T]]] =
-    documents.tail.foldLeft(indexer(List(documents.head))) { (future, doc) =>
+    documents.tail.foldLeft(indexer(documents.head)) { (future, doc) =>
       future.flatMap { _ =>
-        indexer(List(doc))
+        indexer(doc)
       }
     }
 }

--- a/pipeline/ingestor/ingestor_images/src/main/scala/weco/pipeline/ingestor/images/Main.scala
+++ b/pipeline/ingestor/ingestor_images/src/main/scala/weco/pipeline/ingestor/images/Main.scala
@@ -43,7 +43,7 @@ object Main extends WellcomeTypesafeApp {
         config,
         client = client,
         namespace = "indexed-images",
-        indexConfig = ImagesIndexConfig.ingested
+        indexConfig = ImagesIndexConfig.indexed
       )
     val msgSender = SNSBuilder
       .buildSNSMessageSender(config, subject = "Sent from the ingestor-images")

--- a/pipeline/ingestor/ingestor_images/src/test/scala/weco/pipeline/ingestor/images/ImagesIngestorFeatureTest.scala
+++ b/pipeline/ingestor/ingestor_images/src/test/scala/weco/pipeline/ingestor/images/ImagesIngestorFeatureTest.scala
@@ -37,7 +37,7 @@ class ImagesIngestorFeatureTest
             val indexer = new ElasticIndexer[Image[Indexed]](
               elasticClient,
               index,
-              ImagesIndexConfig.ingested)
+              ImagesIndexConfig.indexed)
             withWorkerService(
               queue,
               retriever,
@@ -66,7 +66,7 @@ class ImagesIngestorFeatureTest
             val indexer = new ElasticIndexer[Image[Indexed]](
               elasticClient,
               index,
-              ImagesIndexConfig.ingested)
+              ImagesIndexConfig.indexed)
             val retriever = new ElasticSourceRetriever[Image[Augmented]](
               elasticClient,
               augmentedIndex

--- a/pipeline/ingestor/ingestor_images/src/test/scala/weco/pipeline/ingestor/images/services/ImagesIndexerTest.scala
+++ b/pipeline/ingestor/ingestor_images/src/test/scala/weco/pipeline/ingestor/images/services/ImagesIndexerTest.scala
@@ -28,7 +28,7 @@ class ImagesIndexerTest
         new ElasticIndexer[Image[ImageState.Augmented]](
           elasticClient,
           index,
-          ImagesIndexConfig.ingested)
+          ImagesIndexConfig.indexed)
       val image = createImageData.toAugmentedImage
       whenReady(imagesIndexer(List(image))) { r =>
         r.isRight shouldBe true
@@ -44,7 +44,7 @@ class ImagesIndexerTest
         new ElasticIndexer[Image[ImageState.Augmented]](
           elasticClient,
           index,
-          ImagesIndexConfig.ingested)
+          ImagesIndexConfig.indexed)
       val images = (1 to 5).map(_ => createImageData.toAugmentedImage)
       whenReady(imagesIndexer(images)) { r =>
         r.isRight shouldBe true
@@ -60,7 +60,7 @@ class ImagesIndexerTest
         new ElasticIndexer[Image[ImageState.Augmented]](
           elasticClient,
           index,
-          ImagesIndexConfig.ingested)
+          ImagesIndexConfig.indexed)
       val image = createImageData.toAugmentedImage
       val newerImage =
         image.copy(
@@ -84,7 +84,7 @@ class ImagesIndexerTest
         new ElasticIndexer[Image[ImageState.Augmented]](
           elasticClient,
           index,
-          ImagesIndexConfig.ingested)
+          ImagesIndexConfig.indexed)
       val image = createImageData.toAugmentedImage
       val olderImage =
         image.copy(

--- a/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/Main.scala
+++ b/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/Main.scala
@@ -44,7 +44,7 @@ object Main extends WellcomeTypesafeApp {
       client = client,
       namespace = "indexed-works",
       indexConfig =
-        WorksIndexConfig.ingested.withRefreshIntervalFromConfig(config)
+        WorksIndexConfig.indexed.withRefreshIntervalFromConfig(config)
     )
     val messageSender = SNSBuilder
       .buildSNSMessageSender(config, subject = "Sent from the ingestor-works")

--- a/pipeline/ingestor/ingestor_works/src/test/scala/weco/pipeline/ingestor/works/fixtures/WorksIngestorFixtures.scala
+++ b/pipeline/ingestor/ingestor_works/src/test/scala/weco/pipeline/ingestor/works/fixtures/WorksIngestorFixtures.scala
@@ -70,7 +70,7 @@ trait WorksIngestorFixtures
     val indexer = new ElasticIndexer[Work[Indexed]](
       client = elasticClient,
       index = indexedIndex,
-      config = WorksIndexConfig.ingested
+      config = WorksIndexConfig.indexed
     )
 
     withWorkerService(

--- a/pipeline/merger/src/main/scala/weco/pipeline/merger/models/MergerOutcome.scala
+++ b/pipeline/merger/src/main/scala/weco/pipeline/merger/models/MergerOutcome.scala
@@ -28,7 +28,6 @@ case class MergerOutcome(resultWorks: Seq[Work[Identified]],
     imagesWithSources.map {
       case ImageDataWithSource(imageData, source) =>
         Image[Initial](
-          version = imageData.version,
           locations = imageData.locations,
           source = source,
           modifiedTime = modifiedTime,

--- a/pipeline/merger/src/main/scala/weco/pipeline/merger/services/Merger.scala
+++ b/pipeline/merger/src/main/scala/weco/pipeline/merger/services/Merger.scala
@@ -2,8 +2,7 @@ package weco.pipeline.merger.services
 
 import cats.data.State
 import weco.catalogue.internal_model.identifiers.{DataState, IdState}
-import weco.catalogue.internal_model.image
-import weco.catalogue.internal_model.image.{ImageData, ParentWorks}
+import weco.catalogue.internal_model.image.ImageData
 import weco.catalogue.internal_model.work.WorkState.Identified
 import weco.catalogue.internal_model.work.{Item, Work, WorkData, WorkState}
 import weco.pipeline.merger.logging.MergerLogging
@@ -186,7 +185,7 @@ object Merger {
 
 object PlatformMerger extends Merger {
   import Merger.WorkMergingOps
-  import weco.catalogue.internal_model.image.ParentWork._
+  import weco.catalogue.internal_model.image.ImageSource.ParentWork._
 
   override def findTarget(
     works: Seq[Work[Identified]]
@@ -203,11 +202,8 @@ object PlatformMerger extends Merger {
           mergedTarget = target,
           imageDataWithSources = standaloneImages(target).map { image =>
             ImageDataWithSource(
-              image,
-              ParentWorks(
-                canonicalWork = target.toParentWork,
-                redirectedWork = None
-              )
+              imageData = image,
+              source = target.toParentWork
             )
           }
         )
@@ -233,12 +229,7 @@ object PlatformMerger extends Merger {
           imageDataWithSources = sourceImageData.map { imageData =>
             ImageDataWithSource(
               imageData = imageData,
-              source = image.ParentWorks(
-                canonicalWork = work.toParentWork,
-                redirectedWork = sources
-                  .find { _.data.imageData.contains(imageData) }
-                  .map(_.toParentWork)
-              )
+              source = work.toParentWork
             )
           }
         )

--- a/pipeline/merger/src/test/scala/weco/pipeline/merger/services/PlatformMergerTest.scala
+++ b/pipeline/merger/src/test/scala/weco/pipeline/merger/services/PlatformMergerTest.scala
@@ -3,11 +3,10 @@ package weco.pipeline.merger.services
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks._
+import weco.catalogue.internal_model.image.ImageSource.ParentWork._
 import weco.catalogue.internal_model.work.WorkState.{Identified, Merged}
 import weco.catalogue.internal_model.work.WorkFsm._
-import weco.catalogue.internal_model.image.ParentWork._
 import weco.catalogue.internal_model.identifiers.IdState
-import weco.catalogue.internal_model.image.ParentWorks
 import weco.catalogue.internal_model.locations.{
   AccessCondition,
   AccessMethod,
@@ -184,10 +183,7 @@ class PlatformMergerTest
     val expectedImage =
       miroWork.data.imageData.head.toInitialImageWith(
         modifiedTime = now,
-        parentWorks = ParentWorks(
-          canonicalWork = expectedMergedWork.toParentWork,
-          redirectedWork = Some(miroWork.toParentWork)
-        )
+        parentWork = expectedMergedWork.toParentWork
       )
     result.mergedWorksWithTime(now) should contain theSameElementsAs List(
       expectedMergedWork,
@@ -235,10 +231,7 @@ class PlatformMergerTest
     val expectedImage =
       miroWork.data.imageData.head.toInitialImageWith(
         modifiedTime = now,
-        parentWorks = ParentWorks(
-          canonicalWork = expectedMergedWork.toParentWork,
-          redirectedWork = Some(miroWork.toParentWork)
-        )
+        parentWork = expectedMergedWork.toParentWork
       )
 
     result.mergedWorksWithTime(now) should contain theSameElementsAs List(
@@ -295,10 +288,7 @@ class PlatformMergerTest
 
     val expectedImage = miroWork.data.imageData.head.toInitialImageWith(
       modifiedTime = now,
-      parentWorks = ParentWorks(
-        canonicalWork = expectedMergedWork.toParentWork,
-        redirectedWork = Some(miroWork.toParentWork)
-      )
+      parentWork = expectedMergedWork.toParentWork
     )
 
     result.mergedWorksWithTime(now) should contain theSameElementsAs List(
@@ -454,10 +444,7 @@ class PlatformMergerTest
     val expectedImage =
       metsWork.data.imageData.head.toInitialImageWith(
         modifiedTime = now,
-        parentWorks = ParentWorks(
-          canonicalWork = expectedMergedWork.toParentWork,
-          redirectedWork = Some(metsWork.toParentWork)
-        )
+        parentWork = expectedMergedWork.toParentWork
       )
 
     result.mergedWorksWithTime(now) should contain theSameElementsAs List(
@@ -547,10 +534,7 @@ class PlatformMergerTest
 
     val expectedImage = miroWork.data.imageData.head.toInitialImageWith(
       modifiedTime = now,
-      parentWorks = ParentWorks(
-        canonicalWork = expectedMergedWork.toParentWork,
-        redirectedWork = Some(miroWork.toParentWork)
-      )
+      parentWork = expectedMergedWork.toParentWork
     )
 
     result.mergedWorksWithTime(now) should contain theSameElementsAs List(
@@ -679,10 +663,7 @@ class PlatformMergerTest
     result.mergedImagesWithTime(now).head shouldBe miroWork.data.imageData.head
       .toInitialImageWith(
         modifiedTime = now,
-        parentWorks = ParentWorks(
-          canonicalWork = miroWork.toParentWork,
-          redirectedWork = None
-        )
+        parentWork = miroWork.toParentWork
       )
   }
 

--- a/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/MetsData.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/MetsData.scala
@@ -84,7 +84,7 @@ case class InvisibleMetsData(
           items = List(item),
           mergeCandidates = List(mergeCandidate),
           thumbnail = thumbnail(sourceIdentifier.value, license, accessStatus),
-          imageData = imageData(version, license, accessStatus, location)
+          imageData = imageData(license, accessStatus, location)
         ),
         invisibilityReasons = List(MetsWorksAreNotVisible)
       )
@@ -168,7 +168,6 @@ case class InvisibleMetsData(
       )
 
   private def imageData(
-    version: Int,
     license: Option[License],
     accessStatus: Option[AccessStatus],
     manifestLocation: DigitalLocation
@@ -185,7 +184,6 @@ case class InvisibleMetsData(
                 sourceIdentifier = ImageUtils
                   .getImageSourceId(recordIdentifier, fileReference.id)
               ),
-              version = version,
               locations = List(
                 DigitalLocation(
                   url = url,

--- a/pipeline/transformer/transformer_miro/src/main/scala/weco/pipeline/transformer/miro/MiroRecordTransformer.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/weco/pipeline/transformer/miro/MiroRecordTransformer.scala
@@ -122,8 +122,7 @@ class MiroRecordTransformer
           contributors = getContributors(miroRecord),
           thumbnail = Some(getThumbnail(miroRecord, overrides)),
           items = getItems(miroRecord, overrides),
-          imageData = List(
-            getImageData(miroRecord, overrides = overrides, version = version))
+          imageData = List(getImageData(miroRecord, overrides = overrides))
         )
 
         Work.Visible[Source](

--- a/pipeline/transformer/transformer_miro/src/main/scala/weco/pipeline/transformer/miro/transformers/MiroImageData.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/weco/pipeline/transformer/miro/transformers/MiroImageData.scala
@@ -11,8 +11,9 @@ import weco.pipeline.transformer.miro.source.MiroRecord
 
 trait MiroImageData extends MiroLocation {
 
-  def getImageData(miroRecord: MiroRecord,
-                   overrides: MiroSourceOverrides): ImageData[IdState.Identifiable] =
+  def getImageData(
+    miroRecord: MiroRecord,
+    overrides: MiroSourceOverrides): ImageData[IdState.Identifiable] =
     ImageData[IdState.Identifiable](
       id = IdState.Identifiable(
         sourceIdentifier = SourceIdentifier(

--- a/pipeline/transformer/transformer_miro/src/main/scala/weco/pipeline/transformer/miro/transformers/MiroImageData.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/weco/pipeline/transformer/miro/transformers/MiroImageData.scala
@@ -12,8 +12,7 @@ import weco.pipeline.transformer.miro.source.MiroRecord
 trait MiroImageData extends MiroLocation {
 
   def getImageData(miroRecord: MiroRecord,
-                   overrides: MiroSourceOverrides,
-                   version: Int): ImageData[IdState.Identifiable] =
+                   overrides: MiroSourceOverrides): ImageData[IdState.Identifiable] =
     ImageData[IdState.Identifiable](
       id = IdState.Identifiable(
         sourceIdentifier = SourceIdentifier(
@@ -22,7 +21,6 @@ trait MiroImageData extends MiroLocation {
           value = miroRecord.imageNumber
         )
       ),
-      version = version,
       locations = List(getLocation(miroRecord, overrides))
     )
 }

--- a/pipeline/transformer/transformer_miro/src/test/scala/weco/pipeline/transformer/miro/transformers/MiroImageDataTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/weco/pipeline/transformer/miro/transformers/MiroImageDataTest.scala
@@ -28,8 +28,7 @@ class MiroImageDataTest
           useRestrictions = Some("CC-0"),
           sourceCode = Some("FDN")
         ),
-        overrides = MiroSourceOverrides.empty,
-        version = 1
+        overrides = MiroSourceOverrides.empty
       )
 
       imageData shouldBe ImageData[IdState.Identifiable](
@@ -40,7 +39,6 @@ class MiroImageDataTest
             value = "B0011308"
           )
         ),
-        version = 1,
         locations = List(
           DigitalLocation(
             url = "https://iiif.wellcomecollection.org/image/B0011308/info.json",
@@ -61,8 +59,7 @@ class MiroImageDataTest
 
       val imageData1 = transformer.getImageData(
         miroRecord = miroRecord,
-        overrides = MiroSourceOverrides.empty,
-        version = 1
+        overrides = MiroSourceOverrides.empty
       )
 
       imageData1.locations.head.license shouldBe Some(License.CC0)
@@ -71,8 +68,7 @@ class MiroImageDataTest
         miroRecord = miroRecord,
         overrides = MiroSourceOverrides(
           license = Some(License.InCopyright)
-        ),
-        version = 1
+        )
       )
 
       imageData2.locations.head.license shouldBe Some(License.InCopyright)


### PR DESCRIPTION
Follows #1878, for https://github.com/wellcomecollection/platform/issues/5302

Pretty much everywhere we've switched to using modifiedTime instead of an integer version, so mostly we're passing around a value that we don't use anywhere. Once you start unravelling that, you get to pull it out of everywhere.

I don't expect this to make a noticeable impact on the compilation times of internal model, but it reduces the amount of code we have to stare at to find it.