### PR TITLE
Add the referenceNumber to top-level TEI works

### DIFF
--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiData.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiData.scala
@@ -119,8 +119,7 @@ case class TeiData(id: String,
   }
   private def toWorkData(
     parentCollectionPath: Option[CollectionPath] = None,
-    referenceNumber: Option[ReferenceNumber] = None)
-    : WorkData[Unidentified] =
+    referenceNumber: Option[ReferenceNumber] = None): WorkData[Unidentified] =
     WorkData[Unidentified](
       title = Some(title),
       description = description,
@@ -148,9 +147,10 @@ case class TeiData(id: String,
       collectionPath = parentCollectionPath match {
         case Some(CollectionPath(parentPath, _)) =>
           Some(CollectionPath(path = s"$parentPath/$id", label = None))
-        case None => Some(
-          CollectionPath(path = id, label = referenceNumber.map(_.underlying))
-        )
+        case None =>
+          Some(
+            CollectionPath(path = id, label = referenceNumber.map(_.underlying))
+          )
       }
     )
 }

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiData.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiData.scala
@@ -147,12 +147,9 @@ case class TeiData(id: String,
       //
       collectionPath = parentCollectionPath match {
         case Some(CollectionPath(parentPath, _)) =>
-          Some(CollectionPath(path = s"$parentPath/$id"))
+          Some(CollectionPath(path = s"$parentPath/$id", label = None))
         case None => Some(
-          CollectionPath(
-            path = id,
-            label = referenceNumber.map(_.underlying)
-          )
+          CollectionPath(path = id, label = referenceNumber.map(_.underlying))
         )
       }
     )

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiXml.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiXml.scala
@@ -31,13 +31,13 @@ class TeiXml(val xml: Elem) extends Logging {
       scribes <- scribesMap
       nestedData <- TeiNestedData.nestedTeiData(xml, title, scribes)
       origin <- origin
-      referenceNumber = TeiReferenceNumber(xml)
+      referenceNumber <- TeiReferenceNumber(xml)
     } yield
       TeiData(
         id = id,
         title = title,
         bNumber = bNumber,
-        referenceNumber = referenceNumber,
+        referenceNumber = Some(referenceNumber),
         description = summary,
         languages = languages,
         notes = languageNotes,
@@ -84,26 +84,14 @@ class TeiXml(val xml: Elem) extends Logging {
 
   private def summary: Result[Option[String]] = TeiOps.summary(xml \\ "msDesc")
 
-  /**
-    * In an XML like this:
-    * <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_15651">
-    *  <teiHeader>
-    *    <fileDesc>
-    *      <publicationStmt>
-    *        <idno type="msID">Well. Jav. 4</idno>
-    *       </publicationStmt>
-    * Extract "Well. Jav. 4" as the title
+  /** For now, we use the reference number as the title.  We don't use
+    * the <title> node because:
+    *
+    *    - On Arabic manuscripts, the <title> is just "Wellcome Library"
+    *    - On other manuscripts, it's the reference number repeated
     */
-  private def title: Result[String] = {
-    val nodes =
-      (xml \ "teiHeader" \ "fileDesc" \ "publicationStmt" \ "idno").toList
-    val maybeTitles = nodes.filter(n => (n \@ "type") == "msID")
-    maybeTitles match {
-      case List(titleNode) => Right(titleNode.text)
-      case Nil             => Left(new RuntimeException("No title found!"))
-      case _               => Left(new RuntimeException("More than one title node!"))
-    }
-  }
+  private def title: Result[String] =
+    TeiReferenceNumber(xml).map(_.underlying)
 
   /**
     * The origin tag contains information about where and when

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiXml.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiXml.scala
@@ -8,7 +8,8 @@ import weco.pipeline.transformer.tei.transformers.{
   TeiContributors,
   TeiLanguages,
   TeiNestedData,
-  TeiPhysicalDescription
+  TeiPhysicalDescription,
+  TeiReferenceNumber
 }
 import weco.pipeline.transformer.transformers.ParsedPeriod
 
@@ -30,11 +31,13 @@ class TeiXml(val xml: Elem) extends Logging {
       scribes <- scribesMap
       nestedData <- TeiNestedData.nestedTeiData(xml, title, scribes)
       origin <- origin
+      referenceNumber = TeiReferenceNumber(xml)
     } yield
       TeiData(
         id = id,
         title = title,
         bNumber = bNumber,
+        referenceNumber = referenceNumber,
         description = summary,
         languages = languages,
         notes = languageNotes,

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiReferenceNumber.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiReferenceNumber.scala
@@ -31,8 +31,10 @@ object TeiReferenceNumber extends Logging {
     ids match {
       case Seq(refNo) => Right(ReferenceNumber(refNo))
       case Nil        => Left(new RuntimeException("No <idno type='msID'> found!"))
-      case other      =>
-        Left(new RuntimeException(s"Multiple instances of <idno type='msID'> found! $other"))
+      case other =>
+        Left(
+          new RuntimeException(
+            s"Multiple instances of <idno type='msID'> found! $other"))
     }
   }
 }

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiReferenceNumber.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiReferenceNumber.scala
@@ -2,14 +2,13 @@ package weco.pipeline.transformer.tei.transformers
 
 import grizzled.slf4j.Logging
 import weco.catalogue.internal_model.identifiers.ReferenceNumber
+import weco.pipeline.transformer.result.Result
 
 import scala.xml.Elem
 
 object TeiReferenceNumber extends Logging {
 
-  /** The reference number is in an <idno type="msID"> block, if present.
-    *
-    * e.g.
+  /** The reference number is in an <idno type="msID"> block, e.g.
     *
     * <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_16046">
     *   <teiHeader>
@@ -23,18 +22,17 @@ object TeiReferenceNumber extends Logging {
     * Note: at time of writing (16 November 2021), it was sufficient to look
     * for the <idno> node without considering the surrounding context.
     */
-  def apply(xml: Elem): Option[ReferenceNumber] = {
+  def apply(xml: Elem): Result[ReferenceNumber] = {
     val ids =
       (xml \\ "idno")
         .map(n => (n \@ "type", n.text))
         .collect { case ("msID", contents) => contents.trim }
 
     ids match {
-      case Seq(refNo) => Some(ReferenceNumber(refNo))
-      case Nil        => None
-      case _          =>
-        warn(s"Could not find unambiguous reference number in $ids")
-        None
+      case Seq(refNo) => Right(ReferenceNumber(refNo))
+      case Nil        => Left(new RuntimeException("No <idno type='msID'> found!"))
+      case other      =>
+        Left(new RuntimeException(s"Multiple instances of <idno type='msID'> found! $other"))
     }
   }
 }

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiReferenceNumber.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiReferenceNumber.scala
@@ -1,0 +1,40 @@
+package weco.pipeline.transformer.tei.transformers
+
+import grizzled.slf4j.Logging
+import weco.catalogue.internal_model.identifiers.ReferenceNumber
+
+import scala.xml.Elem
+
+object TeiReferenceNumber extends Logging {
+
+  /** The reference number is in an <idno type="msID"> block, if present.
+    *
+    * e.g.
+    *
+    * <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_16046">
+    *   <teiHeader>
+    *     <fileDesc>
+    *       <publicationStmt>
+    *         <idno>UkLW</idno>
+    *         <idno type="msID">WMS_Arabic_404</idno>
+    *         <idno type="catalogue">Fihrist</idno>
+    *       </publicationStmt>
+    *
+    * Note: at time of writing (16 November 2021), it was sufficient to look
+    * for the <idno> node without considering the surrounding context.
+    */
+  def apply(xml: Elem): Option[ReferenceNumber] = {
+    val ids =
+      (xml \\ "idno")
+        .map(n => (n \@ "type", n.text))
+        .collect { case ("msID", contents) => contents.trim }
+
+    ids match {
+      case Seq(refNo) => Some(ReferenceNumber(refNo))
+      case Nil        => None
+      case _          =>
+        warn(s"Could not find unambiguous reference number in $ids")
+        None
+    }
+  }
+}

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiTransformerTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiTransformerTest.scala
@@ -68,14 +68,12 @@ class TeiTransformerTest
           description =
             Some("1 copy of al-Qānūn fī al-ṭibb by Avicenna, 980-1037"),
           format = Some(Format.ArchivesAndManuscripts),
-          collectionPath =
-            Some(
-              CollectionPath(
-                path = "manuscript_15651",
-                label = Some("MS_Arabic_1")
-              )
+          collectionPath = Some(
+            CollectionPath(
+              path = "manuscript_15651",
+              label = Some("MS_Arabic_1")
             )
-          ,
+          ),
           physicalDescription = Some(
             "Oriental paper of two colours: 'beige' and 'biscuit' and thickness of 0.10 mm.; Material: chart; 529 ff.; leaf dimensions: width 215mm, height 336mm; written dimensions: width 125mm, height 220mm")
         ),
@@ -119,8 +117,8 @@ class TeiTransformerTest
                     noteType = NoteType.EndsNote
                   ),
                 ),
-                collectionPath =
-                  Some(CollectionPath(path = "manuscript_15651/MS_Arabic_1-item1")),
+                collectionPath = Some(
+                  CollectionPath(path = "manuscript_15651/MS_Arabic_1-item1")),
                 format = Some(Format.ArchivesAndManuscripts),
                 contributors = contributors
               )

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiTransformerTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiTransformerTest.scala
@@ -69,7 +69,13 @@ class TeiTransformerTest
             Some("1 copy of al-Qānūn fī al-ṭibb by Avicenna, 980-1037"),
           format = Some(Format.ArchivesAndManuscripts),
           collectionPath =
-            Some(CollectionPath(path = "manuscript_15651", label = None)),
+            Some(
+              CollectionPath(
+                path = "manuscript_15651",
+                label = Some("MS_Arabic_1")
+              )
+            )
+          ,
           physicalDescription = Some(
             "Oriental paper of two colours: 'beige' and 'biscuit' and thickness of 0.10 mm.; Material: chart; 529 ff.; leaf dimensions: width 215mm, height 336mm; written dimensions: width 125mm, height 220mm")
         ),
@@ -114,7 +120,7 @@ class TeiTransformerTest
                   ),
                 ),
                 collectionPath =
-                  Some(CollectionPath("manuscript_15651/MS_Arabic_1-item1")),
+                  Some(CollectionPath(path = "manuscript_15651/MS_Arabic_1-item1")),
                 format = Some(Format.ArchivesAndManuscripts),
                 contributors = contributors
               )

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/transformers/TeiReferenceNumberTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/transformers/TeiReferenceNumberTest.scala
@@ -1,17 +1,18 @@
 package weco.pipeline.transformer.tei.transformers
 
+import org.scalatest.EitherValues
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.catalogue.internal_model.identifiers.ReferenceNumber
 
-class TeiReferenceNumberTest extends AnyFunSpec with Matchers {
-  it("returns None if it can't find a reference number") {
-    val refNo = TeiReferenceNumber(
+class TeiReferenceNumberTest extends AnyFunSpec with Matchers with EitherValues {
+  it("returns a Left[error] if it can't find a reference number") {
+    val err = TeiReferenceNumber(
       <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_16046">
       </TEI>
     )
 
-    refNo shouldBe None
+    err.left.value.getMessage shouldBe "No <idno type='msID'> found!"
   }
 
   it("finds a single reference number") {
@@ -29,7 +30,7 @@ class TeiReferenceNumberTest extends AnyFunSpec with Matchers {
       </TEI>
     )
 
-    refNo shouldBe Some(ReferenceNumber("WMS_Arabic_404"))
+    refNo.value shouldBe ReferenceNumber("WMS_Arabic_404")
   }
 
   it("removes whitespace from the reference numbers") {
@@ -45,10 +46,10 @@ class TeiReferenceNumberTest extends AnyFunSpec with Matchers {
       </TEI>
     )
 
-    refNo shouldBe Some(ReferenceNumber("WMS_Arabic_405"))
+    refNo.value shouldBe ReferenceNumber("WMS_Arabic_405")
   }
 
-  it("returns None if the reference number is ambiguous") {
+  it("fails if the reference number is ambiguous") {
     val refNo = TeiReferenceNumber(
       <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_16200">
         <teiHeader>
@@ -62,6 +63,6 @@ class TeiReferenceNumberTest extends AnyFunSpec with Matchers {
       </TEI>
     )
 
-    refNo shouldBe None
+    refNo.left.value.getMessage should startWith("Multiple instances of <idno type='msID'> found!")
   }
 }

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/transformers/TeiReferenceNumberTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/transformers/TeiReferenceNumberTest.scala
@@ -1,0 +1,67 @@
+package weco.pipeline.transformer.tei.transformers
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import weco.catalogue.internal_model.identifiers.ReferenceNumber
+
+class TeiReferenceNumberTest extends AnyFunSpec with Matchers {
+  it("returns None if it can't find a reference number") {
+    val refNo = TeiReferenceNumber(
+      <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_16046">
+      </TEI>
+    )
+
+    refNo shouldBe None
+  }
+
+  it("finds a single reference number") {
+    val refNo = TeiReferenceNumber(
+      <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_16046">
+        <teiHeader>
+          <fileDesc>
+            <publicationStmt>
+              <idno>UkLW</idno>
+              <idno type="msID">WMS_Arabic_404</idno>
+              <idno type="catalogue">Fihrist</idno>
+            </publicationStmt>
+          </fileDesc>
+        </teiHeader>
+      </TEI>
+    )
+
+    refNo shouldBe Some(ReferenceNumber("WMS_Arabic_404"))
+  }
+
+  it("removes whitespace from the reference numbers") {
+    val refNo = TeiReferenceNumber(
+      <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_16047">
+        <teiHeader>
+          <fileDesc>
+            <publicationStmt>
+              <idno type="msID">WMS_Arabic_405 </idno>
+            </publicationStmt>
+          </fileDesc>
+        </teiHeader>
+      </TEI>
+    )
+
+    refNo shouldBe Some(ReferenceNumber("WMS_Arabic_405"))
+  }
+
+  it("returns None if the reference number is ambiguous") {
+    val refNo = TeiReferenceNumber(
+      <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_16200">
+        <teiHeader>
+          <fileDesc>
+            <publicationStmt>
+              <idno type="msID">WMS_Arabic_200</idno>
+              <idno type="msID">WMS_Arabic_201</idno>
+            </publicationStmt>
+          </fileDesc>
+        </teiHeader>
+      </TEI>
+    )
+
+    refNo shouldBe None
+  }
+}

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/transformers/TeiReferenceNumberTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/transformers/TeiReferenceNumberTest.scala
@@ -5,7 +5,10 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.catalogue.internal_model.identifiers.ReferenceNumber
 
-class TeiReferenceNumberTest extends AnyFunSpec with Matchers with EitherValues {
+class TeiReferenceNumberTest
+    extends AnyFunSpec
+    with Matchers
+    with EitherValues {
   it("returns a Left[error] if it can't find a reference number") {
     val err = TeiReferenceNumber(
       <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="manuscript_16046">
@@ -63,6 +66,7 @@ class TeiReferenceNumberTest extends AnyFunSpec with Matchers with EitherValues 
       </TEI>
     )
 
-    refNo.left.value.getMessage should startWith("Multiple instances of <idno type='msID'> found!")
+    refNo.left.value.getMessage should startWith(
+      "Multiple instances of <idno type='msID'> found!")
   }
 }


### PR DESCRIPTION
For https://github.com/wellcomecollection/catalogue-pipeline/issues/1970. I ran this over all the TEI files and it identifies a unique reference number in every case (pending the XML fixes in https://github.com/wellcomecollection/wellcome-collection-tei/pull/40).