### PR TITLE
Highlight nodes in the matcher graph which don't correspond to a Work processed by the matcher

### DIFF
--- a/pipeline/matcher/scripts/get_graph.py
+++ b/pipeline/matcher/scripts/get_graph.py
@@ -58,7 +58,7 @@ def add_miro_image(*, graph, canonical_id, miro_id, **kwargs):
         >
         """.strip(),
         _attributes={"shape": "box"},
-        **kwargs
+        **kwargs,
     )
 
 
@@ -118,10 +118,15 @@ def main(index_date, work_id, emit_work_data, miro_images):
 
         if node_is_work and source == "Miro" and miro_images:
             add_miro_image(
-                graph=graph, miro_id=node["source_id"], canonical_id=node["id"], style=node_style
+                graph=graph,
+                miro_id=node["source_id"],
+                canonical_id=node["id"],
+                style=node_style,
             )
         else:
-            graph.node(node["id"], label=fr"{source}\n{node['source_id']}", style=node_style)
+            graph.node(
+                node["id"], label=fr"{source}\n{node['source_id']}", style=node_style
+            )
 
         graph.edges([(node["id"], dest) for dest in links])
 

--- a/pipeline/matcher/scripts/get_graph.py
+++ b/pipeline/matcher/scripts/get_graph.py
@@ -32,7 +32,7 @@ def get_aws_session(*, role_arn):
     )
 
 
-def add_miro_image(*, graph, canonical_id, miro_id):
+def add_miro_image(*, graph, canonical_id, miro_id, **kwargs):
     """
     If the --miro-images option is selected, include a thumbnail of
     the Miro image in the visual graph.
@@ -58,6 +58,7 @@ def add_miro_image(*, graph, canonical_id, miro_id):
         >
         """.strip(),
         _attributes={"shape": "box"},
+        **kwargs
     )
 
 
@@ -89,6 +90,8 @@ def main(index_date, work_id, emit_work_data, miro_images):
         session, index_date=index_date, component_id=component_id
     )
 
+    node_versions = {node["id"]: node.get("version") for node in graph_component}
+
     node_ids = [node["id"] for node in graph_component]
     node_links = [node["linkedIds"] for node in graph_component]
     nodes = get_nodes_properties(
@@ -100,16 +103,25 @@ def main(index_date, work_id, emit_work_data, miro_images):
         [dest for dest in ids if dest not in deleted_node_ids] for ids in node_links
     ]
     for node, links in filter(
-        lambda x: x[0]["type"] != "Deleted", zip(nodes, valid_node_links)
+        lambda x: x, zip(nodes, valid_node_links)
     ):
         source = source_type_labels.get(node["source_id_type"], node["source_id_type"])
 
-        if source == "Miro" and miro_images:
+        if node_versions[node["id"]] is None:
+            node_style = "dashed"
+        else:
+            node_style = ""
+
+        if source == "Miro" and miro_images and node["type"] != "Deleted":
             add_miro_image(
-                graph=graph, miro_id=node["source_id"], canonical_id=node["id"]
+                graph=graph, miro_id=node["source_id"], canonical_id=node["id"], style=node_style
             )
         else:
-            graph.node(node["id"], label=fr"{source}\n{node['source_id']}")
+            label = fr"{source}\n{node['source_id']}"
+            if node["type"] == "Deleted":
+                label += "\n(deleted)"
+
+            graph.node(node["id"], label=label, style=node_style)
 
         graph.edges([(node["id"], dest) for dest in links])
 

--- a/pipeline/matcher/scripts/get_graph.py
+++ b/pipeline/matcher/scripts/get_graph.py
@@ -101,26 +101,27 @@ def main(index_date, work_id, emit_work_data, miro_images):
     for node, links in zip(nodes, node_links):
         source = source_type_labels.get(node["source_id_type"], node["source_id_type"])
 
+        node_is_work = node_versions[node["id"]] is not None
+
+        if node_is_work and node["type"] == "Deleted":
+            continue
+
         # Highlight nodes which are in the matcher graph but which don't
         # correspond to a Work processed by the matcher.
         #
         # If there are any of these Works in the result, the merger won't
         # do any merging at all.
-        if node_versions[node["id"]] is None:
+        if not node_is_work:
             node_style = "dashed"
         else:
             node_style = ""
 
-        if source == "Miro" and miro_images and node["type"] != "Deleted":
+        if node_is_work and source == "Miro" and miro_images:
             add_miro_image(
                 graph=graph, miro_id=node["source_id"], canonical_id=node["id"], style=node_style
             )
         else:
-            label = fr"{source}\n{node['source_id']}"
-            if node["type"] == "Deleted":
-                label += "\n(deleted)"
-
-            graph.node(node["id"], label=label, style=node_style)
+            graph.node(node["id"], label=fr"{source}\n{node['source_id']}", style=node_style)
 
         graph.edges([(node["id"], dest) for dest in links])
 

--- a/pipeline/matcher/scripts/get_graph.py
+++ b/pipeline/matcher/scripts/get_graph.py
@@ -98,15 +98,14 @@ def main(index_date, work_id, emit_work_data, miro_images):
         es, index_date=index_date, work_ids=node_ids, fetch_complete_work=emit_work_data
     )
 
-    deleted_node_ids = {node["id"] for node in nodes if node["type"] == "Deleted"}
-    valid_node_links = [
-        [dest for dest in ids if dest not in deleted_node_ids] for ids in node_links
-    ]
-    for node, links in filter(
-        lambda x: x, zip(nodes, valid_node_links)
-    ):
+    for node, links in zip(nodes, node_links):
         source = source_type_labels.get(node["source_id_type"], node["source_id_type"])
 
+        # Highlight nodes which are in the matcher graph but which don't
+        # correspond to a Work processed by the matcher.
+        #
+        # If there are any of these Works in the result, the merger won't
+        # do any merging at all.
         if node_versions[node["id"]] is None:
             node_style = "dashed"
         else:


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5375

This changes the matcher graph to expose the "dummy" nodes it creates when Work A points to Work B, but we haven't seen Work B yet. Previously these could be filtered out if (as in this case) the unseen Work had been deleted. The presence of this Work which the matcher hasn't seen causes problems in the merger, because a single Work the matcher hasn't seen will cause the merger to skip merging anything.

<img width="644" alt="Screenshot 2021-11-25 at 16 16 33" src="https://user-images.githubusercontent.com/301220/143474807-5aaa3562-ac63-4d79-8b91-cfe703a948c5.png">

For some reason the matcher never saw the Miro work, and so the Calm/Sierra works are being left unmerged.