### PR TITLE
Log bib IDs with their prefix + check digit

### DIFF
--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraDescription.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraDescription.scala
@@ -66,7 +66,7 @@ object SierraDescription
           // best to handle it later.
           case Subfield("u", contents) =>
             warn(
-              s"Bib $bibId has MARC 520 ǂu which doesn't look like a URL: $contents")
+              s"${bibId.withCheckDigit} has MARC 520 ǂu which doesn't look like a URL: $contents")
             contents
 
           case Subfield(_, contents) => contents

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraElectronicResources.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraElectronicResources.scala
@@ -131,16 +131,16 @@ object SierraElectronicResources extends SierraQueryOps with Logging {
 
       case Seq(Subfield(_, content)) =>
         warn(
-          s"Record ${id.withCheckDigit} has a value in 856 ǂu which isn't a URL: $content")
+          s"${id.withCheckDigit} has a value in 856 ǂu which isn't a URL: $content")
         None
 
       case Nil =>
-        warn(s"Record ${id.withCheckDigit} has a field 856 without any URLs")
+        warn(s"${id.withCheckDigit} has a field 856 without any URLs")
         None
 
       case other =>
         warn(
-          s"Record ${id.withCheckDigit} has a field 856 with repeated subfield ǂu")
+          s"${id.withCheckDigit} has a field 856 with repeated subfield ǂu")
         None
     }
 

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraElectronicResources.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraElectronicResources.scala
@@ -139,8 +139,7 @@ object SierraElectronicResources extends SierraQueryOps with Logging {
         None
 
       case other =>
-        warn(
-          s"${id.withCheckDigit} has a field 856 with repeated subfield ǂu")
+        warn(s"${id.withCheckDigit} has a field 856 with repeated subfield ǂu")
         None
     }
 

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraLanguages.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraLanguages.scala
@@ -56,7 +56,7 @@ object SierraLanguages
         .map {
           case (_, Some(lang)) => Some(lang)
           case (code, None) =>
-            warn(s"$bibId: Unrecognised code in MARC 041 ǂa: $code")
+            warn(s"${bibId.withCheckDigit}: Unrecognised code in MARC 041 ǂa: $code")
             None
         }
 
@@ -78,7 +78,7 @@ object SierraLanguages
         None
 
       case _ =>
-        warn(s"$bibId: Unrecognised primary language: $lang")
+        warn(s"${bibId.withCheckDigit}: Unrecognised primary language: $lang")
         None
     }
 }


### PR DESCRIPTION
We always use the full form (e.g. b12345678) when talking to Collections Information, so make sure we log it in that form.

I thought I was going to make a bigger change here in our handling of 856 web linking entries, but all the issues I found are data quality problems in Sierra that I've passed to Collections Information.