### PR TITLE
Update rules for requesting to enable more requests

### DIFF
--- a/builds/publish_image_with_weco_deploy.sh
+++ b/builds/publish_image_with_weco_deploy.sh
@@ -43,7 +43,7 @@ docker run --tty --rm \
   --env AWS_PROFILE \
   --volume ~/.aws:/root/.aws \
   --volume /var/run/docker.sock:/var/run/docker.sock \
-  --volume ~/.docker:/root/.docker \
+  --volume "$DOCKER_CONFIG:/root/.docker" \
   --volume "$ROOT:$ROOT" \
   --workdir "$ROOT" \
   "$ECR_REGISTRY/$WECO_DEPLOY_IMAGE" \

--- a/builds/run_sbt_task_in_docker.sh
+++ b/builds/run_sbt_task_in_docker.sh
@@ -25,7 +25,7 @@ docker run --tty --rm \
   --volume ~/.ivy2:/root/.ivy2 \
   --volume "$HOST_COURSIER_CACHE:/root/$LINUX_COURSIER_CACHE" \
   --volume /var/run/docker.sock:/var/run/docker.sock \
-  --volume ~/.docker:/root/.docker \
+  --volume "$DOCKER_CONFIG":/root/.docker \
   --net host \
   --volume "$ROOT:$ROOT" \
   --workdir "$ROOT" \

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala
@@ -299,10 +299,7 @@ object SierraRulesForRequesting {
               "sgmoh",
               "somet",
               "somge",
-              "somhe",
-              "somhi",
               "somja",
-              "sompa",
               "sompr",
               "somsy") =>
         NotRequestable.NeedsManualRequest(

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala
@@ -33,6 +33,9 @@ import weco.sierra.models.data.SierraItemData
   *   -   Variable length fields on items
   *       https://documentation.iii.com/sierrahelp/Content/sril/sril_records_varfld_types_item.html
   *
+  * This is based on a copy of the Rules for Requesting as sent from LS&S
+  * on 19 November 2021.
+  *
   */
 object SierraRulesForRequesting {
   def apply(itemData: SierraItemData): RulesForRequestingResult =
@@ -275,10 +278,7 @@ object SierraRulesForRequesting {
       //    v|i||79||=|sgmoh||
       //    v|i||79||=|somet||
       //    v|i||79||=|somge||
-      //    v|i||79||=|somhe||
-      //    v|i||79||=|somhi||
       //    v|i||79||=|somja||
-      //    v|i||79||=|sompa||
       //    v|i||79||=|sompr||
       //    q|i||79||=|somsy||Please complete a manual request slip.  This item cannot be requested online.
       //

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequestingTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequestingTest.scala
@@ -191,10 +191,7 @@ class SierraRulesForRequestingTest
         "sgmoh",
         "somet",
         "somge",
-        "somhe",
-        "somhi",
         "somja",
-        "sompa",
         "sompr",
         "somsy")
 


### PR DESCRIPTION
Branwen noticed that some Hebrew manuscripts (somhe) weren't requestable on wc.org/works but they were in Encore, because the Rules for Requesting had changed in Sierra but not in the pipeline. This brings them back up-to-date.