### PR TITLE
Handle explicit/implicit notes without a <locus>

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Note.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Note.scala
@@ -62,7 +62,7 @@ case object NoteType {
     NoteType(id = "colophon", label = "Colophon note")
 
   val BeginsNote: NoteType = NoteType(id = "begins-note", label = "Begins")
-  val endsNote: NoteType = NoteType(id = "ends-note", label = "Ends")
+  val EndsNote: NoteType = NoteType(id = "ends-note", label = "Ends")
 }
 
 case object Note {

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/NormaliseText.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/NormaliseText.scala
@@ -2,7 +2,7 @@ package weco.pipeline.transformer.tei
 
 object NormaliseText {
   def apply(s: String): Option[String] = {
-    val result = s.collapseNewlines.trim
+    val result = s.collapseNewlines.collapseRepeatedSpaces.trim
 
     if (result.nonEmpty) Some(result) else None
   }
@@ -22,5 +22,18 @@ object NormaliseText {
       s.split("\n")
         .map(_.trim)
         .mkString(" ")
+
+    // Sometimes an XML value in a tag creates weird spacing, e.g.
+    //
+    //      This corresponds to <ref> Lepsius </ref> 17, line 11
+    //
+    // When you call .text on this element, you get a double space around "Lepsius".
+    // We want to collapse that into a single space.
+    //
+    // Note the use of a literal space character rather than the regex whitespace group \s
+    // is deliberate here -- we don't want to collapse consecutive whitespace if they're,
+    // say, two newlines.
+    def collapseRepeatedSpaces: String =
+      s.replaceAll("[ ]{2,}", " ")
   }
 }

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiNotes.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiNotes.scala
@@ -67,7 +67,12 @@ object TeiNotes {
         // The <locus> tag in an incipit/explicit tells us where this extract comes from;
         // so this is clear in the display prefix it with a colon.
         val locus = (n \ "locus").text
-        val contents = n.text.replaceAll(s"$locus\\s*", s"$locus: ")
+
+        val contents = if (locus.isEmpty) {
+          n.text
+        } else {
+          n.text.replaceAll(s"$locus\\s*", s"$locus: ")
+        }
 
         (n.label, NormaliseText(contents))
       }

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiNotes.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiNotes.scala
@@ -75,6 +75,6 @@ object TeiNotes {
         case ("incipit", Some(contents)) =>
           Note(contents = contents, noteType = NoteType.BeginsNote)
         case ("explicit", Some(contents)) =>
-          Note(contents = contents, noteType = NoteType.endsNote)
+          Note(contents = contents, noteType = NoteType.EndsNote)
       }
 }

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiTransformerTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiTransformerTest.scala
@@ -110,7 +110,7 @@ class TeiTransformerTest
                   Note(
                     contents =
                       "Fol. 528a.12: فصل فى انتفاخ الاظفار والحكة فيها تعالج بما البحر غلسا دايما فيزول به وبطبيخ العدس والكرسنه او بطبيخ الخنثى ومن اضمدته البنبوس والزفت والتين الاصفر المطبوخ مجموعة وفرادى",
-                    noteType = NoteType.endsNote
+                    noteType = NoteType.EndsNote
                   ),
                 ),
                 collectionPath =

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/transformers/TeiNestedDataTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/transformers/TeiNestedDataTest.scala
@@ -396,7 +396,7 @@ class TeiNestedDataTest extends AnyFunSpec with TeiGenerators with Matchers with
     result.value.map { data => data.notes } shouldBe List(
       List(
         Note(contents = "F. 1v: oṃ namaḥ japāpuṣyena saṃkāśaṃ kāśyapeyaṃ mahādyutiṃ tam ahaṃ sarvapāpaghnaṃ praṇato smi divākaraṃ sūryāya namaḥ", noteType = NoteType.BeginsNote),
-        Note(contents = "F. 3r: ||12|| navagrahastotraṃ saṃpūraṇaṃ", noteType = NoteType.endsNote),
+        Note(contents = "F. 3r: ||12|| navagrahastotraṃ saṃpūraṇaṃ", noteType = NoteType.EndsNote),
       ),
     )
   }

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/transformers/TeiNotesTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/transformers/TeiNotesTest.scala
@@ -116,7 +116,7 @@ class TeiNotesTest extends AnyFunSpec with Matchers {
         ),
         Note(
           contents = "F. 3r: ||12|| navagrahastotraṃ saṃpūraṇaṃ",
-          noteType = NoteType.endsNote),
+          noteType = NoteType.EndsNote),
       )
     }
   }

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/transformers/TeiNotesTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/transformers/TeiNotesTest.scala
@@ -119,5 +119,33 @@ class TeiNotesTest extends AnyFunSpec with Matchers {
           noteType = NoteType.EndsNote),
       )
     }
+
+    it("handles an explicit note without a <locus>") {
+      // e.g. Egyptian/Egyptian_MS_4.xml
+      val xml: Elem =
+        <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="Wellcome_Alpha_932">
+          <teiHeader xml:lang="eng">
+            <fileDesc>
+              <sourceDesc>
+                <msDesc>
+                  <msContents>
+                    <explicit> ink Mnw m prt. f
+                      <note> the last legible line is the 10th line from the top and the penulitmate line of the column. This corresponds to <ref> Lepsius</ref> 17, line 11 </note>
+                    </explicit>
+                  </msContents>
+                </msDesc>
+              </sourceDesc>
+            </fileDesc>
+          </teiHeader>
+        </TEI>
+
+      TeiNotes(xml) shouldBe List(
+        Note(
+          contents =
+            "ink Mnw m prt. f the last legible line is the 10th line from the top and the penulitmate line of the column. This corresponds to Lepsius 17, line 11",
+          noteType = NoteType.EndsNote
+        ),
+      )
+    }
   }
 }


### PR DESCRIPTION
For https://wellcomecollection.org/works/zn895yfc

I suspect this will also fix all the begins/ends notes which are `: :` and similar – the bad find/replace was inserting colons, so the final strings were non-empty and not being removed.