### PR TITLE
Don't throw an exception on languages without a label

### DIFF
--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiLanguages.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiLanguages.scala
@@ -46,6 +46,8 @@ object TeiLanguages {
         (langId, label) match {
           case (Right(id), label) if label.trim.nonEmpty =>
             TeiLanguageData(id, label)
+          case (Right(id), _) =>
+            Left(new Throwable(s"Missing label for language node with id=$id"))
           case (Left(err), _) => Left(err)
         }
       }

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/transformers/TeiLanguagesTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/transformers/TeiLanguagesTest.scala
@@ -79,6 +79,7 @@ class TeiLanguagesTest
     val result = TeiLanguages(xml)
 
     result shouldBe a[Left[_, _]]
-    result.left.get.getMessage should startWith("Missing label for language node")
+    result.left.get.getMessage should startWith(
+      "Missing label for language node")
   }
 }

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/transformers/TeiLanguagesTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/transformers/TeiLanguagesTest.scala
@@ -67,4 +67,18 @@ class TeiLanguagesTest
     result shouldBe a[Left[_, _]]
     result.left.get.getMessage should include("language ID")
   }
+
+  it("skips languages without a label") {
+    val xml =
+      teiXml(
+        languages = List(
+          <textLang mainLang="he"></textLang>
+        )
+      )
+
+    val result = TeiLanguages(xml)
+
+    result shouldBe a[Left[_, _]]
+    result.left.get.getMessage should startWith("Missing label for language node")
+  }
 }


### PR DESCRIPTION
Previously this would throw an unhandled MatchError.