### PR TITLE
Use the new status/opacmsg for "restricted"

### DIFF
--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -190,8 +190,8 @@ object SierraItemAccess extends SierraQueryOps with Logging {
       // Example: b29459126 / i19023340
       case (
           Some(0),
-          Some(Status.Restricted),
-          Some(OpacMsg.OnlineRequest),
+          Some(Status.Available),
+          Some(OpacMsg.Restricted),
           Requestable,
           Some(LocationType.ClosedStores)) =>
         AccessCondition(

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/source/OpacMsg.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/source/OpacMsg.scala
@@ -10,4 +10,5 @@ object OpacMsg {
   val Unavailable = "u"
   val StaffUseOnly = "s"
   val AskAtDesk = "i"
+  val Restricted = "c"
 }

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/source/Status.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/source/Status.scala
@@ -6,7 +6,6 @@ object Status {
   val Missing = "m"
   val Unavailable = "r"
   val Closed = "h"
-  val Restricted = "6"
   val OnHoldshelf = "!"
   val Withdrawn = "x"
 }

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -55,12 +55,12 @@ class SierraItemAccessTest
                 display = "Closed stores Arch. & MSS"),
               "88" -> FixedField(
                 label = "STATUS",
-                value = "6",
-                display = "Restricted"),
+                value = "-",
+                display = "Available"),
               "108" -> FixedField(
                 label = "OPACMSG",
-                value = "f",
-                display = "Online request"),
+                value = "c",
+                display = "Restricted"),
             )
           )
 


### PR DESCRIPTION
Something weird has happened in Sierra so that if a user requests a restricted item, the item becomes "open" when it returns to the closed stores.  This is clearly suboptimal.

To fix this, LS&S have changed how restricted items are recorded in Sierra. Quoting an email from Louise Simon:

> Opacmsg – 'c' Restricted 
> I’ve created a new Opacmsg code = 'c' Restricted (NB 'r' was already in use for Reading Room).
>
> Item Status – '6' Restricted. 
> This code has been deleted.
>
> I’ve updated all the restricted items so that Status = '-' Available and Opacmsg = 'c' Restricted.

This patch applies that change so our code, so restricted items will
appear as such on wc.org/works.