### PR TITLE
Bump the timeout on this queue to account for double-sending

### DIFF
--- a/mets_adapter/mets_adapter/src/test/scala/weco/pipeline/mets_adapter/services/MetsAdapterWorkerServiceTest.scala
+++ b/mets_adapter/mets_adapter/src/test/scala/weco/pipeline/mets_adapter/services/MetsAdapterWorkerServiceTest.scala
@@ -358,7 +358,7 @@ class MetsAdapterWorkerServiceTest
                         MemoryMessageSender),
                        R]): R =
     withActorSystem { implicit actorSystem =>
-      withLocalSqsQueuePair(visibilityTimeout = 2 seconds) {
+      withLocalSqsQueuePair(visibilityTimeout = 3 seconds) {
         case QueuePair(queue, dlq) =>
           withSQSStream[NotificationMessage, R](queue) { stream =>
             val workerService = new MetsAdapterWorkerService(


### PR DESCRIPTION
See https://buildkite.com/wellcomecollection/catalogue-pipeline/builds/5686#b1c93e0c-40f9-4e0c-b36d-c3c974c8e319