### PR TITLE
Remove the normalised concept constructors from internal model

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/parse/Parser.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/parse/Parser.scala
@@ -31,6 +31,5 @@ trait Parser[T] extends Logging {
   *  Parser implementations intended to be used as implicit parameters
   */
 package object parsers {
-
   implicit val DateParser: Parser[InstantRange] = PeriodParser
 }

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/AbstractRootConcept.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/AbstractRootConcept.scala
@@ -53,12 +53,8 @@ case class Place[+State](
 ) extends AbstractConcept[State]
 
 object Place {
-  def apply[State >: IdState.Unidentifiable.type](label: String): Place[State] =
-    Place(IdState.Unidentifiable, label)
-
-  def normalised[State >: IdState.Unidentifiable.type](
-    label: String): Place[State] =
-    Place(label.trimTrailing(':'))
+  def apply(label: String): Place[IdState.Unidentifiable.type] =
+    Place(id = IdState.Unidentifiable, label = label)
 }
 
 sealed trait AbstractAgent[+State] extends AbstractRootConcept[State] {

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/AbstractRootConcept.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/AbstractRootConcept.scala
@@ -85,13 +85,8 @@ case class Organisation[+State](
 ) extends AbstractAgent[State]
 
 object Organisation {
-  def apply[State >: IdState.Unidentifiable.type](
-    label: String): Organisation[State] =
-    Organisation(IdState.Unidentifiable, label)
-
-  def normalised[State >: IdState.Unidentifiable.type](
-    label: String): Organisation[State] =
-    Organisation(label.trimTrailing(','))
+  def apply(label: String): Organisation[IdState.Unidentifiable.type] =
+    Organisation(id = IdState.Unidentifiable, label = label)
 }
 
 case class Person[+State](

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/AbstractRootConcept.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/AbstractRootConcept.scala
@@ -16,13 +16,8 @@ case class Concept[+State](
 ) extends AbstractConcept[State]
 
 object Concept {
-  def apply[State >: IdState.Unidentifiable.type](
-    label: String): Concept[State] =
-    Concept(IdState.Unidentifiable, label)
-
-  def normalised[State](id: State = IdState.Unidentifiable,
-                        label: String): Concept[State] =
-    Concept(id, label.trimTrailingPeriod)
+  def apply(label: String): Concept[IdState.Unidentifiable.type] =
+    Concept(id = IdState.Unidentifiable, label = label)
 }
 
 case class Period[+State](

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/AbstractRootConcept.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/AbstractRootConcept.scala
@@ -27,10 +27,12 @@ case class Period[+State](
 ) extends AbstractConcept[State]
 
 object Period {
-  def apply[State >: IdState.Unidentifiable.type](
-    label: String,
-    range: Option[InstantRange]): Period[State] =
-    Period(IdState.Unidentifiable, label, range)
+  def apply(label: String, range: InstantRange): Period[IdState.Unidentifiable.type] =
+    Period(
+      id = IdState.Unidentifiable,
+      label = label,
+      range = Some(range)
+    )
 
   def apply[State >: IdState.Unidentifiable.type](
     label: String): Period[State] = {

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/AbstractRootConcept.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/AbstractRootConcept.scala
@@ -102,20 +102,8 @@ case class Person[+State](
 ) extends AbstractAgent[State]
 
 object Person {
-  def apply[State >: IdState.Unidentifiable.type](
-    label: String): Person[State] =
-    Person(IdState.Unidentifiable, label)
-
-  def normalised[State >: IdState.Unidentifiable.type](
-    label: String,
-    prefix: Option[String] = None,
-    numeration: Option[String] = None
-  ): Person[State] =
-    Person(
-      id = IdState.Unidentifiable,
-      label = label.trimTrailing(','),
-      prefix = prefix,
-      numeration = numeration)
+  def apply(label: String): Person[IdState.Unidentifiable.type] =
+    Person(id = IdState.Unidentifiable, label = label)
 }
 
 case class Meeting[+State](

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/AbstractRootConcept.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/AbstractRootConcept.scala
@@ -71,12 +71,8 @@ case class Agent[+State](
 ) extends AbstractAgent[State]
 
 object Agent {
-  def apply[State >: IdState.Unidentifiable.type](label: String): Agent[State] =
-    Agent(IdState.Unidentifiable, label)
-
-  def normalised[State >: IdState.Unidentifiable.type](
-    label: String): Agent[State] =
-    Agent(label.trimTrailing(','))
+  def apply(label: String): Agent[IdState.Unidentifiable.type] =
+    Agent(id = IdState.Unidentifiable, label = label)
 }
 
 case class Organisation[+State](

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/AbstractRootConcept.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/AbstractRootConcept.scala
@@ -124,11 +124,6 @@ case class Meeting[+State](
 ) extends AbstractAgent[State]
 
 object Meeting {
-  def apply[State >: IdState.Unidentifiable.type](
-    label: String): Meeting[State] =
-    Meeting(IdState.Unidentifiable, label)
-
-  def normalised[State >: IdState.Unidentifiable.type](
-    label: String): Meeting[State] =
-    Meeting(label.trimTrailing(','))
+  def apply(label: String): Meeting[IdState.Unidentifiable.type] =
+    Meeting(id = IdState.Unidentifiable, label = label)
 }

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/AbstractRootConcept.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/AbstractRootConcept.scala
@@ -25,7 +25,8 @@ case class Period[+State](
 ) extends AbstractConcept[State]
 
 object Period {
-  def apply(label: String, range: InstantRange): Period[IdState.Unidentifiable.type] =
+  def apply(label: String,
+            range: InstantRange): Period[IdState.Unidentifiable.type] =
     Period(
       id = IdState.Unidentifiable,
       label = label,

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/AbstractRootConcept.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/AbstractRootConcept.scala
@@ -1,7 +1,5 @@
 package weco.catalogue.internal_model.work
 
-import weco.catalogue.internal_model.parse.parsers.DateParser
-import weco.catalogue.internal_model.text.TextNormalisation._
 import weco.catalogue.internal_model.identifiers.{HasId, IdState}
 
 sealed trait AbstractRootConcept[+State] extends HasId[State] {
@@ -33,15 +31,6 @@ object Period {
       label = label,
       range = Some(range)
     )
-
-  def apply[State >: IdState.Unidentifiable.type](
-    label: String): Period[State] = {
-    val normalisedLabel = label.trimTrailingPeriod
-    Period(
-      IdState.Unidentifiable,
-      normalisedLabel,
-      InstantRange.parse(normalisedLabel))
-  }
 }
 
 case class Place[+State](

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Genre.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Genre.scala
@@ -4,20 +4,3 @@ case class Genre[+State](
   label: String,
   concepts: List[AbstractConcept[State]] = Nil
 )
-
-object Genre {
-  def normalised[State](
-    label: String,
-    concepts: List[AbstractConcept[State]]): Genre[State] = {
-    val normalisedLabel =
-      label
-        .stripSuffix(".")
-        .trim
-        .replace("Electronic Books", "Electronic books")
-
-    Genre(
-      label = normalisedLabel,
-      concepts = concepts
-    )
-  }
-}

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/InstantRange.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/InstantRange.scala
@@ -1,7 +1,5 @@
 package weco.catalogue.internal_model.work
 
-import weco.catalogue.internal_model.parse.Parser
-
 import java.time.{Instant, LocalDate, LocalDateTime, ZoneOffset}
 
 // We're not extending this yet, as we don't actually want it to be part of
@@ -63,8 +61,4 @@ object InstantRange {
     to = end.to,
     label = end.label
   )
-
-  def parse(label: String)(
-    implicit parser: Parser[InstantRange]): Option[InstantRange] =
-    parser(label)
 }

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/ConceptTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/ConceptTest.scala
@@ -9,7 +9,11 @@ import weco.catalogue.internal_model.identifiers.IdState
 
 class ConceptTest extends AnyFunSpec with Matchers with JsonAssertions {
 
-  val concept = Concept[IdState.Minted](label = "Woodwork")
+  val concept: Concept[IdState.Minted] = Concept(
+    id = IdState.Unidentifiable,
+    label = "Woodwork"
+  )
+
   val expectedJson =
     s"""{
         "id": {"type": "Unidentifiable"},

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/generators/ProductionEventGenerators.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/generators/ProductionEventGenerators.scala
@@ -13,7 +13,12 @@ trait ProductionEventGenerators extends RandomGenerators {
       label = randomAlphanumeric(25),
       places = List(Place(randomAlphanumeric(10))),
       agents = List(Person(randomAlphanumeric(10))),
-      dates = List(Period(dateLabel.getOrElse(randomAlphanumeric(5)))),
+      dates = List(
+        Period(
+          id = IdState.Unidentifiable,
+          label = dateLabel.getOrElse(randomAlphanumeric(5))
+        )
+      ),
       function = function
     )
 

--- a/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/CalmTransformer.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/CalmTransformer.scala
@@ -2,7 +2,6 @@ package weco.pipeline.transformer.calm
 
 import grizzled.slf4j.Logging
 import weco.catalogue.internal_model.identifiers._
-import weco.catalogue.internal_model.parse.PeriodParser
 import weco.catalogue.internal_model.work.DeletedReason.{
   DeletedFromSource,
   SuppressedFromSource
@@ -20,6 +19,7 @@ import weco.pipeline.transformer.calm.models.{
 }
 import weco.pipeline.transformer.calm.transformers._
 import weco.pipeline.transformer.result.Result
+import weco.pipeline.transformer.transformers.ParsedPeriod
 
 object CalmTransformer
     extends Transformer[CalmSourceData]
@@ -241,7 +241,7 @@ object CalmTransformer
       case dates =>
         List(
           ProductionEvent(
-            dates = dates.map(Period(_)),
+            dates = dates.map(ParsedPeriod(_)),
             label = dates.mkString(" "),
             places = Nil,
             agents = Nil,

--- a/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/CalmTransformer.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/CalmTransformer.scala
@@ -241,7 +241,7 @@ object CalmTransformer
       case dates =>
         List(
           ProductionEvent(
-            dates = dates.map(date => Period(date, PeriodParser(date))),
+            dates = dates.map(Period(_)),
             label = dates.mkString(" "),
             places = Nil,
             agents = Nil,

--- a/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/CalmTransformer.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/CalmTransformer.scala
@@ -12,12 +12,7 @@ import weco.catalogue.internal_model.work.WorkState.Source
 import weco.catalogue.internal_model.work._
 import weco.catalogue.source_model.calm.CalmRecord
 import weco.pipeline.transformer.Transformer
-import weco.pipeline.transformer.calm.models.CalmTransformerException.{
-  LevelMissing,
-  RefNoMissing,
-  TitleMissing,
-  _
-}
+import weco.pipeline.transformer.calm.models.CalmTransformerException._
 import weco.pipeline.transformer.calm.models.{
   CalmRecordOps,
   CalmSourceData,

--- a/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/CalmTransformerTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/CalmTransformerTest.scala
@@ -221,13 +221,11 @@ class CalmTransformerTest
         ProductionEvent(
           dates = List(
             Period(
-              "c.1900 and 1914",
-              Some(
-                InstantRange(
-                  LocalDate of (1890, 1, 1),
-                  LocalDate of (1914, 12, 31),
-                  "c.1900 and 1914"
-                )
+              label = "c.1900 and 1914",
+              range = InstantRange(
+                LocalDate of(1890, 1, 1),
+                LocalDate of(1914, 12, 31),
+                "c.1900 and 1914"
               )
             )
           ),

--- a/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/CalmTransformerTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/CalmTransformerTest.scala
@@ -223,8 +223,8 @@ class CalmTransformerTest
             Period(
               label = "c.1900 and 1914",
               range = InstantRange(
-                LocalDate of(1890, 1, 1),
-                LocalDate of(1914, 12, 31),
+                LocalDate of (1890, 1, 1),
+                LocalDate of (1914, 12, 31),
                 "c.1900 and 1914"
               )
             )

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/parse/DateParserUtils.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/parse/DateParserUtils.scala
@@ -1,4 +1,4 @@
-package weco.catalogue.internal_model.parse
+package weco.pipeline.transformer.parse
 
 import fastparse._
 import NoWhitespace._

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/parse/FuzzyDate.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/parse/FuzzyDate.scala
@@ -1,4 +1,4 @@
-package weco.catalogue.internal_model.parse
+package weco.pipeline.transformer.parse
 
 import java.time.LocalDate
 

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/parse/Lex.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/parse/Lex.scala
@@ -1,4 +1,4 @@
-package weco.catalogue.internal_model.parse
+package weco.pipeline.transformer.parse
 
 import fastparse._
 import NoWhitespace._

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/parse/Parser.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/parse/Parser.scala
@@ -1,4 +1,4 @@
-package weco.catalogue.internal_model.parse
+package weco.pipeline.transformer.parse
 
 import fastparse._
 import grizzled.slf4j.Logging

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/parse/PeriodParser.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/parse/PeriodParser.scala
@@ -1,4 +1,4 @@
-package weco.catalogue.internal_model.parse
+package weco.pipeline.transformer.parse
 
 import fastparse._
 import NoWhitespace._

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/parse/Qualifier.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/parse/Qualifier.scala
@@ -1,4 +1,4 @@
-package weco.catalogue.internal_model.parse
+package weco.pipeline.transformer.parse
 
 import fastparse._
 import NoWhitespace._

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/parse/ToInstantRange.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/parse/ToInstantRange.scala
@@ -1,4 +1,4 @@
-package weco.catalogue.internal_model.parse
+package weco.pipeline.transformer.parse
 
 import weco.catalogue.internal_model.work.InstantRange
 

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/text/TextNormalisation.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/text/TextNormalisation.scala
@@ -1,4 +1,4 @@
-package weco.catalogue.internal_model.text
+package weco.pipeline.transformer.text
 
 import scala.util.matching.Regex
 

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/transformers/ConceptsTransformer.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/transformers/ConceptsTransformer.scala
@@ -1,7 +1,7 @@
 package weco.pipeline.transformer.transformers
 
 import weco.catalogue.internal_model.text.TextNormalisation._
-import weco.catalogue.internal_model.work.{Genre, Meeting}
+import weco.catalogue.internal_model.work.{Genre, Meeting, Person}
 
 trait ConceptsTransformer {
   implicit class GenreOps[State](g: Genre[State]) {
@@ -19,5 +19,10 @@ trait ConceptsTransformer {
   implicit class MeetingOps[State](m: Meeting[State]) {
     def normalised: Meeting[State] =
       m.copy(label = m.label.trimTrailing(','))
+  }
+
+  implicit class PersonOps[State](p: Person[State]) {
+    def normalised: Person[State] =
+      p.copy(label = p.label.trimTrailing(','))
   }
 }

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/transformers/ConceptsTransformer.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/transformers/ConceptsTransformer.scala
@@ -3,6 +3,7 @@ package weco.pipeline.transformer.transformers
 import weco.catalogue.internal_model.text.TextNormalisation._
 import weco.catalogue.internal_model.work.{
   Agent,
+  Concept,
   Genre,
   Meeting,
   Organisation,
@@ -14,6 +15,11 @@ trait ConceptsTransformer {
   implicit class AgentOps[State](a: Agent[State]) {
     def normalised: Agent[State] =
       a.copy(label = a.label.trimTrailing(','))
+  }
+
+  implicit class ConceptOps[State](c: Concept[State]) {
+    def normalised: Concept[State] =
+      c.copy(label = c.label.trimTrailingPeriod)
   }
 
   implicit class GenreOps[State](g: Genre[State]) {

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/transformers/ConceptsTransformer.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/transformers/ConceptsTransformer.scala
@@ -1,15 +1,7 @@
 package weco.pipeline.transformer.transformers
 
-import weco.catalogue.internal_model.text.TextNormalisation._
-import weco.catalogue.internal_model.work.{
-  Agent,
-  Concept,
-  Genre,
-  Meeting,
-  Organisation,
-  Person,
-  Place
-}
+import weco.catalogue.internal_model.work._
+import weco.pipeline.transformer.text.TextNormalisation._
 
 trait ConceptsTransformer {
   implicit class AgentOps[State](a: Agent[State]) {

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/transformers/ConceptsTransformer.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/transformers/ConceptsTransformer.scala
@@ -1,0 +1,17 @@
+package weco.pipeline.transformer.transformers
+
+import weco.catalogue.internal_model.work.Genre
+
+trait ConceptsTransformer {
+  implicit class GenreOps[State](g: Genre[State]) {
+    def normalised: Genre[State] = {
+      val normalisedLabel =
+        g.label
+          .stripSuffix(".")
+          .trim
+          .replace("Electronic Books", "Electronic books")
+
+      g.copy(label = normalisedLabel)
+    }
+  }
+}

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/transformers/ConceptsTransformer.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/transformers/ConceptsTransformer.scala
@@ -1,7 +1,7 @@
 package weco.pipeline.transformer.transformers
 
 import weco.catalogue.internal_model.text.TextNormalisation._
-import weco.catalogue.internal_model.work.{Genre, Meeting, Person}
+import weco.catalogue.internal_model.work.{Genre, Meeting, Organisation, Person}
 
 trait ConceptsTransformer {
   implicit class GenreOps[State](g: Genre[State]) {
@@ -19,6 +19,11 @@ trait ConceptsTransformer {
   implicit class MeetingOps[State](m: Meeting[State]) {
     def normalised: Meeting[State] =
       m.copy(label = m.label.trimTrailing(','))
+  }
+
+  implicit class OrganisationOps[State](o: Organisation[State]) {
+    def normalised: Organisation[State] =
+      o.copy(label = o.label.trimTrailing(','))
   }
 
   implicit class PersonOps[State](p: Person[State]) {

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/transformers/ConceptsTransformer.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/transformers/ConceptsTransformer.scala
@@ -1,9 +1,14 @@
 package weco.pipeline.transformer.transformers
 
 import weco.catalogue.internal_model.text.TextNormalisation._
-import weco.catalogue.internal_model.work.{Genre, Meeting, Organisation, Person}
+import weco.catalogue.internal_model.work.{Agent, Genre, Meeting, Organisation, Person}
 
 trait ConceptsTransformer {
+  implicit class AgentOps[State](a: Agent[State]) {
+    def normalised: Agent[State] =
+      a.copy(label = a.label.trimTrailing(','))
+  }
+
   implicit class GenreOps[State](g: Genre[State]) {
     def normalised: Genre[State] = {
       val normalisedLabel =

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/transformers/ConceptsTransformer.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/transformers/ConceptsTransformer.scala
@@ -1,6 +1,7 @@
 package weco.pipeline.transformer.transformers
 
-import weco.catalogue.internal_model.work.Genre
+import weco.catalogue.internal_model.text.TextNormalisation._
+import weco.catalogue.internal_model.work.{Genre, Meeting}
 
 trait ConceptsTransformer {
   implicit class GenreOps[State](g: Genre[State]) {
@@ -13,5 +14,10 @@ trait ConceptsTransformer {
 
       g.copy(label = normalisedLabel)
     }
+  }
+
+  implicit class MeetingOps[State](m: Meeting[State]) {
+    def normalised: Meeting[State] =
+      m.copy(label = m.label.trimTrailing(','))
   }
 }

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/transformers/ConceptsTransformer.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/transformers/ConceptsTransformer.scala
@@ -1,7 +1,14 @@
 package weco.pipeline.transformer.transformers
 
 import weco.catalogue.internal_model.text.TextNormalisation._
-import weco.catalogue.internal_model.work.{Agent, Genre, Meeting, Organisation, Person}
+import weco.catalogue.internal_model.work.{
+  Agent,
+  Genre,
+  Meeting,
+  Organisation,
+  Person,
+  Place
+}
 
 trait ConceptsTransformer {
   implicit class AgentOps[State](a: Agent[State]) {
@@ -34,5 +41,10 @@ trait ConceptsTransformer {
   implicit class PersonOps[State](p: Person[State]) {
     def normalised: Person[State] =
       p.copy(label = p.label.trimTrailing(','))
+  }
+
+  implicit class PlaceOps[State](pl: Place[State]) {
+    def normalised: Place[State] =
+      pl.copy(label = pl.label.trimTrailing(':'))
   }
 }

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/transformers/ParsedPeriod.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/transformers/ParsedPeriod.scala
@@ -1,0 +1,16 @@
+package weco.pipeline.transformer.transformers
+
+import weco.catalogue.internal_model.text.TextNormalisation._
+import weco.catalogue.internal_model.identifiers.IdState
+import weco.catalogue.internal_model.work.{InstantRange, Period}
+import weco.catalogue.internal_model.parse.parsers.DateParser
+
+object ParsedPeriod {
+  def apply(label: String): Period[IdState.Unidentifiable.type] = {
+    val normalisedLabel = label.trimTrailingPeriod
+    Period(
+      IdState.Unidentifiable,
+      normalisedLabel,
+      InstantRange.parse(normalisedLabel))
+  }
+}

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/transformers/ParsedPeriod.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/transformers/ParsedPeriod.scala
@@ -1,9 +1,9 @@
 package weco.pipeline.transformer.transformers
 
 import weco.catalogue.internal_model.identifiers.IdState
-import weco.catalogue.internal_model.text.TextNormalisation._
 import weco.catalogue.internal_model.work.Period
 import weco.pipeline.transformer.parse.PeriodParser
+import weco.pipeline.transformer.text.TextNormalisation._
 
 object ParsedPeriod {
   def apply(label: String): Period[IdState.Unidentifiable.type] = {

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/transformers/ParsedPeriod.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/transformers/ParsedPeriod.scala
@@ -1,16 +1,17 @@
 package weco.pipeline.transformer.transformers
 
-import weco.catalogue.internal_model.text.TextNormalisation._
 import weco.catalogue.internal_model.identifiers.IdState
-import weco.catalogue.internal_model.work.{InstantRange, Period}
-import weco.catalogue.internal_model.parse.parsers.DateParser
+import weco.catalogue.internal_model.text.TextNormalisation._
+import weco.catalogue.internal_model.work.Period
+import weco.pipeline.transformer.parse.PeriodParser
 
 object ParsedPeriod {
   def apply(label: String): Period[IdState.Unidentifiable.type] = {
     val normalisedLabel = label.trimTrailingPeriod
     Period(
-      IdState.Unidentifiable,
-      normalisedLabel,
-      InstantRange.parse(normalisedLabel))
+      id = IdState.Unidentifiable,
+      label = normalisedLabel,
+      range = PeriodParser(normalisedLabel)
+    )
   }
 }

--- a/pipeline/transformer/transformer_common/src/test/scala/weco/pipeline/transformer/parse/DateParserTest.scala
+++ b/pipeline/transformer/transformer_common/src/test/scala/weco/pipeline/transformer/parse/DateParserTest.scala
@@ -1,11 +1,11 @@
-package weco.catalogue.internal_model.parse
+package weco.pipeline.transformer.parse
 
 import org.scalatest.matchers.should.Matchers
 import java.time.LocalDate
 
 import org.scalatest.funspec.AnyFunSpec
-import weco.catalogue.internal_model.parse.parsers.DateParser
 import weco.catalogue.internal_model.work.InstantRange
+import weco.pipeline.transformer.parse.parsers.DateParser
 
 class DateParserTest extends AnyFunSpec with Matchers {
 

--- a/pipeline/transformer/transformer_common/src/test/scala/weco/pipeline/transformer/parse/PeriodParserTest.scala
+++ b/pipeline/transformer/transformer_common/src/test/scala/weco/pipeline/transformer/parse/PeriodParserTest.scala
@@ -1,4 +1,4 @@
-package weco.catalogue.internal_model.parse
+package weco.pipeline.transformer.parse
 
 import java.time.LocalDate
 

--- a/pipeline/transformer/transformer_common/src/test/scala/weco/pipeline/transformer/text/TextNormalisationTest.scala
+++ b/pipeline/transformer/transformer_common/src/test/scala/weco/pipeline/transformer/text/TextNormalisationTest.scala
@@ -1,4 +1,4 @@
-package weco.catalogue.internal_model.text
+package weco.pipeline.transformer.text
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.prop.TableDrivenPropertyChecks._

--- a/pipeline/transformer/transformer_common/src/test/scala/weco/pipeline/transformer/transformers/ParsedPeriodTest.scala
+++ b/pipeline/transformer/transformer_common/src/test/scala/weco/pipeline/transformer/transformers/ParsedPeriodTest.scala
@@ -32,4 +32,3 @@ class ParsedPeriodTest extends AnyFunSpec with Matchers {
     }
   }
 }
-

--- a/pipeline/transformer/transformer_common/src/test/scala/weco/pipeline/transformer/transformers/ParsedPeriodTest.scala
+++ b/pipeline/transformer/transformer_common/src/test/scala/weco/pipeline/transformer/transformers/ParsedPeriodTest.scala
@@ -1,10 +1,10 @@
-package weco.catalogue.internal_model.work
+package weco.pipeline.transformer.transformers
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.prop.TableDrivenPropertyChecks._
 import org.scalatest.matchers.should.Matchers
 
-class PeriodTest extends AnyFunSpec with Matchers {
+class ParsedPeriodTest extends AnyFunSpec with Matchers {
   it("should add a range to a when there id a parsable label") {
     forAll(
       Table(
@@ -12,7 +12,7 @@ class PeriodTest extends AnyFunSpec with Matchers {
         "1909",
         "[2123]",
       )) { label =>
-      Period(label).range shouldNot be(None)
+      ParsedPeriod(label).range shouldNot be(None)
     }
   }
 
@@ -28,7 +28,8 @@ class PeriodTest extends AnyFunSpec with Matchers {
         "[^216]",
         "[216]",
       )) { label =>
-      Period(label).range shouldBe None
+      ParsedPeriod(label).range shouldBe None
     }
   }
 }
+

--- a/pipeline/transformer/transformer_miro/src/main/scala/weco/pipeline/transformer/miro/transformers/MiroCreatedDate.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/weco/pipeline/transformer/miro/transformers/MiroCreatedDate.scala
@@ -3,11 +3,12 @@ package weco.pipeline.transformer.miro.transformers
 import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.work.Period
 import weco.pipeline.transformer.miro.source.MiroRecord
+import weco.pipeline.transformer.transformers.ParsedPeriod
 
 trait MiroCreatedDate {
   def getCreatedDate(miroRecord: MiroRecord): Option[Period[IdState.Unminted]] =
     if (collectionIsV(miroRecord.imageNumber))
-      miroRecord.artworkDate.map(Period(_))
+      miroRecord.artworkDate.map(ParsedPeriod(_))
     else
       None
 

--- a/pipeline/transformer/transformer_miro/src/main/scala/weco/pipeline/transformer/miro/transformers/MiroGenres.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/weco/pipeline/transformer/miro/transformers/MiroGenres.scala
@@ -1,9 +1,9 @@
 package weco.pipeline.transformer.miro.transformers
 
-import weco.catalogue.internal_model.text.TextNormalisation._
 import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.work.{Concept, Genre}
 import weco.pipeline.transformer.miro.source.MiroRecord
+import weco.pipeline.transformer.text.TextNormalisation._
 import weco.pipeline.transformer.transformers.ConceptsTransformer
 
 trait MiroGenres extends ConceptsTransformer {

--- a/pipeline/transformer/transformer_miro/src/main/scala/weco/pipeline/transformer/miro/transformers/MiroGenres.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/weco/pipeline/transformer/miro/transformers/MiroGenres.scala
@@ -13,9 +13,11 @@ trait MiroGenres extends ConceptsTransformer {
     (miroRecord.physFormat.toList ++ miroRecord.lcGenre.toList).map { label =>
       val normalisedLabel = label.sentenceCase
 
+      val concept = Concept(label = normalisedLabel).normalised
+
       val genre = Genre(
         label = normalisedLabel,
-        concepts = List(Concept.normalised(label = normalisedLabel))
+        concepts = List(concept)
       )
 
       genre.normalised

--- a/pipeline/transformer/transformer_miro/src/main/scala/weco/pipeline/transformer/miro/transformers/MiroGenres.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/weco/pipeline/transformer/miro/transformers/MiroGenres.scala
@@ -4,16 +4,20 @@ import weco.catalogue.internal_model.text.TextNormalisation._
 import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.work.{Concept, Genre}
 import weco.pipeline.transformer.miro.source.MiroRecord
+import weco.pipeline.transformer.transformers.ConceptsTransformer
 
-trait MiroGenres {
+trait MiroGenres extends ConceptsTransformer {
   def getGenres(miroRecord: MiroRecord): List[Genre[IdState.Unminted]] =
     // Populate the genres field.  This is based on two fields in the XML,
     // <image_phys_format> and <image_lc_genre>.
     (miroRecord.physFormat.toList ++ miroRecord.lcGenre.toList).map { label =>
       val normalisedLabel = label.sentenceCase
-      Genre.normalised(
+
+      val genre = Genre(
         label = normalisedLabel,
         concepts = List(Concept.normalised(label = normalisedLabel))
       )
+
+      genre.normalised
     }.distinct
 }

--- a/pipeline/transformer/transformer_miro/src/main/scala/weco/pipeline/transformer/miro/transformers/MiroSubjects.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/weco/pipeline/transformer/miro/transformers/MiroSubjects.scala
@@ -1,9 +1,9 @@
 package weco.pipeline.transformer.miro.transformers
 
-import weco.catalogue.internal_model.text.TextNormalisation._
 import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.work.{Concept, Subject}
 import weco.pipeline.transformer.miro.source.MiroRecord
+import weco.pipeline.transformer.text.TextNormalisation._
 
 trait MiroSubjects {
 

--- a/pipeline/transformer/transformer_miro/src/test/scala/weco/pipeline/transformer/miro/transformers/MiroRecordTransformerTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/weco/pipeline/transformer/miro/transformers/MiroRecordTransformerTest.scala
@@ -16,6 +16,7 @@ import weco.catalogue.source_model.miro.MiroSourceOverrides
 import weco.pipeline.transformer.miro.generators.MiroRecordGenerators
 import weco.pipeline.transformer.miro.models.MiroMetadata
 import weco.pipeline.transformer.miro.source.MiroRecord
+import weco.pipeline.transformer.transformers.ParsedPeriod
 
 class MiroRecordTransformerTest
     extends AnyFunSpec
@@ -188,7 +189,7 @@ class MiroRecordTransformerTest
         imageNumber = "V1234567"
       )
     )
-    work.data.createdDate shouldBe Some(Period(date))
+    work.data.createdDate shouldBe Some(ParsedPeriod(date))
   }
 
   it("does not pass through the value of the creation date on non-V records") {

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraAgents.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraAgents.scala
@@ -17,24 +17,23 @@ trait SierraAgents extends SierraQueryOps with ConceptsTransformer {
     subfields: List[Subfield],
     normalisePerson: Boolean = false): Option[Person[IdState.Unminted]] =
     getLabel(subfields).map { label =>
-      // The rule is to only normalise the 'Person' label when a contributor.  Strictly a 'Person' within
-      // 'Subjects' (sourced from Marc 600) should not be normalised -- however, as these labels
-      // are not expected to have punctuation normalisation should not change the 'Person' label for 'Subjects'
-      // In which case normalisation is effectively a no-op and the test can be removed and Person.normalised
-      // always returned when confident in the data.
-      if (normalisePerson)
-        Person.normalised(
-          label = label,
-          prefix = None,
-          numeration = None
-        )
-      else
+      val person =
         Person(
           id = IdState.Unidentifiable,
           label = label,
           prefix = None,
           numeration = None
         )
+
+      // The rule is to only normalise the 'Person' label when a contributor.  Strictly a 'Person' within
+      // 'Subjects' (sourced from Marc 600) should not be normalised -- however, as these labels
+      // are not expected to have punctuation normalisation should not change the 'Person' label for 'Subjects'
+      // In which case normalisation is effectively a no-op and the test can be removed and Person.normalised
+      // always returned when confident in the data.
+      if (normalisePerson)
+        person.normalised
+      else
+        person
     }
 
   // This is used to construct an Organisation from MARC tags 110 and 710.

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraAgents.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraAgents.scala
@@ -1,6 +1,10 @@
 package weco.pipeline.transformer.sierra.transformers
 
-import weco.catalogue.internal_model.identifiers.{IdState, IdentifierType, SourceIdentifier}
+import weco.catalogue.internal_model.identifiers.{
+  IdState,
+  IdentifierType,
+  SourceIdentifier
+}
 import weco.catalogue.internal_model.work.{Meeting, Organisation, Person}
 import weco.pipeline.transformer.transformers.ConceptsTransformer
 import weco.sierra.models.SierraQueryOps

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraAgents.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraAgents.scala
@@ -46,7 +46,7 @@ trait SierraAgents extends SierraQueryOps with ConceptsTransformer {
   def getOrganisation(
     subfields: List[Subfield]): Option[Organisation[IdState.Unminted]] =
     getLabel(subfields.filterNot(_.tag == "n"))
-      .map { Organisation.normalised }
+      .map { Organisation(_).normalised }
 
   def getMeeting(subfields: List[Subfield]): Option[Meeting[IdState.Unminted]] =
     getLabel(subfields.withTags("a", "c", "d", "t"))

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraAgents.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraAgents.scala
@@ -1,15 +1,12 @@
 package weco.pipeline.transformer.sierra.transformers
 
-import weco.catalogue.internal_model.identifiers.{
-  IdState,
-  IdentifierType,
-  SourceIdentifier
-}
+import weco.catalogue.internal_model.identifiers.{IdState, IdentifierType, SourceIdentifier}
 import weco.catalogue.internal_model.work.{Meeting, Organisation, Person}
+import weco.pipeline.transformer.transformers.ConceptsTransformer
 import weco.sierra.models.SierraQueryOps
 import weco.sierra.models.marc.Subfield
 
-trait SierraAgents extends SierraQueryOps {
+trait SierraAgents extends SierraQueryOps with ConceptsTransformer {
   // This is used to construct a Person from MARc tags 100, 700 and 600.
   // For all these cases:
   //  - subfield $a populates the person label
@@ -54,7 +51,7 @@ trait SierraAgents extends SierraQueryOps {
 
   def getMeeting(subfields: List[Subfield]): Option[Meeting[IdState.Unminted]] =
     getLabel(subfields.withTags("a", "c", "d", "t"))
-      .map { Meeting.normalised }
+      .map { Meeting(_).normalised }
 
   /* Given an agent and the associated MARC subfields, look for instances of subfield $0,
    * which are used for identifiers.

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraConcepts.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraConcepts.scala
@@ -5,10 +5,12 @@ import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.work.{
   AbstractConcept,
   Concept,
-  Period,
   Place
 }
-import weco.pipeline.transformer.transformers.ConceptsTransformer
+import weco.pipeline.transformer.transformers.{
+  ConceptsTransformer,
+  ParsedPeriod
+}
 import weco.sierra.models.SierraQueryOps
 import weco.sierra.models.marc.{Subfield, VarField}
 
@@ -95,7 +97,7 @@ trait SierraConcepts extends SierraQueryOps with ConceptsTransformer {
     subdivisionSubfields.map { subfield =>
       subfield.tag match {
         case "v" | "x" => Concept(label = subfield.content).normalised
-        case "y"       => Period(label = subfield.content)
+        case "y"       => ParsedPeriod(label = subfield.content)
         case "z"       => Place(label = subfield.content).normalised
       }
     }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraConcepts.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraConcepts.scala
@@ -62,11 +62,11 @@ trait SierraConcepts extends SierraQueryOps with ConceptsTransformer {
   //
   // Note that some identifiers have an identifier scheme in
   // indicator 2, but no ID.  In this case, we just ignore it.
-  def identifyConcept[T](concept: T, varField: VarField): IdState.Unminted =
+  def identifyConcept(ontologyType: String, varField: VarField): IdState.Unminted =
     getIdentifierSubfieldContents(varField) match {
       case Seq(subfieldContent) =>
-        maybeAddIdentifier[T](
-          concept = concept,
+        maybeAddIdentifier(
+          ontologyType = ontologyType,
           varField = varField,
           identifierSubfieldContent = subfieldContent
         )
@@ -75,15 +75,15 @@ trait SierraConcepts extends SierraQueryOps with ConceptsTransformer {
 
   // If there's exactly one subfield $0 on the VarField, add an identifier
   // if possible.
-  private def maybeAddIdentifier[T](
-    concept: T,
+  private def maybeAddIdentifier(
+    ontologyType: String,
     varField: VarField,
     identifierSubfieldContent: String): IdState.Unminted =
     SierraConceptIdentifier
       .maybeFindIdentifier(
         varField = varField,
         identifierSubfieldContent = identifierSubfieldContent,
-        ontologyType = concept.getClass.getSimpleName
+        ontologyType = ontologyType
       )
       .map(IdState.Identifiable(_))
       .getOrElse(IdState.Unidentifiable)
@@ -94,7 +94,7 @@ trait SierraConcepts extends SierraQueryOps with ConceptsTransformer {
     : List[AbstractConcept[IdState.Unminted]] =
     subdivisionSubfields.map { subfield =>
       subfield.tag match {
-        case "v" | "x" => Concept.normalised(label = subfield.content)
+        case "v" | "x" => Concept(label = subfield.content).normalised
         case "y"       => Period(label = subfield.content)
         case "z"       => Place(label = subfield.content).normalised
       }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraConcepts.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraConcepts.scala
@@ -2,11 +2,7 @@ package weco.pipeline.transformer.sierra.transformers
 
 import weco.catalogue.internal_model.text.TextNormalisation._
 import weco.catalogue.internal_model.identifiers.IdState
-import weco.catalogue.internal_model.work.{
-  AbstractConcept,
-  Concept,
-  Place
-}
+import weco.catalogue.internal_model.work.{AbstractConcept, Concept, Place}
 import weco.pipeline.transformer.transformers.{
   ConceptsTransformer,
   ParsedPeriod
@@ -64,7 +60,8 @@ trait SierraConcepts extends SierraQueryOps with ConceptsTransformer {
   //
   // Note that some identifiers have an identifier scheme in
   // indicator 2, but no ID.  In this case, we just ignore it.
-  def identifyConcept(ontologyType: String, varField: VarField): IdState.Unminted =
+  def identifyConcept(ontologyType: String,
+                      varField: VarField): IdState.Unminted =
     getIdentifierSubfieldContents(varField) match {
       case Seq(subfieldContent) =>
         maybeAddIdentifier(

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraConcepts.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraConcepts.scala
@@ -1,8 +1,8 @@
 package weco.pipeline.transformer.sierra.transformers
 
-import weco.catalogue.internal_model.text.TextNormalisation._
 import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.work.{AbstractConcept, Concept, Place}
+import weco.pipeline.transformer.text.TextNormalisation._
 import weco.pipeline.transformer.transformers.{
   ConceptsTransformer,
   ParsedPeriod

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraConcepts.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraConcepts.scala
@@ -8,10 +8,11 @@ import weco.catalogue.internal_model.work.{
   Period,
   Place
 }
+import weco.pipeline.transformer.transformers.ConceptsTransformer
 import weco.sierra.models.SierraQueryOps
 import weco.sierra.models.marc.{Subfield, VarField}
 
-trait SierraConcepts extends SierraQueryOps {
+trait SierraConcepts extends SierraQueryOps with ConceptsTransformer {
 
   // Get the label.  This is populated by the label of subfield $a, followed
   // by other subfields, in the order they come from MARC.  The labels are
@@ -95,7 +96,7 @@ trait SierraConcepts extends SierraQueryOps {
       subfield.tag match {
         case "v" | "x" => Concept.normalised(label = subfield.content)
         case "y"       => Period(label = subfield.content)
-        case "z"       => Place.normalised(label = subfield.content)
+        case "z"       => Place(label = subfield.content).normalised
       }
     }
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraGenres.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraGenres.scala
@@ -68,7 +68,12 @@ object SierraGenres
     primarySubfields: List[Subfield],
     varField: VarField): List[Concept[IdState.Unminted]] =
     primarySubfields.map { subfield =>
-      val concept = Concept.normalised(label = subfield.content)
-      concept.copy(id = identifyConcept(concept, varField))
+      Concept(
+        id = identifyConcept(
+          ontologyType = "Concept",
+          varField = varField
+        ),
+        label = subfield.content
+      ).normalised
     }
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraGenres.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraGenres.scala
@@ -2,6 +2,7 @@ package weco.pipeline.transformer.sierra.transformers
 
 import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.work.{Concept, Genre}
+import weco.pipeline.transformer.transformers.ConceptsTransformer
 import weco.sierra.models.SierraQueryOps
 import weco.sierra.models.data.SierraBibData
 import weco.sierra.models.marc.{Subfield, VarField}
@@ -39,7 +40,8 @@ import weco.sierra.models.marc.{Subfield, VarField}
 object SierraGenres
     extends SierraDataTransformer
     with SierraQueryOps
-    with SierraConcepts {
+    with SierraConcepts
+    with ConceptsTransformer {
 
   type Output = List[Genre[IdState.Unminted]]
 
@@ -56,7 +58,7 @@ object SierraGenres
         val concepts = getPrimaryConcept(primarySubfields, varField = varField) ++ getSubdivisions(
           subdivisionSubfields)
 
-        Genre.normalised(label = label, concepts = concepts)
+        Genre(label = label, concepts = concepts).normalised
       }
       .distinct
 

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraProduction.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraProduction.scala
@@ -4,7 +4,10 @@ import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.work._
 import weco.pipeline.transformer.sierra.exceptions.CataloguingException
 import weco.pipeline.transformer.sierra.transformers.parsers.Marc008Parser
-import weco.pipeline.transformer.transformers.ConceptsTransformer
+import weco.pipeline.transformer.transformers.{
+  ConceptsTransformer,
+  ParsedPeriod
+}
 import weco.sierra.models.SierraQueryOps
 import weco.sierra.models.data.SierraBibData
 import weco.sierra.models.identifiers.SierraBibNumber
@@ -297,5 +300,5 @@ object SierraProduction
     varfield
       .subfieldsWithTag(subfieldTag)
       .contents
-      .map(Period(_))
+      .map(ParsedPeriod(_))
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraProduction.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraProduction.scala
@@ -281,7 +281,7 @@ object SierraProduction
     varfield
       .subfieldsWithTag(subfieldTag)
       .contents
-      .map(Place.normalised)
+      .map(Place(_).normalised)
 
   private def agentsFromSubfields(
     varfield: VarField,

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraProduction.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraProduction.scala
@@ -4,6 +4,7 @@ import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.work._
 import weco.pipeline.transformer.sierra.exceptions.CataloguingException
 import weco.pipeline.transformer.sierra.transformers.parsers.Marc008Parser
+import weco.pipeline.transformer.transformers.ConceptsTransformer
 import weco.sierra.models.SierraQueryOps
 import weco.sierra.models.data.SierraBibData
 import weco.sierra.models.identifiers.SierraBibNumber
@@ -11,7 +12,8 @@ import weco.sierra.models.marc.{Subfield, VarField}
 
 object SierraProduction
     extends SierraIdentifiedDataTransformer
-    with SierraQueryOps {
+    with SierraQueryOps
+    with ConceptsTransformer {
 
   type Output = List[ProductionEvent[IdState.Unminted]]
 
@@ -287,7 +289,7 @@ object SierraProduction
     varfield
       .subfieldsWithTag(subfieldTag)
       .contents
-      .map(Agent.normalised)
+      .map(Agent(_).normalised)
 
   private def datesFromSubfields(
     varfield: VarField,

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/parsers/Marc008DateParser.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/parsers/Marc008DateParser.scala
@@ -2,9 +2,9 @@ package weco.pipeline.transformer.sierra.transformers.parsers
 
 import fastparse._, NoWhitespace._
 
-import weco.catalogue.internal_model.parse.DateParserImplicits._
-import weco.catalogue.internal_model.parse._
 import weco.catalogue.internal_model.work.InstantRange
+import weco.pipeline.transformer.parse.DateParserImplicits._
+import weco.pipeline.transformer.parse._
 
 /**
   *  Parses Marc 008 date information into InstantRange

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/parsers/Marc008Parser.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/parsers/Marc008Parser.scala
@@ -23,7 +23,6 @@ object Marc008Parser extends Parser[ProductionEvent[IdState.Unminted]] {
             dates = List(
               Period(label = instantRange.label, range = instantRange)
             ),
-
             places = place.toList,
             function = None)
       }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/parsers/Marc008Parser.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/parsers/Marc008Parser.scala
@@ -20,7 +20,9 @@ object Marc008Parser extends Parser[ProductionEvent[IdState.Unminted]] {
           ProductionEvent(
             label = instantRange.label,
             agents = Nil,
-            dates = Period(instantRange.label, Some(instantRange)) :: Nil,
+            dates = List(
+              Period(label = instantRange.label, range = instantRange)
+            ),
             places = place.toList,
             function = None)
       }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/parsers/Marc008Parser.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/parsers/Marc008Parser.scala
@@ -2,9 +2,9 @@ package weco.pipeline.transformer.sierra.transformers.parsers
 
 import fastparse._, NoWhitespace._
 
-import weco.catalogue.internal_model.parse.Parser
 import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.work.{Period, ProductionEvent}
+import weco.pipeline.transformer.parse.Parser
 
 /**
   *  Parses Marc 008 fields into ProductionEvent
@@ -23,6 +23,7 @@ object Marc008Parser extends Parser[ProductionEvent[IdState.Unminted]] {
             dates = List(
               Period(label = instantRange.label, range = instantRange)
             ),
+
             places = place.toList,
             function = None)
       }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/parsers/MarcPlaceParser.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/parsers/MarcPlaceParser.scala
@@ -2,9 +2,9 @@ package weco.pipeline.transformer.sierra.transformers.parsers
 
 import fastparse._, NoWhitespace._
 
-import weco.catalogue.internal_model.parse.Parser
 import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.work.Place
+import weco.pipeline.transformer.parse.Parser
 
 /**
   *  Parses Marc country information

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/subjects/SierraConceptSubjects.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/subjects/SierraConceptSubjects.scala
@@ -1,9 +1,9 @@
 package weco.pipeline.transformer.sierra.transformers.subjects
 
-import weco.catalogue.internal_model.text.TextNormalisation._
 import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.work._
 import weco.pipeline.transformer.sierra.transformers.SierraConcepts
+import weco.pipeline.transformer.text.TextNormalisation._
 import weco.pipeline.transformer.transformers.ParsedPeriod
 import weco.sierra.models.identifiers.SierraBibNumber
 import weco.sierra.models.marc.{Subfield, VarField}

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/subjects/SierraConceptSubjects.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/subjects/SierraConceptSubjects.scala
@@ -67,12 +67,11 @@ object SierraConceptSubjects
         primarySubfields,
         varField = varfield) ++ getSubdivisions(subdivisionSubfields)
 
-      val subject = Subject(
+      Subject(
+        id = identifyConcept(ontologyType = "Subject", varfield),
         label = label,
         concepts = concepts
       )
-
-      subject.copy(id = identifyConcept(subject, varfield))
     }
   }
 

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/subjects/SierraConceptSubjects.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/subjects/SierraConceptSubjects.scala
@@ -4,6 +4,7 @@ import weco.catalogue.internal_model.text.TextNormalisation._
 import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.work._
 import weco.pipeline.transformer.sierra.transformers.SierraConcepts
+import weco.pipeline.transformer.transformers.ParsedPeriod
 import weco.sierra.models.identifiers.SierraBibNumber
 import weco.sierra.models.marc.{Subfield, VarField}
 
@@ -83,7 +84,7 @@ object SierraConceptSubjects
 
       varField.marcTag.get match {
         case "650" => Concept(label = label)
-        case "648" => Period(label = label)
+        case "648" => ParsedPeriod(label = label)
         case "651" => Place(label = label)
       }
     }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/subjects/SierraSubjectsTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/subjects/SierraSubjectsTransformer.scala
@@ -1,9 +1,9 @@
 package weco.pipeline.transformer.sierra.transformers.subjects
 
-import weco.catalogue.internal_model.text.TextNormalisation._
 import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.work.Subject
 import weco.pipeline.transformer.sierra.transformers.SierraIdentifiedDataTransformer
+import weco.pipeline.transformer.text.TextNormalisation._
 import weco.sierra.models.SierraQueryOps
 import weco.sierra.models.data.SierraBibData
 import weco.sierra.models.identifiers.SierraBibNumber

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraConceptsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraConceptsTest.scala
@@ -7,16 +7,12 @@ import weco.catalogue.internal_model.identifiers.{
   IdentifierType,
   SourceIdentifier
 }
-import weco.catalogue.internal_model.work.Concept
 import weco.sierra.generators.MarcGenerators
 import weco.sierra.models.marc.Subfield
 
 class SierraConceptsTest extends AnyFunSpec with Matchers with MarcGenerators {
 
   it("extracts identifiers from subfield 0") {
-    val concept =
-      Concept(label = "Perservering puffins push past perspiration")
-
     val maybeIdentifiedConcept = transformer.identifyConcept(
       ontologyType = "Concept",
       varField = createVarFieldWith(
@@ -39,8 +35,6 @@ class SierraConceptsTest extends AnyFunSpec with Matchers with MarcGenerators {
   }
 
   it("normalises and deduplicates identifiers in subfield 0") {
-    val concept = Concept(label = "Metaphysical mice migrating to Mars")
-
     val maybeIdentifiedConcept = transformer.identifyConcept(
       ontologyType = "Concept",
       varField = createVarFieldWith(
@@ -72,8 +66,6 @@ class SierraConceptsTest extends AnyFunSpec with Matchers with MarcGenerators {
   }
 
   it("ignores multiple instances of subfield 0 in the otherIdentifiers") {
-    val concept = Concept(label = "Hitchhiking horses hurry home")
-
     val maybeIdentifiedConcept = transformer.identifyConcept(
       ontologyType = "Concept",
       varField = createVarFieldWith(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraConceptsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraConceptsTest.scala
@@ -18,7 +18,7 @@ class SierraConceptsTest extends AnyFunSpec with Matchers with MarcGenerators {
       Concept(label = "Perservering puffins push past perspiration")
 
     val maybeIdentifiedConcept = transformer.identifyConcept(
-      concept = concept,
+      ontologyType = "Concept",
       varField = createVarFieldWith(
         marcTag = "CCC",
         indicator2 = "0",
@@ -42,7 +42,7 @@ class SierraConceptsTest extends AnyFunSpec with Matchers with MarcGenerators {
     val concept = Concept(label = "Metaphysical mice migrating to Mars")
 
     val maybeIdentifiedConcept = transformer.identifyConcept(
-      concept = concept,
+      ontologyType = "Concept",
       varField = createVarFieldWith(
         marcTag = "CCC",
         indicator2 = "0",
@@ -75,7 +75,7 @@ class SierraConceptsTest extends AnyFunSpec with Matchers with MarcGenerators {
     val concept = Concept(label = "Hitchhiking horses hurry home")
 
     val maybeIdentifiedConcept = transformer.identifyConcept(
-      concept = concept,
+      ontologyType = "Concept",
       varField = createVarFieldWith(
         marcTag = "CCC",
         subfields = List(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraGenresTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraGenresTest.scala
@@ -7,7 +7,8 @@ import weco.catalogue.internal_model.identifiers.{
   IdentifierType,
   SourceIdentifier
 }
-import weco.catalogue.internal_model.work.{Concept, Genre, Period, Place}
+import weco.catalogue.internal_model.work.{Concept, Genre, Place}
+import weco.pipeline.transformer.transformers.ParsedPeriod
 import weco.sierra.generators.{MarcGenerators, SierraDataGenerators}
 import weco.sierra.models.marc.{Subfield, VarField}
 
@@ -131,7 +132,7 @@ class SierraGenresTest
           label = "A Content - Y Content",
           concepts = List(
             Concept(label = "A Content"),
-            Period(label = "Y Content")
+            ParsedPeriod(label = "Y Content")
           )))
 
     val bibData = createSierraBibDataWith(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraProductionTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraProductionTest.scala
@@ -6,11 +6,11 @@ import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.work.{
   Agent,
   Concept,
-  Period,
   Place,
   ProductionEvent
 }
 import weco.pipeline.transformer.sierra.exceptions.CataloguingException
+import weco.pipeline.transformer.transformers.ParsedPeriod
 import weco.sierra.generators.{MarcGenerators, SierraDataGenerators}
 import weco.sierra.models.marc.{Subfield, VarField}
 
@@ -63,9 +63,9 @@ class SierraProductionTest
         ))
 
       production.dates shouldBe List(
-        Period(label = "1955"),
-        Period(label = "1984"),
-        Period(label = "1999")
+        ParsedPeriod(label = "1955"),
+        ParsedPeriod(label = "1984"),
+        ParsedPeriod(label = "1999")
       )
     }
 
@@ -123,9 +123,9 @@ class SierraProductionTest
         ))
 
       production.dates shouldBe List(
-        Period(label = "1981"),
-        Period(label = "April 15, 1977"),
-        Period(label = "1973 printing")
+        ParsedPeriod(label = "1981"),
+        ParsedPeriod(label = "April 15, 1977"),
+        ParsedPeriod(label = "1973 printing")
       )
 
       production.function shouldBe Some(Concept("Manufacture"))
@@ -170,7 +170,7 @@ class SierraProductionTest
             Agent("Arts Council of Great Britain"),
             Agent("CTD Printers")
           ),
-          dates = List(Period("1976;"), Period("1974")),
+          dates = List(ParsedPeriod("1976;"), ParsedPeriod("1974")),
           function = Some(Concept("Manufacture"))
         ),
         ProductionEvent(
@@ -182,7 +182,7 @@ class SierraProductionTest
               "Toxicology Information Program, National Library of Medicine [producer] ;"),
             Agent("National Technical Information Service [distributor]")
           ),
-          dates = List(Period("1974-")),
+          dates = List(ParsedPeriod("1974-")),
           function = None
         )
       )
@@ -205,8 +205,8 @@ class SierraProductionTest
       )
 
       production.dates shouldBe List(
-        Period(label = "1984"),
-        Period(label = "1999")
+        ParsedPeriod(label = "1984"),
+        ParsedPeriod(label = "1999")
       )
     }
   }
@@ -250,9 +250,9 @@ class SierraProductionTest
         ))
 
       production.dates shouldBe List(
-        Period(label = "2002"),
-        Period(label = "1983"),
-        Period(label = "copyright 2005")
+        ParsedPeriod(label = "2002"),
+        ParsedPeriod(label = "1983"),
+        ParsedPeriod(label = "copyright 2005")
       )
     }
 
@@ -396,14 +396,14 @@ class SierraProductionTest
           label = "Columbia, S.C. : H.W. Williams Co., 1982",
           places = List(Place("Columbia, S.C.")),
           agents = List(Agent("H.W. Williams Co.")),
-          dates = List(Period("1982")),
+          dates = List(ParsedPeriod("1982")),
           function = Some(Concept("Publication"))
         ),
         ProductionEvent(
           label = "Washington : U.S. G.P.O., 1981-",
           places = List(Place("Washington")),
           agents = List(Agent("U.S. G.P.O.")),
-          dates = List(Period("1981-")),
+          dates = List(ParsedPeriod("1981-")),
           function = Some(Concept("Distribution"))
         )
       )
@@ -432,9 +432,9 @@ class SierraProductionTest
         Agent(label = "Iverson Ltd.")
       )
       production.dates shouldBe List(
-        Period(label = "2002"),
-        Period(label = "1983"),
-        Period(label = "copyright 2005")
+        ParsedPeriod(label = "2002"),
+        ParsedPeriod(label = "1983"),
+        ParsedPeriod(label = "copyright 2005")
       )
     }
   }
@@ -493,7 +493,7 @@ class SierraProductionTest
           agents = List(
             Agent("Morgan Kaufmann Publishers")
           ),
-          dates = List(Period("2004")),
+          dates = List(ParsedPeriod("2004")),
           function = None
         )
       )
@@ -524,7 +524,7 @@ class SierraProductionTest
           label = "London : Wellcome Trust, 1992",
           places = List(Place("London")),
           agents = List(Agent("Wellcome Trust")),
-          dates = List(Period("1992")),
+          dates = List(ParsedPeriod("1992")),
           function = None
         )
       )
@@ -556,7 +556,7 @@ class SierraProductionTest
           label = "2019",
           places = List(),
           agents = List(),
-          dates = List(Period("2019")),
+          dates = List(ParsedPeriod("2019")),
           function = None
         )
       )
@@ -577,7 +577,7 @@ class SierraProductionTest
           label = "1757",
           places = List(Place("England")),
           agents = List(),
-          dates = List(Period("1757")),
+          dates = List(ParsedPeriod("1757")),
           function = None))
     }
 
@@ -597,7 +597,7 @@ class SierraProductionTest
           label = "2002 London",
           places = List(Place("London")),
           agents = List(),
-          dates = List(Period("2002")),
+          dates = List(ParsedPeriod("2002")),
           function = Some(Concept("Publication"))))
     }
 
@@ -617,7 +617,7 @@ class SierraProductionTest
           label = "2002 London",
           places = List(Place("London")),
           agents = List(),
-          dates = List(Period("2002")),
+          dates = List(ParsedPeriod("2002")),
           function = None))
     }
 
@@ -635,7 +635,7 @@ class SierraProductionTest
           label = "London",
           places = List(Place("London")),
           agents = List(),
-          dates = List(Period("1757")),
+          dates = List(ParsedPeriod("1757")),
           function = None))
     }
 
@@ -668,7 +668,7 @@ class SierraProductionTest
         places = List(Place("[Netherne, Surrey],")),
         agents = Nil,
         dates = List(
-          Period("1972").copy(
+          ParsedPeriod("1972").copy(
             label = "B̷A̴D̸ ̴U̶N̸P̵A̸R̸S̷E̷A̶B̵L̶E̸ ̵N̴O̴N̶S̵E̷N̷S̴E̴")),
         function = Some(Concept("Production"))
       )

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraTransformerTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraTransformerTest.scala
@@ -34,6 +34,7 @@ import weco.catalogue.source_model.generators.SierraRecordGenerators
 import weco.catalogue.source_model.sierra._
 import weco.pipeline.transformer.sierra.SierraTransformer
 import weco.pipeline.transformer.sierra.exceptions.SierraTransformerException
+import weco.pipeline.transformer.transformers.ParsedPeriod
 import weco.sierra.generators.MarcGenerators
 import weco.sierra.models.identifiers.{SierraBibNumber, SierraItemNumber}
 import weco.sierra.models.marc.{Subfield, VarField}
@@ -420,7 +421,7 @@ class SierraTransformerTest
             label = "Peaceful Poetry 1923",
             places = List(),
             agents = List(Agent(label = "Peaceful Poetry")),
-            dates = List(Period("1923")),
+            dates = List(ParsedPeriod("1923")),
             function = None
           )
         )

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/parsers/Marc008ParserTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/parsers/Marc008ParserTest.scala
@@ -22,11 +22,11 @@ class Marc008ParserTest extends AnyFunSpec with Matchers {
           dates = List(
             Period(
               label = "1757",
-              range = Some(
+              range =
                 InstantRange(
                   LocalDate of (1757, 1, 1),
                   LocalDate of (1757, 12, 31),
-                  "1757")))),
+                  "1757"))),
           places = List(Place("England")),
           function = None
         ))
@@ -41,11 +41,11 @@ class Marc008ParserTest extends AnyFunSpec with Matchers {
           dates = List(
             Period(
               label = "2003",
-              range = Some(
+              range =
                 InstantRange(
                   LocalDate of (2003, 1, 1),
                   LocalDate of (2003, 12, 31),
-                  "2003")))),
+                  "2003"))),
           places = List(Place("England")),
           function = None
         ))
@@ -60,11 +60,11 @@ class Marc008ParserTest extends AnyFunSpec with Matchers {
           dates = List(
             Period(
               label = "1908/11/21",
-              range = Some(
+              range =
                 InstantRange(
                   LocalDate of (1908, 11, 21),
                   LocalDate of (1908, 11, 21),
-                  "1908/11/21")))),
+                  "1908/11/21"))),
           places = List(Place("Egypt")),
           function = None
         ))
@@ -79,11 +79,11 @@ class Marc008ParserTest extends AnyFunSpec with Matchers {
           dates = List(
             Period(
               label = "1600-1699",
-              range = Some(
+              range =
                 InstantRange(
                   LocalDate of (1600, 1, 1),
                   LocalDate of (1699, 12, 31),
-                  "1600-1699")))),
+                  "1600-1699"))),
           places = Nil,
           function = None
         ))

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/parsers/Marc008ParserTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/parsers/Marc008ParserTest.scala
@@ -22,11 +22,10 @@ class Marc008ParserTest extends AnyFunSpec with Matchers {
           dates = List(
             Period(
               label = "1757",
-              range =
-                InstantRange(
-                  LocalDate of (1757, 1, 1),
-                  LocalDate of (1757, 12, 31),
-                  "1757"))),
+              range = InstantRange(
+                LocalDate of (1757, 1, 1),
+                LocalDate of (1757, 12, 31),
+                "1757"))),
           places = List(Place("England")),
           function = None
         ))
@@ -41,11 +40,10 @@ class Marc008ParserTest extends AnyFunSpec with Matchers {
           dates = List(
             Period(
               label = "2003",
-              range =
-                InstantRange(
-                  LocalDate of (2003, 1, 1),
-                  LocalDate of (2003, 12, 31),
-                  "2003"))),
+              range = InstantRange(
+                LocalDate of (2003, 1, 1),
+                LocalDate of (2003, 12, 31),
+                "2003"))),
           places = List(Place("England")),
           function = None
         ))
@@ -60,11 +58,10 @@ class Marc008ParserTest extends AnyFunSpec with Matchers {
           dates = List(
             Period(
               label = "1908/11/21",
-              range =
-                InstantRange(
-                  LocalDate of (1908, 11, 21),
-                  LocalDate of (1908, 11, 21),
-                  "1908/11/21"))),
+              range = InstantRange(
+                LocalDate of (1908, 11, 21),
+                LocalDate of (1908, 11, 21),
+                "1908/11/21"))),
           places = List(Place("Egypt")),
           function = None
         ))
@@ -79,11 +76,10 @@ class Marc008ParserTest extends AnyFunSpec with Matchers {
           dates = List(
             Period(
               label = "1600-1699",
-              range =
-                InstantRange(
-                  LocalDate of (1600, 1, 1),
-                  LocalDate of (1699, 12, 31),
-                  "1600-1699"))),
+              range = InstantRange(
+                LocalDate of (1600, 1, 1),
+                LocalDate of (1699, 12, 31),
+                "1600-1699"))),
           places = Nil,
           function = None
         ))

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/subjects/SierraConceptSubjectsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/subjects/SierraConceptSubjectsTest.scala
@@ -7,7 +7,8 @@ import weco.catalogue.internal_model.identifiers.{
   IdentifierType,
   SourceIdentifier
 }
-import weco.catalogue.internal_model.work.{Concept, Period, Place, Subject}
+import weco.catalogue.internal_model.work.{Concept, Place, Subject}
+import weco.pipeline.transformer.transformers.ParsedPeriod
 import weco.sierra.generators.{MarcGenerators, SierraDataGenerators}
 import weco.sierra.models.marc.{Subfield, VarField}
 
@@ -133,7 +134,7 @@ class SierraConceptSubjectsTest
         label = "A Content - Y Content",
         concepts = List(
           Concept(label = "A Content"),
-          Period(label = "Y Content")
+          ParsedPeriod(label = "Y Content")
         )
       )
     )
@@ -218,7 +219,7 @@ class SierraConceptSubjectsTest
       Subject(
         label = "A Content - X Content - V Content",
         concepts = List(
-          Period(label = "A Content"),
+          ParsedPeriod(label = "A Content"),
           Concept(label = "X Content"),
           Concept(label = "V Content")
         )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -176,7 +176,6 @@ object CatalogueDependencies {
       WellcomeDependencies.elasticsearchLibrary ++
       WellcomeDependencies.elasticsearchTypesafeLibrary ++
       WellcomeDependencies.jsonLibrary ++
-      ExternalDependencies.parseDependencies ++
       ExternalDependencies.scalacheckDependencies ++
       ExternalDependencies.enumeratumDependencies ++
       ExternalDependencies.scalaXmlDependencies ++
@@ -207,7 +206,8 @@ object CatalogueDependencies {
     WellcomeDependencies.typesafeLibrary
 
   val transformerCommonDependencies: Seq[ModuleID] =
-    WellcomeDependencies.storageLibrary
+    WellcomeDependencies.storageLibrary ++
+      ExternalDependencies.parseDependencies
 
   val idminterDependencies: Seq[ModuleID] =
     ExternalDependencies.mySqlDependencies ++


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5298

## Before

We have a bunch of methods in the internal model library that:

- allow us to construct "normalised" concepts, e.g.

    ```scala
    object Concept {
      def normalised(label: String): Concept(label = label.trimWhitespace)
    }
    ```

- allow us to parse values from source data for time periods, e.g.

    ```scala
    object Period {
      def parse(label: String): Period(label = label.trimWhitespace, range = InstantRange.parse(label))
    }
    ```

These are in the internal model library so they're made available to every application, but we only ever use them in the transformers. Stronger – we should never use them outside the transformers, because they're meant for modifying the source data.

## After

This patch moves all this parsing-esque logic into the transformer_common library in the new `ConceptsTransformer` trait and `ParsedPeriod` model. Implicit resolution continues to dominate the compilation time of internal model, so hopefully moving a bunch of those implicits into a less-widely used library will make builds faster.