### PR TITLE
Remove the 'label' from the collectionPath

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/CollectionPath.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/CollectionPath.scala
@@ -1,10 +1,9 @@
 package weco.catalogue.internal_model.work
 
-/**
-  * A CollectionPath represents the position of an individual work in a
+/** A CollectionPath represents the position of an individual work in a
   * collection hierarchy.
+  *
+  * This is an internal value used by the relation embedder to construct trees,
+  * not a value we display publicly.
   */
-case class CollectionPath(
-  path: String,
-  label: Option[String] = None,
-)
+case class CollectionPath(path: String)

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/index/WorksIndexConfigTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/index/WorksIndexConfigTest.scala
@@ -139,8 +139,7 @@ class WorksIndexConfigTest
   // only exists at the `data.collectionPath` level
   it("puts a work with a collection") {
     val collectionPath = CollectionPath(
-      path = "PATH/FOR/THE/COLLECTION",
-      label = Some("PATH/FOR/THE/COLLECTION")
+      path = "PATH/FOR/THE/COLLECTION"
     )
 
     val work = indexedWork().collectionPath(collectionPath)

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/ArchiveRelationsCache.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/ArchiveRelationsCache.scala
@@ -50,7 +50,7 @@ class ArchiveRelationsCache(works: Map[String, RelationWork]) extends Logging {
     */
   def getAvailabilities(work: Work[Merged]): Set[Availability] =
     work.data.collectionPath match {
-      case Some(CollectionPath(workPath, _)) =>
+      case Some(CollectionPath(workPath)) =>
         val affectedPaths = paths.knownDescendentsOf(workPath) :+ workPath
 
         works
@@ -107,7 +107,7 @@ object ArchiveRelationsCache {
           work.data.collectionPath -> work
         }
         .collect {
-          case (Some(CollectionPath(path, _)), work) =>
+          case (Some(CollectionPath(path)), work) =>
             path -> work
         }
         .toMap

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/ArchiveRelationsCache.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/ArchiveRelationsCache.scala
@@ -10,7 +10,7 @@ class ArchiveRelationsCache(works: Map[String, RelationWork]) extends Logging {
   def apply(work: Work[Merged]): Relations =
     work.data.collectionPath
       .map {
-        case CollectionPath(path, _) =>
+        case CollectionPath(path) =>
           val (siblingsPreceding, siblingsSucceeding) = getSiblings(path)
           val ancestors = getAncestors(path)
           val children = getChildren(path)

--- a/pipeline/relation_embedder/router/src/main/scala/weco/pipeline/router/RouterWorkerService.scala
+++ b/pipeline/relation_embedder/router/src/main/scala/weco/pipeline/router/RouterWorkerService.scala
@@ -44,7 +44,7 @@ class RouterWorkerService[MsgDestination](
       // We don't expect TEI works to have a collectionPath field populated.
       case (None, relations) =>
         Success(List(work.transition[Denormalised]((relations, Set.empty))))
-      case (Some(CollectionPath(path, _)), relations)
+      case (Some(CollectionPath(path)), relations)
           if relations == Relations.none =>
         pathsMsgSender.send(path).map(_ => Nil)
       case (collectionPath, relations) =>

--- a/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/CalmTransformer.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/CalmTransformer.scala
@@ -149,7 +149,7 @@ object CalmTransformer
         otherIdentifiers = otherIdentifiers(record),
         format = Some(Format.ArchivesAndManuscripts),
         collectionPath = Some(collectionPath),
-        referenceNumber = collectionPath.label.map(ReferenceNumber(_)),
+        referenceNumber = referenceNumber(record),
         subjects = subjects(record),
         languages = languages,
         mergeCandidates = CalmMergeCandidates(record),
@@ -193,14 +193,13 @@ object CalmTransformer
       .getOrElse(Left(TitleMissing))
 
   def collectionPath(record: CalmRecord): Result[CollectionPath] =
-    record
-      .get("RefNo")
-      .map { path =>
-        Right(
-          CollectionPath(path = path, label = record.get("AltRefNo"))
-        )
-      }
-      .getOrElse(Left(RefNoMissing))
+    record.get("RefNo") match {
+      case Some(path) => Right(CollectionPath(path = path))
+      case None       => Left(RefNoMissing)
+    }
+
+  def referenceNumber(record: CalmRecord): Option[ReferenceNumber] =
+    record.get("AltRefNo").map(ReferenceNumber(_))
 
   def workType(record: CalmRecord): Result[WorkType] =
     record

--- a/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/CalmTransformerTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/CalmTransformerTest.scala
@@ -46,12 +46,7 @@ class CalmTransformerTest
         data = WorkData[DataState.Unidentified](
           title = Some("abc"),
           format = Some(Format.ArchivesAndManuscripts),
-          collectionPath = Some(
-            CollectionPath(
-              path = "a/b/c",
-              label = Some("a.b.c")
-            )
-          ),
+          collectionPath = Some(CollectionPath(path = "a/b/c")),
           referenceNumber = Some(ReferenceNumber("a.b.c")),
           otherIdentifiers = List(
             SourceIdentifier(


### PR DESCRIPTION
This value is duplicated in the referenceNumber field for Calm works, and not populated on other works.  We can remove it without losing anything.