### PR TITLE
Don't declare separate types for each instance of Note – make internal model compile faster?

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Availability.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Availability.scala
@@ -91,12 +91,12 @@ object Availabilities {
     // See https://github.com/wellcomecollection/platform/issues/5190
     def isInOtherLibrary: Boolean =
       n match {
-        case t: TermsOfUse => termsAreOtherInstitution(t)
-        case _             => false
+        case Note.TermsOfUse(terms) => termsAreOtherInstitution(terms)
+        case _                      => false
       }
 
-    def termsAreOtherInstitution(termsOfUse: TermsOfUse): Boolean =
-      termsOfUse.content match {
+    def termsAreOtherInstitution(terms: String): Boolean =
+      terms match {
         case t if t.toLowerCase.contains("available at") => true
         case t if t.toLowerCase.contains("available by appointment at") =>
           true

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Note.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Note.scala
@@ -1,61 +1,46 @@
 package weco.catalogue.internal_model.work
 
-sealed trait Note {
-  val content: String
+case class NoteType(id: String, label: String)
+
+case object NoteType {
+  val GeneralNote                = NoteType(id = "general-note", label = "Notes")
+  val BibliographicalInformation = NoteType(id = "bibliographic-info", label = "Bibliographic information")
+  val FundingInformation         = NoteType(id = "funding-info", label = "Funding information")
+  val TimeAndPlaceNote           = NoteType(id = "time-and-place-note", label = "Time and place note")
+  val CreditsNote                = NoteType(id = "credits", label = "Creator/production credits")
+  val ContentsNote               = NoteType(id = "contents", label = "Contents")
+  val CiteAsNote                 = NoteType(id = "reference", label = "Reference")
+  val DissertationNote           = NoteType(id = "dissertation-note", label = "Dissertation note")
+  val LocationOfOriginalNote     = NoteType(id = "location-of-original", label = "Location of original")
+  val LocationOfDuplicatesNote   = NoteType(id = "location-of-duplicates", label = "Location of duplicates")
+  val BindingInformation         = NoteType(id = "binding-detail", label = "Binding detail")
+  val BiographicalNote           = NoteType(id = "biographical-note", label = "Biographical note")
+  val ReproductionNote           = NoteType(id = "reproduction-note", label = "Reproduction note")
+  val TermsOfUse                 = NoteType(id = "terms-of-use", label = "Terms of use")
+  val CopyrightNote              = NoteType(id = "copyright-note", label = "Copyright note")
+  val PublicationsNote           = NoteType(id = "publication-note", label = "Publications note")
+  val ExhibitionsNote            = NoteType(id = "exhibitions-note", label = "Exhibitions note")
+  val AwardsNote                 = NoteType(id = "awards-note", label = "Awards note")
+  val OwnershipNote              = NoteType(id = "ownership-note", label = "Ownership note")
+  val AcquisitionNote            = NoteType(id = "acquisition-note", label = "Acquisition note")
+  val AppraisalNote              = NoteType(id = "appraisal-note", label = "Appraisal note")
+  val AccrualsNote               = NoteType(id = "accruals-note", label = "Accruals note")
+  val RelatedMaterial            = NoteType(id = "related-material", label = "Related material")
+  val FindingAids                = NoteType(id = "finding-aids", label = "Finding aids")
+  val ArrangementNote            = NoteType(id = "arrangement-note", label = "Arrangement")
+  val LetteringNote              = NoteType(id = "lettering-note", label = "Lettering note")
+  val LanguageNote               = NoteType(id = "language-note", label = "Language note")
+  val ReferencesNote             = NoteType(id = "references-note", label = "References note")
 }
 
-case class GeneralNote(content: String) extends Note
+case class Note(noteType: NoteType, contents: String)
 
-case class BibliographicalInformation(content: String) extends Note
-
-case class FundingInformation(content: String) extends Note
-
-case class TimeAndPlaceNote(content: String) extends Note
-
-case class CreditsNote(content: String) extends Note
-
-case class ContentsNote(content: String) extends Note
-
-case class DissertationNote(content: String) extends Note
-
-case class CiteAsNote(content: String) extends Note
-
-case class LocationOfOriginalNote(content: String) extends Note
-
-case class LocationOfDuplicatesNote(content: String) extends Note
-
-case class BindingInformation(content: String) extends Note
-
-case class BiographicalNote(content: String) extends Note
-
-case class ReproductionNote(content: String) extends Note
-
-case class TermsOfUse(content: String) extends Note
-
-case class CopyrightNote(content: String) extends Note
-
-case class PublicationsNote(content: String) extends Note
-
-case class ExhibitionsNote(content: String) extends Note
-
-case class AwardsNote(content: String) extends Note
-
-case class OwnershipNote(content: String) extends Note
-
-case class AcquisitionNote(content: String) extends Note
-
-case class AppraisalNote(content: String) extends Note
-
-case class AccrualsNote(content: String) extends Note
-
-case class RelatedMaterial(content: String) extends Note
-
-case class FindingAids(content: String) extends Note
-
-case class ArrangementNote(content: String) extends Note
-
-case class LetteringNote(content: String) extends Note
-
-case class LanguageNote(content: String) extends Note
-
-case class ReferencesNote(content: String) extends Note
+case object Note {
+  object TermsOfUse {
+    def unapply(n: Note): Option[String] =
+      n.noteType match {
+        case NoteType.TermsOfUse => Some(n.contents)
+        case _                   => None
+      }
+  }
+}

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Note.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Note.scala
@@ -3,34 +3,49 @@ package weco.catalogue.internal_model.work
 case class NoteType(id: String, label: String)
 
 case object NoteType {
-  val GeneralNote                = NoteType(id = "general-note", label = "Notes")
-  val BibliographicalInformation = NoteType(id = "bibliographic-info", label = "Bibliographic information")
-  val FundingInformation         = NoteType(id = "funding-info", label = "Funding information")
-  val TimeAndPlaceNote           = NoteType(id = "time-and-place-note", label = "Time and place note")
-  val CreditsNote                = NoteType(id = "credits", label = "Creator/production credits")
-  val ContentsNote               = NoteType(id = "contents", label = "Contents")
-  val CiteAsNote                 = NoteType(id = "reference", label = "Reference")
-  val DissertationNote           = NoteType(id = "dissertation-note", label = "Dissertation note")
-  val LocationOfOriginalNote     = NoteType(id = "location-of-original", label = "Location of original")
-  val LocationOfDuplicatesNote   = NoteType(id = "location-of-duplicates", label = "Location of duplicates")
-  val BindingInformation         = NoteType(id = "binding-detail", label = "Binding detail")
-  val BiographicalNote           = NoteType(id = "biographical-note", label = "Biographical note")
-  val ReproductionNote           = NoteType(id = "reproduction-note", label = "Reproduction note")
-  val TermsOfUse                 = NoteType(id = "terms-of-use", label = "Terms of use")
-  val CopyrightNote              = NoteType(id = "copyright-note", label = "Copyright note")
-  val PublicationsNote           = NoteType(id = "publication-note", label = "Publications note")
-  val ExhibitionsNote            = NoteType(id = "exhibitions-note", label = "Exhibitions note")
-  val AwardsNote                 = NoteType(id = "awards-note", label = "Awards note")
-  val OwnershipNote              = NoteType(id = "ownership-note", label = "Ownership note")
-  val AcquisitionNote            = NoteType(id = "acquisition-note", label = "Acquisition note")
-  val AppraisalNote              = NoteType(id = "appraisal-note", label = "Appraisal note")
-  val AccrualsNote               = NoteType(id = "accruals-note", label = "Accruals note")
-  val RelatedMaterial            = NoteType(id = "related-material", label = "Related material")
-  val FindingAids                = NoteType(id = "finding-aids", label = "Finding aids")
-  val ArrangementNote            = NoteType(id = "arrangement-note", label = "Arrangement")
-  val LetteringNote              = NoteType(id = "lettering-note", label = "Lettering note")
-  val LanguageNote               = NoteType(id = "language-note", label = "Language note")
-  val ReferencesNote             = NoteType(id = "references-note", label = "References note")
+  val GeneralNote = NoteType(id = "general-note", label = "Notes")
+  val BibliographicalInformation =
+    NoteType(id = "bibliographic-info", label = "Bibliographic information")
+  val FundingInformation =
+    NoteType(id = "funding-info", label = "Funding information")
+  val TimeAndPlaceNote =
+    NoteType(id = "time-and-place-note", label = "Time and place note")
+  val CreditsNote =
+    NoteType(id = "credits", label = "Creator/production credits")
+  val ContentsNote = NoteType(id = "contents", label = "Contents")
+  val CiteAsNote = NoteType(id = "reference", label = "Reference")
+  val DissertationNote =
+    NoteType(id = "dissertation-note", label = "Dissertation note")
+  val LocationOfOriginalNote =
+    NoteType(id = "location-of-original", label = "Location of original")
+  val LocationOfDuplicatesNote =
+    NoteType(id = "location-of-duplicates", label = "Location of duplicates")
+  val BindingInformation =
+    NoteType(id = "binding-detail", label = "Binding detail")
+  val BiographicalNote =
+    NoteType(id = "biographical-note", label = "Biographical note")
+  val ReproductionNote =
+    NoteType(id = "reproduction-note", label = "Reproduction note")
+  val TermsOfUse = NoteType(id = "terms-of-use", label = "Terms of use")
+  val CopyrightNote = NoteType(id = "copyright-note", label = "Copyright note")
+  val PublicationsNote =
+    NoteType(id = "publication-note", label = "Publications note")
+  val ExhibitionsNote =
+    NoteType(id = "exhibitions-note", label = "Exhibitions note")
+  val AwardsNote = NoteType(id = "awards-note", label = "Awards note")
+  val OwnershipNote = NoteType(id = "ownership-note", label = "Ownership note")
+  val AcquisitionNote =
+    NoteType(id = "acquisition-note", label = "Acquisition note")
+  val AppraisalNote = NoteType(id = "appraisal-note", label = "Appraisal note")
+  val AccrualsNote = NoteType(id = "accruals-note", label = "Accruals note")
+  val RelatedMaterial =
+    NoteType(id = "related-material", label = "Related material")
+  val FindingAids = NoteType(id = "finding-aids", label = "Finding aids")
+  val ArrangementNote = NoteType(id = "arrangement-note", label = "Arrangement")
+  val LetteringNote = NoteType(id = "lettering-note", label = "Lettering note")
+  val LanguageNote = NoteType(id = "language-note", label = "Language note")
+  val ReferencesNote =
+    NoteType(id = "references-note", label = "References note")
 }
 
 case class Note(noteType: NoteType, contents: String)

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Note.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Note.scala
@@ -2,6 +2,18 @@ package weco.catalogue.internal_model.work
 
 case class NoteType(id: String, label: String)
 
+case class Note(noteType: NoteType, contents: String)
+
+// We used to have a sealed trait for Note, with a separate subclass for each
+// type of Note.  We moved away from that to a parametrised NoteType for
+// a few reasons:
+//
+//    - Having lots of subtypes means Circe has to create lots of implicit JSON
+//      encoders and decoders, which slows the build down
+//    - Every time we change the note types, we have to update the API code before
+//      we can use them
+//    - We don't actually care about NoteType being an enumerated type
+//
 case object NoteType {
   val GeneralNote = NoteType(id = "general-note", label = "Notes")
   val BibliographicalInformation =
@@ -47,8 +59,6 @@ case object NoteType {
   val ReferencesNote =
     NoteType(id = "references-note", label = "References note")
 }
-
-case class Note(noteType: NoteType, contents: String)
 
 case object Note {
   object TermsOfUse {

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/AvailabilityTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/AvailabilityTest.scala
@@ -75,7 +75,9 @@ class AvailabilityTest
       val work = denormalisedWork()
         .items(List(createIdentifiedPhysicalItem))
         .notes(
-          List(TermsOfUse("Available at Churchill Archives Centre"))
+          List(
+            Note(contents = "Available at Churchill Archives Centre", noteType = NoteType.TermsOfUse)
+          )
         )
       val workAvailabilities = Availabilities.forWorkData(work.data)
 

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/AvailabilityTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/AvailabilityTest.scala
@@ -76,7 +76,9 @@ class AvailabilityTest
         .items(List(createIdentifiedPhysicalItem))
         .notes(
           List(
-            Note(contents = "Available at Churchill Archives Centre", noteType = NoteType.TermsOfUse)
+            Note(
+              contents = "Available at Churchill Archives Centre",
+              noteType = NoteType.TermsOfUse)
           )
         )
       val workAvailabilities = Availabilities.forWorkData(work.data)

--- a/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/transformers/CalmLanguages.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/transformers/CalmLanguages.scala
@@ -1,6 +1,6 @@
 package weco.pipeline.transformer.calm.transformers
 
-import weco.catalogue.internal_model.work.LanguageNote
+import weco.catalogue.internal_model.work.{Note, NoteType}
 import weco.catalogue.internal_model.languages.{Language, MarcLanguageCodeList}
 
 import scala.util.matching.Regex
@@ -19,16 +19,16 @@ object CalmLanguages {
   // e.g. "Mainly in German, smaller parts in English."
   //
   def apply(
-    languageFieldValues: List[String]): (List[Language], List[LanguageNote]) =
+    languageFieldValues: List[String]): (List[Language], List[Note]) =
     languageFieldValues
-      .foldLeft((List[Language](), List[LanguageNote]())) {
+      .foldLeft((List[Language](), List[Note]())) {
         case ((languages, notes), value) =>
           val (newLanguages, newNotes) = parseSingleValue(value)
           ((languages ++ newLanguages).distinct, (notes ++ newNotes).distinct)
       }
 
   private def parseSingleValue(
-    languageField: String): (List[Language], List[LanguageNote]) =
+    languageField: String): (List[Language], List[Note]) =
     languageField match {
       case value if value.trim.nonEmpty =>
         parseLanguages(value) match {
@@ -42,7 +42,12 @@ object CalmLanguages {
           case None =>
             (
               guessLanguages(value),
-              List(LanguageNote(value.replace("recieved", "received")))
+              List(
+                Note(
+                  contents = value.replace("recieved", "received"),
+                  noteType = NoteType.LanguageNote
+                )
+              )
             )
         }
 

--- a/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/transformers/CalmLanguages.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/transformers/CalmLanguages.scala
@@ -18,8 +18,7 @@ object CalmLanguages {
   // languages we can, and keep the original sentence in a note.
   // e.g. "Mainly in German, smaller parts in English."
   //
-  def apply(
-    languageFieldValues: List[String]): (List[Language], List[Note]) =
+  def apply(languageFieldValues: List[String]): (List[Language], List[Note]) =
     languageFieldValues
       .foldLeft((List[Language](), List[Note]())) {
         case ((languages, notes), value) =>

--- a/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/transformers/CalmNotes.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/transformers/CalmNotes.scala
@@ -6,26 +6,26 @@ import weco.pipeline.transformer.calm.NormaliseText
 import weco.pipeline.transformer.calm.models.CalmRecordOps
 
 object CalmNotes extends CalmRecordOps {
-  private val notesMapping = List(
-    ("AdminHistory", BiographicalNote(_)),
-    ("CustodialHistory", OwnershipNote(_)),
-    ("Acquisition", AcquisitionNote(_)),
-    ("Appraisal", AppraisalNote(_)),
-    ("Accruals", AccrualsNote(_)),
-    ("RelatedMaterial", RelatedMaterial(_)),
-    ("PubInNote", PublicationsNote(_)),
-    ("UserWrapped4", FindingAids(_)),
-    ("Copyright", CopyrightNote(_)),
-    ("Arrangement", ArrangementNote(_)),
-    ("Copies", LocationOfDuplicatesNote(_)),
+  private val noteTypeMapping = List(
+    ("AdminHistory", NoteType.BiographicalNote),
+    ("CustodialHistory", NoteType.OwnershipNote),
+    ("Acquisition", NoteType.AcquisitionNote),
+    ("Appraisal", NoteType.AppraisalNote),
+    ("Accruals", NoteType.AccrualsNote),
+    ("RelatedMaterial", NoteType.RelatedMaterial),
+    ("PubInNote", NoteType.PublicationsNote),
+    ("UserWrapped4", NoteType.FindingAids),
+    ("Copyright", NoteType.CopyrightNote),
+    ("Arrangement", NoteType.ArrangementNote),
+    ("Copies", NoteType.LocationOfDuplicatesNote),
   )
 
   def apply(record: CalmRecord): List[Note] =
-    notesMapping.flatMap {
-      case (key, createNote) =>
+    noteTypeMapping.flatMap {
+      case (key, noteType) =>
         record
           .getList(key)
           .map(NormaliseText(_))
-          .map(createNote)
+          .map(contents => Note(contents = contents, noteType = noteType))
     }
 }

--- a/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/transformers/CalmTermsOfUse.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/transformers/CalmTermsOfUse.scala
@@ -2,7 +2,7 @@ package weco.pipeline.transformer.calm.transformers
 
 import grizzled.slf4j.Logging
 import weco.catalogue.internal_model.locations.AccessStatus
-import weco.catalogue.internal_model.work.TermsOfUse
+import weco.catalogue.internal_model.work.{Note, NoteType}
 import weco.catalogue.source_model.calm.CalmRecord
 import weco.pipeline.transformer.calm.models.CalmRecordOps
 
@@ -10,7 +10,7 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
 object CalmTermsOfUse extends CalmRecordOps with Logging {
-  def apply(record: CalmRecord): List[TermsOfUse] = {
+  def apply(record: CalmRecord): List[Note] = {
     val accessConditions = getAccessConditions(record)
     val accessStatus = CalmAccessStatus(record)
 
@@ -102,7 +102,9 @@ object CalmTermsOfUse extends CalmRecordOps with Logging {
           if (parts.isEmpty) None else Some(parts.mkString(" "))
       }
 
-    terms.map(TermsOfUse).toList
+    terms
+      .map(contents => Note(contents = contents, noteType = NoteType.TermsOfUse))
+      .toList
   }
 
   // e.g. 1 January 2021

--- a/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/CalmTransformerTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/CalmTransformerTest.scala
@@ -83,7 +83,10 @@ class CalmTransformerTest
             Language(label = "Russian", id = "rus")
           ),
           notes = List(
-            LanguageNote("English, with Russian commentary")
+            Note(
+              contents = "English, with Russian commentary",
+              noteType = NoteType.LanguageNote
+            )
           )
         )
       )
@@ -172,7 +175,7 @@ class CalmTransformerTest
       "CatalogueStatus" -> "Catalogued"
     )
     val termsOfUse = CalmTransformer(record, version).right.get.data.notes
-      .collectFirst { case TermsOfUse(content) => content }
+      .collectFirst { case Note.TermsOfUse(contents) => contents }
 
     termsOfUse shouldBe Some("nope. nope. Restricted until 10 October 2050.")
   }
@@ -374,8 +377,8 @@ class CalmTransformerTest
       "CatalogueStatus" -> "Catalogued"
     )
     CalmTransformer(record, version).right.get.data.notes should contain theSameElementsAs List(
-      CopyrightNote("no copyright"),
-      ArrangementNote("meet at midnight")
+      Note(contents = "no copyright", noteType = NoteType.CopyrightNote),
+      Note(contents = "meet at midnight", noteType = NoteType.ArrangementNote)
     )
   }
 
@@ -575,7 +578,10 @@ class CalmTransformerTest
 
     workData.languages shouldBe empty
     workData.notes should contain(
-      LanguageNote("Some freeform discussion of the language")
+      Note(
+        contents = "Some freeform discussion of the language",
+        noteType = NoteType.LanguageNote
+      )
     )
   }
 

--- a/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/transformers/CalmLanguagesTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/transformers/CalmLanguagesTest.scala
@@ -5,7 +5,7 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.{TableDrivenPropertyChecks, TableFor2}
 import weco.catalogue.internal_model.languages.Language
-import weco.catalogue.internal_model.work.LanguageNote
+import weco.catalogue.internal_model.work.{Note, NoteType}
 
 class CalmLanguagesTest
     extends AnyFunSpec
@@ -172,7 +172,9 @@ class CalmLanguagesTest
       case (languageField, expectedLanguages) =>
         val (languages, languageNotes) = CalmLanguages(List(languageField))
         languages shouldBe expectedLanguages
-        languageNotes shouldBe List(LanguageNote(languageField))
+        languageNotes shouldBe List(
+          Note(contents = languageField, noteType = NoteType.LanguageNote)
+        )
     }
   }
 
@@ -188,10 +190,11 @@ class CalmLanguagesTest
 
     languages shouldBe List(Language(label = "English", id = "eng"))
     languageNotes shouldBe List(
-      LanguageNote(
-        "The majority of this collection is in English, however Kitzinger received " +
+      Note(
+        contents = "The majority of this collection is in English, however Kitzinger received " +
           "letters from around the world and travelled widely for conferences so some " +
-          "material is not."
+          "material is not.",
+        noteType = NoteType.LanguageNote
       ))
   }
 
@@ -215,8 +218,8 @@ class CalmLanguagesTest
     )
 
     notes shouldBe List(
-      LanguageNote("French with a Polish translation"),
-      LanguageNote("Chinese inscription")
+      Note(contents = "French with a Polish translation", noteType = NoteType.LanguageNote),
+      Note(contents = "Chinese inscription", noteType = NoteType.LanguageNote)
     )
   }
 
@@ -235,7 +238,7 @@ class CalmLanguagesTest
     )
 
     notes shouldBe List(
-      LanguageNote("Chinese inscription")
+      Note(contents = "Chinese inscription", noteType = NoteType.LanguageNote)
     )
   }
 

--- a/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/transformers/CalmLanguagesTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/transformers/CalmLanguagesTest.scala
@@ -218,7 +218,9 @@ class CalmLanguagesTest
     )
 
     notes shouldBe List(
-      Note(contents = "French with a Polish translation", noteType = NoteType.LanguageNote),
+      Note(
+        contents = "French with a Polish translation",
+        noteType = NoteType.LanguageNote),
       Note(contents = "Chinese inscription", noteType = NoteType.LanguageNote)
     )
   }

--- a/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/transformers/CalmNotesTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/transformers/CalmNotesTest.scala
@@ -26,17 +26,39 @@ class CalmNotesTest extends AnyFunSpec with Matchers with CalmRecordGenerators {
     // The ordering of the Notes field is arbitrary, because the underlying
     // Calm data is arbitrary.
     notes should contain theSameElementsAs List(
-      Note(contents = "Administered by the Active Administrator", noteType = NoteType.BiographicalNote),
-      Note(contents = "Collected by the Careful Custodian", noteType = NoteType.OwnershipNote),
-      Note(contents = "Acquired by the Academic Archivists", noteType = NoteType.AcquisitionNote),
-      Note(contents = "Appraised by the Affable Appraiser", noteType = NoteType.AppraisalNote),
-      Note(contents = "Accrued by the Alliterative Acquirer", noteType = NoteType.AccrualsNote),
-      Note(contents = "Related to the Radiant Records", noteType = NoteType.RelatedMaterial),
-      Note(contents = "Published in the Public Pamphlet", noteType = NoteType.PublicationsNote),
-      Note(contents = "Wrapped in the Worldly Words", noteType = NoteType.FindingAids),
-      Note(contents = "Copyright the Creative Consortium", noteType = NoteType.CopyrightNote),
-      Note(contents = "Arranged in an Adorable Alignment", noteType = NoteType.ArrangementNote),
-      Note(contents = "A copy is contained in the Circular Church", noteType = NoteType.LocationOfDuplicatesNote),
+      Note(
+        contents = "Administered by the Active Administrator",
+        noteType = NoteType.BiographicalNote),
+      Note(
+        contents = "Collected by the Careful Custodian",
+        noteType = NoteType.OwnershipNote),
+      Note(
+        contents = "Acquired by the Academic Archivists",
+        noteType = NoteType.AcquisitionNote),
+      Note(
+        contents = "Appraised by the Affable Appraiser",
+        noteType = NoteType.AppraisalNote),
+      Note(
+        contents = "Accrued by the Alliterative Acquirer",
+        noteType = NoteType.AccrualsNote),
+      Note(
+        contents = "Related to the Radiant Records",
+        noteType = NoteType.RelatedMaterial),
+      Note(
+        contents = "Published in the Public Pamphlet",
+        noteType = NoteType.PublicationsNote),
+      Note(
+        contents = "Wrapped in the Worldly Words",
+        noteType = NoteType.FindingAids),
+      Note(
+        contents = "Copyright the Creative Consortium",
+        noteType = NoteType.CopyrightNote),
+      Note(
+        contents = "Arranged in an Adorable Alignment",
+        noteType = NoteType.ArrangementNote),
+      Note(
+        contents = "A copy is contained in the Circular Church",
+        noteType = NoteType.LocationOfDuplicatesNote),
     )
   }
 

--- a/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/transformers/CalmNotesTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/transformers/CalmNotesTest.scala
@@ -26,17 +26,17 @@ class CalmNotesTest extends AnyFunSpec with Matchers with CalmRecordGenerators {
     // The ordering of the Notes field is arbitrary, because the underlying
     // Calm data is arbitrary.
     notes should contain theSameElementsAs List(
-      BiographicalNote("Administered by the Active Administrator"),
-      OwnershipNote("Collected by the Careful Custodian"),
-      AcquisitionNote("Acquired by the Academic Archivists"),
-      AppraisalNote("Appraised by the Affable Appraiser"),
-      AccrualsNote("Accrued by the Alliterative Acquirer"),
-      RelatedMaterial("Related to the Radiant Records"),
-      PublicationsNote("Published in the Public Pamphlet"),
-      FindingAids("Wrapped in the Worldly Words"),
-      CopyrightNote("Copyright the Creative Consortium"),
-      ArrangementNote("Arranged in an Adorable Alignment"),
-      LocationOfDuplicatesNote("A copy is contained in the Circular Church"),
+      Note(contents = "Administered by the Active Administrator", noteType = NoteType.BiographicalNote),
+      Note(contents = "Collected by the Careful Custodian", noteType = NoteType.OwnershipNote),
+      Note(contents = "Acquired by the Academic Archivists", noteType = NoteType.AcquisitionNote),
+      Note(contents = "Appraised by the Affable Appraiser", noteType = NoteType.AppraisalNote),
+      Note(contents = "Accrued by the Alliterative Acquirer", noteType = NoteType.AccrualsNote),
+      Note(contents = "Related to the Radiant Records", noteType = NoteType.RelatedMaterial),
+      Note(contents = "Published in the Public Pamphlet", noteType = NoteType.PublicationsNote),
+      Note(contents = "Wrapped in the Worldly Words", noteType = NoteType.FindingAids),
+      Note(contents = "Copyright the Creative Consortium", noteType = NoteType.CopyrightNote),
+      Note(contents = "Arranged in an Adorable Alignment", noteType = NoteType.ArrangementNote),
+      Note(contents = "A copy is contained in the Circular Church", noteType = NoteType.LocationOfDuplicatesNote),
     )
   }
 

--- a/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/transformers/CalmTermsOfUseTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/transformers/CalmTermsOfUseTest.scala
@@ -2,7 +2,8 @@ package weco.pipeline.transformer.calm.transformers
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import weco.catalogue.internal_model.work.TermsOfUse
+import weco.catalogue.internal_model.work.NoteType
+import weco.catalogue.source_model.calm.CalmRecord
 import weco.catalogue.source_model.generators.CalmRecordGenerators
 
 class CalmTermsOfUseTest
@@ -17,8 +18,8 @@ class CalmTermsOfUseTest
         "The papers are available subject to the usual conditions of access to Archives and Manuscripts material.")
     )
 
-    CalmTermsOfUse(record) shouldBe List(TermsOfUse(
-      "The papers are available subject to the usual conditions of access to Archives and Manuscripts material."))
+    getTermsOfUseNotes(record) shouldBe List(
+      "The papers are available subject to the usual conditions of access to Archives and Manuscripts material.")
   }
 
   it("handles an item which is closed") {
@@ -27,8 +28,7 @@ class CalmTermsOfUseTest
       ("AccessConditions", "Closed on depositor agreement."),
     )
 
-    CalmTermsOfUse(record) shouldBe List(
-      TermsOfUse("Closed on depositor agreement."))
+    getTermsOfUseNotes(record) shouldBe List("Closed on depositor agreement.")
   }
 
   it("handles an item which is restricted") {
@@ -39,8 +39,8 @@ class CalmTermsOfUseTest
         "Digital records cannot be ordered or viewed online. Requests to view digital records onsite are considered on a case by case basis. Please contact collections@wellcome.ac.uk for more details."),
     )
 
-    CalmTermsOfUse(record) shouldBe List(TermsOfUse(
-      "Digital records cannot be ordered or viewed online. Requests to view digital records onsite are considered on a case by case basis. Please contact collections@wellcome.ac.uk for more details."))
+    getTermsOfUseNotes(record) shouldBe List(
+      "Digital records cannot be ordered or viewed online. Requests to view digital records onsite are considered on a case by case basis. Please contact collections@wellcome.ac.uk for more details.")
   }
 
   it(
@@ -53,9 +53,8 @@ class CalmTermsOfUseTest
       ("ClosedUntil", "01/01/2039")
     )
 
-    CalmTermsOfUse(record) shouldBe List(
-      TermsOfUse(
-        "Closed under the Data Protection Act until 1st January 2039."))
+    getTermsOfUseNotes(record) shouldBe List(
+      "Closed under the Data Protection Act until 1st January 2039.")
   }
 
   it(
@@ -68,8 +67,8 @@ class CalmTermsOfUseTest
       ("UserDate1", "01/01/2039")
     )
 
-    CalmTermsOfUse(record) shouldBe List(TermsOfUse(
-      "This file is restricted until 01/01/2039 for data protection reasons. Readers must complete and sign a Restricted Access undertaking form to apply for access."))
+    getTermsOfUseNotes(record) shouldBe List(
+      "This file is restricted until 01/01/2039 for data protection reasons. Readers must complete and sign a Restricted Access undertaking form to apply for access.")
   }
 
   it(
@@ -82,8 +81,8 @@ class CalmTermsOfUseTest
       ("UserDate1", "01/01/2060")
     )
 
-    CalmTermsOfUse(record) shouldBe List(TermsOfUse(
-      "This file is restricted for data protection reasons. When a reader arrives onsite, they will be required to sign a Restricted Access form agreeing to anonymise personal data before viewing the file. Restricted until 1 January 2060."))
+    getTermsOfUseNotes(record) shouldBe List(
+      "This file is restricted for data protection reasons. When a reader arrives onsite, they will be required to sign a Restricted Access form agreeing to anonymise personal data before viewing the file. Restricted until 1 January 2060.")
   }
 
   it(
@@ -94,9 +93,8 @@ class CalmTermsOfUseTest
       ("ClosedUntil", "01/01/2039")
     )
 
-    CalmTermsOfUse(record) shouldBe List(
-      TermsOfUse(
-        "Closed under the Data Protection Act. Closed until 1 January 2039."))
+    getTermsOfUseNotes(record) shouldBe List(
+      "Closed under the Data Protection Act. Closed until 1 January 2039.")
   }
 
   it("creates a note for a closed item with no conditions") {
@@ -105,8 +103,7 @@ class CalmTermsOfUseTest
       ("ClosedUntil", "01/01/2068")
     )
 
-    CalmTermsOfUse(record) shouldBe List(
-      TermsOfUse("Closed until 1 January 2068."))
+    getTermsOfUseNotes(record) shouldBe List("Closed until 1 January 2068.")
   }
 
   it("doesn't create a note for an item with just a status") {
@@ -132,8 +129,8 @@ class CalmTermsOfUseTest
       ("UserDate1", "01/01/2072")
     )
 
-    CalmTermsOfUse(record) shouldBe List(TermsOfUse(
-      "Permission must be obtained from <a href=\"mailto:barbie.antonis@gmail.com\">the Winnicott Trust</a>, and the usual conditions of access to Archives and Manuscripts material apply; a Reader's Undertaking must be completed. In addition there are Data Protection restrictions on this item and an additional application for access must be completed. Restricted until 1 January 2072."))
+    getTermsOfUseNotes(record) shouldBe List(
+      "Permission must be obtained from <a href=\"mailto:barbie.antonis@gmail.com\">the Winnicott Trust</a>, and the usual conditions of access to Archives and Manuscripts material apply; a Reader's Undertaking must be completed. In addition there are Data Protection restrictions on this item and an additional application for access must be completed. Restricted until 1 January 2072.")
   }
 
   it("adds a missing full stop to access conditions") {
@@ -145,8 +142,8 @@ class CalmTermsOfUseTest
       ("ClosedUntil", "01/01/2055")
     )
 
-    CalmTermsOfUse(record) shouldBe List(TermsOfUse(
-      "This file is closed for data protection reasons and cannot be accessed. Closed until 1 January 2055."))
+    getTermsOfUseNotes(record) shouldBe List(
+      "This file is closed for data protection reasons and cannot be accessed. Closed until 1 January 2055.")
   }
 
   it("removes trailing whitespace") {
@@ -158,8 +155,8 @@ class CalmTermsOfUseTest
       ("UserDate1", "01/01/2024")
     )
 
-    CalmTermsOfUse(record) shouldBe List(TermsOfUse(
-      "This file is restricted until 01/01/2024 for data protection reasons. Readers must complete and sign a Restricted Access undertaking form to apply for access."))
+    getTermsOfUseNotes(record) shouldBe List(
+      "This file is restricted until 01/01/2024 for data protection reasons. Readers must complete and sign a Restricted Access undertaking form to apply for access.")
   }
 
   it("handles the fallback case") {
@@ -171,13 +168,23 @@ class CalmTermsOfUseTest
         "The papers are available subject to the usual conditions of access to Archives and Manuscripts material. In addition a Restricted Access form must be completed to apply for access to this file.")
     )
 
-    CalmTermsOfUse(record) shouldBe List(TermsOfUse(
-      "The papers are available subject to the usual conditions of access to Archives and Manuscripts material. In addition a Restricted Access form must be completed to apply for access to this file. Restricted until 1 January 2066."))
+    getTermsOfUseNotes(record) shouldBe List(
+      "The papers are available subject to the usual conditions of access to Archives and Manuscripts material. In addition a Restricted Access form must be completed to apply for access to this file. Restricted until 1 January 2066.")
   }
 
   it("returns no note if there's no useful access info") {
     val record = createCalmRecord
 
     CalmTermsOfUse(record) shouldBe empty
+  }
+
+  private def getTermsOfUseNotes(record: CalmRecord): List[String] = {
+    val notes = CalmTermsOfUse(record)
+
+    notes.forall {
+      _.noteType == NoteType.TermsOfUse
+    }
+
+    notes.map(_.contents)
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraNotes.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraNotes.scala
@@ -84,7 +84,8 @@ object SierraNotes extends SierraDataTransformer with SierraQueryOps {
   //
   private def createLocationOfNote(vf: VarField): Note =
     vf.indicator1 match {
-      case Some("2") => createNoteFromContents(NoteType.LocationOfDuplicatesNote)(vf)
-      case _         => createNoteFromContents(NoteType.LocationOfOriginalNote)(vf)
+      case Some("2") =>
+        createNoteFromContents(NoteType.LocationOfDuplicatesNote)(vf)
+      case _ => createNoteFromContents(NoteType.LocationOfOriginalNote)(vf)
     }
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraNotes.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraNotes.scala
@@ -11,37 +11,37 @@ object SierraNotes extends SierraDataTransformer with SierraQueryOps {
   private val globallySuppressedSubfields = Set("5")
 
   val notesFields = Map(
-    "500" -> createNoteFromContents(GeneralNote),
-    "501" -> createNoteFromContents(GeneralNote),
-    "502" -> createNoteFromContents(DissertationNote),
-    "504" -> createNoteFromContents(BibliographicalInformation),
-    "505" -> createNoteFromContents(ContentsNote),
-    "506" -> createNoteFromContents(TermsOfUse),
-    "508" -> createNoteFromContents(CreditsNote),
-    "510" -> createNoteFromContents(ReferencesNote),
-    "511" -> createNoteFromContents(CreditsNote),
-    "514" -> createNoteFromContents(LetteringNote),
-    "518" -> createNoteFromContents(TimeAndPlaceNote),
-    "524" -> createNoteFromContents(CiteAsNote),
-    "533" -> createNoteFromContents(ReproductionNote),
-    "534" -> createNoteFromContents(ReproductionNote),
+    "500" -> createNoteFromContents(NoteType.GeneralNote),
+    "501" -> createNoteFromContents(NoteType.GeneralNote),
+    "502" -> createNoteFromContents(NoteType.DissertationNote),
+    "504" -> createNoteFromContents(NoteType.BibliographicalInformation),
+    "505" -> createNoteFromContents(NoteType.ContentsNote),
+    "506" -> createNoteFromContents(NoteType.TermsOfUse),
+    "508" -> createNoteFromContents(NoteType.CreditsNote),
+    "510" -> createNoteFromContents(NoteType.ReferencesNote),
+    "511" -> createNoteFromContents(NoteType.CreditsNote),
+    "514" -> createNoteFromContents(NoteType.LetteringNote),
+    "518" -> createNoteFromContents(NoteType.TimeAndPlaceNote),
+    "524" -> createNoteFromContents(NoteType.CiteAsNote),
+    "533" -> createNoteFromContents(NoteType.ReproductionNote),
+    "534" -> createNoteFromContents(NoteType.ReproductionNote),
     "535" -> createLocationOfNote _,
-    "536" -> createNoteFromContents(FundingInformation),
-    "540" -> createNoteFromContents(TermsOfUse),
-    "542" -> createNoteFromContents(CopyrightNote),
-    "545" -> createNoteFromContents(BiographicalNote),
-    "546" -> createNoteFromContents(LanguageNote),
-    "547" -> createNoteFromContents(GeneralNote),
-    "562" -> createNoteFromContents(GeneralNote),
-    "563" -> createNoteFromContents(BindingInformation),
-    "581" -> createNoteFromContents(PublicationsNote),
-    "585" -> createNoteFromContents(ExhibitionsNote),
-    "586" -> createNoteFromContents(AwardsNote),
+    "536" -> createNoteFromContents(NoteType.FundingInformation),
+    "540" -> createNoteFromContents(NoteType.TermsOfUse),
+    "542" -> createNoteFromContents(NoteType.CopyrightNote),
+    "545" -> createNoteFromContents(NoteType.BiographicalNote),
+    "546" -> createNoteFromContents(NoteType.LanguageNote),
+    "547" -> createNoteFromContents(NoteType.GeneralNote),
+    "562" -> createNoteFromContents(NoteType.GeneralNote),
+    "563" -> createNoteFromContents(NoteType.BindingInformation),
+    "581" -> createNoteFromContents(NoteType.PublicationsNote),
+    "585" -> createNoteFromContents(NoteType.ExhibitionsNote),
+    "586" -> createNoteFromContents(NoteType.AwardsNote),
     // 591 subfield ǂ9 contains barcodes that we don't want to show on /works.
     "591" -> createNoteFromContents(
-      GeneralNote,
+      NoteType.GeneralNote,
       suppressedSubfields = Set("9")),
-    "593" -> createNoteFromContents(CopyrightNote),
+    "593" -> createNoteFromContents(NoteType.CopyrightNote),
   )
 
   def apply(bibData: SierraBibData): List[Note] =
@@ -53,7 +53,7 @@ object SierraNotes extends SierraDataTransformer with SierraQueryOps {
         //
         // See https://www.loc.gov/marc/bibliographic/bd561.html
         case vf @ VarField(_, Some("561"), _, Some("1"), _, _) =>
-          Some((vf, Some(createNoteFromContents(OwnershipNote))))
+          Some((vf, Some(createNoteFromContents(NoteType.OwnershipNote))))
 
         case vf @ VarField(_, Some(marcTag), _, _, _, _) =>
           Some((vf, notesFields.get(marcTag)))
@@ -64,7 +64,7 @@ object SierraNotes extends SierraDataTransformer with SierraQueryOps {
       }
 
   private def createNoteFromContents(
-    createNote: String => Note,
+    noteType: NoteType,
     suppressedSubfields: Set[String] = Set()): VarField => Note =
     (varField: VarField) => {
       val contents =
@@ -74,7 +74,7 @@ object SierraNotes extends SierraDataTransformer with SierraQueryOps {
           .contents
           .mkString(" ")
 
-      createNote(contents)
+      Note(contents = contents, noteType = noteType)
     }
 
   // In MARC 535, indicator 1 takes the following values:
@@ -84,7 +84,7 @@ object SierraNotes extends SierraDataTransformer with SierraQueryOps {
   //
   private def createLocationOfNote(vf: VarField): Note =
     vf.indicator1 match {
-      case Some("2") => createNoteFromContents(LocationOfDuplicatesNote)(vf)
-      case _         => createNoteFromContents(LocationOfOriginalNote)(vf)
+      case Some("2") => createNoteFromContents(NoteType.LocationOfDuplicatesNote)(vf)
+      case _         => createNoteFromContents(NoteType.LocationOfOriginalNote)(vf)
     }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraNotesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraNotesTest.scala
@@ -15,34 +15,84 @@ class SierraNotesTest
 
   it("extracts notes from all fields") {
     val notes = List(
-      "500" -> Note(contents = "general note a", noteType = NoteType.GeneralNote),
-      "501" -> Note(contents = "general note b", noteType = NoteType.GeneralNote),
-      "502" -> Note(contents = "dissertation note", noteType = NoteType.DissertationNote),
-      "504" -> Note(contents = "bib info a", noteType = NoteType.BibliographicalInformation),
-      "505" -> Note(contents = "contents note", noteType = NoteType.ContentsNote),
-      "506" -> Note(contents = "typical terms of use", noteType = NoteType.TermsOfUse),
-      "508" -> Note(contents = "credits note a", noteType = NoteType.CreditsNote),
-      "510" -> Note(contents = "references a", noteType = NoteType.ReferencesNote),
-      "511" -> Note(contents = "credits note b", noteType = NoteType.CreditsNote),
-      "514" -> Note(contents = "Completeness:", noteType = NoteType.LetteringNote),
-      "518" -> Note(contents = "time and place note", noteType = NoteType.TimeAndPlaceNote),
+      "500" -> Note(
+        contents = "general note a",
+        noteType = NoteType.GeneralNote),
+      "501" -> Note(
+        contents = "general note b",
+        noteType = NoteType.GeneralNote),
+      "502" -> Note(
+        contents = "dissertation note",
+        noteType = NoteType.DissertationNote),
+      "504" -> Note(
+        contents = "bib info a",
+        noteType = NoteType.BibliographicalInformation),
+      "505" -> Note(
+        contents = "contents note",
+        noteType = NoteType.ContentsNote),
+      "506" -> Note(
+        contents = "typical terms of use",
+        noteType = NoteType.TermsOfUse),
+      "508" -> Note(
+        contents = "credits note a",
+        noteType = NoteType.CreditsNote),
+      "510" -> Note(
+        contents = "references a",
+        noteType = NoteType.ReferencesNote),
+      "511" -> Note(
+        contents = "credits note b",
+        noteType = NoteType.CreditsNote),
+      "514" -> Note(
+        contents = "Completeness:",
+        noteType = NoteType.LetteringNote),
+      "518" -> Note(
+        contents = "time and place note",
+        noteType = NoteType.TimeAndPlaceNote),
       "524" -> Note(contents = "cite as note", noteType = NoteType.CiteAsNote),
-      "533" -> Note(contents = "reproduction a", noteType = NoteType.ReproductionNote),
-      "534" -> Note(contents = "reproduction b", noteType = NoteType.ReproductionNote),
-      "535" -> Note(contents = "location of original note", noteType = NoteType.LocationOfOriginalNote),
-      "536" -> Note(contents = "funding information", noteType = NoteType.FundingInformation),
+      "533" -> Note(
+        contents = "reproduction a",
+        noteType = NoteType.ReproductionNote),
+      "534" -> Note(
+        contents = "reproduction b",
+        noteType = NoteType.ReproductionNote),
+      "535" -> Note(
+        contents = "location of original note",
+        noteType = NoteType.LocationOfOriginalNote),
+      "536" -> Note(
+        contents = "funding information",
+        noteType = NoteType.FundingInformation),
       "540" -> Note(contents = "terms of use", noteType = NoteType.TermsOfUse),
-      "542" -> Note(contents = "copyright a", noteType = NoteType.CopyrightNote),
-      "545" -> Note(contents = "bib info b", noteType = NoteType.BiographicalNote),
-      "546" -> Note(contents = "Marriage certificate: German; Fraktur.", noteType = NoteType.LanguageNote),
-      "547" -> Note(contents = "general note c", noteType = NoteType.GeneralNote),
-      "562" -> Note(contents = "general note d", noteType = NoteType.GeneralNote),
-      "563" -> Note(contents = "binding info note", noteType = NoteType.BindingInformation),
-      "581" -> Note(contents = "publications b", noteType = NoteType.PublicationsNote),
-      "585" -> Note(contents = "exhibitions", noteType = NoteType.ExhibitionsNote),
+      "542" -> Note(
+        contents = "copyright a",
+        noteType = NoteType.CopyrightNote),
+      "545" -> Note(
+        contents = "bib info b",
+        noteType = NoteType.BiographicalNote),
+      "546" -> Note(
+        contents = "Marriage certificate: German; Fraktur.",
+        noteType = NoteType.LanguageNote),
+      "547" -> Note(
+        contents = "general note c",
+        noteType = NoteType.GeneralNote),
+      "562" -> Note(
+        contents = "general note d",
+        noteType = NoteType.GeneralNote),
+      "563" -> Note(
+        contents = "binding info note",
+        noteType = NoteType.BindingInformation),
+      "581" -> Note(
+        contents = "publications b",
+        noteType = NoteType.PublicationsNote),
+      "585" -> Note(
+        contents = "exhibitions",
+        noteType = NoteType.ExhibitionsNote),
       "586" -> Note(contents = "awards", noteType = NoteType.AwardsNote),
-      "591" -> Note(contents = "A general, unspecified note", noteType = NoteType.GeneralNote),
-      "593" -> Note(contents = "copyright b", noteType = NoteType.CopyrightNote),
+      "591" -> Note(
+        contents = "A general, unspecified note",
+        noteType = NoteType.GeneralNote),
+      "593" -> Note(
+        contents = "copyright b",
+        noteType = NoteType.CopyrightNote),
     )
     SierraNotes(bibData(notes)) shouldBe notes.map(_._2)
   }
@@ -64,7 +114,8 @@ class SierraNotesTest
   }
 
   it("preserves HTML in notes fields") {
-    val notes = List("500" -> Note(contents = "<p>note</p>", noteType = NoteType.GeneralNote))
+    val notes = List(
+      "500" -> Note(contents = "<p>note</p>", noteType = NoteType.GeneralNote))
     SierraNotes(bibData(notes)) shouldBe notes.map(_._2)
   }
 
@@ -82,7 +133,9 @@ class SierraNotesTest
       )
     )
     SierraNotes(bibData) shouldBe List(
-      Note(contents = "1st part. 2nd part. 3rd part.", noteType = NoteType.GeneralNote)
+      Note(
+        contents = "1st part. 2nd part. 3rd part.",
+        noteType = NoteType.GeneralNote)
     )
   }
 
@@ -113,8 +166,12 @@ class SierraNotesTest
     )
 
     SierraNotes(bibData) shouldBe List(
-      Note(contents = "The originals are in Oman", noteType = NoteType.LocationOfOriginalNote),
-      Note(contents = "The duplicates are in Denmark", noteType = NoteType.LocationOfDuplicatesNote),
+      Note(
+        contents = "The originals are in Oman",
+        noteType = NoteType.LocationOfOriginalNote),
+      Note(
+        contents = "The duplicates are in Denmark",
+        noteType = NoteType.LocationOfDuplicatesNote),
     )
   }
 
@@ -151,7 +208,9 @@ class SierraNotesTest
       )
     )
     SierraNotes(bibData) shouldBe List(
-      Note(contents = "Provenance: one plate in the set of plates", noteType = NoteType.OwnershipNote)
+      Note(
+        contents = "Provenance: one plate in the set of plates",
+        noteType = NoteType.OwnershipNote)
     )
   }
 
@@ -204,7 +263,8 @@ class SierraNotesTest
 
     SierraNotes(bibData) should contain theSameElementsAs List(
       Note(
-        contents = "Copy 1. Note: The author's presentation inscription on verso of 2nd leaf.",
+        contents =
+          "Copy 1. Note: The author's presentation inscription on verso of 2nd leaf.",
         noteType = NoteType.GeneralNote
       )
     )

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraNotesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraNotesTest.scala
@@ -15,42 +15,42 @@ class SierraNotesTest
 
   it("extracts notes from all fields") {
     val notes = List(
-      "500" -> GeneralNote("general note a"),
-      "501" -> GeneralNote("general note b"),
-      "502" -> DissertationNote("dissertation note"),
-      "504" -> BibliographicalInformation("bib info a"),
-      "505" -> ContentsNote("contents note"),
-      "506" -> TermsOfUse("typical terms of use"),
-      "508" -> CreditsNote("credits note a"),
-      "510" -> ReferencesNote("references a"),
-      "511" -> CreditsNote("credits note b"),
-      "514" -> LetteringNote("Completeness:"),
-      "518" -> TimeAndPlaceNote("time and place note"),
-      "524" -> CiteAsNote("cite as note"),
-      "533" -> ReproductionNote("reproduction a"),
-      "534" -> ReproductionNote("reproduction b"),
-      "535" -> LocationOfOriginalNote("location of original note"),
-      "536" -> FundingInformation("funding information"),
-      "540" -> TermsOfUse("terms of use"),
-      "542" -> CopyrightNote("copyright a"),
-      "545" -> BiographicalNote("bib info b"),
-      "546" -> LanguageNote("Marriage certificate: German; Fraktur."),
-      "547" -> GeneralNote("general note c"),
-      "562" -> GeneralNote("general note d"),
-      "563" -> BindingInformation("binding info note"),
-      "581" -> PublicationsNote("publications b"),
-      "585" -> ExhibitionsNote("exhibitions"),
-      "586" -> AwardsNote("awards"),
-      "591" -> GeneralNote("A general, unspecified note"),
-      "593" -> CopyrightNote("copyright b"),
+      "500" -> Note(contents = "general note a", noteType = NoteType.GeneralNote),
+      "501" -> Note(contents = "general note b", noteType = NoteType.GeneralNote),
+      "502" -> Note(contents = "dissertation note", noteType = NoteType.DissertationNote),
+      "504" -> Note(contents = "bib info a", noteType = NoteType.BibliographicalInformation),
+      "505" -> Note(contents = "contents note", noteType = NoteType.ContentsNote),
+      "506" -> Note(contents = "typical terms of use", noteType = NoteType.TermsOfUse),
+      "508" -> Note(contents = "credits note a", noteType = NoteType.CreditsNote),
+      "510" -> Note(contents = "references a", noteType = NoteType.ReferencesNote),
+      "511" -> Note(contents = "credits note b", noteType = NoteType.CreditsNote),
+      "514" -> Note(contents = "Completeness:", noteType = NoteType.LetteringNote),
+      "518" -> Note(contents = "time and place note", noteType = NoteType.TimeAndPlaceNote),
+      "524" -> Note(contents = "cite as note", noteType = NoteType.CiteAsNote),
+      "533" -> Note(contents = "reproduction a", noteType = NoteType.ReproductionNote),
+      "534" -> Note(contents = "reproduction b", noteType = NoteType.ReproductionNote),
+      "535" -> Note(contents = "location of original note", noteType = NoteType.LocationOfOriginalNote),
+      "536" -> Note(contents = "funding information", noteType = NoteType.FundingInformation),
+      "540" -> Note(contents = "terms of use", noteType = NoteType.TermsOfUse),
+      "542" -> Note(contents = "copyright a", noteType = NoteType.CopyrightNote),
+      "545" -> Note(contents = "bib info b", noteType = NoteType.BiographicalNote),
+      "546" -> Note(contents = "Marriage certificate: German; Fraktur.", noteType = NoteType.LanguageNote),
+      "547" -> Note(contents = "general note c", noteType = NoteType.GeneralNote),
+      "562" -> Note(contents = "general note d", noteType = NoteType.GeneralNote),
+      "563" -> Note(contents = "binding info note", noteType = NoteType.BindingInformation),
+      "581" -> Note(contents = "publications b", noteType = NoteType.PublicationsNote),
+      "585" -> Note(contents = "exhibitions", noteType = NoteType.ExhibitionsNote),
+      "586" -> Note(contents = "awards", noteType = NoteType.AwardsNote),
+      "591" -> Note(contents = "A general, unspecified note", noteType = NoteType.GeneralNote),
+      "593" -> Note(contents = "copyright b", noteType = NoteType.CopyrightNote),
     )
     SierraNotes(bibData(notes)) shouldBe notes.map(_._2)
   }
 
   it("extracts all notes when duplicate fields") {
     val notes = List(
-      "500" -> GeneralNote("note a"),
-      "500" -> GeneralNote("note b"),
+      "500" -> Note(contents = "note a", noteType = NoteType.GeneralNote),
+      "500" -> Note(contents = "note b", noteType = NoteType.GeneralNote),
     )
     SierraNotes(bibData(notes)) shouldBe notes.map(_._2)
   }
@@ -64,7 +64,7 @@ class SierraNotesTest
   }
 
   it("preserves HTML in notes fields") {
-    val notes = List("500" -> GeneralNote("<p>note</p>"))
+    val notes = List("500" -> Note(contents = "<p>note</p>", noteType = NoteType.GeneralNote))
     SierraNotes(bibData(notes)) shouldBe notes.map(_._2)
   }
 
@@ -82,14 +82,14 @@ class SierraNotesTest
       )
     )
     SierraNotes(bibData) shouldBe List(
-      GeneralNote("1st part. 2nd part. 3rd part.")
+      Note(contents = "1st part. 2nd part. 3rd part.", noteType = NoteType.GeneralNote)
     )
   }
 
   it("does not concatenate separate varfields") {
     val notes = List(
-      "500" -> GeneralNote("1st note."),
-      "500" -> GeneralNote("2nd note."),
+      "500" -> Note(contents = "1st note.", noteType = NoteType.GeneralNote),
+      "500" -> Note(contents = "2nd note.", noteType = NoteType.GeneralNote),
     )
     SierraNotes(bibData(notes)) shouldBe notes.map(_._2)
   }
@@ -113,8 +113,8 @@ class SierraNotesTest
     )
 
     SierraNotes(bibData) shouldBe List(
-      LocationOfOriginalNote("The originals are in Oman"),
-      LocationOfDuplicatesNote("The duplicates are in Denmark")
+      Note(contents = "The originals are in Oman", noteType = NoteType.LocationOfOriginalNote),
+      Note(contents = "The duplicates are in Denmark", noteType = NoteType.LocationOfDuplicatesNote),
     )
   }
 
@@ -151,7 +151,7 @@ class SierraNotesTest
       )
     )
     SierraNotes(bibData) shouldBe List(
-      OwnershipNote("Provenance: one plate in the set of plates")
+      Note(contents = "Provenance: one plate in the set of plates", noteType = NoteType.OwnershipNote)
     )
   }
 
@@ -203,13 +203,15 @@ class SierraNotesTest
     val bibData = createSierraBibDataWith(varFields = varFields)
 
     SierraNotes(bibData) should contain theSameElementsAs List(
-      GeneralNote(
-        "Copy 1. Note: The author's presentation inscription on verso of 2nd leaf.")
+      Note(
+        contents = "Copy 1. Note: The author's presentation inscription on verso of 2nd leaf.",
+        noteType = NoteType.GeneralNote
+      )
     )
   }
 
   def bibData(contents: List[(String, Note)]): SierraBibData =
-    bibData(contents.map { case (tag, note) => (tag, note.content) }: _*)
+    bibData(contents.map { case (tag, note) => (tag, note.contents) }: _*)
 
   def bibData(contents: (String, String)*): SierraBibData =
     createSierraBibDataWith(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraTransformerTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraTransformerTest.scala
@@ -425,7 +425,8 @@ class SierraTransformerTest
           )
         )
       )
-      .notes(List(Note(contents = "It's a note", noteType = NoteType.GeneralNote)))
+      .notes(List(
+        Note(contents = "It's a note", noteType = NoteType.GeneralNote)))
       .lettering(lettering)
       .languages(expectedLanguages)
   }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraTransformerTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraTransformerTest.scala
@@ -425,7 +425,7 @@ class SierraTransformerTest
           )
         )
       )
-      .notes(List(GeneralNote("It's a note")))
+      .notes(List(Note(contents = "It's a note", noteType = NoteType.GeneralNote)))
       .lettering(lettering)
       .languages(expectedLanguages)
   }


### PR DESCRIPTION
Creating the implicit JSON encoders/decoders for Note is surprisingly expensive (~10% of implicit resolution) – because we have a lot of different subtypes to create encoders/decoders for.

We don't really need the separate types, so I want to try removing them and switching to something closer to what we do in the API, and see if it helps the compilation times of internal model.

This also means we can change the Note types in the pipeline without having to make a corresponding change in the API repo.

For https://github.com/wellcomecollection/platform/issues/5298