### PR TITLE
Support production within msParts

### DIFF
--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiXml.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiXml.scala
@@ -84,8 +84,6 @@ class TeiXml(val xml: Elem) extends Logging {
   private def title: Result[String] =
     TeiReferenceNumber(xml).map(_.underlying)
 
-
-
   private def getId: Result[String] = TeiOps.getIdFrom(xml)
 }
 

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiXml.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiXml.scala
@@ -1,21 +1,11 @@
 package weco.pipeline.transformer.tei
 
 import grizzled.slf4j.Logging
-import weco.catalogue.internal_model.identifiers.IdState.Unminted
-import weco.catalogue.internal_model.work.{Organisation, Place, ProductionEvent}
 import weco.pipeline.transformer.result.Result
-import weco.pipeline.transformer.tei.transformers.{
-  TeiContributors,
-  TeiLanguages,
-  TeiNestedData,
-  TeiPhysicalDescription,
-  TeiReferenceNumber,
-  TeiSubjects
-}
-import weco.pipeline.transformer.transformers.ParsedPeriod
+import weco.pipeline.transformer.tei.transformers._
 
 import scala.util.Try
-import scala.xml.{Elem, NodeSeq, XML}
+import scala.xml.{Elem, XML}
 class TeiXml(val xml: Elem) extends Logging {
   val id: String =
     getId.getOrElse(throw new RuntimeException(s"Could not find an id in XML!"))
@@ -31,7 +21,6 @@ class TeiXml(val xml: Elem) extends Logging {
       (languages, languageNotes) = languageData
       scribes <- scribesMap
       nestedData <- TeiNestedData.nestedTeiData(xml, title, scribes)
-      origin <- origin
       referenceNumber <- TeiReferenceNumber(xml)
     } yield
       TeiData(
@@ -44,7 +33,7 @@ class TeiXml(val xml: Elem) extends Logging {
         notes = languageNotes,
         contributors = scribes.getOrElse(id, Nil),
         nestedTeiData = nestedData,
-        origin = origin,
+        origin = TeiProduction(xml),
         physicalDescription = TeiPhysicalDescription(xml),
         subjects = TeiSubjects(xml)
       )
@@ -95,73 +84,7 @@ class TeiXml(val xml: Elem) extends Logging {
   private def title: Result[String] =
     TeiReferenceNumber(xml).map(_.underlying)
 
-  /**
-    * The origin tag contains information about where and when
-    * the manuscript was written. This is an example:
-    *  <history>
-    *      <origin>
-    *          <origPlace>
-    *              <country><!-- insert --></country>,
-    *              <region><!-- insert --></region>,
-    *              <settlement><!-- insert --></settlement>,
-    *              <orgName><!-- insert --></orgName>
-    *          </origPlace>
-    *          <origDate calendar=""><!-- insert --></origDate>
-    *      </origin>
-    *  </history>
-    *
-    */
-  private def origin: Result[List[ProductionEvent[Unminted]]] = {
-    val origin = xml \\ "history" \ "origin"
-    val origPlace = origin \ "origPlace"
-    val country = (origPlace \ "country").text.trim
-    val region = (origPlace \ "region").text.trim
-    val settlement = (origPlace \ "settlement").text.trim
-    val organisation = (origPlace \ "orgName").text.trim
-    val date = parseDate(origin)
-    val place =
-      List(country, region, settlement).filterNot(_.isEmpty).mkString(", ")
-    val agents =
-      if (organisation.isEmpty) Nil else List(Organisation(organisation))
-    val places = if (place.isEmpty) Nil else List(Place(place))
-    val dates = if (date.isEmpty) Nil else List(ParsedPeriod(date))
-    val label = List(place, date).filterNot(_.isEmpty).mkString(", ")
-    (agents, places, dates) match {
-      case (Nil, Nil, Nil) => Right(Nil)
-      case _ =>
-        Right(
-          List(
-            ProductionEvent(
-              label = label,
-              places = places,
-              agents = agents,
-              dates = dates
-            )))
-    }
 
-  }
-
-  /**
-    * Dates are in a origDate tag and can be in different calendars,
-    * so we need to look for the one in the gregorian calendar.
-    * Also, sometimes the date can contain notes, as in this example, so we need to strip them:
-    * <origDate calendar="Gregorian">ca.1732-63AD
-    *  <note>from watermarks</note>
-    * </origDate>
-    */
-  private def parseDate(origin: NodeSeq) = {
-    val dateNodes = (origin \ "origDate").filter(n =>
-      (n \@ "calendar").toLowerCase == "gregorian")
-    val date =
-      if (dateNodes.exists(_.child.size > 1))
-        dateNodes
-          .flatMap(_.child)
-          .collect { case node if node.label != "note" => node.text }
-          .mkString
-          .trim
-      else dateNodes.text.trim
-    date
-  }
 
   private def getId: Result[String] = TeiOps.getIdFrom(xml)
 }

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiNestedData.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiNestedData.scala
@@ -80,6 +80,7 @@ object TeiNestedData extends Logging {
               description = description,
               nestedTeiData = items,
               contributors = scribesMap.getOrElse(id, Nil),
+              origin = TeiProduction(node \ "history" \ "origin"),
               physicalDescription = TeiPhysicalDescription(node)
             )
           }

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiProduction.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiProduction.scala
@@ -1,0 +1,81 @@
+package weco.pipeline.transformer.tei.transformers
+
+import weco.catalogue.internal_model.identifiers.IdState.Unminted
+import weco.catalogue.internal_model.work.{Organisation, Place, ProductionEvent}
+import weco.pipeline.transformer.transformers.ParsedPeriod
+
+import scala.xml.{Elem, NodeSeq}
+
+object TeiProduction {
+  def apply(xml: Elem): List[ProductionEvent[Unminted]] = apply(xml \\ "msDesc" \ "history" \ "origin")
+
+  def apply(node: NodeSeq): List[ProductionEvent[Unminted]] =
+    origin(node)
+
+  /**
+   * The origin tag contains information about where and when
+   * the manuscript was written. This is an example:
+   *  <history>
+   *      <origin>
+   *          <origPlace>
+   *              <country><!-- insert --></country>,
+   *              <region><!-- insert --></region>,
+   *              <settlement><!-- insert --></settlement>,
+   *              <orgName><!-- insert --></orgName>
+   *          </origPlace>
+   *          <origDate calendar=""><!-- insert --></origDate>
+   *      </origin>
+   *  </history>
+   *
+   */
+  private def origin(origin: NodeSeq): List[ProductionEvent[Unminted]] = {
+    val origPlace = origin \ "origPlace"
+    val country = (origPlace \ "country").text.trim
+    val region = (origPlace \ "region").text.trim
+    val settlement = (origPlace \ "settlement").text.trim
+    val organisation = (origPlace \ "orgName").text.trim
+    val date = parseDate(origin)
+    val place =
+      List(country, region, settlement).filterNot(_.isEmpty).mkString(", ")
+    val agents =
+      if (organisation.isEmpty) Nil else List(Organisation(organisation))
+    val places = if (place.isEmpty) Nil else List(Place(place))
+    val dates = if (date.isEmpty) Nil else List(ParsedPeriod(date))
+    val label = List(place, date).filterNot(_.isEmpty).mkString(", ")
+    (agents, places, dates) match {
+      case (Nil, Nil, Nil) => Nil
+      case _ =>
+
+          List(
+            ProductionEvent(
+              label = label,
+              places = places,
+              agents = agents,
+              dates = dates
+            ))
+    }
+
+  }
+
+  /**
+   * Dates are in a origDate tag and can be in different calendars,
+   * so we need to look for the one in the gregorian calendar.
+   * Also, sometimes the date can contain notes, as in this example, so we need to strip them:
+   * <origDate calendar="Gregorian">ca.1732-63AD
+   *  <note>from watermarks</note>
+   * </origDate>
+   */
+  private def parseDate(origin: NodeSeq) = {
+    val dateNodes = (origin \ "origDate").filter(n =>
+      (n \@ "calendar").toLowerCase == "gregorian")
+    val date =
+      if (dateNodes.exists(_.child.size > 1))
+        dateNodes
+          .flatMap(_.child)
+          .collect { case node if node.label != "note" => node.text }
+          .mkString
+          .trim
+      else dateNodes.text.trim
+    date
+  }
+}

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiProduction.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiProduction.scala
@@ -7,27 +7,28 @@ import weco.pipeline.transformer.transformers.ParsedPeriod
 import scala.xml.{Elem, NodeSeq}
 
 object TeiProduction {
-  def apply(xml: Elem): List[ProductionEvent[Unminted]] = apply(xml \\ "msDesc" \ "history" \ "origin")
+  def apply(xml: Elem): List[ProductionEvent[Unminted]] =
+    apply(xml \\ "msDesc" \ "history" \ "origin")
 
   def apply(node: NodeSeq): List[ProductionEvent[Unminted]] =
     origin(node)
 
   /**
-   * The origin tag contains information about where and when
-   * the manuscript was written. This is an example:
-   *  <history>
-   *      <origin>
-   *          <origPlace>
-   *              <country><!-- insert --></country>,
-   *              <region><!-- insert --></region>,
-   *              <settlement><!-- insert --></settlement>,
-   *              <orgName><!-- insert --></orgName>
-   *          </origPlace>
-   *          <origDate calendar=""><!-- insert --></origDate>
-   *      </origin>
-   *  </history>
-   *
-   */
+    * The origin tag contains information about where and when
+    * the manuscript was written. This is an example:
+    *  <history>
+    *      <origin>
+    *          <origPlace>
+    *              <country><!-- insert --></country>,
+    *              <region><!-- insert --></region>,
+    *              <settlement><!-- insert --></settlement>,
+    *              <orgName><!-- insert --></orgName>
+    *          </origPlace>
+    *          <origDate calendar=""><!-- insert --></origDate>
+    *      </origin>
+    *  </history>
+    *
+    */
   private def origin(origin: NodeSeq): List[ProductionEvent[Unminted]] = {
     val origPlace = origin \ "origPlace"
     val country = (origPlace \ "country").text.trim
@@ -45,26 +46,25 @@ object TeiProduction {
     (agents, places, dates) match {
       case (Nil, Nil, Nil) => Nil
       case _ =>
-
-          List(
-            ProductionEvent(
-              label = label,
-              places = places,
-              agents = agents,
-              dates = dates
-            ))
+        List(
+          ProductionEvent(
+            label = label,
+            places = places,
+            agents = agents,
+            dates = dates
+          ))
     }
 
   }
 
   /**
-   * Dates are in a origDate tag and can be in different calendars,
-   * so we need to look for the one in the gregorian calendar.
-   * Also, sometimes the date can contain notes, as in this example, so we need to strip them:
-   * <origDate calendar="Gregorian">ca.1732-63AD
-   *  <note>from watermarks</note>
-   * </origDate>
-   */
+    * Dates are in a origDate tag and can be in different calendars,
+    * so we need to look for the one in the gregorian calendar.
+    * Also, sometimes the date can contain notes, as in this example, so we need to strip them:
+    * <origDate calendar="Gregorian">ca.1732-63AD
+    *  <note>from watermarks</note>
+    * </origDate>
+    */
   private def parseDate(origin: NodeSeq) = {
     val dateNodes = (origin \ "origDate").filter(n =>
       (n \@ "calendar").toLowerCase == "gregorian")

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiXmlTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiXmlTest.scala
@@ -5,7 +5,6 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.catalogue.internal_model.work._
 import weco.pipeline.transformer.tei.generators.TeiGenerators
-import weco.pipeline.transformer.transformers.ParsedPeriod
 import weco.sierra.generators.SierraIdentifierGenerators
 
 import scala.xml.Elem
@@ -163,123 +162,20 @@ class TeiXmlTest
       Contributor(Person("Steve Rogers"), List(ContributionRole("scribe")))
     )
   }
-  describe("origin") {
-    it("extracts the origin country") {
-      val result = new TeiXml(
-        teiXml(
-          id,
-          origPlace = Some(origPlace(country = Some("India")))
-        )).parse
 
-      result.value.origin shouldBe List(
-        ProductionEvent(
-          "India",
-          places = List(Place("India")),
-          agents = Nil,
-          dates = Nil))
-    }
+  it("extracts the origin for the wrapper work") {
+    val result = new TeiXml(
+      teiXml(
+        id,
+        history = Some(history(origPlace = Some(origPlace(country = Some("India")))))
+      )).parse
 
-    it("extracts the origin - country region and settlement") {
-      val result = new TeiXml(
-        teiXml(
-          id,
-          origPlace = Some(
-            origPlace(
-              country = Some("United Kingdom"),
-              region = Some("England"),
-              settlement = Some("London")))
-        )).parse
-
-      val label = "United Kingdom, England, London"
-      result.value.origin shouldBe List(
-        ProductionEvent(
-          label,
-          places = List(Place(label)),
-          agents = Nil,
-          dates = Nil))
-    }
-
-    it("ignores text not in country region or settlement") {
-      val result = new TeiXml(
-        teiXml(
-          id,
-          origPlace = Some(
-            origPlace(
-              country = Some("United Kingdom"),
-              region = Some("England"),
-              settlement = Some("London"),
-              label = Some("stuff")))
-        )).parse
-
-      val label = "United Kingdom, England, London"
-      result.value.origin shouldBe List(
-        ProductionEvent(
-          label,
-          places = List(Place(label)),
-          agents = Nil,
-          dates = Nil))
-    }
-
-    it("returns an agent if there is an orgName") {
-      val result = new TeiXml(
-        teiXml(
-          id,
-          origPlace = Some(
-            origPlace(
-              country = Some("Egypt"),
-              settlement = Some("Wadi El Natrun"),
-              orgName = Some("Monastery of St Macarius the Great")))
-        )).parse
-
-      val label = "Egypt, Wadi El Natrun"
-      result.value.origin shouldBe List(
-        ProductionEvent(
-          label,
-          places = List(Place(label)),
-          agents = List(Organisation("Monastery of St Macarius the Great")),
-          dates = Nil))
-    }
-
-    it("returns a date") {
-      val result = new TeiXml(
-        teiXml(
-          id,
-          originDates = List(originDate("Gregorian", "1756"))
-        )).parse
-
-      result.value.origin shouldBe List(
-        ProductionEvent(
-          label = "1756",
-          places = Nil,
-          agents = Nil,
-          dates = List(ParsedPeriod("1756"))))
-    }
-
-    it("doesn't return a date if the calendar is not Gregorian") {
-      val result = new TeiXml(
-        teiXml(
-          id,
-          originDates = List(originDate("hijri", "5 Ramaḍān 838 (part 1)"))
-        )).parse
-
-      result.value.origin shouldBe Nil
-    }
-
-    it("ignores non text nodes in the label") {
-      val result = new TeiXml(
-        teiXml(
-          id,
-          originDates = List(<origDate calendar="gregorian">ca.1732-63AD
-          <note>from watermarks</note>
-        </origDate>)
-        )).parse
-      result.value.origin shouldBe List(
-        ProductionEvent(
-          label = "ca.1732-63AD",
-          places = Nil,
-          agents = Nil,
-          dates = List(ParsedPeriod("ca.1732-63AD"))))
-    }
+    result.value.origin shouldBe List(
+      ProductionEvent(
+        "India",
+        places = List(Place("India")),
+        agents = Nil,
+        dates = Nil))
   }
 
   it("extracts material description for the wrapper work"){

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/generators/TeiGenerators.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/generators/TeiGenerators.scala
@@ -84,9 +84,7 @@ trait TeiGenerators extends RandomGenerators { this: Suite =>
       {history.getOrElse(NodeSeq.Empty)}
     </msPart>
 
-  def history(
-               origPlace: Option[Elem] = None,
-               originDates: List[Elem] = Nil)=
+  def history(origPlace: Option[Elem] = None, originDates: List[Elem] = Nil) =
     <history>
       <origin>
         {origPlace.getOrElse(NodeSeq.Empty)}

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/generators/TeiGenerators.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/generators/TeiGenerators.scala
@@ -17,8 +17,7 @@ trait TeiGenerators extends RandomGenerators { this: Suite =>
     catalogues: List[Elem] = Nil,
     authors: List[Elem] = Nil,
     physDesc: Option[Elem] = None,
-    origPlace: Option[Elem] = None,
-    originDates: List[Elem] = Nil,
+    history: Option[Elem] = None,
     profileDesc: Option[Elem] = None
   ): Elem =
     <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id={id}>
@@ -36,12 +35,7 @@ trait TeiGenerators extends RandomGenerators { this: Suite =>
               {msContents(summary, languages, items, authors)}
               {parts}
               {physDesc.getOrElse(NodeSeq.Empty)}
-              <history>
-                <origin>
-                  {origPlace.getOrElse(NodeSeq.Empty)}
-                  {originDates}
-                </origin>
-              </history>
+              {history.getOrElse(NodeSeq.Empty)}
             </msDesc>
           </sourceDesc>
         </fileDesc>
@@ -81,12 +75,24 @@ trait TeiGenerators extends RandomGenerators { this: Suite =>
   def msPart(
     id: String,
     msContents: Option[Elem] = None,
-    physDesc: Option[Elem] = None
+    physDesc: Option[Elem] = None,
+    history: Option[Elem] = None
   ) =
     <msPart xml:id={id}>
       {msContents.getOrElse(NodeSeq.Empty)}
       {physDesc.getOrElse(NodeSeq.Empty)}
+      {history.getOrElse(NodeSeq.Empty)}
     </msPart>
+
+  def history(
+               origPlace: Option[Elem] = None,
+               originDates: List[Elem] = Nil)=
+    <history>
+      <origin>
+        {origPlace.getOrElse(NodeSeq.Empty)}
+        {originDates}
+      </origin>
+    </history>
 
   def profileDesc(keywords: List[Elem]) = <profileDesc>
       <textClass>

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/transformers/TeiNestedDataTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/transformers/TeiNestedDataTest.scala
@@ -459,4 +459,19 @@ class TeiNestedDataTest extends AnyFunSpec with TeiGenerators with Matchers with
     result.value shouldBe List(
       TeiData(id = itemId, title = itemTitle, notes = List(Note(NoteType.LocusNote, "pp11 - 28"))))
   }
+
+  it("extracts the origin for a part") {
+    val result = TeiNestedData.nestedTeiData(
+      teiXml(
+        id,
+        parts = List(msPart(id = "partId", history = Some(history(origPlace = Some(origPlace(country = Some("India")))))))
+      ), wrapperTitle, Map.empty)
+
+    result.value.head.origin shouldBe List(
+      ProductionEvent(
+        "India",
+        places = List(Place("India")),
+        agents = Nil,
+        dates = Nil))
+  }
 }

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/transformers/TeiProductionTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/transformers/TeiProductionTest.scala
@@ -1,0 +1,130 @@
+package weco.pipeline.transformer.tei.transformers
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import weco.catalogue.internal_model.work.{Organisation, Place, ProductionEvent}
+import weco.pipeline.transformer.tei.generators.TeiGenerators
+import weco.pipeline.transformer.transformers.ParsedPeriod
+
+class TeiProductionTest extends AnyFunSpec with TeiGenerators with Matchers {
+  val id = "id"
+  it("extracts the origin country") {
+
+    val elem = teiXml(
+      id,
+      history = Some(history(origPlace = Some(origPlace(country = Some("India")))))
+    )
+    println(elem.toString())
+    val result = TeiProduction(
+      elem)
+
+    result shouldBe List(
+      ProductionEvent(
+        "India",
+        places = List(Place("India")),
+        agents = Nil,
+        dates = Nil))
+  }
+
+  it("extracts the origin - country region and settlement") {
+    val result = TeiProduction(
+      teiXml(
+        id,
+        history = Some(history(origPlace = Some(
+          origPlace(
+            country = Some("United Kingdom"),
+            region = Some("England"),
+            settlement = Some("London")))))
+      ))
+
+    val label = "United Kingdom, England, London"
+    result shouldBe List(
+      ProductionEvent(
+        label,
+        places = List(Place(label)),
+        agents = Nil,
+        dates = Nil))
+  }
+
+  it("ignores text not in country region or settlement") {
+    val result = TeiProduction(
+      teiXml(
+        id,
+        history = Some(history(origPlace = Some(
+          origPlace(
+            country = Some("United Kingdom"),
+            region = Some("England"),
+            settlement = Some("London"),
+            label = Some("stuff")))))
+      ))
+
+    val label = "United Kingdom, England, London"
+    result shouldBe List(
+      ProductionEvent(
+        label,
+        places = List(Place(label)),
+        agents = Nil,
+        dates = Nil))
+  }
+
+  it("returns an agent if there is an orgName") {
+    val result = TeiProduction(
+      teiXml(
+        id,
+        history = Some(history(origPlace = Some(
+          origPlace(
+            country = Some("Egypt"),
+            settlement = Some("Wadi El Natrun"),
+            orgName = Some("Monastery of St Macarius the Great")))))
+      ))
+
+    val label = "Egypt, Wadi El Natrun"
+    result shouldBe List(
+      ProductionEvent(
+        label,
+        places = List(Place(label)),
+        agents = List(Organisation("Monastery of St Macarius the Great")),
+        dates = Nil))
+  }
+
+  it("returns a date") {
+    val result = TeiProduction(
+      teiXml(
+        id,
+        history = Some(history(originDates = List(originDate("Gregorian", "1756"))))
+      ))
+
+    result shouldBe List(
+      ProductionEvent(
+        label = "1756",
+        places = Nil,
+        agents = Nil,
+        dates = List(ParsedPeriod("1756"))))
+  }
+
+  it("doesn't return a date if the calendar is not Gregorian") {
+    val result = TeiProduction(
+      teiXml(
+        id,
+        history = Some(history(originDates = List(originDate("hijri", "5 Ramaḍān 838 (part 1)"))))
+      ))
+
+    result shouldBe Nil
+  }
+
+  it("ignores non text nodes in the label") {
+    val result = TeiProduction(
+      teiXml(
+        id,
+        history = Some(history(originDates = List(<origDate calendar="gregorian">ca.1732-63AD
+          <note>from watermarks</note>
+        </origDate>)))
+      ))
+    result shouldBe List(
+      ProductionEvent(
+        label = "ca.1732-63AD",
+        places = Nil,
+        agents = Nil,
+        dates = List(ParsedPeriod("ca.1732-63AD"))))
+  }
+}


### PR DESCRIPTION
Spotted while looking at https://wellcomecollection.org/works/yymfrybs: The tei xml has a `origin block for the whole manuscript and another for the part https://github.com/wellcomecollection/wellcome-collection-tei/blob/main/Greek/MS_MSL_14.xml#L742-L746