### PR TITLE
Don't wait after autoformatting

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 steps:
   - command: .buildkite/scripts/run_autoformat.py
     label: "autoformat"
-  - wait
+
   - command: .buildkite/scripts/run_job.py internal_model
     label: "internal model"
 


### PR DESCRIPTION
This means builds will finish faster!  If we have a pull request build that fails because we pushed an autoformat commit, that kicks off a new build – and then Buildkite cancel the intermediate builds, so we're not running tasks we don't care about.

(See settings in https://buildkite.com/wellcomecollection/catalogue-pipeline/settings/builds)