### PR TITLE
Add the ESTC identifier type to internal model

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/IdentifierType.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/IdentifierType.scala
@@ -126,7 +126,7 @@ object IdentifierType extends Enum[IdentifierType] {
     val label = "Fihrist Authority"
   }
 
-  // http://estc.bl.uk/
+  // http://estc.bl.uk/ / https://www.wikidata.org/wiki/Property:P3939
   case object ESTC extends IdentifierType {
     val id = "bl-estc-citation-no"
     val label = "British Library English Short Title Catalogue"

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/IdentifierType.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/IdentifierType.scala
@@ -125,4 +125,10 @@ object IdentifierType extends Enum[IdentifierType] {
     val id = "fihrist"
     val label = "Fihrist Authority"
   }
+
+  // http://estc.bl.uk/
+  case object ESTC extends IdentifierType {
+    val id = "bl-estc-citation-no"
+    val label = "British Library English Short Title Catalogue"
+  }
 }


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5358

This should be merged before we make any transformer changes, so we can get it into the catalogue API – otherwise the catalogue API will be unable to decode works with ESTC identifiers, and will 500 whenever they appear in search results.