### PR TITLE
Add the implicit Work encoders in the transformers

### DIFF
--- a/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/Main.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/Main.scala
@@ -6,6 +6,7 @@ import com.typesafe.config.Config
 import weco.catalogue.internal_model.index.WorksIndexConfig
 import weco.catalogue.internal_model.work.Work
 import weco.catalogue.internal_model.work.WorkState.Source
+import weco.catalogue.internal_model.Implicits._
 import weco.catalogue.source_model.calm.CalmRecord
 import weco.elasticsearch.typesafe.ElasticBuilder
 import weco.json.JsonUtil._

--- a/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/Main.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/Main.scala
@@ -6,6 +6,7 @@ import com.typesafe.config.Config
 import weco.catalogue.internal_model.index.WorksIndexConfig
 import weco.catalogue.internal_model.work.Work
 import weco.catalogue.internal_model.work.WorkState.Source
+import weco.catalogue.internal_model.Implicits._
 import weco.elasticsearch.typesafe.ElasticBuilder
 import weco.json.JsonUtil._
 import weco.messaging.sns.NotificationMessage

--- a/pipeline/transformer/transformer_miro/src/main/scala/weco/pipeline/transformer/miro/Main.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/weco/pipeline/transformer/miro/Main.scala
@@ -6,6 +6,7 @@ import com.typesafe.config.Config
 import weco.catalogue.internal_model.index.WorksIndexConfig
 import weco.catalogue.internal_model.work.Work
 import weco.catalogue.internal_model.work.WorkState.Source
+import weco.catalogue.internal_model.Implicits._
 import weco.elasticsearch.typesafe.ElasticBuilder
 import weco.json.JsonUtil._
 import weco.messaging.sns.NotificationMessage

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/Main.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/Main.scala
@@ -6,6 +6,7 @@ import com.typesafe.config.Config
 import weco.catalogue.internal_model.index.WorksIndexConfig
 import weco.catalogue.internal_model.work.Work
 import weco.catalogue.internal_model.work.WorkState.Source
+import weco.catalogue.internal_model.Implicits._
 import weco.catalogue.source_model.sierra.SierraTransformable
 import weco.elasticsearch.typesafe.ElasticBuilder
 import weco.json.JsonUtil._

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/Main.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/Main.scala
@@ -6,6 +6,7 @@ import com.typesafe.config.Config
 import weco.catalogue.internal_model.index.WorksIndexConfig
 import weco.catalogue.internal_model.work.Work
 import weco.catalogue.internal_model.work.WorkState.Source
+import weco.catalogue.internal_model.Implicits._
 import weco.elasticsearch.typesafe.ElasticBuilder
 import weco.json.JsonUtil._
 import weco.messaging.sns.NotificationMessage


### PR DESCRIPTION
These are among the slowest apps to build, and they all need a full copy of the Work encoder.  Why are we creating it from scratch, when we could be importing a prebuilt version?

🤞 targeting the slowest bit of the current pipeline build