### PR TITLE
Create a proper item access message if an Open Shelves item is in use

### DIFF
--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/RulesForRequestingResult.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/RulesForRequestingResult.scala
@@ -17,7 +17,7 @@ object NotRequestable {
 
   case class ContactUs(message: String) extends NotRequestable
 
-  case class OnHold(message: String) extends NotRequestable
+  case class InUseByAnotherReader(message: String) extends NotRequestable
 
   case class OnOpenShelves(message: String) extends NotRequestable
   case class OnExhibition(message: String) extends NotRequestable

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -273,7 +273,7 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           _,
           _,
           _,
-          NotRequestable.OnHold(_),
+          NotRequestable.InUseByAnotherReader(_),
           Some(LocationType.ClosedStores)) =>
         AccessCondition(
           method = AccessMethod.NotRequestable,

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -12,6 +12,10 @@ import weco.catalogue.source_model.sierra.source.{OpacMsg, Status}
 import weco.sierra.models.SierraQueryOps
 import weco.sierra.models.data.SierraItemData
 
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import scala.util.Try
+
 /** There are multiple sources of truth for item information in Sierra, and whether
   * a given item can be requested online.
   *
@@ -282,6 +286,26 @@ object SierraItemAccess extends SierraQueryOps with Logging {
             "Item is in use by another reader. Please ask at Enquiry Desk.")
         )
 
+      // Note that items can borrowed even if they're on the open shelves, but this
+      // isn't something that's available to regular library members, so don't be
+      // specific about why the item is unavailable.
+      case (
+          _,
+          _,
+          _,
+          NotRequestable.InUseByAnotherReader(_),
+          Some(LocationType.OpenShelves)) =>
+        val noteText = itemData.dueDate match {
+          case Some(d) => s"This item is temporarily unavailable. It is due for return on ${d.format(displayFormat)}."
+          case _       => "This item is temporarily unavailable."
+        }
+
+        AccessCondition(
+          method = AccessMethod.OpenShelves,
+          status = Some(AccessStatus.TemporarilyUnavailable),
+          note = Some(noteText)
+        )
+
       // If we can't work out how this item should be handled, then let's mark it
       // as unavailable for now.
       //
@@ -301,12 +325,27 @@ object SierraItemAccess extends SierraQueryOps with Logging {
         )
     }
 
+  // e.g. 1 January 2021
+  private val displayFormat = DateTimeFormatter.ofPattern("d MMMM yyyy")
+
   implicit class ItemDataAccessOps(itemData: SierraItemData) {
     def status: Option[String] =
       itemData.fixedFields.get("88").map { _.value.trim }
 
     def opacmsg: Option[String] =
       itemData.fixedFields.get("108").map { _.value.trim }
+
+    // e.g. 2020-09-01
+    private val dueDateFormat = DateTimeFormatter.ofPattern("yyyy-M-d")
+
+    def dueDate: Option[LocalDate] =
+      itemData.fixedFields.get("65")
+        .map { _.value.trim }
+        .map {
+          // e.g. 2020-09-01T03:00:00Z
+          _.split("T").head
+        }
+        .flatMap { s => Try(LocalDate.parse(s, dueDateFormat)).toOption }
   }
 
   // The display note field has been used for multiple purposes, in particular:

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -296,8 +296,9 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           NotRequestable.InUseByAnotherReader(_),
           Some(LocationType.OpenShelves)) =>
         val noteText = itemData.dueDate match {
-          case Some(d) => s"This item is temporarily unavailable. It is due for return on ${d.format(displayFormat)}."
-          case _       => "This item is temporarily unavailable."
+          case Some(d) =>
+            s"This item is temporarily unavailable. It is due for return on ${d.format(displayFormat)}."
+          case _ => "This item is temporarily unavailable."
         }
 
         AccessCondition(
@@ -339,13 +340,16 @@ object SierraItemAccess extends SierraQueryOps with Logging {
     private val dueDateFormat = DateTimeFormatter.ofPattern("yyyy-M-d")
 
     def dueDate: Option[LocalDate] =
-      itemData.fixedFields.get("65")
+      itemData.fixedFields
+        .get("65")
         .map { _.value.trim }
         .map {
           // e.g. 2020-09-01T03:00:00Z
           _.split("T").head
         }
-        .flatMap { s => Try(LocalDate.parse(s, dueDateFormat)).toOption }
+        .flatMap { s =>
+          Try(LocalDate.parse(s, dueDateFormat)).toOption
+        }
   }
 
   // The display note field has been used for multiple purposes, in particular:

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala
@@ -125,7 +125,7 @@ object SierraRulesForRequesting {
           if i.fixedField("87").getOrElse("0") != "0" || i
             .fixedField("88")
             .contains("!") =>
-        NotRequestable.OnHold(
+        NotRequestable.InUseByAnotherReader(
           "Item is in use by another reader. Please ask at Enquiry Desk.")
 
       // These cases cover the lines:

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -802,6 +802,49 @@ class SierraItemAccessTest
           note = Some("This item is missing.")
         )
     }
+
+    it("is not available if it has a due date") {
+      val itemData = createSierraItemDataWith(
+        fixedFields = Map(
+          "65" -> FixedField(
+            label = "DUE DATE",
+            value = "2020-09-01T03:00:00Z"
+          ),
+          "79" -> FixedField(
+            label = "LOCATION",
+            value = "wgpvm",
+            display = "History of Medicine"
+          ),
+          "87" -> FixedField(
+            label = "LOANRULE",
+            value = "14"
+          ),
+          "88" -> FixedField(
+            label = "STATUS",
+            value = "-",
+            display = "Available"
+          ),
+          "108" -> FixedField(
+            label = "OPACMSG",
+            value = "o",
+            display = "Open shelves"
+          )
+        )
+      )
+
+      val (ac, _) = SierraItemAccess(
+        location = Some(LocationType.OpenShelves),
+        itemData = itemData
+      )
+
+      ac shouldBe AccessCondition(
+        method = AccessMethod.OpenShelves,
+        status = Some(AccessStatus.TemporarilyUnavailable),
+        note = Some(
+          "This item is temporarily unavailable. It is due for return on 1 September 2020."
+        )
+      )
+    }
   }
 
   it("handles the case where we can't map the access data") {

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequestingTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequestingTest.scala
@@ -65,7 +65,7 @@ class SierraRulesForRequestingTest
       fixedFields = Map("87" -> FixedField(label = "LOANRULE", value = "1"))
     )
 
-    SierraRulesForRequesting(item) shouldBe NotRequestable.OnHold(
+    SierraRulesForRequesting(item) shouldBe NotRequestable.InUseByAnotherReader(
       "Item is in use by another reader. Please ask at Enquiry Desk.")
   }
 
@@ -74,7 +74,7 @@ class SierraRulesForRequestingTest
       fixedFields = Map("88" -> FixedField(label = "STATUS", value = "!"))
     )
 
-    SierraRulesForRequesting(item) shouldBe NotRequestable.OnHold(
+    SierraRulesForRequesting(item) shouldBe NotRequestable.InUseByAnotherReader(
       "Item is in use by another reader. Please ask at Enquiry Desk.")
   }
 


### PR DESCRIPTION
This is for an item that Carla spotted – we don't handle OpenShelves items which are in use correctly.