### PR TITLE
Cap the max number of tasks when not reindexing

### DIFF
--- a/pipeline/terraform/stack/service_image_inferrer.tf
+++ b/pipeline/terraform/stack/service_image_inferrer.tf
@@ -189,7 +189,7 @@ module "image_inferrer" {
   # the max capacity?
   min_capacity = var.min_capacity
 
-  max_capacity = min(10, var.max_capacity)
+  max_capacity = min(10, local.max_capacity)
 
   scale_down_adjustment = local.scale_down_adjustment
   scale_up_adjustment   = min(1, local.scale_up_adjustment)

--- a/pipeline/terraform/stack/service_ingestor_images.tf
+++ b/pipeline/terraform/stack/service_ingestor_images.tf
@@ -72,7 +72,7 @@ module "ingestor_images" {
   subnets = var.subnets
 
   min_capacity = var.min_capacity
-  max_capacity = var.max_capacity
+  max_capacity = local.max_capacity
 
   scale_down_adjustment = local.scale_down_adjustment
   scale_up_adjustment   = local.scale_up_adjustment

--- a/pipeline/terraform/stack/service_ingestor_works.tf
+++ b/pipeline/terraform/stack/service_ingestor_works.tf
@@ -75,7 +75,7 @@ module "ingestor_works" {
   subnets = var.subnets
 
   min_capacity = var.min_capacity
-  max_capacity = var.max_capacity
+  max_capacity = local.max_capacity
 
   scale_down_adjustment = local.scale_down_adjustment
   scale_up_adjustment   = local.scale_up_adjustment

--- a/pipeline/terraform/stack/service_merger.tf
+++ b/pipeline/terraform/stack/service_merger.tf
@@ -49,7 +49,7 @@ module "merger" {
   subnets = var.subnets
 
   min_capacity = var.min_capacity
-  max_capacity = var.max_capacity
+  max_capacity = local.max_capacity
 
   scale_down_adjustment = local.scale_down_adjustment
   scale_up_adjustment   = local.scale_up_adjustment

--- a/pipeline/terraform/stack/service_work_batcher.tf
+++ b/pipeline/terraform/stack/service_work_batcher.tf
@@ -54,7 +54,7 @@ module "batcher" {
   subnets = var.subnets
 
   min_capacity = var.min_capacity
-  max_capacity = min(1, var.max_capacity)
+  max_capacity = min(1, local.max_capacity)
 
   scale_down_adjustment = local.scale_down_adjustment
   scale_up_adjustment   = local.scale_up_adjustment

--- a/pipeline/terraform/stack/service_work_relation_embedder.tf
+++ b/pipeline/terraform/stack/service_work_relation_embedder.tf
@@ -47,7 +47,7 @@ module "relation_embedder" {
 
   # NOTE: limit to avoid >500 concurrent scroll contexts
   min_capacity = var.min_capacity
-  max_capacity = min(10, var.max_capacity)
+  max_capacity = min(10, local.max_capacity)
 
   scale_down_adjustment = local.scale_down_adjustment
   scale_up_adjustment   = local.scale_up_adjustment

--- a/pipeline/terraform/stack/service_work_router.tf
+++ b/pipeline/terraform/stack/service_work_router.tf
@@ -46,7 +46,7 @@ module "router" {
   subnets = var.subnets
 
   min_capacity = var.min_capacity
-  max_capacity = min(10, var.max_capacity)
+  max_capacity = min(10, local.max_capacity)
 
   scale_down_adjustment = local.scale_down_adjustment
   scale_up_adjustment   = local.scale_up_adjustment


### PR DESCRIPTION
This got dropped when we unsplit the pipeline; it's meant to prevent putting excessive load on the pipeline/API cluster after the initial reindex.