### PR TITLE
Fix an issue where we don't fetch suppressed works from the matcher graph

### DIFF
--- a/pipeline/matcher/src/main/scala/weco/pipeline/matcher/storage/WorkGraphStore.scala
+++ b/pipeline/matcher/src/main/scala/weco/pipeline/matcher/storage/WorkGraphStore.scala
@@ -23,8 +23,10 @@ class WorkGraphStore(workNodeDao: WorkNodeDao)(implicit _ec: ExecutionContext) {
   //
   // Suppressed works should never be linking to other works, so we only need
   // to do this extra search pass once.
-  private def getSuppressedWorksLinkedFrom(affectedWorks: Set[WorkNode]): Future[Set[WorkNode]] = {
-    val missingIds = affectedWorks.flatMap(_.linkedIds) -- affectedWorks.map(_.id)
+  private def getSuppressedWorksLinkedFrom(
+    affectedWorks: Set[WorkNode]): Future[Set[WorkNode]] = {
+    val missingIds = affectedWorks.flatMap(_.linkedIds) -- affectedWorks.map(
+      _.id)
 
     if (missingIds.isEmpty) {
       Future.successful(Set())

--- a/pipeline/matcher/src/main/scala/weco/pipeline/matcher/storage/WorkGraphStore.scala
+++ b/pipeline/matcher/src/main/scala/weco/pipeline/matcher/storage/WorkGraphStore.scala
@@ -11,7 +11,27 @@ class WorkGraphStore(workNodeDao: WorkNodeDao)(implicit _ec: ExecutionContext) {
       directlyAffectedWorks <- workNodeDao.get(w.ids)
       affectedComponentIds = directlyAffectedWorks.map(_.componentId)
       affectedWorks <- workNodeDao.getByComponentIds(affectedComponentIds)
-    } yield affectedWorks
+      suppressedWorks <- getSuppressedWorksLinkedFrom(affectedWorks)
+    } yield affectedWorks ++ suppressedWorks
+
+  // Suppressed works are singletons in the matcher graph, so we don't find
+  // them when searching by component ID -- but we might refer to them in
+  // one of the affected works.
+  //
+  // We want to retrieve the copy of the suppressed node from the graph store,
+  // so we don't overwrite them when we store the updated graph.
+  //
+  // Suppressed works should never be linking to other works, so we only need
+  // to do this extra search pass once.
+  private def getSuppressedWorksLinkedFrom(affectedWorks: Set[WorkNode]): Future[Set[WorkNode]] = {
+    val missingIds = affectedWorks.flatMap(_.linkedIds) -- affectedWorks.map(_.id)
+
+    if (missingIds.isEmpty) {
+      Future.successful(Set())
+    } else {
+      workNodeDao.get(missingIds)
+    }
+  }
 
   def put(nodes: Set[WorkNode]): Future[Unit] =
     workNodeDao.put(nodes)

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/storage/WorkGraphStoreTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/storage/WorkGraphStoreTest.scala
@@ -198,7 +198,6 @@ class WorkGraphStoreTest
 
       withWorkGraphTable { graphTable =>
         withWorkGraphStore(graphTable) { workGraphStore =>
-
           // First store C in the table
           val nodesC = WorkGraphUpdater.update(workC, affectedNodes = Set())
           nodesC.head.suppressed shouldBe true


### PR DESCRIPTION
This means we end up blatting suppressed works in the matcher graph, which in turn breaks merging of any works in the same graph.

Follows https://github.com/wellcomecollection/catalogue-pipeline/pull/1987. This patch adds a regression test for the bug described in https://github.com/wellcomecollection/platform/issues/5375#issuecomment-980061590, and then the least invasive/likely-to-break fix I could think of.