### PR TITLE
Explain why we have the "version" field on the Work model

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Work.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Work.scala
@@ -20,11 +20,15 @@ import java.time.Instant
   */
 sealed trait Work[State <: WorkState] {
 
-  val version: Int
   val state: State
   val data: WorkData[State#WorkDataState]
 
   def sourceIdentifier: SourceIdentifier = state.sourceIdentifier
+
+  // This version has no meaning in the pipeline -- it comes from the version
+  // in the adapter, so we can trace a Work back to the exact source record
+  // that was used to create it in the transformer.
+  val version: Int
 
   def id: String = state.id
 

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Work.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Work.scala
@@ -25,9 +25,13 @@ sealed trait Work[State <: WorkState] {
 
   def sourceIdentifier: SourceIdentifier = state.sourceIdentifier
 
-  // This version has no meaning in the pipeline -- it comes from the version
-  // in the adapter, so we can trace a Work back to the exact source record
-  // that was used to create it in the transformer.
+  // This version comes from the version in the adapter, so we can trace
+  // a Work back to the exact source record that was used to create it
+  // in the transformer.
+  //
+  // It should only be trusted for ordering updates of an individual Work.
+  // You cannot compare the version between different Works -- use the
+  // modifiedTime instead.
   val version: Int
 
   def id: String = state.id


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/platform/issues/5302

I had a go at removing this, but it is useful for very particular reasons. Ideally it'd be renamed "sourceVersion", but that's a bigger problem than I care to undertake right now. I can at least document why it's here to save the next person scratching their head about it.