### PR TITLE
What if we don't use the automatically derived encoders/decoders?

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/Implicits.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/Implicits.scala
@@ -32,21 +32,21 @@ object Implicits {
   // dependencies (thus preventing duplicate work)
 
   implicit val _decAccessCondition: Decoder[AccessCondition] =
-    deriveConfiguredDecoder
+    AccessCondition.decoder
   implicit val _decNote: Decoder[Note] = deriveConfiguredDecoder
 
   implicit val _decIdentifierType: Decoder[IdentifierType] =
     IdentifierType.identifierTypeDecoder
   implicit val _decSourceIdentifier: Decoder[SourceIdentifier] =
-    deriveConfiguredDecoder
+    SourceIdentifier.decoder
   implicit val _decCanonicalId: Decoder[CanonicalId] = CanonicalId.decoder
   implicit val _decReferenceNumber: Decoder[ReferenceNumber] =
     ReferenceNumber.decoder
 
   implicit val _decIdStateIdentified: Decoder[IdState.Identified] =
-    deriveConfiguredDecoder
+    IdState.Identified.decoder
   implicit val _decIdStateIdentifiable: Decoder[IdState.Identifiable] =
-    deriveConfiguredDecoder
+    IdState.Identifiable.decoder
   implicit val _decIdStateUnminted: Decoder[IdState.Unminted] =
     deriveConfiguredDecoder
   implicit val _decIdStateMinted: Decoder[IdState.Minted] =
@@ -296,13 +296,13 @@ object Implicits {
     deriveConfiguredDecoder
 
   implicit val _encAccessCondition: Encoder[AccessCondition] =
-    deriveConfiguredEncoder
+    AccessCondition.encoder
   implicit val _encNote: Encoder[Note] = deriveConfiguredEncoder
 
   implicit val _encIdentifierType: Encoder[IdentifierType] =
     IdentifierType.identifierTypeEncoder
   implicit val _encSourceIdentifier: Encoder[SourceIdentifier] =
-    deriveConfiguredEncoder
+    SourceIdentifier.encoder
   implicit val _encCanonicalId: Encoder[CanonicalId] = CanonicalId.encoder
   implicit val _envReferenceNumber: Encoder[ReferenceNumber] =
     ReferenceNumber.encoder

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/IdState.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/IdState.scala
@@ -38,10 +38,26 @@ object IdState {
 
   case object Identified {
     implicit val encoder: Encoder[Identified] =
-      Encoder.forProduct3[Identified, CanonicalId, SourceIdentifier, List[SourceIdentifier]]("canonicalId", "sourceIdentifier", "otherIdentifiers")((id: Identified) => (id.canonicalId, id.sourceIdentifier, id.otherIdentifiers))
+      Encoder.forProduct3[
+        Identified,
+        CanonicalId,
+        SourceIdentifier,
+        List[SourceIdentifier]](
+        "canonicalId",
+        "sourceIdentifier",
+        "otherIdentifiers")((id: Identified) =>
+        (id.canonicalId, id.sourceIdentifier, id.otherIdentifiers))
 
     implicit val decoder: Decoder[Identified] =
-      Decoder.forProduct3[Identified, CanonicalId, SourceIdentifier, List[SourceIdentifier]]("canonicalId", "sourceIdentifier", "otherIdentifiers")((canonicalId, sourceIdentifier, otherIdentifiers) => Identified(canonicalId, sourceIdentifier, otherIdentifiers))
+      Decoder.forProduct3[
+        Identified,
+        CanonicalId,
+        SourceIdentifier,
+        List[SourceIdentifier]](
+        "canonicalId",
+        "sourceIdentifier",
+        "otherIdentifiers")((canonicalId, sourceIdentifier, otherIdentifiers) =>
+        Identified(canonicalId, sourceIdentifier, otherIdentifiers))
   }
 
   /** Represents an ID that has not yet been minted, but will have a canonicalId
@@ -57,10 +73,22 @@ object IdState {
 
   case object Identifiable {
     implicit val encoder: Encoder[Identifiable] =
-      Encoder.forProduct3[Identifiable, SourceIdentifier, List[SourceIdentifier], String]("sourceIdentifier", "otherIdentifiers", "identifiedType")((id: Identifiable) => (id.sourceIdentifier, id.otherIdentifiers, id.identifiedType))
+      Encoder.forProduct3[
+        Identifiable,
+        SourceIdentifier,
+        List[SourceIdentifier],
+        String]("sourceIdentifier", "otherIdentifiers", "identifiedType")(
+        (id: Identifiable) =>
+          (id.sourceIdentifier, id.otherIdentifiers, id.identifiedType))
 
     implicit val decoder: Decoder[Identifiable] =
-      Decoder.forProduct3[Identifiable, SourceIdentifier, List[SourceIdentifier], String]("sourceIdentifier", "otherIdentifiers", "identifiedType")((sourceIdentifier, otherIdentifiers, identifiedType) => Identifiable(sourceIdentifier, otherIdentifiers, identifiedType))
+      Decoder.forProduct3[
+        Identifiable,
+        SourceIdentifier,
+        List[SourceIdentifier],
+        String]("sourceIdentifier", "otherIdentifiers", "identifiedType")(
+        (sourceIdentifier, otherIdentifiers, identifiedType) =>
+          Identifiable(sourceIdentifier, otherIdentifiers, identifiedType))
   }
 
   /** Represents an ID that has no sourceIdentifier and thus impossible to have a

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/IdState.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/IdState.scala
@@ -1,5 +1,7 @@
 package weco.catalogue.internal_model.identifiers
 
+import io.circe.{Decoder, Encoder}
+
 /** Represents an ID that is attached to individual pieces of work data.
   *  The ID can be in 3 possible states:
   *
@@ -34,6 +36,14 @@ object IdState {
     def allSourceIdentifiers = sourceIdentifier +: otherIdentifiers
   }
 
+  case object Identified {
+    implicit val encoder: Encoder[Identified] =
+      Encoder.forProduct3[Identified, CanonicalId, SourceIdentifier, List[SourceIdentifier]]("canonicalId", "sourceIdentifier", "otherIdentifiers")((id: Identified) => (id.canonicalId, id.sourceIdentifier, id.otherIdentifiers))
+
+    implicit val decoder: Decoder[Identified] =
+      Decoder.forProduct3[Identified, CanonicalId, SourceIdentifier, List[SourceIdentifier]]("canonicalId", "sourceIdentifier", "otherIdentifiers")((canonicalId, sourceIdentifier, otherIdentifiers) => Identified(canonicalId, sourceIdentifier, otherIdentifiers))
+  }
+
   /** Represents an ID that has not yet been minted, but will have a canonicalId
     *  assigned later in the pipeline. */
   case class Identifiable(
@@ -43,6 +53,14 @@ object IdState {
   ) extends Unminted {
     def maybeCanonicalId = None
     def allSourceIdentifiers = sourceIdentifier +: otherIdentifiers
+  }
+
+  case object Identifiable {
+    implicit val encoder: Encoder[Identifiable] =
+      Encoder.forProduct3[Identifiable, SourceIdentifier, List[SourceIdentifier], String]("sourceIdentifier", "otherIdentifiers", "identifiedType")((id: Identifiable) => (id.sourceIdentifier, id.otherIdentifiers, id.identifiedType))
+
+    implicit val decoder: Decoder[Identifiable] =
+      Decoder.forProduct3[Identifiable, SourceIdentifier, List[SourceIdentifier], String]("sourceIdentifier", "otherIdentifiers", "identifiedType")((sourceIdentifier, otherIdentifiers, identifiedType) => Identifiable(sourceIdentifier, otherIdentifiers, identifiedType))
   }
 
   /** Represents an ID that has no sourceIdentifier and thus impossible to have a

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/SourceIdentifier.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/SourceIdentifier.scala
@@ -1,5 +1,7 @@
 package weco.catalogue.internal_model.identifiers
 
+import io.circe.{Decoder, Encoder}
+
 /** An identifier received from one of the original sources */
 case class SourceIdentifier(
   identifierType: IdentifierType,
@@ -11,4 +13,12 @@ case class SourceIdentifier(
     s"SourceIdentifier value contains whitespaces: <$value>")
 
   override def toString = s"${identifierType.id}/$value"
+}
+
+case object SourceIdentifier {
+  implicit val encoder: Encoder[SourceIdentifier] =
+    Encoder.forProduct3[SourceIdentifier, IdentifierType, String, String]("identifierType", "ontologyType", "value")(id => (id.identifierType, id.ontologyType, id.value))
+
+  implicit val decoder: Decoder[SourceIdentifier] =
+    Decoder.forProduct3[SourceIdentifier, IdentifierType, String, String]("identifierType", "ontologyType", "value")((identifierType, ontologyType, value) => SourceIdentifier(identifierType, ontologyType, value))
 }

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/SourceIdentifier.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/SourceIdentifier.scala
@@ -17,8 +17,15 @@ case class SourceIdentifier(
 
 case object SourceIdentifier {
   implicit val encoder: Encoder[SourceIdentifier] =
-    Encoder.forProduct3[SourceIdentifier, IdentifierType, String, String]("identifierType", "ontologyType", "value")(id => (id.identifierType, id.ontologyType, id.value))
+    Encoder.forProduct3[SourceIdentifier, IdentifierType, String, String](
+      "identifierType",
+      "ontologyType",
+      "value")(id => (id.identifierType, id.ontologyType, id.value))
 
   implicit val decoder: Decoder[SourceIdentifier] =
-    Decoder.forProduct3[SourceIdentifier, IdentifierType, String, String]("identifierType", "ontologyType", "value")((identifierType, ontologyType, value) => SourceIdentifier(identifierType, ontologyType, value))
+    Decoder.forProduct3[SourceIdentifier, IdentifierType, String, String](
+      "identifierType",
+      "ontologyType",
+      "value")((identifierType, ontologyType, value) =>
+      SourceIdentifier(identifierType, ontologyType, value))
 }

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessCondition.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessCondition.scala
@@ -22,8 +22,21 @@ case object AccessCondition {
     AccessCondition(method = method, status = Some(status))
 
   implicit val encoder: Encoder[AccessCondition] =
-    Encoder.forProduct4[AccessCondition, AccessMethod, Option[AccessStatus], Option[String], Option[String]]("method", "status", "note", "terms")((ac: AccessCondition) => (ac.method, ac.status, ac.note, ac.terms))
+    Encoder.forProduct4[
+      AccessCondition,
+      AccessMethod,
+      Option[AccessStatus],
+      Option[String],
+      Option[String]]("method", "status", "note", "terms")(
+      (ac: AccessCondition) => (ac.method, ac.status, ac.note, ac.terms))
 
   implicit val decoder: Decoder[AccessCondition] =
-    Decoder.forProduct4[AccessCondition, AccessMethod, Option[AccessStatus], Option[String], Option[String]]("method", "status", "note", "terms")((method, status, note, terms) => AccessCondition(method, status, note, terms))
+    Decoder.forProduct4[
+      AccessCondition,
+      AccessMethod,
+      Option[AccessStatus],
+      Option[String],
+      Option[String]]("method", "status", "note", "terms")(
+      (method, status, note, terms) =>
+        AccessCondition(method, status, note, terms))
 }

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessCondition.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessCondition.scala
@@ -1,5 +1,8 @@
 package weco.catalogue.internal_model.locations
 
+import io.circe.{Decoder, Encoder}
+import weco.json.JsonUtil._
+
 case class AccessCondition(
   method: AccessMethod,
   status: Option[AccessStatus] = None,
@@ -17,4 +20,10 @@ case class AccessCondition(
 case object AccessCondition {
   def apply(method: AccessMethod, status: AccessStatus): AccessCondition =
     AccessCondition(method = method, status = Some(status))
+
+  implicit val encoder: Encoder[AccessCondition] =
+    Encoder.forProduct4[AccessCondition, AccessMethod, Option[AccessStatus], Option[String], Option[String]]("method", "status", "note", "terms")((ac: AccessCondition) => (ac.method, ac.status, ac.note, ac.terms))
+
+  implicit val decoder: Decoder[AccessCondition] =
+    Decoder.forProduct4[AccessCondition, AccessMethod, Option[AccessStatus], Option[String], Option[String]]("method", "status", "note", "terms")((method, status, note, terms) => AccessCondition(method, status, note, terms))
 }

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Availability.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Availability.scala
@@ -91,12 +91,12 @@ object Availabilities {
     // See https://github.com/wellcomecollection/platform/issues/5190
     def isInOtherLibrary: Boolean =
       n match {
-        case t: TermsOfUse => termsAreOtherInstitution(t)
-        case _             => false
+        case Note.TermsOfUse(termsOfUse) => termsAreOtherInstitution(termsOfUse)
+        case _                           => false
       }
 
-    def termsAreOtherInstitution(termsOfUse: TermsOfUse): Boolean =
-      termsOfUse.content match {
+    def termsAreOtherInstitution(termsOfUse: String): Boolean = {
+      termsOfUse match {
         case t if t.toLowerCase.contains("available at") => true
         case t if t.toLowerCase.contains("available by appointment at") =>
           true
@@ -113,6 +113,7 @@ object Availabilities {
 
         case _ => false
       }
+    }
   }
 
   private def when[T](condition: Boolean)(result: T): Option[T] =

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Note.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Note.scala
@@ -1,61 +1,148 @@
 package weco.catalogue.internal_model.work
 
-sealed trait Note {
-  val content: String
+case class NoteType(id: String, label: String)
+
+case class Note(contents: String, noteType: NoteType)
+
+case object Note {
+  object General {
+    def apply(contents: String): Note =
+      Note(contents = contents, noteType = NoteType(id = "general-note", label = "Notes"))
+  }
+
+  object BibliographicalInformation {
+    def apply(contents: String): Note =
+      Note(contents = contents, noteType = NoteType(id = "bibliographic-info", label = "Bibliographic information"))
+  }
+
+  object TimeAndPlace {
+    def apply(contents: String): Note =
+      Note(contents = contents, noteType = NoteType(id = "time-and-place-note", label = "Time and place note"))
+  }
+
+  object CreditsNote {
+    def apply(contents: String): Note =
+      Note(contents = contents, noteType = NoteType(id = "credits", label = "Creator/production credits"))
+  }
+
+  object ContentsNote {
+    def apply(contents: String): Note =
+      Note(contents = contents, noteType = NoteType(id = "contents", label = "Contents"))
+  }
+
+  object CiteAsNote {
+    def apply(contents: String): Note =
+      Note(contents = contents, noteType = NoteType(id = "reference", label = "Reference"))
+  }
+
+  object DissertationNote {
+    def apply(contents: String): Note =
+      Note(contents = contents, noteType = NoteType(id = "dissertation-note", label = "Dissertation note"))
+  }
+
+  object LocationOfOriginalNote {
+    def apply(contents: String): Note =
+      Note(contents = contents, noteType = NoteType(id = "location-of-original", label = "Location of original"))
+  }
+
+  object LocationOfDuplicatesNote {
+    def apply(contents: String): Note =
+      Note(contents = contents, noteType = NoteType(id = "location-of-duplicates", label = "Location of duplicates"))
+  }
+
+  object BindingInformation {
+    def apply(contents: String): Note =
+      Note(contents = contents, noteType = NoteType(id = "binding-detail", label = "Binding detail"))
+  }
+
+  object BiographicalNote {
+    def apply(contents: String): Note =
+      Note(contents = contents, noteType = NoteType(id = "biographical-note", label = "Biographical note"))
+  }
+
+  object ReproductionNote {
+    def apply(contents: String): Note =
+      Note(contents = contents, noteType = NoteType(id = "reproduction-note", label = "Reproduction note"))
+  }
+
+  object TermsOfUse {
+    def apply(contents: String): Note =
+      Note(contents = contents, noteType = NoteType(id = "terms-of-use", label = "Terms of use"))
+
+    def unapply(note: Note): Option[String] =
+      note.noteType.id match {
+        case "terms-of-use" => Some(note.contents)
+        case _              => None
+      }
+  }
+
+  object CopyrightNote {
+    def apply(contents: String): Note =
+      Note(contents = contents, noteType = NoteType(id = "copyright-note", label = "Copyright note"))
+  }
+
+  object PublicationsNote {
+    def apply(contents: String): Note =
+      Note(contents = contents, noteType = NoteType(id = "publication-note", label = "Publications note"))
+  }
+
+  object ExhibitionsNote {
+    def apply(contents: String): Note =
+      Note(contents = contents, noteType = NoteType(id = "exhibitions-note", label = "Exhibitions note"))
+  }
+
+  object AwardsNote {
+    def apply(contents: String): Note =
+      Note(contents = contents, noteType = NoteType(id = "awards-note", label = "Awards note"))
+  }
+
+  object OwnershipNote {
+    def apply(contents: String): Note =
+      Note(contents = contents, noteType = NoteType(id = "ownership-note", label = "Ownership note"))
+  }
+
+  object AcquisitionNote {
+    def apply(contents: String): Note =
+      Note(contents = contents, noteType = NoteType(id = "acquisition-note", label = "Acquisition note"))
+  }
+
+  object AppraisalNote {
+    def apply(contents: String): Note =
+      Note(contents = contents, noteType = NoteType(id = "appraisal-note", label = "Appraisal note"))
+  }
+
+  object AccrualsNote {
+    def apply(contents: String): Note =
+      Note(contents = contents, noteType = NoteType(id = "accruals-note", label = "Accruals note"))
+  }
+
+  object RelatedMaterial {
+    def apply(contents: String): Note =
+      Note(contents = contents, noteType = NoteType(id = "related-material", label = "Related material"))
+  }
+
+  object FindingAids {
+    def apply(contents: String): Note =
+      Note(contents = contents, noteType = NoteType(id = "finding-aids", label = "Finding aids"))
+  }
+
+  object ArrangementNote {
+    def apply(contents: String): Note =
+      Note(contents = contents, noteType = NoteType(id = "arrangement-note", label = "Arrangement"))
+  }
+
+  object LetteringNote {
+    def apply(contents: String): Note =
+      Note(contents = contents, noteType = NoteType(id = "lettering-note", label = "Lettering note"))
+  }
+
+  object LanguageNote {
+    def apply(contents: String): Note =
+      Note(contents = contents, noteType = NoteType(id = "language-note", label = "Language note"))
+  }
+
+  object ReferencesNote {
+    def apply(contents: String): Note =
+      Note(contents = contents, noteType = NoteType(id = "references-note", label = "References note"))
+  }
 }
-
-case class GeneralNote(content: String) extends Note
-
-case class BibliographicalInformation(content: String) extends Note
-
-case class FundingInformation(content: String) extends Note
-
-case class TimeAndPlaceNote(content: String) extends Note
-
-case class CreditsNote(content: String) extends Note
-
-case class ContentsNote(content: String) extends Note
-
-case class DissertationNote(content: String) extends Note
-
-case class CiteAsNote(content: String) extends Note
-
-case class LocationOfOriginalNote(content: String) extends Note
-
-case class LocationOfDuplicatesNote(content: String) extends Note
-
-case class BindingInformation(content: String) extends Note
-
-case class BiographicalNote(content: String) extends Note
-
-case class ReproductionNote(content: String) extends Note
-
-case class TermsOfUse(content: String) extends Note
-
-case class CopyrightNote(content: String) extends Note
-
-case class PublicationsNote(content: String) extends Note
-
-case class ExhibitionsNote(content: String) extends Note
-
-case class AwardsNote(content: String) extends Note
-
-case class OwnershipNote(content: String) extends Note
-
-case class AcquisitionNote(content: String) extends Note
-
-case class AppraisalNote(content: String) extends Note
-
-case class AccrualsNote(content: String) extends Note
-
-case class RelatedMaterial(content: String) extends Note
-
-case class FindingAids(content: String) extends Note
-
-case class ArrangementNote(content: String) extends Note
-
-case class LetteringNote(content: String) extends Note
-
-case class LanguageNote(content: String) extends Note
-
-case class ReferencesNote(content: String) extends Note

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Note.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Note.scala
@@ -7,67 +7,103 @@ case class Note(contents: String, noteType: NoteType)
 case object Note {
   object General {
     def apply(contents: String): Note =
-      Note(contents = contents, noteType = NoteType(id = "general-note", label = "Notes"))
+      Note(
+        contents = contents,
+        noteType = NoteType(id = "general-note", label = "Notes"))
   }
 
   object BibliographicalInformation {
     def apply(contents: String): Note =
-      Note(contents = contents, noteType = NoteType(id = "bibliographic-info", label = "Bibliographic information"))
+      Note(
+        contents = contents,
+        noteType = NoteType(
+          id = "bibliographic-info",
+          label = "Bibliographic information"))
   }
 
   object TimeAndPlace {
     def apply(contents: String): Note =
-      Note(contents = contents, noteType = NoteType(id = "time-and-place-note", label = "Time and place note"))
+      Note(
+        contents = contents,
+        noteType =
+          NoteType(id = "time-and-place-note", label = "Time and place note"))
   }
 
   object CreditsNote {
     def apply(contents: String): Note =
-      Note(contents = contents, noteType = NoteType(id = "credits", label = "Creator/production credits"))
+      Note(
+        contents = contents,
+        noteType =
+          NoteType(id = "credits", label = "Creator/production credits"))
   }
 
   object ContentsNote {
     def apply(contents: String): Note =
-      Note(contents = contents, noteType = NoteType(id = "contents", label = "Contents"))
+      Note(
+        contents = contents,
+        noteType = NoteType(id = "contents", label = "Contents"))
   }
 
   object CiteAsNote {
     def apply(contents: String): Note =
-      Note(contents = contents, noteType = NoteType(id = "reference", label = "Reference"))
+      Note(
+        contents = contents,
+        noteType = NoteType(id = "reference", label = "Reference"))
   }
 
   object DissertationNote {
     def apply(contents: String): Note =
-      Note(contents = contents, noteType = NoteType(id = "dissertation-note", label = "Dissertation note"))
+      Note(
+        contents = contents,
+        noteType =
+          NoteType(id = "dissertation-note", label = "Dissertation note"))
   }
 
   object LocationOfOriginalNote {
     def apply(contents: String): Note =
-      Note(contents = contents, noteType = NoteType(id = "location-of-original", label = "Location of original"))
+      Note(
+        contents = contents,
+        noteType =
+          NoteType(id = "location-of-original", label = "Location of original"))
   }
 
   object LocationOfDuplicatesNote {
     def apply(contents: String): Note =
-      Note(contents = contents, noteType = NoteType(id = "location-of-duplicates", label = "Location of duplicates"))
+      Note(
+        contents = contents,
+        noteType = NoteType(
+          id = "location-of-duplicates",
+          label = "Location of duplicates"))
   }
 
   object BindingInformation {
     def apply(contents: String): Note =
-      Note(contents = contents, noteType = NoteType(id = "binding-detail", label = "Binding detail"))
+      Note(
+        contents = contents,
+        noteType = NoteType(id = "binding-detail", label = "Binding detail"))
   }
 
   object BiographicalNote {
     def apply(contents: String): Note =
-      Note(contents = contents, noteType = NoteType(id = "biographical-note", label = "Biographical note"))
+      Note(
+        contents = contents,
+        noteType =
+          NoteType(id = "biographical-note", label = "Biographical note"))
   }
 
   object ReproductionNote {
     def apply(contents: String): Note =
-      Note(contents = contents, noteType = NoteType(id = "reproduction-note", label = "Reproduction note"))
+      Note(
+        contents = contents,
+        noteType =
+          NoteType(id = "reproduction-note", label = "Reproduction note"))
   }
 
   object TermsOfUse {
     def apply(contents: String): Note =
-      Note(contents = contents, noteType = NoteType(id = "terms-of-use", label = "Terms of use"))
+      Note(
+        contents = contents,
+        noteType = NoteType(id = "terms-of-use", label = "Terms of use"))
 
     def unapply(note: Note): Option[String] =
       note.noteType.id match {
@@ -78,71 +114,100 @@ case object Note {
 
   object CopyrightNote {
     def apply(contents: String): Note =
-      Note(contents = contents, noteType = NoteType(id = "copyright-note", label = "Copyright note"))
+      Note(
+        contents = contents,
+        noteType = NoteType(id = "copyright-note", label = "Copyright note"))
   }
 
   object PublicationsNote {
     def apply(contents: String): Note =
-      Note(contents = contents, noteType = NoteType(id = "publication-note", label = "Publications note"))
+      Note(
+        contents = contents,
+        noteType =
+          NoteType(id = "publication-note", label = "Publications note"))
   }
 
   object ExhibitionsNote {
     def apply(contents: String): Note =
-      Note(contents = contents, noteType = NoteType(id = "exhibitions-note", label = "Exhibitions note"))
+      Note(
+        contents = contents,
+        noteType = NoteType(id = "exhibitions-note", label = "Exhibitions note"))
   }
 
   object AwardsNote {
     def apply(contents: String): Note =
-      Note(contents = contents, noteType = NoteType(id = "awards-note", label = "Awards note"))
+      Note(
+        contents = contents,
+        noteType = NoteType(id = "awards-note", label = "Awards note"))
   }
 
   object OwnershipNote {
     def apply(contents: String): Note =
-      Note(contents = contents, noteType = NoteType(id = "ownership-note", label = "Ownership note"))
+      Note(
+        contents = contents,
+        noteType = NoteType(id = "ownership-note", label = "Ownership note"))
   }
 
   object AcquisitionNote {
     def apply(contents: String): Note =
-      Note(contents = contents, noteType = NoteType(id = "acquisition-note", label = "Acquisition note"))
+      Note(
+        contents = contents,
+        noteType = NoteType(id = "acquisition-note", label = "Acquisition note"))
   }
 
   object AppraisalNote {
     def apply(contents: String): Note =
-      Note(contents = contents, noteType = NoteType(id = "appraisal-note", label = "Appraisal note"))
+      Note(
+        contents = contents,
+        noteType = NoteType(id = "appraisal-note", label = "Appraisal note"))
   }
 
   object AccrualsNote {
     def apply(contents: String): Note =
-      Note(contents = contents, noteType = NoteType(id = "accruals-note", label = "Accruals note"))
+      Note(
+        contents = contents,
+        noteType = NoteType(id = "accruals-note", label = "Accruals note"))
   }
 
   object RelatedMaterial {
     def apply(contents: String): Note =
-      Note(contents = contents, noteType = NoteType(id = "related-material", label = "Related material"))
+      Note(
+        contents = contents,
+        noteType = NoteType(id = "related-material", label = "Related material"))
   }
 
   object FindingAids {
     def apply(contents: String): Note =
-      Note(contents = contents, noteType = NoteType(id = "finding-aids", label = "Finding aids"))
+      Note(
+        contents = contents,
+        noteType = NoteType(id = "finding-aids", label = "Finding aids"))
   }
 
   object ArrangementNote {
     def apply(contents: String): Note =
-      Note(contents = contents, noteType = NoteType(id = "arrangement-note", label = "Arrangement"))
+      Note(
+        contents = contents,
+        noteType = NoteType(id = "arrangement-note", label = "Arrangement"))
   }
 
   object LetteringNote {
     def apply(contents: String): Note =
-      Note(contents = contents, noteType = NoteType(id = "lettering-note", label = "Lettering note"))
+      Note(
+        contents = contents,
+        noteType = NoteType(id = "lettering-note", label = "Lettering note"))
   }
 
   object LanguageNote {
     def apply(contents: String): Note =
-      Note(contents = contents, noteType = NoteType(id = "language-note", label = "Language note"))
+      Note(
+        contents = contents,
+        noteType = NoteType(id = "language-note", label = "Language note"))
   }
 
   object ReferencesNote {
     def apply(contents: String): Note =
-      Note(contents = contents, noteType = NoteType(id = "references-note", label = "References note"))
+      Note(
+        contents = contents,
+        noteType = NoteType(id = "references-note", label = "References note"))
   }
 }

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/AvailabilityTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/AvailabilityTest.scala
@@ -75,7 +75,7 @@ class AvailabilityTest
       val work = denormalisedWork()
         .items(List(createIdentifiedPhysicalItem))
         .notes(
-          List(TermsOfUse("Available at Churchill Archives Centre"))
+          List(Note.TermsOfUse("Available at Churchill Archives Centre"))
         )
       val workAvailabilities = Availabilities.forWorkData(work.data)
 


### PR DESCRIPTION
Experimenting with https://github.com/wellcomecollection/platform/issues/5298

We spend a lot of time coming up with implicit encoders/decoders. What if we cut Shapeless out of the equation (somewhat) and tell Circe exactly how do decode/encode some of the more expensive classes?