### PR TITLE
Add a local TEI transformer test

### DIFF
--- a/pipeline/transformer/transformer_tei/TeiLocalTransformerTest.scala.txt
+++ b/pipeline/transformer/transformer_tei/TeiLocalTransformerTest.scala.txt
@@ -1,0 +1,56 @@
+package weco.pipeline.transformer.tei
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import weco.storage.fixtures.S3Fixtures
+import weco.storage.store.s3.S3TypedStore
+
+import java.io.FileInputStream
+import java.nio.file.{Files, Path, Paths}
+import java.util.stream.Collectors
+import scala.collection.JavaConverters._
+import scala.util.{Failure, Success, Try}
+import scala.xml.XML
+
+class TeiLocalTransformerTest extends AnyFunSpec with Matchers with S3Fixtures {
+
+  /** This test runs the TEI transformer over every XML file in the TEI repo.
+    *
+    * Because there are relatively few TEI files, you can run this locally to see
+    * if there are any files that can't be handled without spinning up a whole pipeline.
+    *
+    */
+  it("handles all the TEI files") {
+    val root = Paths.get("/Users/alexwlchan/repos", "wellcome-collection-tei")
+    val xmlPaths =
+      Files
+        .walk(root)
+        .collect(Collectors.toList[Path])
+        .asScala
+        .filter { Files.isRegularFile(_) }
+        .filter { _.getFileName.toString.endsWith(".xml") }
+
+    val transformer = new TeiTransformer(store = S3TypedStore[String])
+
+    xmlPaths
+      .filterNot { _.toString.endsWith("/Wellcome_TEI_Manuscript_Guidelines.xml") }
+      .filterNot { _.toString.contains("/Templates/") }
+      .foreach { p =>
+        val xml = XML.load(new FileInputStream(p.toAbsolutePath.toString))
+
+        val result = Try {
+          val teiXml = new TeiXml(xml)
+
+          transformer(teiXml)
+        }
+
+        result match {
+          case Success(Right(_))  => ()
+          case Success(Left(err)) => println(s"Unable to transform $p:\n$err\n")
+          case Failure(err)       =>
+            println(s"Unexpected error in $p:\n$err\n")
+            throw err
+        }
+      }
+  }
+}


### PR DESCRIPTION
This is how I found the language bug in https://github.com/wellcomecollection/catalogue-pipeline/pull/1891 – I ran it against a recent checkout of the TEI data.