### PR TITLE
Copy languages onto inner works in the TEI transformer

### DIFF
--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiData.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiData.scala
@@ -32,7 +32,7 @@ case class TeiData(id: String,
   def toWork(time: Instant, version: Int): Work[Source] = {
     val topLevelData = toWorkData
 
-    val internalDataStubs: Result[List[InternalWork.Source]] =
+    val internalWorks: Result[List[InternalWork.Source]] =
       nestedTeiData.map { teiDatas =>
         teiDatas.map { data =>
           InternalWork.Source(
@@ -46,7 +46,7 @@ case class TeiData(id: String,
     // and don't send any inner Works.
     //
     // TODO: check logic for copying languages from wrapping works to inner works
-    val (workData, internalWorkStubs) = internalDataStubs match {
+    val (workData, internalWorkStubs) = internalWorks match {
       case Right(List(InternalWork.Source(_, singleItemData))) =>
         (topLevelData.copy(title = singleItemData.title), List())
       case Right(data) => (topLevelData, data)

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiData.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiData.scala
@@ -94,7 +94,8 @@ case class TeiData(id: String,
   }
 
   implicit class InternalWorkOps(internalWorks: List[InternalWork.Source]) {
-    def withLanguage(topLevel: WorkData[Unidentified]): List[InternalWork.Source] =
+    def withLanguage(
+      topLevel: WorkData[Unidentified]): List[InternalWork.Source] =
       // If all the individual items/parts all use the same language,
       // it's specified once at the top level but not on the individual
       // entries.  The individual entries will not have languages.
@@ -103,11 +104,12 @@ case class TeiData(id: String,
       // onto the individual items/parts, so they'll appear on the
       // corresponding Works.
       internalWorks.flatMap(_.workData.languages) match {
-        case Nil => internalWorks.map { w =>
-          w.copy(
-            workData = w.workData.copy(languages = topLevel.languages)
-          )
-        }
+        case Nil =>
+          internalWorks.map { w =>
+            w.copy(
+              workData = w.workData.copy(languages = topLevel.languages)
+            )
+          }
 
         case _ => internalWorks
       }

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiDataTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiDataTest.scala
@@ -205,4 +205,61 @@ class TeiDataTest
       work.data.title shouldBe Some(innerTeiData.title)
     }
   }
+
+  describe("setting the languages") {
+    describe("when the languages are only set on the top-level Work") {
+      // This is based loosely on Tamil_1
+      val languages = List(Language(id = "tam", label = "Tamil"))
+      val teiData = createTeiDataWith(
+        languages = languages,
+        nestedTeiData = Right(List(
+          createTeiDataWith(languages = List()),
+          createTeiDataWith(languages = List()),
+          createTeiDataWith(languages = List()),
+        ))
+      )
+
+      val work = teiData.toWork(time = Instant.now(), version = 1)
+
+      it("keeps the languages on the top-level Work") {
+        work.data.languages shouldBe languages
+      }
+
+      it("copies the languages to the internal Works") {
+        work.state.internalWorkStubs.foreach { _.workData.languages shouldBe languages }
+      }
+    }
+
+    describe("when the languages are only set on the internal Works") {
+      // This is based loosely on MS_Malay_9
+      val malay = Language(id = "mal", label = "Malay")
+      val english = Language(id = "eng", label = "English")
+
+      val innerLanguages = List(
+        List(malay, english),
+        List(malay),
+        List(english)
+      )
+
+      val teiData = createTeiDataWith(
+        languages = List(),
+        nestedTeiData = Right(
+          innerLanguages.map {
+            languages => createTeiDataWith(languages = languages)
+          }
+        )
+      )
+
+      val work = teiData.toWork(time = Instant.now(), version = 1)
+
+      it("preserves the languages on the internal Works") {
+        work.state.internalWorkStubs.map(_.workData.languages) shouldBe innerLanguages
+      }
+
+      // TODO: Would this be a useful thing to do?
+      it("does not copy the union of the languages to the top-level Work") {
+        work.data.languages shouldBe Nil
+      }
+    }
+  }
 }

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiDataTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiDataTest.scala
@@ -212,11 +212,12 @@ class TeiDataTest
       val languages = List(Language(id = "tam", label = "Tamil"))
       val teiData = createTeiDataWith(
         languages = languages,
-        nestedTeiData = Right(List(
-          createTeiDataWith(languages = List()),
-          createTeiDataWith(languages = List()),
-          createTeiDataWith(languages = List()),
-        ))
+        nestedTeiData = Right(
+          List(
+            createTeiDataWith(languages = List()),
+            createTeiDataWith(languages = List()),
+            createTeiDataWith(languages = List()),
+          ))
       )
 
       val work = teiData.toWork(time = Instant.now(), version = 1)
@@ -226,7 +227,9 @@ class TeiDataTest
       }
 
       it("copies the languages to the internal Works") {
-        work.state.internalWorkStubs.foreach { _.workData.languages shouldBe languages }
+        work.state.internalWorkStubs.foreach {
+          _.workData.languages shouldBe languages
+        }
       }
     }
 
@@ -244,8 +247,8 @@ class TeiDataTest
       val teiData = createTeiDataWith(
         languages = List(),
         nestedTeiData = Right(
-          innerLanguages.map {
-            languages => createTeiDataWith(languages = languages)
+          innerLanguages.map { languages =>
+            createTeiDataWith(languages = languages)
           }
         )
       )
@@ -253,7 +256,8 @@ class TeiDataTest
       val work = teiData.toWork(time = Instant.now(), version = 1)
 
       it("preserves the languages on the internal Works") {
-        work.state.internalWorkStubs.map(_.workData.languages) shouldBe innerLanguages
+        work.state.internalWorkStubs
+          .map(_.workData.languages) shouldBe innerLanguages
       }
 
       // TODO: Would this be a useful thing to do?

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/generators/TeiDataGenerators.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/generators/TeiDataGenerators.scala
@@ -1,16 +1,19 @@
 package weco.pipeline.transformer.tei.generators
 
+import weco.catalogue.internal_model.languages.Language
 import weco.fixtures.RandomGenerators
 import weco.pipeline.transformer.result.Result
 import weco.pipeline.transformer.tei.TeiData
 
 trait TeiDataGenerators extends RandomGenerators {
   def createTeiDataWith(
-    id: String,
+    id: String = randomAlphanumeric(),
+    languages: List[Language] = Nil,
     nestedTeiData: Result[List[TeiData]] = Right(Nil)): TeiData =
     TeiData(
       id = id,
       title = s"title-${randomAlphanumeric()}",
+      languages = languages,
       nestedTeiData = nestedTeiData
     )
 }


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/platform/issues/5321

This implements the most basic rule: if there's a language on the top-level entry but none of the nested entries, we copy the languages down.  Otherwise, we do nothing.

e.g.

    A     = {English, German}
      A/1 = {}
      A/2 = {}

In this case, we'd copy {English, German} on to A/1 and A/2.

This patch doesn't implement two more complex rules:

-   If there's a language on the nested entries but not the top-level entry, we don't currently copy the languages to the top-level. e.g.

        A     = {}
          A/1 = {English}
          A/2 = {German}

    In this case, we don't copy {English, German} to A.

    We could do this in a subsequent patch, but I'm not sure it's something we definitely want to do.  We should discuss if we want to do this (and whether it sets a precedent for doing something similar for Calm works).

-   If the structure is more complicated, we don't do anything with the languages.  e.g.

        A
          A/1      = {English}
             A/1/1 = {}
             A/1/2 = {}
             A/1/3 = {}
          A/2      = {German}
             A/2/1 = {}
             A/2/2 = {}

    In this case, we won't copy the languages on to A/1/1,2,3 or A/2/1,2. We could do that, but it's more complicated to implement and I don't know if there are any examples.  Let's do it in a subsequent patch if we think it's worth doing.