### PR TITLE
Split deployment of the pipeline/adapters

### DIFF
--- a/.buildkite/pipeline.deploy-adapters.yml
+++ b/.buildkite/pipeline.deploy-adapters.yml
@@ -79,9 +79,3 @@ steps:
               "--confirmation-wait-for", 3600]
     agents:
       queue: nano
-  - label: deploy pipeline
-    commands:
-      - pip3 install --user boto3 httpx
-      - .buildkite/scripts/deploy_latest_pipeline.py
-    agents:
-      queue: nano

--- a/.buildkite/pipeline.deploy-pipeline.yml
+++ b/.buildkite/pipeline.deploy-pipeline.yml
@@ -1,0 +1,6 @@
+  - label: deploy pipeline
+    commands:
+      - pip3 install --user boto3 httpx
+      - .buildkite/scripts/deploy_latest_pipeline.py
+    agents:
+      queue: nano

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -89,9 +89,22 @@ steps:
     env:
       PROJECTS: internal_model
     command: .buildkite/scripts/publish.py
-  - label: trigger service deployments
+  - label: trigger adapter deployments
     if: build.branch == "main"
-    trigger: "catalogue-pipeline-deploy-prod"
+    trigger: "catalogue-pipeline-deploy-adapter"
+    async: true
+    build:
+      message: "${BUILDKITE_MESSAGE}"
+      commit: "${BUILDKITE_COMMIT}"
+      branch: "${BUILDKITE_BRANCH}"
+      env:
+        BUILDKITE_PULL_REQUEST: "${BUILDKITE_PULL_REQUEST}"
+        BUILDKITE_PULL_REQUEST_BASE_BRANCH: "${BUILDKITE_PULL_REQUEST_BASE_BRANCH}"
+        BUILDKITE_PULL_REQUEST_REPO: "${BUILDKITE_PULL_REQUEST_REPO}"
+
+  - label: trigger pipeline deployments
+    if: build.branch == "main"
+    trigger: "catalogue-pipeline-deploy-pipeline"
     async: true
     build:
       message: "${BUILDKITE_MESSAGE}"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -91,7 +91,7 @@ steps:
     command: .buildkite/scripts/publish.py
   - label: trigger adapter deployments
     if: build.branch == "main"
-    trigger: "catalogue-pipeline-deploy-adapter"
+    trigger: "catalogue-pipeline-deploy-adapters"
     async: true
     build:
       message: "${BUILDKITE_MESSAGE}"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # catalogue-pipeline
 
-[![Build status](https://badge.buildkite.com/0ca819db1215b66ecb17019d8ee5331d8e537094d051141219.svg?branch=main)](https://buildkite.com/wellcomecollection/catalogue-pipeline) [![Deployment status](https://img.shields.io/buildkite/120d56989228052f1539823186545fd7e1665aaa2cb98d0c91/main.svg?label=deployment)](https://buildkite.com/wellcomecollection/catalogue-pipeline-deploy-prod)
+[![Build status](https://badge.buildkite.com/0ca819db1215b66ecb17019d8ee5331d8e537094d051141219.svg?branch=main)](https://buildkite.com/wellcomecollection/catalogue-pipeline) [![Adapter deployment status](https://img.shields.io/buildkite/2fb18a042947b93fb2b05a8c7b48c5db0e7fd0f9210bb993d5/main.svg?label=adapter%20deployment)](https://buildkite.com/wellcomecollection/catalogue-pipeline-deploy-adapter) [![Pipeline deployment status](https://img.shields.io/buildkite/120d56989228052f1539823186545fd7e1665aaa2cb98d0c91/main.svg?label=pipeline%20deployment)](https://buildkite.com/wellcomecollection/catalogue-pipeline-deploy-pipeline)
 
 The catalogue pipeline creates the search index for our [unified collections search][search].
 It populates an Elasticsearch index with data which can then be read by our [catalogue API][api].


### PR DESCRIPTION
We expect the pipeline deployment might fail sometimes if the internal model version has changed, but we never expect the adapter deployment to fail.

Closes https://github.com/wellcomecollection/platform/issues/5315