### PR TITLE
Add ESTC identifiers in the Sierra transformer

### DIFF
--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraIdentifiers.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraIdentifiers.scala
@@ -1,6 +1,9 @@
 package weco.pipeline.transformer.sierra.transformers
 
-import weco.catalogue.internal_model.identifiers.{IdentifierType, SourceIdentifier}
+import weco.catalogue.internal_model.identifiers.{
+  IdentifierType,
+  SourceIdentifier
+}
 import weco.sierra.models.SierraQueryOps
 import weco.sierra.models.data.SierraBibData
 import weco.sierra.models.identifiers.SierraBibNumber
@@ -28,7 +31,8 @@ object SierraIdentifiers
     * We use the eight-digit ID with check digit as the sourceIdentifier on the Work.
     *
     */
-  private def createSierraIdentifier(bibId: SierraBibNumber): List[SourceIdentifier] =
+  private def createSierraIdentifier(
+    bibId: SierraBibNumber): List[SourceIdentifier] =
     List(
       SourceIdentifier(
         identifierType = IdentifierType.SierraIdentifier,
@@ -137,9 +141,12 @@ object SierraIdentifiers
     * These are also included in the notes field on a Work; we add them here
     * so they're easily searchable.
     */
-  private def getEstcReferences(bibData: SierraBibData): List[SourceIdentifier] =
+  private def getEstcReferences(
+    bibData: SierraBibData): List[SourceIdentifier] =
     bibData.varFields
-      .filter { vf => vf.marcTag.contains("510") }
+      .filter { vf =>
+        vf.marcTag.contains("510")
+      }
       .map { _.subfields }
       .collect {
         // We only care about the case where there are two subfields,

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraIdentifiersTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraIdentifiersTest.scala
@@ -341,4 +341,81 @@ class SierraIdentifiersTest
       )
     )
   }
+
+  describe("ESTC references in MARC 510 ǂc") {
+    it("extracts a valid ESTC reference") {
+      val bibData = createSierraBibDataWith(
+        varFields = List(
+          VarField(
+            marcTag = "510",
+            subfields = List(
+              Subfield(tag = "a", content = "ESTC"),
+              Subfield(tag = "c", content = "N16242")
+            )
+          )
+        )
+      )
+
+      val otherIdentifiers = SierraIdentifiers(createSierraBibNumber, bibData)
+      otherIdentifiers should contain(
+        SourceIdentifier(
+          identifierType = IdentifierType.ESTC,
+          value = "N16242",
+          ontologyType = "Work"
+        )
+      )
+    }
+
+    it("skips the identifier if ǂa is not 'ESTC'") {
+      val bibData = createSierraBibDataWith(
+        varFields = List(
+          VarField(
+            marcTag = "510",
+            subfields = List(
+              Subfield(tag = "a", content = "notESTC"),
+              Subfield(tag = "c", content = "N16242")
+            )
+          )
+        )
+      )
+
+      val otherIdentifiers = SierraIdentifiers(createSierraBibNumber, bibData)
+      otherIdentifiers.filter { _.identifierType == IdentifierType.ESTC } shouldBe empty
+    }
+
+    it("skips the identifier if ǂc doesn't look like an ESTC reference") {
+      val bibData = createSierraBibDataWith(
+        varFields = List(
+          VarField(
+            marcTag = "510",
+            subfields = List(
+              Subfield(tag = "a", content = "ESTC"),
+              Subfield(tag = "c", content = "cf. Teerink-Scouten 500")
+            )
+          )
+        )
+      )
+
+      val otherIdentifiers = SierraIdentifiers(createSierraBibNumber, bibData)
+      otherIdentifiers.filter { _.identifierType == IdentifierType.ESTC } shouldBe empty
+    }
+
+    it("skips the identifier if there are multiple values of subfield ǂc") {
+      val bibData = createSierraBibDataWith(
+        varFields = List(
+          VarField(
+            marcTag = "510",
+            subfields = List(
+              Subfield(tag = "a", content = "ESTC"),
+              Subfield(tag = "c", content = "NCBEL,"),
+              Subfield(tag = "c", content = "II:1306")
+            )
+          )
+        )
+      )
+
+      val otherIdentifiers = SierraIdentifiers(createSierraBibNumber, bibData)
+      otherIdentifiers.filter { _.identifierType == IdentifierType.ESTC } shouldBe empty
+    }
+  }
 }


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5358

I haven't looked to see if any of these identifiers are used in Sierra works that get merged with Calm (and so might need handling in the merger) – I'll wait until this is deployed before I add that.