### PR TITLE
Don't let a missing work block merging

### DIFF
--- a/pipeline/matcher/src/main/scala/weco/pipeline/matcher/matcher/WorkMatcher.scala
+++ b/pipeline/matcher/src/main/scala/weco/pipeline/matcher/matcher/WorkMatcher.scala
@@ -94,7 +94,17 @@ class WorkMatcher(
       .groupBy { _.componentId }
       .map {
         case (_, workNodes) =>
-          MatchedIdentifiers(workNodes.map(WorkIdentifier(_)))
+          // The matcher graph may include nodes for Works it hasn't seen yet, or which
+          // don't exist.  These are placeholders, in case we see the Work later -- but we
+          // shouldn't expose their existence to other services.
+          //
+          // We only send identifiers that correspond to real Works.
+          val identifiers =
+            workNodes
+              .collect { case WorkNode(id, Some(version), _, _, _) => WorkIdentifier(id, version) }
+
+          MatchedIdentifiers(identifiers)
       }
+      .filter { _.identifiers.nonEmpty}
       .toSet
 }

--- a/pipeline/matcher/src/main/scala/weco/pipeline/matcher/matcher/WorkMatcher.scala
+++ b/pipeline/matcher/src/main/scala/weco/pipeline/matcher/matcher/WorkMatcher.scala
@@ -101,10 +101,13 @@ class WorkMatcher(
           // We only send identifiers that correspond to real Works.
           val identifiers =
             workNodes
-              .collect { case WorkNode(id, Some(version), _, _, _) => WorkIdentifier(id, version) }
+              .collect {
+                case WorkNode(id, Some(version), _, _, _) =>
+                  WorkIdentifier(id, version)
+              }
 
           MatchedIdentifiers(identifiers)
       }
-      .filter { _.identifiers.nonEmpty}
+      .filter { _.identifiers.nonEmpty }
       .toSet
 }

--- a/pipeline/matcher/src/main/scala/weco/pipeline/matcher/models/WorkIdentifier.scala
+++ b/pipeline/matcher/src/main/scala/weco/pipeline/matcher/models/WorkIdentifier.scala
@@ -4,18 +4,12 @@ import weco.catalogue.internal_model.identifiers.CanonicalId
 import weco.catalogue.internal_model.work.Work
 import weco.catalogue.internal_model.work.WorkState.Identified
 
-case class WorkIdentifier(identifier: CanonicalId, version: Option[Int])
+case class WorkIdentifier(identifier: CanonicalId, version: Int)
 
 object WorkIdentifier {
-  def apply(work: WorkNode): WorkIdentifier =
-    WorkIdentifier(work.id, work.version)
-
   def apply(work: Work[Identified]): WorkIdentifier =
     WorkIdentifier(
       identifier = work.state.canonicalId,
-      version = Some(work.version)
+      version = work.version
     )
-
-  def apply(identifier: CanonicalId, version: Int): WorkIdentifier =
-    WorkIdentifier(identifier, Some(version))
 }

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/matcher/WorkMatcherTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/matcher/WorkMatcherTest.scala
@@ -78,8 +78,7 @@ class WorkMatcherTest
               Set(
                 MatchedIdentifiers(
                   Set(
-                    WorkIdentifier(idA, work.version),
-                    WorkIdentifier(idB, None))))
+                    WorkIdentifier(idA, work.version))))
 
             val savedWorkNodes = scanTable[WorkNode](graphTable)
               .map(_.right.value)

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/matcher/WorkMatcherTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/matcher/WorkMatcherTest.scala
@@ -75,10 +75,7 @@ class WorkMatcherTest
           whenReady(workMatcher.matchWork(work)) { matcherResult =>
             assertRecent(matcherResult.createdTime)
             matcherResult.works shouldBe
-              Set(
-                MatchedIdentifiers(
-                  Set(
-                    WorkIdentifier(idA, work.version))))
+              Set(MatchedIdentifiers(Set(WorkIdentifier(idA, work.version))))
 
             val savedWorkNodes = scanTable[WorkNode](graphTable)
               .map(_.right.value)

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/services/MatcherWorkerServiceTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/services/MatcherWorkerServiceTest.scala
@@ -65,8 +65,7 @@ class MatcherWorkerServiceTest
       Set(
         MatchedIdentifiers(
           identifiers = Set(
-            WorkIdentifier(idA, version = Some(1)),
-            WorkIdentifier(idB, version = None)
+            WorkIdentifier(idA, version = 1),
           )
         )
       )

--- a/pipeline/merger/src/main/scala/weco/pipeline/merger/services/IdentifiedWorkLookup.scala
+++ b/pipeline/merger/src/main/scala/weco/pipeline/merger/services/IdentifiedWorkLookup.scala
@@ -16,40 +16,27 @@ class IdentifiedWorkLookup(retriever: Retriever[Work[Identified]])(
       "You should never look up an empty list of WorkIdentifiers!"
     )
 
-    val workIds = workIdentifiers
-      .collect {
-        case WorkIdentifier(identifier, Some(_)) => identifier.toString
-      }
+    val workIds = workIdentifiers.map { _.identifier.toString }
+    assert(workIds.nonEmpty)
 
-    // If none of the work identifiers had a version, we'll discard anything
-    // we get from the retriever, so skip going out to it.
-    if (workIds.isEmpty) {
-      Future.successful(
-        workIdentifiers.map { _ =>
-          None
-        }
-      )
-    } else {
-      retriever(workIds)
-        .map {
-          case RetrieverMultiResult(works, notFound) if notFound.isEmpty =>
-            workIdentifiers
-              .map {
-                case WorkIdentifier(_, None) => None
-                case WorkIdentifier(id, Some(version)) =>
-                  val work = works(id.toString)
-                  // We only want to get the exact versions of the works specified
-                  // by the matcher.
-                  //
-                  // e.g. if the matcher said "combine Av1 and Bv2", and we look
-                  // in the retriever and find {Av2, Bv3}, we shouldn't merge
-                  // these -- we should wait for the matcher to confirm we should
-                  // still be merging these two works.
-                  if (work.version == version) Some(work) else None
-              }
-          case RetrieverMultiResult(_, notFound) =>
-            throw new RuntimeException(s"Works not found: $notFound")
-        }
-    }
+    retriever(workIds)
+      .map {
+        case RetrieverMultiResult(works, notFound) if notFound.isEmpty =>
+          workIdentifiers
+            .map {
+              case WorkIdentifier(id, version) =>
+                val work = works(id.toString)
+                // We only want to get the exact versions of the works specified
+                // by the matcher.
+                //
+                // e.g. if the matcher said "combine Av1 and Bv2", and we look
+                // in the retriever and find {Av2, Bv3}, we shouldn't merge
+                // these -- we should wait for the matcher to confirm we should
+                // still be merging these two works.
+                if (work.version == version) Some(work) else None
+            }
+        case RetrieverMultiResult(_, notFound) =>
+          throw new RuntimeException(s"Works not found: $notFound")
+      }
   }
 }

--- a/pipeline/merger/src/test/scala/weco/pipeline/merger/MergerIntegrationTest.scala
+++ b/pipeline/merger/src/test/scala/weco/pipeline/merger/MergerIntegrationTest.scala
@@ -683,15 +683,16 @@ class MergerIntegrationTest
     withContext { implicit context =>
       Given("the works")
       val calm = calmIdentifiedWork()
-        .mergeCandidates(List(
-          MergeCandidate(
-            id = IdState.Identified(
-              canonicalId = createCanonicalId,
-              sourceIdentifier = createMiroSourceIdentifier
-            ),
-            reason = "CALM/Miro work"
-          )
-        ))
+        .mergeCandidates(
+          List(
+            MergeCandidate(
+              id = IdState.Identified(
+                canonicalId = createCanonicalId,
+                sourceIdentifier = createMiroSourceIdentifier
+              ),
+              reason = "CALM/Miro work"
+            )
+          ))
 
       val sierra = sierraIdentifiedWork()
         .mergeCandidates(List(createCalmMergeCandidateFor(calm)))

--- a/pipeline/merger/src/test/scala/weco/pipeline/merger/MergerIntegrationTest.scala
+++ b/pipeline/merger/src/test/scala/weco/pipeline/merger/MergerIntegrationTest.scala
@@ -703,7 +703,7 @@ class MergerIntegrationTest
 
       Then("the Sierra work is redirected to the Calm work")
       context.getMerged(sierra) should beRedirectedTo(calm)
-      context.getMerged(sierra) should beVisible
+      context.getMerged(calm) should beVisible
     }
   }
 }

--- a/pipeline/merger/src/test/scala/weco/pipeline/merger/MergerIntegrationTest.scala
+++ b/pipeline/merger/src/test/scala/weco/pipeline/merger/MergerIntegrationTest.scala
@@ -3,12 +3,13 @@ package weco.pipeline.merger
 import org.scalatest.GivenWhenThen
 import org.scalatest.featurespec.AnyFeatureSpec
 import org.scalatest.matchers.should.Matchers
-import weco.catalogue.internal_model.identifiers.IdentifierType
+import weco.catalogue.internal_model.identifiers.{IdState, IdentifierType}
 import weco.catalogue.internal_model.work.DeletedReason.SuppressedFromSource
 import weco.catalogue.internal_model.work.{
   CollectionPath,
   Format,
-  InvisibilityReason
+  InvisibilityReason,
+  MergeCandidate
 }
 import weco.catalogue.internal_model.work.generators.SourceWorkGenerators
 import weco.fixtures.TimeAssertions
@@ -675,6 +676,34 @@ class MergerIntegrationTest
 
       Then("the Sierra work is redirected to the Calm work")
       context.getMerged(sierra) should beRedirectedTo(calm)
+    }
+  }
+
+  Scenario("Miro, Calm and Sierra but the Miro is missing") {
+    withContext { implicit context =>
+      Given("the works")
+      val calm = calmIdentifiedWork()
+        .mergeCandidates(List(
+          MergeCandidate(
+            id = IdState.Identified(
+              canonicalId = createCanonicalId,
+              sourceIdentifier = createMiroSourceIdentifier
+            ),
+            reason = "CALM/Miro work"
+          )
+        ))
+
+      val sierra = sierraIdentifiedWork()
+        .mergeCandidates(List(createCalmMergeCandidateFor(calm)))
+
+      When("the works are processed by the matcher/merger")
+      // Note: the order is significant here.  The bug only reproduces under
+      // certain orderings.
+      processWorks(calm, sierra)
+
+      Then("the Sierra work is redirected to the Calm work")
+      context.getMerged(sierra) should beRedirectedTo(calm)
+      context.getMerged(sierra) should beVisible
     }
   }
 }

--- a/pipeline/merger/src/test/scala/weco/pipeline/merger/services/IdentifiedWorkLookupTest.scala
+++ b/pipeline/merger/src/test/scala/weco/pipeline/merger/services/IdentifiedWorkLookupTest.scala
@@ -41,22 +41,6 @@ class IdentifiedWorkLookupTest
     }
   }
 
-  it("returns None if asked to fetch a Work without a version") {
-    val work = identifiedWork().withVersion(0)
-    val workId = WorkIdentifier(work.state.canonicalId, version = None)
-
-    val retriever = new MemoryRetriever[Work[Identified]](
-      index = mutable.Map(work.id -> work)
-    )
-
-    val identifiedWorkLookup = new IdentifiedWorkLookup(retriever)
-
-    whenReady(
-      identifiedWorkLookup.fetchAllWorks(workIdentifiers = List(workId))) {
-      _ shouldBe Seq(None)
-    }
-  }
-
   it("returns None if the stored version has a higher version") {
     val oldWork = identifiedWork()
     val newWork = oldWork.withVersion(oldWork.version + 1)


### PR DESCRIPTION
Another bit of fixing following https://github.com/wellcomecollection/platform/issues/5375 – if we have a non-existent Work in the matcher graph, we just don't tell the merger about it.