### PR TITLE
Update ECS service module to version with circuit breaker protection

### DIFF
--- a/infrastructure/modules/worker/main.tf
+++ b/infrastructure/modules/worker/main.tf
@@ -4,7 +4,7 @@ locals {
 }
 
 module "service" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/service?ref=v3.5.2"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/service?ref=v3.11.0"
 
   task_definition_arn            = module.task_definition.arn
   service_name                   = var.name
@@ -31,7 +31,7 @@ module "service" {
 }
 
 module "autoscaling" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/autoscaling?ref=v3.5.2"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/autoscaling?ref=v3.11.0"
 
   name = var.name
 
@@ -46,7 +46,7 @@ module "autoscaling" {
 }
 
 module "task_definition" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v3.5.2"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v3.11.0"
 
   cpu    = var.cpu
   memory = var.memory
@@ -61,7 +61,7 @@ module "task_definition" {
 }
 
 module "app_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.5.2"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.11.0"
 
   name  = var.name
   image = var.image
@@ -73,20 +73,20 @@ module "app_container" {
 }
 
 module "app_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.5.2"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.11.0"
   secrets   = var.secret_env_vars
   role_name = module.task_definition.task_execution_role_name
 }
 
 module "log_router_container" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/firelens?ref=v3.5.2"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/firelens?ref=v3.11.0"
   namespace = var.name
 
   use_privatelink_endpoint = true
 }
 
 module "log_router_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.5.2"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.11.0"
   secrets   = var.shared_logging_secrets
   role_name = module.task_definition.task_execution_role_name
 }

--- a/infrastructure/modules/workers_with_sidecar/main.tf
+++ b/infrastructure/modules/workers_with_sidecar/main.tf
@@ -10,7 +10,7 @@ locals {
 }
 
 module "service" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/service?ref=v3.5.2"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/service?ref=v3.11.0"
 
   task_definition_arn            = module.task_definition.arn
   service_name                   = var.name
@@ -35,7 +35,7 @@ module "service" {
 }
 
 module "autoscaling" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/autoscaling?ref=v3.5.2"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/autoscaling?ref=v3.11.0"
 
   name = var.name
 
@@ -50,7 +50,7 @@ module "autoscaling" {
 }
 
 module "task_definition" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v3.5.2"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v3.11.0"
 
   cpu    = var.cpu
   memory = var.memory
@@ -63,7 +63,7 @@ module "task_definition" {
 }
 
 module "app_container" {
-  source   = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.5.2"
+  source   = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.11.0"
   for_each = var.apps
 
   name  = each.key
@@ -83,13 +83,13 @@ module "app_container" {
 }
 
 module "app_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.5.2"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.11.0"
   secrets   = local.all_secret_env_vars
   role_name = module.task_definition.task_execution_role_name
 }
 
 module "sidecar_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.5.2"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.11.0"
 
   name  = var.sidecar_name
   image = var.sidecar_image
@@ -111,21 +111,21 @@ module "sidecar_container" {
 }
 
 module "sidecar_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.5.2"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.11.0"
   secrets   = var.sidecar_secret_env_vars
   role_name = module.task_definition.task_execution_role_name
 }
 
 
 module "log_router_container" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/firelens?ref=v3.5.2"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/firelens?ref=v3.11.0"
   namespace = var.name
 
   use_privatelink_endpoint = true
 }
 
 module "log_router_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.5.2"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.11.0"
   secrets   = var.shared_logging_secrets
   role_name = module.task_definition.task_execution_role_name
 }


### PR DESCRIPTION
Enabling the ECS deployment circuit breaker , turns on detection of repeated failed attempts to start tasks as part of an ECS deployment and will "cancel" a deployment if a particular threshold for failed tasks is met.

See: https://github.com/wellcomecollection/platform/issues/5306

Note: This is applied.