### PR TITLE
change search.identifiers field from keyword to text

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksIndexConfig.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksIndexConfig.scala
@@ -214,7 +214,7 @@ object WorksIndexConfig extends IndexConfigFields {
         )
 
       val search = objectField("search").fields(
-        keywordField("identifiers"),
+        textField("identifiers").analyzer("whitespace_analyzer"),
         textField("relations").analyzer("with_slashes_text_analyzer"),
         multilingualField("titlesAndContributors")
       )

--- a/common/internal_model/src/test/resources/WorksIndexConfig.json
+++ b/common/internal_model/src/test/resources/WorksIndexConfig.json
@@ -327,7 +327,8 @@
         "type" : "object",
         "properties" : {
           "identifiers" : {
-            "type" : "keyword"
+            "type" : "text",
+            "analyzer" : "whitespace_analyzer"
           },
           "relations" : {
             "type" : "text",


### PR DESCRIPTION
Rank identifier tests are passing with the `search.identifiers` field set to whitespace-analysed `text`, instead of `keyword` ([as predicted in this comment](https://github.com/wellcomecollection/catalogue-pipeline/pull/1964#issuecomment-967101670)).

[Corresponding query change in the catalogue API repo](https://github.com/wellcomecollection/catalogue-api/pull/312)