### PR TITLE
Map reference numbers

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksIndexConfig.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksIndexConfig.scala
@@ -133,7 +133,8 @@ object WorksIndexConfig extends IndexConfigFields {
           objectField("imageData").fields(
             objectField("id").fields(canonicalId, sourceIdentifier)
           ),
-          keywordField("workType")
+          keywordField("workType"),
+          keywordField("referenceNumber")
         )
 
       // We copy the collectionPath label and the tokenized fields into the

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksIndexConfig.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksIndexConfig.scala
@@ -193,6 +193,7 @@ object WorksIndexConfig extends IndexConfigFields {
         )
 
       val search = objectField("search").fields(
+        keywordField("identifiers"),
         textField("relations").analyzer("with_slashes_text_analyzer"),
         multilingualField("titlesAndContributors")
       )

--- a/common/internal_model/src/test/resources/WorksIndexConfig.json
+++ b/common/internal_model/src/test/resources/WorksIndexConfig.json
@@ -320,6 +320,9 @@
       "search" : {
         "type" : "object",
         "properties" : {
+          "identifiers" : {
+            "type" : "keyword"
+          },
           "relations" : {
             "type" : "text",
             "analyzer" : "with_slashes_text_analyzer"

--- a/common/internal_model/src/test/resources/WorksIndexConfig.json
+++ b/common/internal_model/src/test/resources/WorksIndexConfig.json
@@ -369,6 +369,9 @@
       "data" : {
         "type" : "object",
         "properties" : {
+          "referenceNumber": {
+            "type" : "keyword"
+          },
           "otherIdentifiers" : {
             "type" : "object",
             "properties" : {

--- a/common/internal_model/src/test/resources/WorksIndexConfig.json
+++ b/common/internal_model/src/test/resources/WorksIndexConfig.json
@@ -172,14 +172,20 @@
         "properties" : {
           "canonicalId" : {
             "type" : "keyword",
-            "normalizer" : "lowercase_normalizer"
+            "normalizer" : "lowercase_normalizer",
+            "copy_to" : [
+              "search.identifiers"
+            ]
           },
           "sourceIdentifier" : {
             "type" : "object",
             "properties" : {
               "value" : {
                 "type" : "keyword",
-                "normalizer" : "lowercase_normalizer"
+                "normalizer" : "lowercase_normalizer",
+                "copy_to" : [
+                  "search.identifiers"
+                ]
               }
             },
             "dynamic" : "false"
@@ -372,15 +378,21 @@
       "data" : {
         "type" : "object",
         "properties" : {
-          "referenceNumber": {
-            "type" : "keyword"
+          "referenceNumber" : {
+            "type" : "keyword",
+            "copy_to" : [
+              "search.identifiers"
+            ]
           },
           "otherIdentifiers" : {
             "type" : "object",
             "properties" : {
               "value" : {
                 "type" : "keyword",
-                "normalizer" : "lowercase_normalizer"
+                "normalizer" : "lowercase_normalizer",
+                "copy_to" : [
+                  "search.identifiers"
+                ]
               }
             }
           },
@@ -490,7 +502,7 @@
                 "analyzer" : "english"
               }
             },
-            "copy_to": [
+            "copy_to" : [
               "search.relations"
             ]
           },
@@ -686,14 +698,20 @@
                 "properties" : {
                   "canonicalId" : {
                     "type" : "keyword",
-                    "normalizer" : "lowercase_normalizer"
+                    "normalizer" : "lowercase_normalizer",
+                    "copy_to" : [
+                      "search.identifiers"
+                    ]
                   },
                   "sourceIdentifier" : {
                     "type" : "object",
                     "properties" : {
                       "value" : {
                         "type" : "keyword",
-                        "normalizer" : "lowercase_normalizer"
+                        "normalizer" : "lowercase_normalizer",
+                        "copy_to" : [
+                          "search.identifiers"
+                        ]
                       }
                     },
                     "dynamic" : "false"
@@ -703,7 +721,10 @@
                     "properties" : {
                       "value" : {
                         "type" : "keyword",
-                        "normalizer" : "lowercase_normalizer"
+                        "normalizer" : "lowercase_normalizer",
+                        "copy_to" : [
+                          "search.identifiers"
+                        ]
                       }
                     }
                   }
@@ -896,14 +917,20 @@
                 "properties" : {
                   "canonicalId" : {
                     "type" : "keyword",
-                    "normalizer" : "lowercase_normalizer"
+                    "normalizer" : "lowercase_normalizer",
+                    "copy_to" : [
+                      "search.identifiers"
+                    ]
                   },
                   "sourceIdentifier" : {
                     "type" : "object",
                     "properties" : {
                       "value" : {
                         "type" : "keyword",
-                        "normalizer" : "lowercase_normalizer"
+                        "normalizer" : "lowercase_normalizer",
+                        "copy_to" : [
+                          "search.identifiers"
+                        ]
                       }
                     },
                     "dynamic" : "false"


### PR DESCRIPTION
- This is part of https://github.com/wellcomecollection/platform/issues/5333, but won't close it until the query has also been updated

This PR: 
- adds `data.referenceNumber` to the mapping
- adds a new `search.identifiers` field, and copies relevant identifiers into it, ready for querying

Adding the `search.identifiers` will allow us to simplify [the section of our query which matches identifiers](https://github.com/wellcomecollection/catalogue-api/blob/main/search/src/main/scala/weco/api/search/elasticsearch/WorksMultiMatcher.scala#L36-L56), rather than extending it even further

