### PR TITLE
Tidy up the comments on some identifiers in internal_model

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/DataState.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/DataState.scala
@@ -5,7 +5,6 @@ package weco.catalogue.internal_model.identifiers
   *
   * - Id (references an ID type, always with a source identifier)
   * - MaybeId (references an ID type, potentially with a source identifier)
-  * - WorkImage (references the type of the image inside the work data)
   */
 sealed trait DataState {
   type Id

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/HasId.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/HasId.scala
@@ -1,6 +1,13 @@
 package weco.catalogue.internal_model.identifiers
 
-/** A trait assigned to all objects that contain some ID value. */
+/** A trait assigned to all objects that contain some ID value.
+  *
+  * This trait isn't used in the pipeline library -- instead, it's used by
+  * one of the serialisers in the display model tests in the catalogue-api repo.
+  *
+  * See https://github.com/wellcomecollection/catalogue-api/blob/f7ce5ae679b90c61ae064a0c6f9517f787c5e886/common/display/src/test/scala/weco/catalogue/display_model/models/DisplaySerialisationTestBase.scala#L115-L121
+  *
+  */
 trait HasId[+T] {
   val id: T
 }

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/IdState.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/IdState.scala
@@ -21,7 +21,8 @@ object IdState {
     otherIdentifiers: List[SourceIdentifier] = Nil,
   ) extends Minted {
     def maybeCanonicalId: Option[CanonicalId] = Some(canonicalId)
-    def allSourceIdentifiers: List[SourceIdentifier] = sourceIdentifier +: otherIdentifiers
+    def allSourceIdentifiers: List[SourceIdentifier] =
+      sourceIdentifier +: otherIdentifiers
   }
 
   /** Represents an ID that has not yet been minted, but will have a canonicalId
@@ -32,7 +33,8 @@ object IdState {
     identifiedType: String = classOf[Identified].getSimpleName,
   ) extends Unminted {
     def maybeCanonicalId: Option[CanonicalId] = None
-    def allSourceIdentifiers: List[SourceIdentifier] = sourceIdentifier +: otherIdentifiers
+    def allSourceIdentifiers: List[SourceIdentifier] =
+      sourceIdentifier +: otherIdentifiers
   }
 
   /** Represents an ID that has no sourceIdentifier and thus impossible to have a

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/IdState.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/IdState.scala
@@ -1,15 +1,5 @@
 package weco.catalogue.internal_model.identifiers
 
-/** Represents an ID that is attached to individual pieces of work data.
-  *  The ID can be in 3 possible states:
-  *
-  *  * Identifiable: contains a sourceIdentifier but does not have a canonicalId
-  *    yet (i.e. pre minter)
-  *  * Identified: contains a sourceIdentifier and a canonicalId (i.e. post
-  *    minter)
-  *  * Unidentifiable: a piece of data that does not have a sourceIdentifier, and
-  *    thus can never have a canonicalId attached
-  *  */
 sealed trait IdState {
   def maybeCanonicalId: Option[CanonicalId]
   def allSourceIdentifiers: List[SourceIdentifier]
@@ -30,8 +20,8 @@ object IdState {
     sourceIdentifier: SourceIdentifier,
     otherIdentifiers: List[SourceIdentifier] = Nil,
   ) extends Minted {
-    def maybeCanonicalId = Some(canonicalId)
-    def allSourceIdentifiers = sourceIdentifier +: otherIdentifiers
+    def maybeCanonicalId: Option[CanonicalId] = Some(canonicalId)
+    def allSourceIdentifiers: List[SourceIdentifier] = sourceIdentifier +: otherIdentifiers
   }
 
   /** Represents an ID that has not yet been minted, but will have a canonicalId
@@ -41,15 +31,15 @@ object IdState {
     otherIdentifiers: List[SourceIdentifier] = Nil,
     identifiedType: String = classOf[Identified].getSimpleName,
   ) extends Unminted {
-    def maybeCanonicalId = None
-    def allSourceIdentifiers = sourceIdentifier +: otherIdentifiers
+    def maybeCanonicalId: Option[CanonicalId] = None
+    def allSourceIdentifiers: List[SourceIdentifier] = sourceIdentifier +: otherIdentifiers
   }
 
   /** Represents an ID that has no sourceIdentifier and thus impossible to have a
     *  canonicalId assigned. Note that it is possible for this ID to be either pre
     *  or post minter. */
   case object Unidentifiable extends Unminted with Minted {
-    def maybeCanonicalId = None
-    def allSourceIdentifiers = Nil
+    def maybeCanonicalId: Option[CanonicalId] = None
+    def allSourceIdentifiers: List[SourceIdentifier] = Nil
   }
 }


### PR DESCRIPTION
I spotted these while fiddling around – tidying up these comments should make it a little easier to wrap our heads around these.