### PR TITLE
Populate the collectionPath field in the TEI transformer

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/CollectionPath.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/CollectionPath.scala
@@ -1,9 +1,18 @@
 package weco.catalogue.internal_model.work
 
-/**
-  * A CollectionPath represents the position of an individual work in a
-  * collection hierarchy.
-  */
+/** Represents the position of an individual work in a collection hierarchy.
+ *
+ * @param path  The internal control field that describes the position of a
+ *              Work within the hierarchy
+ * @param label The path we'll display as publicly visible on /works
+ *
+ * Note that these two don't have to be the same (although they often are).
+ *
+ * e.g. in Calm the path is the RefNo, the label is the AltRefNo.  A work could
+ * have the RefNo PPDAL/E/2/13/1 but the AltRefNo PP/DAL/E/2/13/1 -- because the
+ * top-level item of the hierarchy is PPDAL (personal papers of A G Dally), not PP.
+ *
+ */
 case class CollectionPath(
   path: String,
   label: Option[String] = None,

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/CollectionPath.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/CollectionPath.scala
@@ -1,18 +1,18 @@
 package weco.catalogue.internal_model.work
 
 /** Represents the position of an individual work in a collection hierarchy.
- *
- * @param path  The internal control field that describes the position of a
- *              Work within the hierarchy
- * @param label The path we'll display as publicly visible on /works
- *
- * Note that these two don't have to be the same (although they often are).
- *
- * e.g. in Calm the path is the RefNo, the label is the AltRefNo.  A work could
- * have the RefNo PPDAL/E/2/13/1 but the AltRefNo PP/DAL/E/2/13/1 -- because the
- * top-level item of the hierarchy is PPDAL (personal papers of A G Dally), not PP.
- *
- */
+  *
+  * @param path  The internal control field that describes the position of a
+  *              Work within the hierarchy
+  * @param label The path we'll display as publicly visible on /works
+  *
+  * Note that these two don't have to be the same (although they often are).
+  *
+  * e.g. in Calm the path is the RefNo, the label is the AltRefNo.  A work could
+  * have the RefNo PPDAL/E/2/13/1 but the AltRefNo PP/DAL/E/2/13/1 -- because the
+  * top-level item of the hierarchy is PPDAL (personal papers of A G Dally), not PP.
+  *
+  */
 case class CollectionPath(
   path: String,
   label: Option[String] = None,

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiDataTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiDataTest.scala
@@ -116,7 +116,8 @@ class TeiDataTest
         languages = firstInnerTeiData.languages,
         description = firstInnerTeiData.description,
         format = Some(ArchivesAndManuscripts),
-        collectionPath = Some(CollectionPath(path = firstInnerTeiData.id, label = None))
+        collectionPath =
+          Some(CollectionPath(path = firstInnerTeiData.id, label = None))
       )
     )
 
@@ -128,7 +129,8 @@ class TeiDataTest
         languages = secondInnerTeiData.languages,
         description = secondInnerTeiData.description,
         format = Some(ArchivesAndManuscripts),
-        collectionPath = Some(CollectionPath(path = secondInnerTeiData.id, label = None))
+        collectionPath =
+          Some(CollectionPath(path = secondInnerTeiData.id, label = None))
       )
     )
     work.state.internalWorkStubs shouldBe List(
@@ -157,7 +159,8 @@ class TeiDataTest
 
       val work = teiData.toWork(time = Instant.now(), version = 1)
 
-      work.data.collectionPath shouldBe Some(CollectionPath(path = "WMS_Example_1", label = None))
+      work.data.collectionPath shouldBe Some(
+        CollectionPath(path = "WMS_Example_1", label = None))
     }
 
     it("uses the ID for a relative path on internal Works") {

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiDataTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiDataTest.scala
@@ -11,12 +11,14 @@ import weco.catalogue.internal_model.identifiers.{
 import weco.catalogue.internal_model.languages.Language
 import weco.catalogue.internal_model.work.Format.ArchivesAndManuscripts
 import weco.catalogue.internal_model.work.{
+  CollectionPath,
   InternalWork,
   MergeCandidate,
   Work,
   WorkData
 }
 import weco.catalogue.internal_model.work.WorkState.Source
+import weco.pipeline.transformer.tei.generators.TeiDataGenerators
 import weco.sierra.generators.SierraIdentifierGenerators
 
 import java.time.Instant
@@ -25,7 +27,8 @@ class TeiDataTest
     extends AnyFunSpec
     with SierraIdentifierGenerators
     with Matchers
-    with IdentifiersGenerators {
+    with IdentifiersGenerators
+    with TeiDataGenerators {
   it("transforms into a work") {
     val title = "This is the title"
     val bnumber = createSierraBibNumber.withCheckDigit
@@ -63,7 +66,8 @@ class TeiDataTest
         mergeCandidates = List(mergeCandidate),
         description = description,
         languages = languages,
-        format = Some(ArchivesAndManuscripts)
+        format = Some(ArchivesAndManuscripts),
+        collectionPath = Some(CollectionPath(path = id, label = None))
       ),
       state = source
     )
@@ -111,7 +115,8 @@ class TeiDataTest
         title = Some(firstInnerTeiData.title),
         languages = firstInnerTeiData.languages,
         description = firstInnerTeiData.description,
-        format = Some(ArchivesAndManuscripts)
+        format = Some(ArchivesAndManuscripts),
+        collectionPath = Some(CollectionPath(path = firstInnerTeiData.id, label = None))
       )
     )
 
@@ -122,7 +127,8 @@ class TeiDataTest
         title = Some(secondInnerTeiData.title),
         languages = secondInnerTeiData.languages,
         description = secondInnerTeiData.description,
-        format = Some(ArchivesAndManuscripts)
+        format = Some(ArchivesAndManuscripts),
+        collectionPath = Some(CollectionPath(path = secondInnerTeiData.id, label = None))
       )
     )
     work.state.internalWorkStubs shouldBe List(
@@ -144,6 +150,38 @@ class TeiDataTest
     work.state.internalWorkStubs shouldBe empty
     work.data.title shouldBe Some(title)
   }
+
+  describe("setting the collectionPath") {
+    it("uses the ID on a top-level Work") {
+      val teiData = createTeiDataWith(id = "WMS_Example_1")
+
+      val work = teiData.toWork(time = Instant.now(), version = 1)
+
+      work.data.collectionPath shouldBe Some(CollectionPath(path = "WMS_Example_1", label = None))
+    }
+
+    it("uses the ID for a relative path on internal Works") {
+      val teiData = createTeiDataWith(
+        id = "WMS_Example_2",
+        nestedTeiData = Right(
+          List(
+            createTeiDataWith(id = "Part_1"),
+            createTeiDataWith(id = "Part_2"),
+            createTeiDataWith(id = "Part_3"),
+          )
+        )
+      )
+
+      val work = teiData.toWork(time = Instant.now(), version = 1)
+
+      work.state.internalWorkStubs.map(_.workData.collectionPath) shouldBe List(
+        Some(CollectionPath(path = "Part_1", label = None)),
+        Some(CollectionPath(path = "Part_2", label = None)),
+        Some(CollectionPath(path = "Part_3", label = None)),
+      )
+    }
+  }
+
   describe("if there's a single inner data") {
     it("uses the title of the item") {
       val innerTeiData = TeiData(

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiTransformerTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiTransformerTest.scala
@@ -57,7 +57,8 @@ class TeiTransformerTest
           description =
             Some("1 copy of al-Qānūn fī al-ṭibb by Avicenna, 980-1037"),
           format = Some(Format.ArchivesAndManuscripts),
-          collectionPath = Some(CollectionPath(path = "manuscript_15651", label = None))
+          collectionPath =
+            Some(CollectionPath(path = "manuscript_15651", label = None))
         ),
         state = Source(sourceIdentifier, modifiedTime)
       )

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiTransformerTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiTransformerTest.scala
@@ -13,6 +13,7 @@ import weco.catalogue.internal_model.languages.Language
 import weco.catalogue.internal_model.work.WorkState.Source
 import weco.catalogue.internal_model.work.generators.InstantGenerators
 import weco.catalogue.internal_model.work.{
+  CollectionPath,
   DeletedReason,
   Format,
   Work,
@@ -55,7 +56,8 @@ class TeiTransformerTest
           title = Some("Wellcome Library"),
           description =
             Some("1 copy of al-Qānūn fī al-ṭibb by Avicenna, 980-1037"),
-          format = Some(Format.ArchivesAndManuscripts)
+          format = Some(Format.ArchivesAndManuscripts),
+          collectionPath = Some(CollectionPath(path = "manuscript_15651", label = None))
         ),
         state = Source(sourceIdentifier, modifiedTime)
       )

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/generators/TeiDataGenerators.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/generators/TeiDataGenerators.scala
@@ -1,0 +1,14 @@
+package weco.pipeline.transformer.tei.generators
+
+import weco.fixtures.RandomGenerators
+import weco.pipeline.transformer.result.Result
+import weco.pipeline.transformer.tei.TeiData
+
+trait TeiDataGenerators extends RandomGenerators {
+  def createTeiDataWith(id: String, nestedTeiData: Result[List[TeiData]] = Right(Nil)): TeiData =
+    TeiData(
+      id = id,
+      title = s"title-${randomAlphanumeric()}",
+      nestedTeiData = nestedTeiData
+    )
+}

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/generators/TeiDataGenerators.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/generators/TeiDataGenerators.scala
@@ -5,7 +5,9 @@ import weco.pipeline.transformer.result.Result
 import weco.pipeline.transformer.tei.TeiData
 
 trait TeiDataGenerators extends RandomGenerators {
-  def createTeiDataWith(id: String, nestedTeiData: Result[List[TeiData]] = Right(Nil)): TeiData =
+  def createTeiDataWith(
+    id: String,
+    nestedTeiData: Result[List[TeiData]] = Right(Nil)): TeiData =
     TeiData(
       id = id,
       title = s"title-${randomAlphanumeric()}",

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/service/TeiTransformerWorkerTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/service/TeiTransformerWorkerTest.scala
@@ -8,6 +8,7 @@ import weco.catalogue.internal_model.identifiers.{
   SourceIdentifier
 }
 import weco.catalogue.internal_model.work.{
+  CollectionPath,
   Format,
   MergeCandidate,
   Work,
@@ -103,7 +104,8 @@ class TeiTransformerWorkerTest
           "Bnumber present in TEI file"
         )
       ),
-      format = Some(Format.ArchivesAndManuscripts)
+      format = Some(Format.ArchivesAndManuscripts),
+      collectionPath = Some(CollectionPath(path = p.id, label = None))
     )
   }
 


### PR DESCRIPTION
Replaces/closes #1898, closes #1899, closes #1900. For https://github.com/wellcomecollection/platform/issues/5309

This patch sets the collectionPath field on all the Works created by the TEI transformer, including the internal work stubs.