### PR TITLE
Use a single definition for ComponentId

### DIFF
--- a/pipeline/matcher/src/main/scala/weco/pipeline/matcher/models/ComponentId.scala
+++ b/pipeline/matcher/src/main/scala/weco/pipeline/matcher/models/ComponentId.scala
@@ -1,0 +1,18 @@
+package weco.pipeline.matcher.models
+
+import org.apache.commons.codec.digest.DigestUtils
+import weco.catalogue.internal_model.identifiers.CanonicalId
+
+object ComponentId {
+
+  /** This is shared by all the Works in the same component -- i.e., all the
+    * Works that are matched together.
+    *
+    * Note that this is based on the *unversioned* identifiers.  This means the
+    * component identifier is stable across different versions of a Work.
+    */
+  def apply(ids: CanonicalId*): String =
+    DigestUtils.sha256Hex(ids.sorted.map(_.underlying).mkString("+"))
+
+  def apply(ids: List[CanonicalId]): String = apply(ids: _*)
+}

--- a/pipeline/matcher/src/main/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdater.scala
+++ b/pipeline/matcher/src/main/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdater.scala
@@ -1,11 +1,11 @@
 package weco.pipeline.matcher.workgraph
 
 import grizzled.slf4j.Logging
-import org.apache.commons.codec.digest.DigestUtils
 import scalax.collection.Graph
 import scalax.collection.GraphPredef._
 import weco.catalogue.internal_model.identifiers.CanonicalId
 import weco.pipeline.matcher.models.{
+  ComponentId,
   VersionExpectedConflictException,
   VersionUnexpectedConflictException,
   WorkNode,
@@ -155,25 +155,11 @@ object WorkGraphUpdater extends Logging {
             id = node.value,
             version = workVersions.get(node.value),
             linkedIds = linkedWorkIds(node),
-            componentId = componentIdentifier(nodeIds),
+            componentId = ComponentId(nodeIds),
             suppressed = suppressedWorks.contains(node.value)
           )
         })
       })
       .toSet
   }
-
-  /** Create the "component identifier".
-    *
-    * This is shared by all the Works in the same component -- i.e., all the
-    * Works that are matched together.
-    *
-    * Note that this is based on the *unversioned* identifiers.  This means the
-    * component identifier is stable across different versions of a Work.
-    *
-    * TODO: Does this need to be a SHA-256 value?
-    * Could we just concatenate all the IDs?
-    */
-  private def componentIdentifier(nodeIds: List[CanonicalId]): String =
-    DigestUtils.sha256Hex(nodeIds.sorted.map(_.underlying).mkString("+"))
 }

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/MatcherFeatureTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/MatcherFeatureTest.scala
@@ -82,7 +82,7 @@ class MatcherFeatureTest
               id = workV1.id,
               version = Some(existingWorkVersion),
               linkedIds = Nil,
-              componentId = ciHash(workV1.id)
+              componentId = ComponentId(workV1.id)
             )
 
             putTableItem(nodeV2, table = graphTable)

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/fixtures/MatcherFixtures.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/fixtures/MatcherFixtures.scala
@@ -1,9 +1,7 @@
 package weco.pipeline.matcher.fixtures
 
-import org.apache.commons.codec.digest.DigestUtils
 import org.scanamo.generic.semiauto.deriveDynamoFormat
 import org.scanamo.DynamoFormat
-import weco.catalogue.internal_model.identifiers.CanonicalId
 import weco.fixtures.TestWith
 import weco.messaging.fixtures.SQS
 import weco.messaging.memory.MemoryMessageSender
@@ -110,7 +108,4 @@ trait MatcherFixtures
     retriever.index ++= Map(work.id.toString -> work)
     sendNotificationToSQS(queue, body = work.id.toString)
   }
-
-  def ciHash(ids: CanonicalId*): String =
-    DigestUtils.sha256Hex(ids.sorted.map(_.underlying).mkString("+"))
 }

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/matcher/WorkMatcherTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/matcher/WorkMatcherTest.scala
@@ -10,6 +10,7 @@ import weco.fixtures.TimeAssertions
 import weco.pipeline.matcher.fixtures.MatcherFixtures
 import weco.pipeline.matcher.generators.WorkStubGenerators
 import weco.pipeline.matcher.models.{
+  ComponentId,
   MatchedIdentifiers,
   MatcherResult,
   WorkIdentifier,
@@ -53,7 +54,7 @@ class WorkMatcherTest
                 id = work.id,
                 version = work.version,
                 linkedIds = Nil,
-                componentId = ciHash(work.id)
+                componentId = ComponentId(work.id)
               )
             )
           }
@@ -89,13 +90,13 @@ class WorkMatcherTest
                 id = idA,
                 version = work.version,
                 linkedIds = List(idB),
-                componentId = ciHash(idA, idB)
+                componentId = ComponentId(idA, idB)
               ),
               WorkNode(
                 id = idB,
                 version = None,
                 linkedIds = Nil,
-                componentId = ciHash(idA, idB)
+                componentId = ComponentId(idA, idB)
               )
             )
           }
@@ -113,19 +114,19 @@ class WorkMatcherTest
             id = idA,
             version = 1,
             linkedIds = List(idB),
-            componentId = ciHash(idA, idB)
+            componentId = ComponentId(idA, idB)
           )
           val existingWorkB = WorkNode(
             id = idB,
             version = 1,
             linkedIds = Nil,
-            componentId = ciHash(idA, idB)
+            componentId = ComponentId(idA, idB)
           )
           val existingWorkC = WorkNode(
             id = idC,
             version = 1,
             linkedIds = Nil,
-            componentId = ciHash(idC)
+            componentId = ComponentId(idC)
           )
 
           putTableItems(
@@ -157,19 +158,19 @@ class WorkMatcherTest
                 id = idA,
                 version = 1,
                 linkedIds = List(idB),
-                componentId = ciHash(idA, idB, idC)
+                componentId = ComponentId(idA, idB, idC)
               ),
               WorkNode(
                 id = idB,
                 version = 2,
                 linkedIds = List(idC),
-                componentId = ciHash(idA, idB, idC)
+                componentId = ComponentId(idA, idB, idC)
               ),
               WorkNode(
                 id = idC,
                 version = 1,
                 linkedIds = Nil,
-                componentId = ciHash(idA, idB, idC))
+                componentId = ComponentId(idA, idB, idC))
             )
           }
         }

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/models/ComponentIdTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/models/ComponentIdTest.scala
@@ -1,0 +1,24 @@
+package weco.pipeline.matcher.models
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import weco.pipeline.matcher.generators.WorkStubGenerators
+
+class ComponentIdTest extends AnyFunSpec with Matchers with WorkStubGenerators {
+  it("creates a different component ID when the IDs change") {
+    ComponentId(idA) should not be ComponentId(idA, idB)
+  }
+
+  it("gives the same component ID regardless of ordering") {
+    val orderings = Set(
+      ComponentId(idA, idB, idC),
+      ComponentId(idA, idC, idB),
+      ComponentId(idB, idA, idC),
+      ComponentId(idB, idC, idA),
+      ComponentId(idC, idA, idB),
+      ComponentId(idC, idB, idA),
+    )
+
+    orderings should have size 1
+  }
+}

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/storage/WorkGraphStoreTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/storage/WorkGraphStoreTest.scala
@@ -7,7 +7,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.funspec.AnyFunSpec
 import weco.pipeline.matcher.fixtures.MatcherFixtures
 import weco.pipeline.matcher.generators.WorkStubGenerators
-import weco.pipeline.matcher.models.WorkNode
+import weco.pipeline.matcher.models.{ComponentId, WorkNode}
 import weco.pipeline.matcher.workgraph.WorkGraphUpdater
 
 import scala.concurrent.duration._
@@ -45,7 +45,7 @@ class WorkGraphStoreTest
               id = idA,
               version = 0,
               linkedIds = Nil,
-              componentId = ciHash(idA))
+              componentId = ComponentId(idA))
 
           putTableItem(work, table = graphTable)
 
@@ -67,13 +67,13 @@ class WorkGraphStoreTest
               id = idA,
               version = 0,
               linkedIds = Nil,
-              componentId = ciHash(idA))
+              componentId = ComponentId(idA))
           val workB =
             WorkNode(
               id = idB,
               version = 0,
               linkedIds = Nil,
-              componentId = ciHash(idB))
+              componentId = ComponentId(idB))
 
           putTableItems(items = Seq(workA, workB), table = graphTable)
 
@@ -95,13 +95,13 @@ class WorkGraphStoreTest
               id = idA,
               version = 0,
               linkedIds = List(idB),
-              componentId = ciHash(idA, idB))
+              componentId = ComponentId(idA, idB))
           val workB =
             WorkNode(
               id = idB,
               version = 0,
               linkedIds = Nil,
-              componentId = ciHash(idA, idB))
+              componentId = ComponentId(idA, idB))
 
           putTableItems(items = Seq(workA, workB), table = graphTable)
 
@@ -125,18 +125,18 @@ class WorkGraphStoreTest
               id = idA,
               version = 0,
               linkedIds = List(idB),
-              componentId = ciHash(idA, idB, idC))
+              componentId = ComponentId(idA, idB, idC))
           val workB =
             WorkNode(
               id = idB,
               version = 0,
               linkedIds = List(idC),
-              componentId = ciHash(idA, idB, idC))
+              componentId = ComponentId(idA, idB, idC))
           val workC = WorkNode(
             id = idC,
             version = 0,
             linkedIds = Nil,
-            componentId = ciHash(idA, idB, idC))
+            componentId = ComponentId(idA, idB, idC))
 
           putTableItems(items = Seq(workA, workB, workC), table = graphTable)
 
@@ -159,19 +159,19 @@ class WorkGraphStoreTest
               id = idA,
               version = 0,
               linkedIds = List(idB),
-              componentId = ciHash(idA, idB))
+              componentId = ComponentId(idA, idB))
           val workB =
             WorkNode(
               id = idB,
               version = 0,
               linkedIds = Nil,
-              componentId = ciHash(idA, idB))
+              componentId = ComponentId(idA, idB))
           val workC =
             WorkNode(
               id = idC,
               version = 0,
               linkedIds = Nil,
-              componentId = ciHash(idC))
+              componentId = ComponentId(idC))
 
           putTableItems(items = Seq(workA, workB, workC), table = graphTable)
 
@@ -233,12 +233,12 @@ class WorkGraphStoreTest
             idA,
             version = 0,
             linkedIds = List(idB),
-            componentId = ciHash(idA, idB))
+            componentId = ComponentId(idA, idB))
           val workNodeB = WorkNode(
             idB,
             version = 0,
             linkedIds = Nil,
-            componentId = ciHash(idA, idB))
+            componentId = ComponentId(idA, idB))
 
           whenReady(workGraphStore.put(Set(workNodeA, workNodeB))) { _ =>
             val savedWorks = scanTable[WorkNode](graphTable)
@@ -269,7 +269,7 @@ class WorkGraphStoreTest
       idA,
       version = 0,
       linkedIds = Nil,
-      componentId = ciHash(idA, idB))
+      componentId = ComponentId(idA, idB))
 
     whenReady(workGraphStore.put(Set(workNode)).failed) {
       _ shouldBe expectedException

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/storage/WorkNodeDaoTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/storage/WorkNodeDaoTest.scala
@@ -8,7 +8,7 @@ import software.amazon.awssdk.services.dynamodb.model.ResourceNotFoundException
 import weco.catalogue.internal_model.identifiers.CanonicalId
 import weco.pipeline.matcher.fixtures.MatcherFixtures
 import weco.pipeline.matcher.generators.WorkStubGenerators
-import weco.pipeline.matcher.models.WorkNode
+import weco.pipeline.matcher.models.{ComponentId, WorkNode}
 import weco.storage.dynamo.DynamoConfig
 
 import javax.naming.ConfigurationException
@@ -41,13 +41,13 @@ class WorkNodeDaoTest
               idA,
               version = 1,
               linkedIds = List(idB),
-              componentId = ciHash(idA, idB))
+              componentId = ComponentId(idA, idB))
           val existingWorkB: WorkNode =
             WorkNode(
               idB,
               version = 0,
               linkedIds = Nil,
-              componentId = ciHash(idA, idB))
+              componentId = ComponentId(idA, idB))
 
           putTableItems(
             items = Seq(existingWorkA, existingWorkB),
@@ -91,19 +91,19 @@ class WorkNodeDaoTest
             idA,
             version = 1,
             linkedIds = List(idB),
-            componentId = ciHash(idA, idB))
+            componentId = ComponentId(idA, idB))
           val existingWorkNodeB: WorkNode =
             WorkNode(
               idB,
               version = 0,
               linkedIds = Nil,
-              componentId = ciHash(idA, idB))
+              componentId = ComponentId(idA, idB))
 
           putTableItems(
             items = Seq(existingWorkNodeA, existingWorkNodeB),
             table = table)
 
-          whenReady(matcherGraphDao.getByComponentIds(Set(ciHash(idA, idB)))) {
+          whenReady(matcherGraphDao.getByComponentIds(Set(ComponentId(idA, idB)))) {
             _ shouldBe Set(existingWorkNodeA, existingWorkNodeB)
           }
         }
@@ -116,7 +116,7 @@ class WorkNodeDaoTest
         dynamoConfig = createDynamoConfigWith(nonExistentTable)
       )
 
-      whenReady(workNodeDao.getByComponentIds(Set(ciHash(idA, idB))).failed) {
+      whenReady(workNodeDao.getByComponentIds(Set(ComponentId(idA, idB))).failed) {
         _ shouldBe a[ResourceNotFoundException]
       }
     }
@@ -130,12 +130,12 @@ class WorkNodeDaoTest
           val badRecord: BadRecord =
             BadRecord(
               id = idA,
-              componentId = ciHash(idA, idB),
+              componentId = ComponentId(idA, idB),
               version = "five")
 
           putTableItem(badRecord, table = table)
 
-          whenReady(workNodeDao.getByComponentIds(Set(ciHash(idA, idB))).failed) {
+          whenReady(workNodeDao.getByComponentIds(Set(ComponentId(idA, idB))).failed) {
             _ shouldBe a[RuntimeException]
           }
         }
@@ -151,7 +151,7 @@ class WorkNodeDaoTest
             idA,
             version = 1,
             linkedIds = List(idA),
-            componentId = ciHash(idA, idB))
+            componentId = ComponentId(idA, idB))
           whenReady(workNodeDao.put(Set(work))) { _ =>
             getTableItem[WorkNode](idA.underlying, table) shouldBe Some(
               Right(work))
@@ -169,7 +169,7 @@ class WorkNodeDaoTest
               id,
               version = 1,
               linkedIds = List(id),
-              componentId = ciHash(id))
+              componentId = ComponentId(id))
           }
 
           val future = workNodeDao.put(works.toSet)
@@ -211,7 +211,7 @@ class WorkNodeDaoTest
           idA,
           version = 1,
           linkedIds = List(idB),
-          componentId = ciHash(idA, idB))
+          componentId = ComponentId(idA, idB))
 
       whenReady(workNodeDao.put(Set(workNode)).failed) {
         _ shouldBe a[ResourceNotFoundException]

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/storage/WorkNodeDaoTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/storage/WorkNodeDaoTest.scala
@@ -103,7 +103,8 @@ class WorkNodeDaoTest
             items = Seq(existingWorkNodeA, existingWorkNodeB),
             table = table)
 
-          whenReady(matcherGraphDao.getByComponentIds(Set(ComponentId(idA, idB)))) {
+          whenReady(
+            matcherGraphDao.getByComponentIds(Set(ComponentId(idA, idB)))) {
             _ shouldBe Set(existingWorkNodeA, existingWorkNodeB)
           }
         }
@@ -116,7 +117,8 @@ class WorkNodeDaoTest
         dynamoConfig = createDynamoConfigWith(nonExistentTable)
       )
 
-      whenReady(workNodeDao.getByComponentIds(Set(ComponentId(idA, idB))).failed) {
+      whenReady(
+        workNodeDao.getByComponentIds(Set(ComponentId(idA, idB))).failed) {
         _ shouldBe a[ResourceNotFoundException]
       }
     }
@@ -135,7 +137,8 @@ class WorkNodeDaoTest
 
           putTableItem(badRecord, table = table)
 
-          whenReady(workNodeDao.getByComponentIds(Set(ComponentId(idA, idB))).failed) {
+          whenReady(
+            workNodeDao.getByComponentIds(Set(ComponentId(idA, idB))).failed) {
             _ shouldBe a[RuntimeException]
           }
         }

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdaterTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdaterTest.scala
@@ -2,9 +2,9 @@ package weco.pipeline.matcher.workgraph
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import weco.pipeline.matcher.fixtures.MatcherFixtures
 import weco.pipeline.matcher.generators.WorkStubGenerators
 import weco.pipeline.matcher.models.{
+  ComponentId,
   VersionExpectedConflictException,
   VersionUnexpectedConflictException,
   WorkNode
@@ -13,7 +13,6 @@ import weco.pipeline.matcher.models.{
 class WorkGraphUpdaterTest
     extends AnyFunSpec
     with Matchers
-    with MatcherFixtures
     with WorkStubGenerators {
 
   describe("Adding links without existing works") {
@@ -27,7 +26,7 @@ class WorkGraphUpdaterTest
           idA,
           version = 1,
           linkedIds = List(),
-          componentId = ciHash(idA)))
+          componentId = ComponentId(idA)))
     }
 
     it("updating nothing with A->B gives A+B:A->B") {
@@ -40,12 +39,12 @@ class WorkGraphUpdaterTest
           idA,
           version = 1,
           linkedIds = List(idB),
-          componentId = ciHash(idA, idB)),
+          componentId = ComponentId(idA, idB)),
         WorkNode(
           idB,
           version = None,
           linkedIds = List(),
-          componentId = ciHash(idA, idB)))
+          componentId = ComponentId(idA, idB)))
     }
 
     it("updating nothing with B->A gives A+B:B->A") {
@@ -58,12 +57,12 @@ class WorkGraphUpdaterTest
           idB,
           version = 1,
           linkedIds = List(idA),
-          componentId = ciHash(idA, idB)),
+          componentId = ComponentId(idA, idB)),
         WorkNode(
           idA,
           version = None,
           linkedIds = List(),
-          componentId = ciHash(idA, idB)))
+          componentId = ComponentId(idA, idB)))
     }
   }
 
@@ -77,12 +76,12 @@ class WorkGraphUpdaterTest
               idA,
               version = 1,
               linkedIds = Nil,
-              componentId = ciHash(idA)),
+              componentId = ComponentId(idA)),
             WorkNode(
               idB,
               version = 1,
               linkedIds = Nil,
-              componentId = ciHash(idB))
+              componentId = ComponentId(idB))
           )
         ) should contain theSameElementsAs
         List(
@@ -90,12 +89,12 @@ class WorkGraphUpdaterTest
             idA,
             version = 2,
             linkedIds = List(idB),
-            componentId = ciHash(idA, idB)),
+            componentId = ComponentId(idA, idB)),
           WorkNode(
             idB,
             version = 1,
             linkedIds = List(),
-            componentId = ciHash(idA, idB)))
+            componentId = ComponentId(idA, idB)))
     }
 
     it("updating A->B with A->B gives A+B:(A->B, B)") {
@@ -107,23 +106,23 @@ class WorkGraphUpdaterTest
               idA,
               version = 1,
               linkedIds = List(idB),
-              componentId = ciHash(idA, idB)),
+              componentId = ComponentId(idA, idB)),
             WorkNode(
               idB,
               version = 1,
               linkedIds = Nil,
-              componentId = ciHash(idA, idB)))
+              componentId = ComponentId(idA, idB)))
         ) shouldBe Set(
         WorkNode(
           idA,
           version = 2,
           linkedIds = List(idB),
-          componentId = ciHash(idA, idB)),
+          componentId = ComponentId(idA, idB)),
         WorkNode(
           idB,
           version = 1,
           linkedIds = List(),
-          componentId = ciHash(idA, idB))
+          componentId = ComponentId(idA, idB))
       )
     }
 
@@ -141,29 +140,29 @@ class WorkGraphUpdaterTest
               idB,
               version = 1,
               linkedIds = Nil,
-              componentId = ciHash(idA, idB)),
+              componentId = ComponentId(idA, idB)),
             WorkNode(
               idC,
               version = 1,
               linkedIds = Nil,
-              componentId = ciHash(idC))
+              componentId = ComponentId(idC))
           )
         ) shouldBe Set(
         WorkNode(
           idA,
           version = 2,
           linkedIds = List(idB),
-          componentId = ciHash(idA, idB, idC)),
+          componentId = ComponentId(idA, idB, idC)),
         WorkNode(
           idB,
           version = 2,
           linkedIds = List(idC),
-          componentId = ciHash(idA, idB, idC)),
+          componentId = ComponentId(idA, idB, idC)),
         WorkNode(
           idC,
           version = 1,
           linkedIds = List(),
-          componentId = ciHash(idA, idB, idC))
+          componentId = ComponentId(idA, idB, idC))
       )
     }
 
@@ -191,22 +190,22 @@ class WorkGraphUpdaterTest
             idA,
             version = 1,
             linkedIds = List(idB),
-            componentId = ciHash(idA, idB, idC, idD)),
+            componentId = ComponentId(idA, idB, idC, idD)),
           WorkNode(
             idB,
             version = 2,
             linkedIds = List(idC),
-            componentId = ciHash(idA, idB, idC, idD)),
+            componentId = ComponentId(idA, idB, idC, idD)),
           WorkNode(
             idC,
             version = 1,
             linkedIds = List(idD),
-            componentId = ciHash(idA, idB, idC, idD)),
+            componentId = ComponentId(idA, idB, idC, idD)),
           WorkNode(
             idD,
             version = 1,
             linkedIds = List(),
-            componentId = ciHash(idA, idB, idC, idD))
+            componentId = ComponentId(idA, idB, idC, idD))
         )
     }
 
@@ -225,17 +224,17 @@ class WorkGraphUpdaterTest
               idB,
               version = 1,
               linkedIds = Nil,
-              componentId = ciHash(idA, idB)),
+              componentId = ComponentId(idA, idB)),
             WorkNode(
               idC,
               version = 1,
               linkedIds = Nil,
-              componentId = ciHash(idC)),
+              componentId = ComponentId(idC)),
             WorkNode(
               idD,
               version = 1,
               linkedIds = Nil,
-              componentId = ciHash(idD))
+              componentId = ComponentId(idD))
           )
         ) shouldBe
         Set(
@@ -243,22 +242,22 @@ class WorkGraphUpdaterTest
             idA,
             version = 2,
             linkedIds = List(idB),
-            componentId = ciHash(idA, idB, idC, idD)),
+            componentId = ComponentId(idA, idB, idC, idD)),
           WorkNode(
             idB,
             version = 2,
             linkedIds = List(idC, idD),
-            componentId = ciHash(idA, idB, idC, idD)),
+            componentId = ComponentId(idA, idB, idC, idD)),
           WorkNode(
             idC,
             version = 1,
             linkedIds = List(),
-            componentId = ciHash(idA, idB, idC, idD)),
+            componentId = ComponentId(idA, idB, idC, idD)),
           WorkNode(
             idD,
             version = 1,
             linkedIds = List(),
-            componentId = ciHash(idA, idB, idC, idD))
+            componentId = ComponentId(idA, idB, idC, idD))
         )
     }
 
@@ -284,17 +283,17 @@ class WorkGraphUpdaterTest
           idA,
           version = 2,
           linkedIds = List(idB),
-          componentId = ciHash(idA, idB, idC)),
+          componentId = ComponentId(idA, idB, idC)),
         WorkNode(
           idB,
           version = 2,
           linkedIds = List(idC),
-          componentId = ciHash(idA, idB, idC)),
+          componentId = ComponentId(idA, idB, idC)),
         WorkNode(
           idC,
           version = 2,
           linkedIds = List(idA),
-          componentId = ciHash(idA, idB, idC))
+          componentId = ComponentId(idA, idB, idC))
       )
     }
   }
@@ -312,19 +311,19 @@ class WorkGraphUpdaterTest
               idA,
               existingVersion,
               linkedIds = Nil,
-              componentId = ciHash(idA)))
+              componentId = ComponentId(idA)))
         ) should contain theSameElementsAs
         List(
           WorkNode(
             idA,
             updateVersion,
             linkedIds = List(idB),
-            componentId = ciHash(idA, idB)),
+            componentId = ComponentId(idA, idB)),
           WorkNode(
             idB,
             version = None,
             linkedIds = List(),
-            componentId = ciHash(idA, idB)))
+            componentId = ComponentId(idA, idB)))
     }
 
     it("doesn't process an update for a lower version") {
@@ -341,7 +340,7 @@ class WorkGraphUpdaterTest
                 idA,
                 existingVersion,
                 linkedIds = Nil,
-                componentId = ciHash(idA)))
+                componentId = ComponentId(idA)))
           )
       }
       thrown.message shouldBe s"update failed, work:$idA v1 is not newer than existing work v3"
@@ -361,24 +360,24 @@ class WorkGraphUpdaterTest
               idA,
               existingVersion,
               linkedIds = List(idB),
-              componentId = ciHash(idA, idB)),
+              componentId = ComponentId(idA, idB)),
             WorkNode(
               idB,
               version = 0,
               linkedIds = List(),
-              componentId = ciHash(idA, idB)))
+              componentId = ComponentId(idA, idB)))
         ) should contain theSameElementsAs
         List(
           WorkNode(
             idA,
             updateVersion,
             linkedIds = List(idB),
-            componentId = ciHash(idA, idB)),
+            componentId = ComponentId(idA, idB)),
           WorkNode(
             idB,
             version = 0,
             linkedIds = List(),
-            componentId = ciHash(idA, idB)))
+            componentId = ComponentId(idA, idB)))
     }
 
     it(
@@ -396,12 +395,12 @@ class WorkGraphUpdaterTest
                 idA,
                 existingVersion,
                 linkedIds = List(idB),
-                componentId = ciHash(idA, idB)),
+                componentId = ComponentId(idA, idB)),
               WorkNode(
                 idB,
                 version = 0,
                 linkedIds = List(),
-                componentId = ciHash(idA, idB)))
+                componentId = ComponentId(idA, idB)))
           )
       }
       thrown.getMessage shouldBe s"update failed, work:$idA v2 already exists with different content! update-ids:Set($idC) != existing-ids:Set($idB)"
@@ -425,12 +424,12 @@ class WorkGraphUpdaterTest
           idA,
           version = 2,
           linkedIds = List(),
-          componentId = ciHash(idA)),
+          componentId = ComponentId(idA)),
         WorkNode(
           idB,
           version = 1,
           linkedIds = List(),
-          componentId = ciHash(idB))
+          componentId = ComponentId(idB))
       )
     }
 
@@ -446,12 +445,12 @@ class WorkGraphUpdaterTest
               componentId = "A+B")
           )
         ) shouldBe Set(
-        WorkNode(idA, version = 2, linkedIds = Nil, componentId = ciHash(idA)),
+        WorkNode(idA, version = 2, linkedIds = Nil, componentId = ComponentId(idA)),
         WorkNode(
           idB,
           version = None,
           linkedIds = Nil,
-          componentId = ciHash(idB))
+          componentId = ComponentId(idB))
       )
     }
 
@@ -479,13 +478,13 @@ class WorkGraphUpdaterTest
           idA,
           version = 2,
           linkedIds = List(idB),
-          componentId = ciHash(idA, idB)),
+          componentId = ComponentId(idA, idB)),
         WorkNode(
           idB,
           version = 3,
           linkedIds = Nil,
-          componentId = ciHash(idA, idB)),
-        WorkNode(idC, version = 1, linkedIds = Nil, componentId = ciHash(idC))
+          componentId = ComponentId(idA, idB)),
+        WorkNode(idC, version = 1, linkedIds = Nil, componentId = ComponentId(idC))
       )
     }
 
@@ -511,17 +510,17 @@ class WorkGraphUpdaterTest
           idA,
           version = 2,
           linkedIds = List(idB),
-          componentId = ciHash(idA, idB, idC)),
+          componentId = ComponentId(idA, idB, idC)),
         WorkNode(
           idB,
           version = 3,
           linkedIds = List(idC),
-          componentId = ciHash(idA, idB, idC)),
+          componentId = ComponentId(idA, idB, idC)),
         WorkNode(
           idC,
           version = 1,
           linkedIds = Nil,
-          componentId = ciHash(idA, idB, idC))
+          componentId = ComponentId(idA, idB, idC))
       )
     }
   }
@@ -536,7 +535,7 @@ class WorkGraphUpdaterTest
               id = idB,
               version = 1,
               linkedIds = List(),
-              componentId = ciHash(idB),
+              componentId = ComponentId(idB),
               suppressed = true)
           )
         )
@@ -546,12 +545,12 @@ class WorkGraphUpdaterTest
           id = idA,
           version = 1,
           linkedIds = List(idB),
-          componentId = ciHash(idA)),
+          componentId = ComponentId(idA)),
         WorkNode(
           id = idB,
           version = 1,
           linkedIds = List(),
-          componentId = ciHash(idB),
+          componentId = ComponentId(idB),
           suppressed = true)
       )
     }
@@ -569,12 +568,12 @@ class WorkGraphUpdaterTest
               id = idA,
               version = 1,
               linkedIds = List(idB),
-              componentId = ciHash(idA, idB)),
+              componentId = ComponentId(idA, idB)),
             WorkNode(
               id = idB,
               version = None,
               linkedIds = List(),
-              componentId = ciHash(idA, idB))
+              componentId = ComponentId(idA, idB))
           )
         )
 
@@ -583,12 +582,12 @@ class WorkGraphUpdaterTest
           id = idA,
           version = 1,
           linkedIds = List(idB),
-          componentId = ciHash(idA)),
+          componentId = ComponentId(idA)),
         WorkNode(
           id = idB,
           version = 1,
           linkedIds = List(),
-          componentId = ciHash(idB),
+          componentId = ComponentId(idB),
           suppressed = true)
       )
     }
@@ -602,23 +601,23 @@ class WorkGraphUpdaterTest
               id = idB,
               version = 1,
               linkedIds = List(idC),
-              componentId = ciHash(idB)),
+              componentId = ComponentId(idB)),
             WorkNode(
               id = idC,
               version = 1,
               linkedIds = List(idD),
-              componentId = ciHash(idC),
+              componentId = ComponentId(idC),
               suppressed = true),
             WorkNode(
               id = idD,
               version = 1,
               linkedIds = List(idE),
-              componentId = ciHash(idD, idE)),
+              componentId = ComponentId(idD, idE)),
             WorkNode(
               id = idE,
               version = 1,
               linkedIds = List(),
-              componentId = ciHash(idD, idE))
+              componentId = ComponentId(idD, idE))
           )
         )
 
@@ -627,28 +626,28 @@ class WorkGraphUpdaterTest
           id = idA,
           version = 1,
           linkedIds = List(idB),
-          componentId = ciHash(idA, idB)),
+          componentId = ComponentId(idA, idB)),
         WorkNode(
           id = idB,
           version = 1,
           linkedIds = List(idC),
-          componentId = ciHash(idA, idB)),
+          componentId = ComponentId(idA, idB)),
         WorkNode(
           id = idC,
           version = 1,
           linkedIds = List(idD),
-          componentId = ciHash(idC),
+          componentId = ComponentId(idC),
           suppressed = true),
         WorkNode(
           id = idD,
           version = 1,
           linkedIds = List(idE),
-          componentId = ciHash(idD, idE)),
+          componentId = ComponentId(idD, idE)),
         WorkNode(
           id = idE,
           version = 1,
           linkedIds = List(),
-          componentId = ciHash(idD, idE))
+          componentId = ComponentId(idD, idE))
       )
     }
 
@@ -691,7 +690,7 @@ class WorkGraphUpdaterTest
           affectedNodes = graph3
         )
 
-      result.map(_.componentId) shouldBe Set(ciHash(idA, idB, idC))
+      result.map(_.componentId) shouldBe Set(ComponentId(idA, idB, idC))
     }
   }
 }

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdaterTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdaterTest.scala
@@ -44,7 +44,8 @@ class WorkGraphUpdaterTest
           idB,
           version = None,
           linkedIds = List(),
-          componentId = ComponentId(idA, idB)))
+          componentId = ComponentId(idA, idB))
+      )
     }
 
     it("updating nothing with B->A gives A+B:B->A") {
@@ -62,7 +63,8 @@ class WorkGraphUpdaterTest
           idA,
           version = None,
           linkedIds = List(),
-          componentId = ComponentId(idA, idB)))
+          componentId = ComponentId(idA, idB))
+      )
     }
   }
 
@@ -94,7 +96,8 @@ class WorkGraphUpdaterTest
             idB,
             version = 1,
             linkedIds = List(),
-            componentId = ComponentId(idA, idB)))
+            componentId = ComponentId(idA, idB))
+        )
     }
 
     it("updating A->B with A->B gives A+B:(A->B, B)") {
@@ -323,7 +326,8 @@ class WorkGraphUpdaterTest
             idB,
             version = None,
             linkedIds = List(),
-            componentId = ComponentId(idA, idB)))
+            componentId = ComponentId(idA, idB))
+        )
     }
 
     it("doesn't process an update for a lower version") {
@@ -365,7 +369,8 @@ class WorkGraphUpdaterTest
               idB,
               version = 0,
               linkedIds = List(),
-              componentId = ComponentId(idA, idB)))
+              componentId = ComponentId(idA, idB))
+          )
         ) should contain theSameElementsAs
         List(
           WorkNode(
@@ -377,7 +382,8 @@ class WorkGraphUpdaterTest
             idB,
             version = 0,
             linkedIds = List(),
-            componentId = ComponentId(idA, idB)))
+            componentId = ComponentId(idA, idB))
+        )
     }
 
     it(
@@ -400,7 +406,8 @@ class WorkGraphUpdaterTest
                 idB,
                 version = 0,
                 linkedIds = List(),
-                componentId = ComponentId(idA, idB)))
+                componentId = ComponentId(idA, idB))
+            )
           )
       }
       thrown.getMessage shouldBe s"update failed, work:$idA v2 already exists with different content! update-ids:Set($idC) != existing-ids:Set($idB)"
@@ -445,7 +452,11 @@ class WorkGraphUpdaterTest
               componentId = "A+B")
           )
         ) shouldBe Set(
-        WorkNode(idA, version = 2, linkedIds = Nil, componentId = ComponentId(idA)),
+        WorkNode(
+          idA,
+          version = 2,
+          linkedIds = Nil,
+          componentId = ComponentId(idA)),
         WorkNode(
           idB,
           version = None,
@@ -484,7 +495,11 @@ class WorkGraphUpdaterTest
           version = 3,
           linkedIds = Nil,
           componentId = ComponentId(idA, idB)),
-        WorkNode(idC, version = 1, linkedIds = Nil, componentId = ComponentId(idC))
+        WorkNode(
+          idC,
+          version = 1,
+          linkedIds = Nil,
+          componentId = ComponentId(idC))
       )
     }
 


### PR DESCRIPTION
There's no point in defining this twice.