### PR TITLE
Remove the WorkGraph model from the matcher

### DIFF
--- a/pipeline/matcher/src/main/scala/weco/pipeline/matcher/matcher/WorkMatcher.scala
+++ b/pipeline/matcher/src/main/scala/weco/pipeline/matcher/matcher/WorkMatcher.scala
@@ -94,7 +94,8 @@ class WorkMatcher(
       case _                     => new RuntimeException(failure.toString)
     }
 
-  private def toMatchedIdentifiers(nodes: Set[WorkNode]): Set[MatchedIdentifiers] =
+  private def toMatchedIdentifiers(
+    nodes: Set[WorkNode]): Set[MatchedIdentifiers] =
     nodes
       .groupBy { _.componentId }
       .map {

--- a/pipeline/matcher/src/main/scala/weco/pipeline/matcher/models/WorkGraph.scala
+++ b/pipeline/matcher/src/main/scala/weco/pipeline/matcher/models/WorkGraph.scala
@@ -1,9 +1,0 @@
-package weco.pipeline.matcher.models
-
-// This holds a collection of nodes in our graph database.
-//
-// Each node describes the directed edges for which it is the source, so
-// this collection describes an entire graph -- a subgraph of the
-// entire graph in our database.
-//
-case class WorkGraph(nodes: Set[WorkNode])

--- a/pipeline/matcher/src/main/scala/weco/pipeline/matcher/storage/WorkGraphStore.scala
+++ b/pipeline/matcher/src/main/scala/weco/pipeline/matcher/storage/WorkGraphStore.scala
@@ -3,20 +3,17 @@ package weco.pipeline.matcher.storage
 import weco.pipeline.matcher.models.WorkNode
 
 import scala.concurrent.{ExecutionContext, Future}
-import weco.pipeline.matcher.models.{WorkGraph, WorkLinks}
+import weco.pipeline.matcher.models.WorkLinks
 
 class WorkGraphStore(workNodeDao: WorkNodeDao)(implicit _ec: ExecutionContext) {
 
-  def findAffectedWorks(workLinks: WorkLinks): Future[WorkGraph] =
+  def findAffectedWorks(workLinks: WorkLinks): Future[Set[WorkNode]] =
     for {
       directlyAffectedWorks <- workNodeDao.get(workLinks.ids)
       affectedComponentIds = directlyAffectedWorks.map(workNode =>
         workNode.componentId)
       affectedWorks <- workNodeDao.getByComponentIds(affectedComponentIds)
-    } yield WorkGraph(affectedWorks)
-
-  def put(graph: WorkGraph): Future[Unit] =
-    put(graph.nodes)
+    } yield affectedWorks
 
   def put(nodes: Set[WorkNode]): Future[Unit] =
     workNodeDao.put(nodes)

--- a/pipeline/matcher/src/main/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdater.scala
+++ b/pipeline/matcher/src/main/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdater.scala
@@ -13,14 +13,14 @@ import weco.pipeline.matcher.models.{
 }
 
 object WorkGraphUpdater extends Logging {
-  def update(links: WorkLinks, existingGraph: Set[WorkNode]): Set[WorkNode] = {
-    checkVersionConflicts(links, existingGraph)
-    doUpdate(links, existingGraph)
+  def update(links: WorkLinks, existingNodes: Set[WorkNode]): Set[WorkNode] = {
+    checkVersionConflicts(links, existingNodes)
+    doUpdate(links, existingNodes)
   }
 
   private def checkVersionConflicts(links: WorkLinks,
-                                    existingGraph: Set[WorkNode]): Unit = {
-    val maybeExistingNode = existingGraph.find(_.id == links.workId)
+                                    existingNodes: Set[WorkNode]): Unit = {
+    val maybeExistingNode = existingNodes.find(_.id == links.workId)
     maybeExistingNode match {
       case Some(WorkNode(_, Some(existingVersion), linkedIds, _)) =>
         if (existingVersion > links.version) {
@@ -40,7 +40,7 @@ object WorkGraphUpdater extends Logging {
   }
 
   private def doUpdate(workLinks: WorkLinks,
-                       existingGraph: Set[WorkNode]): Set[WorkNode] = {
+                       existingNodes: Set[WorkNode]): Set[WorkNode] = {
 
     // Find everything that's in the existing graph, but which isn't
     // the node we're updating.
@@ -54,7 +54,7 @@ object WorkGraphUpdater extends Logging {
     // If we're updating work B, then this list will be (A C D E).
     //
     val linkedWorks =
-      existingGraph.filterNot(_.id == workLinks.workId)
+      existingNodes.filterNot(_.id == workLinks.workId)
 
     // Create a map (work ID) -> (version) for every work in the graph.
     //
@@ -91,7 +91,7 @@ object WorkGraphUpdater extends Logging {
 
     // Get the IDs of all the works in this graph, and construct a Graph object.
     val workIds =
-      existingGraph
+      existingNodes
         .flatMap { node =>
           node.id +: node.linkedIds
         } + workLinks.workId

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/matcher/WorkMatcherTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/matcher/WorkMatcherTest.scala
@@ -17,7 +17,6 @@ import weco.pipeline.matcher.generators.WorkLinksGenerators
 import weco.pipeline.matcher.models.{
   MatchedIdentifiers,
   MatcherResult,
-  WorkGraph,
   WorkIdentifier,
   WorkLinks,
   WorkNode
@@ -234,11 +233,11 @@ class WorkMatcherTest
         val idC = identifierC.canonicalId
 
         val future = workGraphStore.put(
-          WorkGraph(Set(
+          Set(
             WorkNode(idA, version = 0, linkedIds = List(idB), componentId),
             WorkNode(idB, version = 0, linkedIds = List(idC), componentId),
             WorkNode(idC, version = 0, linkedIds = Nil, componentId),
-          )))
+          ))
 
         whenReady(future) { _ =>
           val links = createWorkLinksWith(
@@ -278,8 +277,8 @@ class WorkMatcherTest
     withWorkMatcher(mockWorkGraphStore) { workMatcher =>
       val expectedException = new RuntimeException("Failed to put")
       when(mockWorkGraphStore.findAffectedWorks(any[WorkLinks]))
-        .thenReturn(Future.successful(WorkGraph(Set.empty)))
-      when(mockWorkGraphStore.put(any[WorkGraph]))
+        .thenReturn(Future.successful(Set[WorkNode]()))
+      when(mockWorkGraphStore.put(any[Set[WorkNode]]))
         .thenThrow(expectedException)
 
       val links = createWorkLinks

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/storage/WorkGraphStoreTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/storage/WorkGraphStoreTest.scala
@@ -30,8 +30,8 @@ class WorkGraphStoreTest
               WorkLinks(
                 createCanonicalId,
                 version = 0,
-                referencedWorkIds = Set.empty))) { workGraph =>
-            workGraph shouldBe empty
+                referencedWorkIds = Set.empty))) {
+            _ shouldBe empty
           }
         }
       }

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/storage/WorkGraphStoreTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/storage/WorkGraphStoreTest.scala
@@ -49,7 +49,8 @@ class WorkGraphStoreTest
               componentId = ciHash(idA))
           put(dynamoClient, graphTable.name)(work)
 
-          val future = workGraphStore.findAffectedWorks(WorkLinks(idA, 0, Set.empty))
+          val future =
+            workGraphStore.findAffectedWorks(WorkLinks(idA, 0, Set.empty))
 
           whenReady(future) {
             _ shouldBe Set(work)
@@ -76,7 +77,8 @@ class WorkGraphStoreTest
           put(dynamoClient, graphTable.name)(workA)
           put(dynamoClient, graphTable.name)(workB)
 
-          val future = workGraphStore.findAffectedWorks(WorkLinks(idA, 0, Set(idB)))
+          val future =
+            workGraphStore.findAffectedWorks(WorkLinks(idA, 0, Set(idB)))
 
           whenReady(future) {
             _ shouldBe Set(workA, workB)
@@ -141,7 +143,8 @@ class WorkGraphStoreTest
           put(dynamoClient, graphTable.name)(workB)
           put(dynamoClient, graphTable.name)(workC)
 
-          val future = workGraphStore.findAffectedWorks(WorkLinks(idA, 0, Set.empty))
+          val future =
+            workGraphStore.findAffectedWorks(WorkLinks(idA, 0, Set.empty))
 
           whenReady(future) {
             _ shouldBe Set(workA, workB, workC)
@@ -202,13 +205,12 @@ class WorkGraphStoreTest
             linkedIds = Nil,
             componentId = ciHash(idA, idB))
 
-          whenReady(workGraphStore.put(Set(workNodeA, workNodeB))) {
-            _ =>
-              val savedWorks = scan[WorkNode](dynamoClient, graphTable.name)
-                .map(_.right.get)
-              savedWorks should contain theSameElementsAs List(
-                workNodeA,
-                workNodeB)
+          whenReady(workGraphStore.put(Set(workNodeA, workNodeB))) { _ =>
+            val savedWorks = scan[WorkNode](dynamoClient, graphTable.name)
+              .map(_.right.get)
+            savedWorks should contain theSameElementsAs List(
+              workNodeA,
+              workNodeB)
           }
         }
       }

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdaterTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdaterTest.scala
@@ -77,19 +77,18 @@ class WorkGraphUpdaterTest
       WorkGraphUpdater
         .update(
           links = WorkLinks(idA, version = 2, referencedWorkIds = Set(idB)),
-          existingNodes =
-            Set(
-              WorkNode(
-                idA,
-                version = 1,
-                linkedIds = Nil,
-                componentId = ciHash(idA)),
-              WorkNode(
-                idB,
-                version = 1,
-                linkedIds = Nil,
-                componentId = ciHash(idB))
-            )
+          existingNodes = Set(
+            WorkNode(
+              idA,
+              version = 1,
+              linkedIds = Nil,
+              componentId = ciHash(idA)),
+            WorkNode(
+              idB,
+              version = 1,
+              linkedIds = Nil,
+              componentId = ciHash(idB))
+          )
         ) should contain theSameElementsAs
         List(
           WorkNode(
@@ -108,18 +107,17 @@ class WorkGraphUpdaterTest
       WorkGraphUpdater
         .update(
           links = WorkLinks(idA, version = 2, referencedWorkIds = Set(idB)),
-          existingNodes =
-            Set(
-              WorkNode(
-                idA,
-                version = 1,
-                linkedIds = List(idB),
-                componentId = ciHash(idA, idB)),
-              WorkNode(
-                idB,
-                version = 1,
-                linkedIds = Nil,
-                componentId = ciHash(idA, idB)))
+          existingNodes = Set(
+            WorkNode(
+              idA,
+              version = 1,
+              linkedIds = List(idB),
+              componentId = ciHash(idA, idB)),
+            WorkNode(
+              idB,
+              version = 1,
+              linkedIds = Nil,
+              componentId = ciHash(idA, idB)))
         ) shouldBe Set(
         WorkNode(
           idA,
@@ -312,13 +310,12 @@ class WorkGraphUpdaterTest
       WorkGraphUpdater
         .update(
           links = WorkLinks(idA, updateVersion, referencedWorkIds = Set(idB)),
-          existingNodes =
-            Set(
-              WorkNode(
-                idA,
-                existingVersion,
-                linkedIds = Nil,
-                componentId = ciHash(idA)))
+          existingNodes = Set(
+            WorkNode(
+              idA,
+              existingVersion,
+              linkedIds = Nil,
+              componentId = ciHash(idA)))
         ) should contain theSameElementsAs
         List(
           WorkNode(
@@ -341,13 +338,12 @@ class WorkGraphUpdaterTest
         WorkGraphUpdater
           .update(
             links = WorkLinks(idA, updateVersion, referencedWorkIds = Set(idB)),
-            existingNodes =
-              Set(
-                WorkNode(
-                  idA,
-                  existingVersion,
-                  linkedIds = Nil,
-                  componentId = ciHash(idA)))
+            existingNodes = Set(
+              WorkNode(
+                idA,
+                existingVersion,
+                linkedIds = Nil,
+                componentId = ciHash(idA)))
           )
       }
       thrown.message shouldBe s"update failed, work:$idA v1 is not newer than existing work v3"
@@ -361,18 +357,17 @@ class WorkGraphUpdaterTest
       WorkGraphUpdater
         .update(
           links = WorkLinks(idA, updateVersion, referencedWorkIds = Set(idB)),
-          existingNodes =
-            Set(
-              WorkNode(
-                idA,
-                existingVersion,
-                linkedIds = List(idB),
-                componentId = ciHash(idA, idB)),
-              WorkNode(
-                idB,
-                version = 0,
-                linkedIds = List(),
-                componentId = ciHash(idA, idB)))
+          existingNodes = Set(
+            WorkNode(
+              idA,
+              existingVersion,
+              linkedIds = List(idB),
+              componentId = ciHash(idA, idB)),
+            WorkNode(
+              idB,
+              version = 0,
+              linkedIds = List(),
+              componentId = ciHash(idA, idB)))
         ) should contain theSameElementsAs
         List(
           WorkNode(
@@ -396,18 +391,17 @@ class WorkGraphUpdaterTest
         WorkGraphUpdater
           .update(
             links = WorkLinks(idA, updateVersion, referencedWorkIds = Set(idA)),
-            existingNodes =
-              Set(
-                WorkNode(
-                  idA,
-                  existingVersion,
-                  linkedIds = List(idB),
-                  componentId = ciHash(idA, idB)),
-                WorkNode(
-                  idB,
-                  version = 0,
-                  linkedIds = List(),
-                  componentId = ciHash(idA, idB)))
+            existingNodes = Set(
+              WorkNode(
+                idA,
+                existingVersion,
+                linkedIds = List(idB),
+                componentId = ciHash(idA, idB)),
+              WorkNode(
+                idB,
+                version = 0,
+                linkedIds = List(),
+                componentId = ciHash(idA, idB)))
           )
       }
       thrown.getMessage shouldBe s"update failed, work:$idA v2 already exists with different content! update-ids:Set($idA) != existing-ids:Set($idB)"
@@ -419,18 +413,13 @@ class WorkGraphUpdaterTest
       WorkGraphUpdater
         .update(
           links = WorkLinks(idA, version = 2, referencedWorkIds = Set.empty),
-          existingNodes =
-            Set(
-              WorkNode(
-                idA,
-                version = 1,
-                linkedIds = List(idB),
-                componentId = "A+B"),
-              WorkNode(
-                idB,
-                version = 1,
-                linkedIds = List(),
-                componentId = "A+B"))
+          existingNodes = Set(
+            WorkNode(
+              idA,
+              version = 1,
+              linkedIds = List(idB),
+              componentId = "A+B"),
+            WorkNode(idB, version = 1, linkedIds = List(), componentId = "A+B"))
         ) shouldBe Set(
         WorkNode(
           idA,
@@ -449,14 +438,13 @@ class WorkGraphUpdaterTest
       WorkGraphUpdater
         .update(
           links = WorkLinks(idA, version = 2, referencedWorkIds = Set.empty),
-          existingNodes =
-            Set(
-              WorkNode(
-                idA,
-                version = 1,
-                linkedIds = List(idB),
-                componentId = "A+B")
-            )
+          existingNodes = Set(
+            WorkNode(
+              idA,
+              version = 1,
+              linkedIds = List(idB),
+              componentId = "A+B")
+          )
         ) shouldBe Set(
         WorkNode(idA, version = 2, linkedIds = Nil, componentId = ciHash(idA)),
         WorkNode(
@@ -471,20 +459,22 @@ class WorkGraphUpdaterTest
       WorkGraphUpdater
         .update(
           links = WorkLinks(idB, version = 3, referencedWorkIds = Set.empty),
-          existingNodes = (Set(
-            WorkNode(
-              idA,
-              version = 2,
-              linkedIds = List(idB),
-              componentId = "A+B+C"),
-            WorkNode(
-              idB,
-              version = 2,
-              linkedIds = List(idC),
-              componentId = "A+B+C"),
-            WorkNode(idC, version = 1, linkedIds = Nil, componentId = "A+B+C")
+          existingNodes = (
+            Set(
+              WorkNode(
+                idA,
+                version = 2,
+                linkedIds = List(idB),
+                componentId = "A+B+C"),
+              WorkNode(
+                idB,
+                version = 2,
+                linkedIds = List(idC),
+                componentId = "A+B+C"),
+              WorkNode(idC, version = 1, linkedIds = Nil, componentId = "A+B+C")
+            )
           )
-        )) shouldBe Set(
+        ) shouldBe Set(
         WorkNode(
           idA,
           version = 2,

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdaterTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdaterTest.scala
@@ -7,7 +7,6 @@ import weco.pipeline.matcher.fixtures.MatcherFixtures
 import weco.pipeline.matcher.models.{
   VersionExpectedConflictException,
   VersionUnexpectedConflictException,
-  WorkGraph,
   WorkLinks,
   WorkNode
 }
@@ -27,9 +26,8 @@ class WorkGraphUpdaterTest
       WorkGraphUpdater
         .update(
           links = WorkLinks(idA, version = 1, referencedWorkIds = Set.empty),
-          existingGraph = WorkGraph(Set.empty)
-        )
-        .nodes shouldBe Set(
+          existingGraph = Set()
+        ) shouldBe Set(
         WorkNode(
           idA,
           version = 1,
@@ -41,9 +39,8 @@ class WorkGraphUpdaterTest
       WorkGraphUpdater
         .update(
           links = WorkLinks(idA, version = 1, referencedWorkIds = Set(idB)),
-          existingGraph = WorkGraph(Set.empty)
-        )
-        .nodes shouldBe Set(
+          existingGraph = Set()
+        ) shouldBe Set(
         WorkNode(
           idA,
           version = 1,
@@ -60,9 +57,8 @@ class WorkGraphUpdaterTest
       WorkGraphUpdater
         .update(
           links = WorkLinks(idB, version = 1, referencedWorkIds = Set(idA)),
-          existingGraph = WorkGraph(Set.empty)
-        )
-        .nodes shouldBe Set(
+          existingGraph = Set()
+        ) shouldBe Set(
         WorkNode(
           idB,
           version = 1,
@@ -81,7 +77,7 @@ class WorkGraphUpdaterTest
       WorkGraphUpdater
         .update(
           links = WorkLinks(idA, version = 2, referencedWorkIds = Set(idB)),
-          existingGraph = WorkGraph(
+          existingGraph =
             Set(
               WorkNode(
                 idA,
@@ -94,9 +90,7 @@ class WorkGraphUpdaterTest
                 linkedIds = Nil,
                 componentId = ciHash(idB))
             )
-          )
-        )
-        .nodes should contain theSameElementsAs
+        ) should contain theSameElementsAs
         List(
           WorkNode(
             idA,
@@ -114,7 +108,7 @@ class WorkGraphUpdaterTest
       WorkGraphUpdater
         .update(
           links = WorkLinks(idA, version = 2, referencedWorkIds = Set(idB)),
-          existingGraph = WorkGraph(
+          existingGraph =
             Set(
               WorkNode(
                 idA,
@@ -125,9 +119,8 @@ class WorkGraphUpdaterTest
                 idB,
                 version = 1,
                 linkedIds = Nil,
-                componentId = ciHash(idA, idB))))
-        )
-        .nodes shouldBe Set(
+                componentId = ciHash(idA, idB)))
+        ) shouldBe Set(
         WorkNode(
           idA,
           version = 2,
@@ -145,7 +138,7 @@ class WorkGraphUpdaterTest
       WorkGraphUpdater
         .update(
           links = WorkLinks(idB, version = 2, referencedWorkIds = Set(idC)),
-          existingGraph = WorkGraph(Set(
+          existingGraph = Set(
             WorkNode(
               idA,
               version = 2,
@@ -161,9 +154,8 @@ class WorkGraphUpdaterTest
               version = 1,
               linkedIds = Nil,
               componentId = ciHash(idC))
-          ))
-        )
-        .nodes shouldBe Set(
+          )
+        ) shouldBe Set(
         WorkNode(
           idA,
           version = 2,
@@ -186,7 +178,7 @@ class WorkGraphUpdaterTest
       WorkGraphUpdater
         .update(
           links = WorkLinks(idB, version = 2, referencedWorkIds = Set(idC)),
-          existingGraph = WorkGraph(Set(
+          existingGraph = Set(
             WorkNode(
               idA,
               version = 1,
@@ -199,9 +191,8 @@ class WorkGraphUpdaterTest
               componentId = "C+D"),
             WorkNode(idB, version = 1, linkedIds = Nil, componentId = "A+B"),
             WorkNode(idD, version = 1, linkedIds = Nil, componentId = "C+D")
-          ))
-        )
-        .nodes shouldBe
+          )
+        ) shouldBe
         Set(
           WorkNode(
             idA,
@@ -230,7 +221,7 @@ class WorkGraphUpdaterTest
       WorkGraphUpdater
         .update(
           links = WorkLinks(idB, version = 2, referencedWorkIds = Set(idC, idD)),
-          existingGraph = WorkGraph(Set(
+          existingGraph = Set(
             WorkNode(
               idA,
               version = 2,
@@ -251,9 +242,8 @@ class WorkGraphUpdaterTest
               version = 1,
               linkedIds = Nil,
               componentId = ciHash(idD))
-          ))
-        )
-        .nodes shouldBe
+          )
+        ) shouldBe
         Set(
           WorkNode(
             idA,
@@ -282,7 +272,7 @@ class WorkGraphUpdaterTest
       WorkGraphUpdater
         .update(
           links = WorkLinks(idC, version = 2, referencedWorkIds = Set(idA)),
-          existingGraph = WorkGraph(Set(
+          existingGraph = Set(
             WorkNode(
               idA,
               version = 2,
@@ -294,9 +284,8 @@ class WorkGraphUpdaterTest
               linkedIds = List(idC),
               componentId = "A+B+C"),
             WorkNode(idC, version = 1, linkedIds = Nil, componentId = "A+B+C")
-          ))
-        )
-        .nodes shouldBe Set(
+          )
+        ) shouldBe Set(
         WorkNode(
           idA,
           version = 2,
@@ -323,15 +312,14 @@ class WorkGraphUpdaterTest
       WorkGraphUpdater
         .update(
           links = WorkLinks(idA, updateVersion, referencedWorkIds = Set(idB)),
-          existingGraph = WorkGraph(
+          existingGraph =
             Set(
               WorkNode(
                 idA,
                 existingVersion,
                 linkedIds = Nil,
-                componentId = ciHash(idA))))
-        )
-        .nodes should contain theSameElementsAs
+                componentId = ciHash(idA)))
+        ) should contain theSameElementsAs
         List(
           WorkNode(
             idA,
@@ -353,13 +341,13 @@ class WorkGraphUpdaterTest
         WorkGraphUpdater
           .update(
             links = WorkLinks(idA, updateVersion, referencedWorkIds = Set(idB)),
-            existingGraph = WorkGraph(
+            existingGraph =
               Set(
                 WorkNode(
                   idA,
                   existingVersion,
                   linkedIds = Nil,
-                  componentId = ciHash(idA))))
+                  componentId = ciHash(idA)))
           )
       }
       thrown.message shouldBe s"update failed, work:$idA v1 is not newer than existing work v3"
@@ -373,7 +361,7 @@ class WorkGraphUpdaterTest
       WorkGraphUpdater
         .update(
           links = WorkLinks(idA, updateVersion, referencedWorkIds = Set(idB)),
-          existingGraph = WorkGraph(
+          existingGraph =
             Set(
               WorkNode(
                 idA,
@@ -384,9 +372,8 @@ class WorkGraphUpdaterTest
                 idB,
                 version = 0,
                 linkedIds = List(),
-                componentId = ciHash(idA, idB))))
-        )
-        .nodes should contain theSameElementsAs
+                componentId = ciHash(idA, idB)))
+        ) should contain theSameElementsAs
         List(
           WorkNode(
             idA,
@@ -409,7 +396,7 @@ class WorkGraphUpdaterTest
         WorkGraphUpdater
           .update(
             links = WorkLinks(idA, updateVersion, referencedWorkIds = Set(idA)),
-            existingGraph = WorkGraph(
+            existingGraph =
               Set(
                 WorkNode(
                   idA,
@@ -420,7 +407,7 @@ class WorkGraphUpdaterTest
                   idB,
                   version = 0,
                   linkedIds = List(),
-                  componentId = ciHash(idA, idB))))
+                  componentId = ciHash(idA, idB)))
           )
       }
       thrown.getMessage shouldBe s"update failed, work:$idA v2 already exists with different content! update-ids:Set($idA) != existing-ids:Set($idB)"
@@ -432,7 +419,7 @@ class WorkGraphUpdaterTest
       WorkGraphUpdater
         .update(
           links = WorkLinks(idA, version = 2, referencedWorkIds = Set.empty),
-          existingGraph = WorkGraph(
+          existingGraph =
             Set(
               WorkNode(
                 idA,
@@ -443,9 +430,8 @@ class WorkGraphUpdaterTest
                 idB,
                 version = 1,
                 linkedIds = List(),
-                componentId = "A+B")))
-        )
-        .nodes shouldBe Set(
+                componentId = "A+B"))
+        ) shouldBe Set(
         WorkNode(
           idA,
           version = 2,
@@ -463,16 +449,15 @@ class WorkGraphUpdaterTest
       WorkGraphUpdater
         .update(
           links = WorkLinks(idA, version = 2, referencedWorkIds = Set.empty),
-          existingGraph = WorkGraph(
+          existingGraph =
             Set(
               WorkNode(
                 idA,
                 version = 1,
                 linkedIds = List(idB),
                 componentId = "A+B")
-            ))
-        )
-        .nodes shouldBe Set(
+            )
+        ) shouldBe Set(
         WorkNode(idA, version = 2, linkedIds = Nil, componentId = ciHash(idA)),
         WorkNode(
           idB,
@@ -486,7 +471,7 @@ class WorkGraphUpdaterTest
       WorkGraphUpdater
         .update(
           links = WorkLinks(idB, version = 3, referencedWorkIds = Set.empty),
-          existingGraph = WorkGraph(Set(
+          existingGraph = (Set(
             WorkNode(
               idA,
               version = 2,
@@ -498,9 +483,8 @@ class WorkGraphUpdaterTest
               linkedIds = List(idC),
               componentId = "A+B+C"),
             WorkNode(idC, version = 1, linkedIds = Nil, componentId = "A+B+C")
-          ))
-        )
-        .nodes shouldBe Set(
+          )
+        )) shouldBe Set(
         WorkNode(
           idA,
           version = 2,
@@ -519,7 +503,7 @@ class WorkGraphUpdaterTest
       WorkGraphUpdater
         .update(
           links = WorkLinks(idB, version = 3, referencedWorkIds = Set(idC)),
-          existingGraph = WorkGraph(Set(
+          existingGraph = Set(
             WorkNode(
               idA,
               version = 2,
@@ -531,9 +515,8 @@ class WorkGraphUpdaterTest
               linkedIds = List(idA, idC),
               componentId = "A+B+C"),
             WorkNode(idC, version = 1, linkedIds = Nil, componentId = "A+B+C")
-          ))
-        )
-        .nodes shouldBe Set(
+          )
+        ) shouldBe Set(
         WorkNode(
           idA,
           version = 2,

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdaterTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdaterTest.scala
@@ -26,7 +26,7 @@ class WorkGraphUpdaterTest
       WorkGraphUpdater
         .update(
           links = WorkLinks(idA, version = 1, referencedWorkIds = Set.empty),
-          existingGraph = Set()
+          existingNodes = Set()
         ) shouldBe Set(
         WorkNode(
           idA,
@@ -39,7 +39,7 @@ class WorkGraphUpdaterTest
       WorkGraphUpdater
         .update(
           links = WorkLinks(idA, version = 1, referencedWorkIds = Set(idB)),
-          existingGraph = Set()
+          existingNodes = Set()
         ) shouldBe Set(
         WorkNode(
           idA,
@@ -57,7 +57,7 @@ class WorkGraphUpdaterTest
       WorkGraphUpdater
         .update(
           links = WorkLinks(idB, version = 1, referencedWorkIds = Set(idA)),
-          existingGraph = Set()
+          existingNodes = Set()
         ) shouldBe Set(
         WorkNode(
           idB,
@@ -77,7 +77,7 @@ class WorkGraphUpdaterTest
       WorkGraphUpdater
         .update(
           links = WorkLinks(idA, version = 2, referencedWorkIds = Set(idB)),
-          existingGraph =
+          existingNodes =
             Set(
               WorkNode(
                 idA,
@@ -108,7 +108,7 @@ class WorkGraphUpdaterTest
       WorkGraphUpdater
         .update(
           links = WorkLinks(idA, version = 2, referencedWorkIds = Set(idB)),
-          existingGraph =
+          existingNodes =
             Set(
               WorkNode(
                 idA,
@@ -138,7 +138,7 @@ class WorkGraphUpdaterTest
       WorkGraphUpdater
         .update(
           links = WorkLinks(idB, version = 2, referencedWorkIds = Set(idC)),
-          existingGraph = Set(
+          existingNodes = Set(
             WorkNode(
               idA,
               version = 2,
@@ -178,7 +178,7 @@ class WorkGraphUpdaterTest
       WorkGraphUpdater
         .update(
           links = WorkLinks(idB, version = 2, referencedWorkIds = Set(idC)),
-          existingGraph = Set(
+          existingNodes = Set(
             WorkNode(
               idA,
               version = 1,
@@ -221,7 +221,7 @@ class WorkGraphUpdaterTest
       WorkGraphUpdater
         .update(
           links = WorkLinks(idB, version = 2, referencedWorkIds = Set(idC, idD)),
-          existingGraph = Set(
+          existingNodes = Set(
             WorkNode(
               idA,
               version = 2,
@@ -272,7 +272,7 @@ class WorkGraphUpdaterTest
       WorkGraphUpdater
         .update(
           links = WorkLinks(idC, version = 2, referencedWorkIds = Set(idA)),
-          existingGraph = Set(
+          existingNodes = Set(
             WorkNode(
               idA,
               version = 2,
@@ -312,7 +312,7 @@ class WorkGraphUpdaterTest
       WorkGraphUpdater
         .update(
           links = WorkLinks(idA, updateVersion, referencedWorkIds = Set(idB)),
-          existingGraph =
+          existingNodes =
             Set(
               WorkNode(
                 idA,
@@ -341,7 +341,7 @@ class WorkGraphUpdaterTest
         WorkGraphUpdater
           .update(
             links = WorkLinks(idA, updateVersion, referencedWorkIds = Set(idB)),
-            existingGraph =
+            existingNodes =
               Set(
                 WorkNode(
                   idA,
@@ -361,7 +361,7 @@ class WorkGraphUpdaterTest
       WorkGraphUpdater
         .update(
           links = WorkLinks(idA, updateVersion, referencedWorkIds = Set(idB)),
-          existingGraph =
+          existingNodes =
             Set(
               WorkNode(
                 idA,
@@ -396,7 +396,7 @@ class WorkGraphUpdaterTest
         WorkGraphUpdater
           .update(
             links = WorkLinks(idA, updateVersion, referencedWorkIds = Set(idA)),
-            existingGraph =
+            existingNodes =
               Set(
                 WorkNode(
                   idA,
@@ -419,7 +419,7 @@ class WorkGraphUpdaterTest
       WorkGraphUpdater
         .update(
           links = WorkLinks(idA, version = 2, referencedWorkIds = Set.empty),
-          existingGraph =
+          existingNodes =
             Set(
               WorkNode(
                 idA,
@@ -449,7 +449,7 @@ class WorkGraphUpdaterTest
       WorkGraphUpdater
         .update(
           links = WorkLinks(idA, version = 2, referencedWorkIds = Set.empty),
-          existingGraph =
+          existingNodes =
             Set(
               WorkNode(
                 idA,
@@ -471,7 +471,7 @@ class WorkGraphUpdaterTest
       WorkGraphUpdater
         .update(
           links = WorkLinks(idB, version = 3, referencedWorkIds = Set.empty),
-          existingGraph = (Set(
+          existingNodes = (Set(
             WorkNode(
               idA,
               version = 2,
@@ -503,7 +503,7 @@ class WorkGraphUpdaterTest
       WorkGraphUpdater
         .update(
           links = WorkLinks(idB, version = 3, referencedWorkIds = Set(idC)),
-          existingGraph = Set(
+          existingNodes = Set(
             WorkNode(
               idA,
               version = 2,


### PR DESCRIPTION
The WorkGraph model is really just a wrapper around `Set[WorkNode]`, and the Work namespace is already pretty busy. Let's drop a type and just pass around sets directly.