### PR TITLE
Remove notes that contain empty values or just non-breaking spaces

### DIFF
--- a/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/models/CalmRecordOps.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/models/CalmRecordOps.scala
@@ -1,6 +1,7 @@
 package weco.pipeline.transformer.calm.models
 
 import weco.catalogue.source_model.calm.CalmRecord
+import weco.pipeline.transformer.text.TextNormalisation._
 
 trait CalmRecordOps {
 
@@ -11,6 +12,7 @@ trait CalmRecordOps {
     def getList(key: String): List[String] =
       record.data
         .getOrElse(key, Nil)
+        .filterNot(_.isWhitespace)
         .map(_.trim)
         .filter(_.nonEmpty)
         .map(fixEncoding)

--- a/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/models/CalmRecordOpsTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/models/CalmRecordOpsTest.scala
@@ -1,0 +1,15 @@
+package weco.pipeline.transformer.calm.models
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import weco.catalogue.source_model.generators.CalmRecordGenerators
+
+class CalmRecordOpsTest extends AnyFunSpec with Matchers with CalmRecordGenerators with CalmRecordOps {
+  it("ignores non-breaking spaces") {
+    val record = createCalmRecordWith(
+      ("LocationOfDuplicates", "\u00a0")
+    )
+
+    record.getList("LocationOfDuplicates") shouldBe empty
+  }
+}

--- a/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/models/CalmRecordOpsTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/models/CalmRecordOpsTest.scala
@@ -4,7 +4,11 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.catalogue.source_model.generators.CalmRecordGenerators
 
-class CalmRecordOpsTest extends AnyFunSpec with Matchers with CalmRecordGenerators with CalmRecordOps {
+class CalmRecordOpsTest
+    extends AnyFunSpec
+    with Matchers
+    with CalmRecordGenerators
+    with CalmRecordOps {
   it("ignores non-breaking spaces") {
     val record = createCalmRecordWith(
       ("LocationOfDuplicates", "\u00a0")

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/text/TextNormalisation.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/text/TextNormalisation.scala
@@ -16,6 +16,14 @@ object TextNormalisation {
       s.replaceAll("""([^\.])\.\s*$""", "$1")
         .replaceAll("""\s*$""", "")
 
+    /** Is this string just whitespace?
+      *
+      * Note that this includes non-breaking spaces as whitespace, which aren't
+      * removed by .trim().
+      */
+    def isWhitespace: Boolean =
+      s.replace('\u00a0', ' ').trim.isEmpty
+
     def sentenceCase: String =
       s.capitalize
   }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraNotes.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraNotes.scala
@@ -1,6 +1,7 @@
 package weco.pipeline.transformer.sierra.transformers
 
 import weco.catalogue.internal_model.work._
+import weco.pipeline.transformer.text.TextNormalisation._
 import weco.sierra.models.SierraQueryOps
 import weco.sierra.models.data.SierraBibData
 import weco.sierra.models.marc.VarField
@@ -62,14 +63,7 @@ object SierraNotes extends SierraDataTransformer with SierraQueryOps {
       .collect {
         case Some((vf, Some(createNote))) => createNote(vf)
       }
-      .filterNot {
-        // There are notes fields where the contents is an empty string, or
-        // a whitespace value like a non-breaking space (\u00a0).
-        //
-        // Ideally we'd remove these values from the source data, but it's much
-        // quicker and easier to filter them here.
-        _.contents.trim.isEmpty
-      }
+      .filterNot { _.contents.isWhitespace }
 
   private def createNoteFromContents(
     noteType: NoteType,

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraNotes.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraNotes.scala
@@ -62,6 +62,14 @@ object SierraNotes extends SierraDataTransformer with SierraQueryOps {
       .collect {
         case Some((vf, Some(createNote))) => createNote(vf)
       }
+      .filterNot {
+        // There are notes fields where the contents is an empty string, or
+        // a whitespace value like a non-breaking space (\u00a0).
+        //
+        // Ideally we'd remove these values from the source data, but it's much
+        // quicker and easier to filter them here.
+        _.contents.trim.isEmpty
+      }
 
   private def createNoteFromContents(
     noteType: NoteType,

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraNotesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraNotesTest.scala
@@ -270,6 +270,22 @@ class SierraNotesTest
     )
   }
 
+  it("skips notes which are just whitespace") {
+    val varFields =
+      List("\u00a0", "", "\t\n").map { content =>
+        VarField(
+          marcTag = "535",
+          subfields = List(
+            Subfield(tag = "a", content = content),
+          )
+        )
+      }
+
+    val bibData = createSierraBibDataWith(varFields = varFields)
+
+    SierraNotes(bibData) shouldBe empty
+  }
+
   def bibData(contents: List[(String, Note)]): SierraBibData =
     bibData(contents.map { case (tag, note) => (tag, note.contents) }: _*)
 


### PR DESCRIPTION
e.g. https://wellcomecollection.org/works/ht7963q2

If there's a non-breaking space (`\u00a0`) in the source field, we don't remove it and end up putting it in the Work. This is clearly silly and we should remove it; the problem is that Scala's `String.trim` method doesn't think that's a whitespace character, so it wasn't being caught by our previous-attempts to remove all-whitespace values.

Spotted while working on https://github.com/wellcomecollection/platform/issues/5318 and https://github.com/wellcomecollection/platform/issues/5282