### PR TITLE
Don't display a range in an enumeration if start/end are the same

### DIFF
--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraHoldingsEnumeration.scala
@@ -147,7 +147,16 @@ object SierraHoldingsEnumeration extends SierraQueryOps with Logging {
         case (label, value) => (label, value.split("-", 2).last)
       }
 
-      s"${concatenateParts(id, startParts)} - ${concatenateParts(id, endParts)}"
+      val startString = concatenateParts(id, startParts)
+      val endString = concatenateParts(id, endParts)
+
+      // It's possible the start/end of the range may be the same.  If so, collapse
+      // them into a single value to make them easier to read.
+      if (startString == endString) {
+        startString
+      } else {
+        s"$startString - $endString"
+      }
     } else {
       concatenateParts(id, parts)
     }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraHoldingsEnumerationTest.scala
@@ -715,6 +715,34 @@ class SierraHoldingsEnumerationTest
     getEnumerations(varFields) shouldBe List("1 Jan. 2001")
   }
 
+  it("collapses a range which has the same start/finish") {
+    // This is based on the holdings record for The Lancet.  Ideally we'd fix
+    // this in the source data, but detecting this issue is somewhat fiddly
+    // and it's pretty easy for us to handle here.
+    val varFields = List(
+      VarField(
+        marcTag = "863",
+        subfields = List(
+          Subfield(tag = "8", content = "2.9"),
+          Subfield(tag = "a", content = "390"),
+          Subfield(tag = "b", content = "10116-10116"),
+          Subfield(tag = "i", content = "2018"),
+        )
+      ),
+      VarField(
+        marcTag = "853",
+        subfields = List(
+          Subfield(tag = "8", content = "2"),
+          Subfield(tag = "a", content = "v."),
+          Subfield(tag = "b", content = "no."),
+          Subfield(tag = "i", content = "(year)"),
+        )
+      )
+    )
+
+    getEnumerations(varFields) shouldBe List("v.390:no.10116 (2018)")
+  }
+
   describe("handles malformed MARC data") {
     it("skips a field 863 if it has a missing sequence number") {
       val varFields = List(


### PR DESCRIPTION
e.g. the range

    v.295:no.10226 (2020) - v.295:no.10226 (2020)

can be simplified to

    v.295:no.10226 (2020)