### PR TITLE
Fix a bug where METS/Sierra works weren't being merged correctly

### DIFF
--- a/pipeline/matcher/src/main/scala/weco/pipeline/matcher/matcher/WorkMatcher.scala
+++ b/pipeline/matcher/src/main/scala/weco/pipeline/matcher/matcher/WorkMatcher.scala
@@ -90,23 +90,23 @@ class WorkMatcher(
 
   import WorkGraphUpdater.GraphComponents
 
-  private def toMatchedIdentifiers(components: GraphComponents): Set[MatchedIdentifiers] =
+  private def toMatchedIdentifiers(
+    components: GraphComponents): Set[MatchedIdentifiers] =
     components
-      .map {
-        workNodes =>
-          // The matcher graph may include nodes for Works it hasn't seen yet, or which
-          // don't exist.  These are placeholders, in case we see the Work later -- but we
-          // shouldn't expose their existence to other services.
-          //
-          // We only send identifiers that correspond to real Works.
-          val identifiers =
-            workNodes
-              .collect {
-                case WorkNode(id, Some(version), _, _, _) =>
-                  WorkIdentifier(id, version)
-              }
+      .map { workNodes =>
+        // The matcher graph may include nodes for Works it hasn't seen yet, or which
+        // don't exist.  These are placeholders, in case we see the Work later -- but we
+        // shouldn't expose their existence to other services.
+        //
+        // We only send identifiers that correspond to real Works.
+        val identifiers =
+          workNodes
+            .collect {
+              case WorkNode(id, Some(version), _, _, _) =>
+                WorkIdentifier(id, version)
+            }
 
-          MatchedIdentifiers(identifiers)
+        MatchedIdentifiers(identifiers)
       }
       .filter { _.identifiers.nonEmpty }
 }

--- a/pipeline/matcher/src/main/scala/weco/pipeline/matcher/models/WorkNode.scala
+++ b/pipeline/matcher/src/main/scala/weco/pipeline/matcher/models/WorkNode.scala
@@ -6,6 +6,11 @@ case class WorkNode(
   id: CanonicalId,
   version: Option[Int],
   linkedIds: List[CanonicalId],
+  // Note: this field really identifies all the works that should be retrieved
+  // together.  It's not a "component" ID in the strict graph sense of the word,
+  // it's used to group works that should be processed together.
+  //
+  // TODO: Check the name of this field to something like "group ID".
   componentId: String,
   // Records whether this work is suppressed in a source system -- if so,
   // we shouldn't be using it to construct matcher graphs.

--- a/pipeline/matcher/src/main/scala/weco/pipeline/matcher/storage/WorkGraphStore.scala
+++ b/pipeline/matcher/src/main/scala/weco/pipeline/matcher/storage/WorkGraphStore.scala
@@ -10,30 +10,8 @@ class WorkGraphStore(workNodeDao: WorkNodeDao)(implicit _ec: ExecutionContext) {
     for {
       directlyAffectedWorks <- workNodeDao.get(w.ids)
       affectedComponentIds = directlyAffectedWorks.map(_.componentId)
-      affectedWorks <- workNodeDao.getByComponentIds(affectedComponentIds)
-      suppressedWorks <- getSuppressedWorksLinkedFrom(affectedWorks)
-    } yield affectedWorks ++ suppressedWorks
-
-  // Suppressed works are singletons in the matcher graph, so we don't find
-  // them when searching by component ID -- but we might refer to them in
-  // one of the affected works.
-  //
-  // We want to retrieve the copy of the suppressed node from the graph store,
-  // so we don't overwrite them when we store the updated graph.
-  //
-  // Suppressed works should never be linking to other works, so we only need
-  // to do this extra search pass once.
-  private def getSuppressedWorksLinkedFrom(
-    affectedWorks: Set[WorkNode]): Future[Set[WorkNode]] = {
-    val missingIds = affectedWorks.flatMap(_.linkedIds) -- affectedWorks.map(
-      _.id)
-
-    if (missingIds.isEmpty) {
-      Future.successful(Set())
-    } else {
-      workNodeDao.get(missingIds)
-    }
-  }
+      result <- workNodeDao.getByComponentIds(affectedComponentIds)
+    } yield result
 
   def put(nodes: Set[WorkNode]): Future[Unit] =
     workNodeDao.put(nodes)

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/storage/WorkGraphStoreTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/storage/WorkGraphStoreTest.scala
@@ -206,13 +206,17 @@ class WorkGraphStoreTest
           // Then store B
           whenReady(workGraphStore.findAffectedWorks(workB)) { affectedNodes =>
             val updatedNodes = WorkGraphUpdater.update(workB, affectedNodes)
-            Await.ready(workGraphStore.put(updatedNodes.flatten), atMost = 1 second)
+            Await.ready(
+              workGraphStore.put(updatedNodes.flatten),
+              atMost = 1 second)
           }
 
           // Then store A
           whenReady(workGraphStore.findAffectedWorks(workA)) { affectedNodes =>
             val updatedNodes = WorkGraphUpdater.update(workA, affectedNodes)
-            Await.ready(workGraphStore.put(updatedNodes.flatten), atMost = 1 second)
+            Await.ready(
+              workGraphStore.put(updatedNodes.flatten),
+              atMost = 1 second)
           }
 
           getExistingTableItem[WorkNode](id = idC.underlying, graphTable).suppressed shouldBe true

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/storage/WorkGraphStoreTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/storage/WorkGraphStoreTest.scala
@@ -200,19 +200,19 @@ class WorkGraphStoreTest
         withWorkGraphStore(graphTable) { workGraphStore =>
           // First store C in the table
           val nodesC = WorkGraphUpdater.update(workC, affectedNodes = Set())
-          nodesC.head.suppressed shouldBe true
-          Await.ready(workGraphStore.put(nodesC), atMost = 1 second)
+          nodesC.head.head.suppressed shouldBe true
+          Await.ready(workGraphStore.put(nodesC.flatten), atMost = 1 second)
 
           // Then store B
           whenReady(workGraphStore.findAffectedWorks(workB)) { affectedNodes =>
             val updatedNodes = WorkGraphUpdater.update(workB, affectedNodes)
-            Await.ready(workGraphStore.put(updatedNodes), atMost = 1 second)
+            Await.ready(workGraphStore.put(updatedNodes.flatten), atMost = 1 second)
           }
 
           // Then store A
           whenReady(workGraphStore.findAffectedWorks(workA)) { affectedNodes =>
             val updatedNodes = WorkGraphUpdater.update(workA, affectedNodes)
-            Await.ready(workGraphStore.put(updatedNodes), atMost = 1 second)
+            Await.ready(workGraphStore.put(updatedNodes.flatten), atMost = 1 second)
           }
 
           getExistingTableItem[WorkNode](id = idC.underlying, graphTable).suppressed shouldBe true

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdaterTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdaterTest.scala
@@ -17,76 +17,94 @@ class WorkGraphUpdaterTest
 
   describe("Adding links without existing works") {
     it("updating nothing with A gives A:A") {
-      WorkGraphUpdater
-        .update(
-          work = createWorkWith(idA, version = 1, referencedWorkIds = Set.empty),
-          affectedNodes = Set()
-        ) shouldBe Set(
+      val result =
+        WorkGraphUpdater
+          .update(
+            work = createWorkWith(idA, version = 1, referencedWorkIds = Set.empty),
+            affectedNodes = Set()
+          )
+
+      result shouldBe Set(
+        Set(
         WorkNode(
           idA,
           version = 1,
           linkedIds = List(),
           componentId = ComponentId(idA)))
+      )
     }
 
     it("updating nothing with A->B gives A+B:A->B") {
-      WorkGraphUpdater
-        .update(
-          work = createWorkWith(idA, version = 1, referencedWorkIds = Set(idB)),
-          affectedNodes = Set()
-        ) shouldBe Set(
-        WorkNode(
-          idA,
-          version = 1,
-          linkedIds = List(idB),
-          componentId = ComponentId(idA, idB)),
-        WorkNode(
-          idB,
-          version = None,
-          linkedIds = List(),
-          componentId = ComponentId(idA, idB))
+      val result =
+        WorkGraphUpdater
+          .update(
+            work = createWorkWith(idA, version = 1, referencedWorkIds = Set(idB)),
+            affectedNodes = Set()
+          )
+
+      result shouldBe Set(
+        Set(
+          WorkNode(
+            idA,
+            version = 1,
+            linkedIds = List(idB),
+            componentId = ComponentId(idA, idB)),
+          WorkNode(
+            idB,
+            version = None,
+            linkedIds = List(),
+            componentId = ComponentId(idA, idB))
+        )
       )
     }
 
     it("updating nothing with B->A gives A+B:B->A") {
-      WorkGraphUpdater
-        .update(
-          work = createWorkWith(idB, version = 1, referencedWorkIds = Set(idA)),
-          affectedNodes = Set()
-        ) shouldBe Set(
-        WorkNode(
-          idB,
-          version = 1,
-          linkedIds = List(idA),
-          componentId = ComponentId(idA, idB)),
-        WorkNode(
-          idA,
-          version = None,
-          linkedIds = List(),
-          componentId = ComponentId(idA, idB))
+      val result =
+        WorkGraphUpdater
+          .update(
+            work = createWorkWith(idB, version = 1, referencedWorkIds = Set(idA)),
+            affectedNodes = Set()
+          )
+
+      result shouldBe Set(
+        Set(
+          WorkNode(
+            idB,
+            version = 1,
+            linkedIds = List(idA),
+            componentId = ComponentId(idA, idB)),
+          WorkNode(
+            idA,
+            version = None,
+            linkedIds = List(),
+            componentId = ComponentId(idA, idB))
+        )
       )
     }
   }
 
   describe("Adding links to existing works") {
     it("updating A, B with A->B gives A+B:(A->B, B)") {
-      WorkGraphUpdater
-        .update(
-          work = createWorkWith(idA, version = 2, referencedWorkIds = Set(idB)),
-          affectedNodes = Set(
-            WorkNode(
-              idA,
-              version = 1,
-              linkedIds = Nil,
-              componentId = ComponentId(idA)),
-            WorkNode(
-              idB,
-              version = 1,
-              linkedIds = Nil,
-              componentId = ComponentId(idB))
-          )
-        ) should contain theSameElementsAs
-        List(
+      val result =
+        WorkGraphUpdater
+          .update(
+            work = createWorkWith(idA, version = 2, referencedWorkIds = Set(idB)),
+            affectedNodes = Set(
+              WorkNode(
+                idA,
+                version = 1,
+                linkedIds = Nil,
+                componentId = ComponentId(idA)),
+              WorkNode(
+                idB,
+                version = 1,
+                linkedIds = Nil,
+                componentId = ComponentId(idB))
+            )
+        )
+
+      result shouldBe Set(
+        Set(
           WorkNode(
             idA,
             version = 2,
@@ -98,96 +116,110 @@ class WorkGraphUpdaterTest
             linkedIds = List(),
             componentId = ComponentId(idA, idB))
         )
+      )
     }
 
     it("updating A->B with A->B gives A+B:(A->B, B)") {
-      WorkGraphUpdater
-        .update(
-          work = createWorkWith(idA, version = 2, referencedWorkIds = Set(idB)),
-          affectedNodes = Set(
-            WorkNode(
-              idA,
-              version = 1,
-              linkedIds = List(idB),
-              componentId = ComponentId(idA, idB)),
-            WorkNode(
-              idB,
-              version = 1,
-              linkedIds = Nil,
-              componentId = ComponentId(idA, idB)))
-        ) shouldBe Set(
-        WorkNode(
-          idA,
-          version = 2,
-          linkedIds = List(idB),
-          componentId = ComponentId(idA, idB)),
-        WorkNode(
-          idB,
-          version = 1,
-          linkedIds = List(),
-          componentId = ComponentId(idA, idB))
+      val result =
+        WorkGraphUpdater
+          .update(
+            work = createWorkWith(idA, version = 2, referencedWorkIds = Set(idB)),
+            affectedNodes = Set(
+              WorkNode(
+                idA,
+                version = 1,
+                linkedIds = List(idB),
+                componentId = ComponentId(idA, idB)),
+              WorkNode(
+                idB,
+                version = 1,
+                linkedIds = Nil,
+                componentId = ComponentId(idA, idB)))
+          )
+
+      result shouldBe Set(
+        Set(
+          WorkNode(
+            idA,
+            version = 2,
+            linkedIds = List(idB),
+            componentId = ComponentId(idA, idB)),
+          WorkNode(
+            idB,
+            version = 1,
+            linkedIds = List(),
+            componentId = ComponentId(idA, idB))
+        )
       )
     }
 
     it("updating A->B, B, C with B->C gives A+B+C:(A->B, B->C, C)") {
-      WorkGraphUpdater
-        .update(
-          work = createWorkWith(idB, version = 2, referencedWorkIds = Set(idC)),
-          affectedNodes = Set(
-            WorkNode(
-              idA,
-              version = 2,
-              linkedIds = List(idB),
-              componentId = "A+B"),
-            WorkNode(
-              idB,
-              version = 1,
-              linkedIds = Nil,
-              componentId = ComponentId(idA, idB)),
-            WorkNode(
-              idC,
-              version = 1,
-              linkedIds = Nil,
-              componentId = ComponentId(idC))
+      val result =
+        WorkGraphUpdater
+          .update(
+            work = createWorkWith(idB, version = 2, referencedWorkIds = Set(idC)),
+            affectedNodes = Set(
+              WorkNode(
+                idA,
+                version = 2,
+                linkedIds = List(idB),
+                componentId = "A+B"),
+              WorkNode(
+                idB,
+                version = 1,
+                linkedIds = Nil,
+                componentId = ComponentId(idA, idB)),
+              WorkNode(
+                idC,
+                version = 1,
+                linkedIds = Nil,
+                componentId = ComponentId(idC))
+            )
           )
-        ) shouldBe Set(
-        WorkNode(
-          idA,
-          version = 2,
-          linkedIds = List(idB),
-          componentId = ComponentId(idA, idB, idC)),
-        WorkNode(
-          idB,
-          version = 2,
-          linkedIds = List(idC),
-          componentId = ComponentId(idA, idB, idC)),
-        WorkNode(
-          idC,
-          version = 1,
-          linkedIds = List(),
-          componentId = ComponentId(idA, idB, idC))
+
+      result shouldBe Set(
+        Set(
+          WorkNode(
+            idA,
+            version = 2,
+            linkedIds = List(idB),
+            componentId = ComponentId(idA, idB, idC)),
+          WorkNode(
+            idB,
+            version = 2,
+            linkedIds = List(idC),
+            componentId = ComponentId(idA, idB, idC)),
+          WorkNode(
+            idC,
+            version = 1,
+            linkedIds = List(),
+            componentId = ComponentId(idA, idB, idC))
+        )
       )
     }
 
     it("updating A->B, C->D with B->C gives A+B+C+D:(A->B, B->C, C->D, D)") {
-      WorkGraphUpdater
-        .update(
-          work = createWorkWith(idB, version = 2, referencedWorkIds = Set(idC)),
-          affectedNodes = Set(
-            WorkNode(
-              idA,
-              version = 1,
-              linkedIds = List(idB),
-              componentId = "A+B"),
-            WorkNode(
-              idC,
-              version = 1,
-              linkedIds = List(idD),
-              componentId = "C+D"),
-            WorkNode(idB, version = 1, linkedIds = Nil, componentId = "A+B"),
-            WorkNode(idD, version = 1, linkedIds = Nil, componentId = "C+D")
+      val result =
+        WorkGraphUpdater
+          .update(
+            work = createWorkWith(idB, version = 2, referencedWorkIds = Set(idC)),
+            affectedNodes = Set(
+              WorkNode(
+                idA,
+                version = 1,
+                linkedIds = List(idB),
+                componentId = "A+B"),
+              WorkNode(
+                idC,
+                version = 1,
+                linkedIds = List(idD),
+                componentId = "C+D"),
+              WorkNode(idB, version = 1, linkedIds = Nil, componentId = "A+B"),
+              WorkNode(idD, version = 1, linkedIds = Nil, componentId = "C+D")
+            )
           )
-        ) shouldBe
+
+      result shouldBe Set(
         Set(
           WorkNode(
             idA,
@@ -210,36 +242,40 @@ class WorkGraphUpdaterTest
             linkedIds = List(),
             componentId = ComponentId(idA, idB, idC, idD))
         )
+      )
     }
 
     it("updating A->B with B->[C,D] gives A+B+C+D:(A->B, B->C&D, C, D") {
-      WorkGraphUpdater
-        .update(
-          work =
-            createWorkWith(idB, version = 2, referencedWorkIds = Set(idC, idD)),
-          affectedNodes = Set(
-            WorkNode(
-              idA,
-              version = 2,
-              linkedIds = List(idB),
-              componentId = "A+B"),
-            WorkNode(
-              idB,
-              version = 1,
-              linkedIds = Nil,
-              componentId = ComponentId(idA, idB)),
-            WorkNode(
-              idC,
-              version = 1,
-              linkedIds = Nil,
-              componentId = ComponentId(idC)),
-            WorkNode(
-              idD,
-              version = 1,
-              linkedIds = Nil,
-              componentId = ComponentId(idD))
+      val result =
+        WorkGraphUpdater
+          .update(
+            work =
+              createWorkWith(idB, version = 2, referencedWorkIds = Set(idC, idD)),
+            affectedNodes = Set(
+              WorkNode(
+                idA,
+                version = 2,
+                linkedIds = List(idB),
+                componentId = "A+B"),
+              WorkNode(
+                idB,
+                version = 1,
+                linkedIds = Nil,
+                componentId = ComponentId(idA, idB)),
+              WorkNode(
+                idC,
+                version = 1,
+                linkedIds = Nil,
+                componentId = ComponentId(idC)),
+              WorkNode(
+                idD,
+                version = 1,
+                linkedIds = Nil,
+                componentId = ComponentId(idD))
+            )
           )
-        ) shouldBe
+
+      result shouldBe Set(
         Set(
           WorkNode(
             idA,
@@ -262,41 +298,47 @@ class WorkGraphUpdaterTest
             linkedIds = List(),
             componentId = ComponentId(idA, idB, idC, idD))
         )
+      )
     }
 
     it("updating A->B->C with A->C gives A+B+C:(A->B, B->C, C->A") {
-      WorkGraphUpdater
-        .update(
-          work = createWorkWith(idC, version = 2, referencedWorkIds = Set(idA)),
-          affectedNodes = Set(
-            WorkNode(
-              idA,
-              version = 2,
-              linkedIds = List(idB),
-              componentId = "A+B+C"),
-            WorkNode(
-              idB,
-              version = 2,
-              linkedIds = List(idC),
-              componentId = "A+B+C"),
-            WorkNode(idC, version = 1, linkedIds = Nil, componentId = "A+B+C")
+      val result =
+        WorkGraphUpdater
+          .update(
+            work = createWorkWith(idC, version = 2, referencedWorkIds = Set(idA)),
+            affectedNodes = Set(
+              WorkNode(
+                idA,
+                version = 2,
+                linkedIds = List(idB),
+                componentId = "A+B+C"),
+              WorkNode(
+                idB,
+                version = 2,
+                linkedIds = List(idC),
+                componentId = "A+B+C"),
+              WorkNode(idC, version = 1, linkedIds = Nil, componentId = "A+B+C")
+            )
           )
-        ) shouldBe Set(
-        WorkNode(
-          idA,
-          version = 2,
-          linkedIds = List(idB),
-          componentId = ComponentId(idA, idB, idC)),
-        WorkNode(
-          idB,
-          version = 2,
-          linkedIds = List(idC),
-          componentId = ComponentId(idA, idB, idC)),
-        WorkNode(
-          idC,
-          version = 2,
-          linkedIds = List(idA),
-          componentId = ComponentId(idA, idB, idC))
+
+      result shouldBe Set(
+        Set(
+          WorkNode(
+            idA,
+            version = 2,
+            linkedIds = List(idB),
+            componentId = ComponentId(idA, idB, idC)),
+          WorkNode(
+            idB,
+            version = 2,
+            linkedIds = List(idC),
+            componentId = ComponentId(idA, idB, idC)),
+          WorkNode(
+            idC,
+            version = 2,
+            linkedIds = List(idA),
+            componentId = ComponentId(idA, idB, idC))
+        )
       )
     }
   }
@@ -305,18 +347,22 @@ class WorkGraphUpdaterTest
     it("processes an update for a newer version") {
       val existingVersion = 1
       val updateVersion = 2
-      WorkGraphUpdater
-        .update(
-          work =
-            createWorkWith(idA, updateVersion, referencedWorkIds = Set(idB)),
-          affectedNodes = Set(
-            WorkNode(
-              idA,
-              existingVersion,
-              linkedIds = Nil,
-              componentId = ComponentId(idA)))
-        ) should contain theSameElementsAs
-        List(
+
+      val result =
+        WorkGraphUpdater
+          .update(
+            work =
+              createWorkWith(idA, updateVersion, referencedWorkIds = Set(idB)),
+            affectedNodes = Set(
+              WorkNode(
+                idA,
+                existingVersion,
+                linkedIds = Nil,
+                componentId = ComponentId(idA)))
+          )
+
+      result shouldBe Set(
+        Set(
           WorkNode(
             idA,
             updateVersion,
@@ -328,6 +374,7 @@ class WorkGraphUpdaterTest
             linkedIds = List(),
             componentId = ComponentId(idA, idB))
         )
+      )
     }
 
     it("doesn't process an update for a lower version") {
@@ -355,24 +402,27 @@ class WorkGraphUpdaterTest
       val existingVersion = 2
       val updateVersion = 2
 
-      WorkGraphUpdater
-        .update(
-          work =
-            createWorkWith(idA, updateVersion, referencedWorkIds = Set(idB)),
-          affectedNodes = Set(
-            WorkNode(
-              idA,
-              existingVersion,
-              linkedIds = List(idB),
-              componentId = ComponentId(idA, idB)),
-            WorkNode(
-              idB,
-              version = 0,
-              linkedIds = List(),
-              componentId = ComponentId(idA, idB))
+      val result =
+        WorkGraphUpdater
+          .update(
+            work =
+              createWorkWith(idA, updateVersion, referencedWorkIds = Set(idB)),
+            affectedNodes = Set(
+              WorkNode(
+                idA,
+                existingVersion,
+                linkedIds = List(idB),
+                componentId = ComponentId(idA, idB)),
+              WorkNode(
+                idB,
+                version = 0,
+                linkedIds = List(),
+                componentId = ComponentId(idA, idB))
+            )
           )
-        ) should contain theSameElementsAs
-        List(
+
+      result shouldBe Set(
+        Set(
           WorkNode(
             idA,
             updateVersion,
@@ -384,6 +434,7 @@ class WorkGraphUpdaterTest
             linkedIds = List(),
             componentId = ComponentId(idA, idB))
         )
+      )
     }
 
     it(
@@ -415,62 +466,121 @@ class WorkGraphUpdaterTest
   }
 
   describe("Removing links") {
-    it("updating  A->B with A gives A:A and B:B") {
-      WorkGraphUpdater
-        .update(
-          work = createWorkWith(idA, version = 2, referencedWorkIds = Set.empty),
-          affectedNodes = Set(
-            WorkNode(
-              idA,
-              version = 1,
-              linkedIds = List(idB),
-              componentId = "A+B"),
-            WorkNode(idB, version = 1, linkedIds = List(), componentId = "A+B"))
-        ) shouldBe Set(
-        WorkNode(
-          idA,
-          version = 2,
-          linkedIds = List(),
-          componentId = ComponentId(idA)),
-        WorkNode(
-          idB,
-          version = 1,
-          linkedIds = List(),
-          componentId = ComponentId(idB))
+    it("updating A->B with A gives A:A and B:B") {
+      val result =
+        WorkGraphUpdater
+          .update(
+            work = createWorkWith(idA, version = 2, referencedWorkIds = Set.empty),
+            affectedNodes = Set(
+              WorkNode(
+                idA,
+                version = 1,
+                linkedIds = List(idB),
+                componentId = "A+B"),
+              WorkNode(idB, version = 1, linkedIds = List(), componentId = "A+B"))
+          )
+
+      result shouldBe Set(
+        Set(
+          WorkNode(
+            idA,
+            version = 2,
+            linkedIds = List(),
+            componentId = ComponentId(idA, idB))
+        ),
+        Set(
+          WorkNode(
+            idB,
+            version = 1,
+            linkedIds = List(),
+            componentId = ComponentId(idA, idB))
+        )
       )
     }
 
     it("updating A->B with A but NO B (*should* not occur) gives A:A and B:B") {
-      WorkGraphUpdater
-        .update(
-          work = createWorkWith(idA, version = 2, referencedWorkIds = Set.empty),
-          affectedNodes = Set(
-            WorkNode(
-              idA,
-              version = 1,
-              linkedIds = List(idB),
-              componentId = "A+B")
+      val result =
+        WorkGraphUpdater
+          .update(
+            work = createWorkWith(idA, version = 2, referencedWorkIds = Set.empty),
+            affectedNodes = Set(
+              WorkNode(
+                idA,
+                version = 1,
+                linkedIds = List(idB),
+                componentId = "A+B")
+            )
           )
-        ) shouldBe Set(
-        WorkNode(
-          idA,
-          version = 2,
-          linkedIds = Nil,
-          componentId = ComponentId(idA)),
-        WorkNode(
-          idB,
-          version = None,
-          linkedIds = Nil,
-          componentId = ComponentId(idB))
+
+      result shouldBe Set(
+        Set(
+          WorkNode(
+            idA,
+            version = 2,
+            linkedIds = Nil,
+            componentId = ComponentId(idA, idB))
+        ),
+        Set(
+          WorkNode(
+            idB,
+            version = None,
+            linkedIds = Nil,
+            componentId = ComponentId(idA, idB))
+        )
       )
     }
 
     it("updating A->B->C with B gives A+B:(A->B, B) and C:C") {
-      WorkGraphUpdater
-        .update(
-          work = createWorkWith(idB, version = 3, referencedWorkIds = Set.empty),
-          affectedNodes = (
-            Set(
+      val result =
+        WorkGraphUpdater
+          .update(
+            work = createWorkWith(idB, version = 3, referencedWorkIds = Set.empty),
+            affectedNodes = (
+              Set(
+                WorkNode(
+                  idA,
+                  version = 2,
+                  linkedIds = List(idB),
+                  componentId = "A+B+C"),
+                WorkNode(
+                  idB,
+                  version = 2,
+                  linkedIds = List(idC),
+                  componentId = "A+B+C"),
+                WorkNode(idC, version = 1, linkedIds = Nil, componentId = "A+B+C")
+              )
+            )
+          )
+
+      result shouldBe Set(
+        Set(
+          WorkNode(
+            idA,
+            version = 2,
+            linkedIds = List(idB),
+            componentId = ComponentId(idA, idB, idC)),
+          WorkNode(
+            idB,
+            version = 3,
+            linkedIds = Nil,
+            componentId = ComponentId(idA, idB, idC)),
+        ),
+        Set(
+          WorkNode(
+            idC,
+            version = 1,
+            linkedIds = Nil,
+            componentId = ComponentId(idA, idB, idC))
+        )
+      )
+    }
+
+    it("updating A<->B->C with B->C gives A+B+C:(A->B, B->C, C)") {
+      val result =
+        WorkGraphUpdater
+          .update(
+            work = createWorkWith(idB, version = 3, referencedWorkIds = Set(idC)),
+            affectedNodes = Set(
               WorkNode(
                 idA,
                 version = 2,
@@ -479,63 +589,30 @@ class WorkGraphUpdaterTest
               WorkNode(
                 idB,
                 version = 2,
-                linkedIds = List(idC),
+                linkedIds = List(idA, idC),
                 componentId = "A+B+C"),
               WorkNode(idC, version = 1, linkedIds = Nil, componentId = "A+B+C")
             )
           )
-        ) shouldBe Set(
-        WorkNode(
-          idA,
-          version = 2,
-          linkedIds = List(idB),
-          componentId = ComponentId(idA, idB)),
-        WorkNode(
-          idB,
-          version = 3,
-          linkedIds = Nil,
-          componentId = ComponentId(idA, idB)),
-        WorkNode(
-          idC,
-          version = 1,
-          linkedIds = Nil,
-          componentId = ComponentId(idC))
-      )
-    }
 
-    it("updating A<->B->C with B->C gives A+B+C:(A->B, B->C, C)") {
-      WorkGraphUpdater
-        .update(
-          work = createWorkWith(idB, version = 3, referencedWorkIds = Set(idC)),
-          affectedNodes = Set(
-            WorkNode(
-              idA,
-              version = 2,
-              linkedIds = List(idB),
-              componentId = "A+B+C"),
-            WorkNode(
-              idB,
-              version = 2,
-              linkedIds = List(idA, idC),
-              componentId = "A+B+C"),
-            WorkNode(idC, version = 1, linkedIds = Nil, componentId = "A+B+C")
-          )
-        ) shouldBe Set(
-        WorkNode(
-          idA,
-          version = 2,
-          linkedIds = List(idB),
-          componentId = ComponentId(idA, idB, idC)),
-        WorkNode(
-          idB,
-          version = 3,
-          linkedIds = List(idC),
-          componentId = ComponentId(idA, idB, idC)),
-        WorkNode(
-          idC,
-          version = 1,
-          linkedIds = Nil,
-          componentId = ComponentId(idA, idB, idC))
+      result shouldBe Set(
+        Set(
+          WorkNode(
+            idA,
+            version = 2,
+            linkedIds = List(idB),
+            componentId = ComponentId(idA, idB, idC)),
+          WorkNode(
+            idB,
+            version = 3,
+            linkedIds = List(idC),
+            componentId = ComponentId(idA, idB, idC)),
+          WorkNode(
+            idC,
+            version = 1,
+            linkedIds = Nil,
+            componentId = ComponentId(idA, idB, idC))
+        )
       )
     }
   }
@@ -556,17 +633,21 @@ class WorkGraphUpdaterTest
         )
 
       result shouldBe Set(
-        WorkNode(
-          id = idA,
-          version = 1,
-          linkedIds = List(idB),
-          componentId = ComponentId(idA)),
-        WorkNode(
-          id = idB,
-          version = 1,
-          linkedIds = List(),
-          componentId = ComponentId(idB),
-          suppressed = true)
+        Set(
+          WorkNode(
+            id = idA,
+            version = 1,
+            linkedIds = List(idB),
+            componentId = ComponentId(idA, idB))
+        ),
+        Set(
+          WorkNode(
+            id = idB,
+            version = 1,
+            linkedIds = List(),
+            componentId = ComponentId(idA, idB),
+            suppressed = true)
+        )
       )
     }
 
@@ -593,17 +674,21 @@ class WorkGraphUpdaterTest
         )
 
       result shouldBe Set(
-        WorkNode(
-          id = idA,
-          version = 1,
-          linkedIds = List(idB),
-          componentId = ComponentId(idA)),
-        WorkNode(
-          id = idB,
-          version = 1,
-          linkedIds = List(),
-          componentId = ComponentId(idB),
-          suppressed = true)
+        Set(
+          WorkNode(
+            id = idA,
+            version = 1,
+            linkedIds = List(idB),
+            componentId = ComponentId(idA, idB))
+        ),
+        Set(
+          WorkNode(
+            id = idB,
+            version = 1,
+            linkedIds = List(),
+            componentId = ComponentId(idA, idB),
+            suppressed = true)
+        )
       )
     }
 
@@ -637,32 +722,38 @@ class WorkGraphUpdaterTest
         )
 
       result shouldBe Set(
-        WorkNode(
-          id = idA,
-          version = 1,
-          linkedIds = List(idB),
-          componentId = ComponentId(idA, idB)),
-        WorkNode(
-          id = idB,
-          version = 1,
-          linkedIds = List(idC),
-          componentId = ComponentId(idA, idB)),
-        WorkNode(
-          id = idC,
-          version = 1,
-          linkedIds = List(idD),
-          componentId = ComponentId(idC),
-          suppressed = true),
-        WorkNode(
-          id = idD,
-          version = 1,
-          linkedIds = List(idE),
-          componentId = ComponentId(idD, idE)),
-        WorkNode(
-          id = idE,
-          version = 1,
-          linkedIds = List(),
-          componentId = ComponentId(idD, idE))
+        Set(
+          WorkNode(
+            id = idA,
+            version = 1,
+            linkedIds = List(idB),
+            componentId = ComponentId(idA, idB, idC, idD, idE)),
+          WorkNode(
+            id = idB,
+            version = 1,
+            linkedIds = List(idC),
+            componentId = ComponentId(idA, idB, idC, idD, idE)),
+        ),
+        Set(
+          WorkNode(
+            id = idC,
+            version = 1,
+            linkedIds = List(idD),
+            componentId = ComponentId(idA, idB, idC, idD, idE),
+            suppressed = true),
+        ),
+        Set(
+          WorkNode(
+            id = idD,
+            version = 1,
+            linkedIds = List(idE),
+            componentId = ComponentId(idA, idB, idC, idD, idE)),
+          WorkNode(
+            id = idE,
+            version = 1,
+            linkedIds = List(),
+            componentId = ComponentId(idA, idB, idC, idD, idE))
+        )
       )
     }
 
@@ -680,13 +771,13 @@ class WorkGraphUpdaterTest
             version = 1,
             referencedWorkIds = Set(idC),
             workType = "Deleted"),
-          affectedNodes = graph1
+          affectedNodes = graph1.flatten
         )
 
       val graph3 =
         WorkGraphUpdater.update(
           work = createWorkWith(idC, version = 1, referencedWorkIds = Set()),
-          affectedNodes = graph2
+          affectedNodes = graph2.flatten
         )
 
       // At this point the graph database knows about all three of A/B/C, but it should
@@ -702,10 +793,10 @@ class WorkGraphUpdaterTest
             version = 2,
             referencedWorkIds = Set(idC),
             workType = "Undeleted"),
-          affectedNodes = graph3
+          affectedNodes = graph3.flatten
         )
 
-      result.map(_.componentId) shouldBe Set(ComponentId(idA, idB, idC))
+      result.flatten.map(_.componentId) shouldBe Set(ComponentId(idA, idB, idC))
     }
   }
 }

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdaterTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdaterTest.scala
@@ -20,17 +20,18 @@ class WorkGraphUpdaterTest
       val result =
         WorkGraphUpdater
           .update(
-            work = createWorkWith(idA, version = 1, referencedWorkIds = Set.empty),
+            work =
+              createWorkWith(idA, version = 1, referencedWorkIds = Set.empty),
             affectedNodes = Set()
           )
 
       result shouldBe Set(
         Set(
-        WorkNode(
-          idA,
-          version = 1,
-          linkedIds = List(),
-          componentId = ComponentId(idA)))
+          WorkNode(
+            idA,
+            version = 1,
+            linkedIds = List(),
+            componentId = ComponentId(idA)))
       )
     }
 
@@ -38,7 +39,8 @@ class WorkGraphUpdaterTest
       val result =
         WorkGraphUpdater
           .update(
-            work = createWorkWith(idA, version = 1, referencedWorkIds = Set(idB)),
+            work =
+              createWorkWith(idA, version = 1, referencedWorkIds = Set(idB)),
             affectedNodes = Set()
           )
 
@@ -62,7 +64,8 @@ class WorkGraphUpdaterTest
       val result =
         WorkGraphUpdater
           .update(
-            work = createWorkWith(idB, version = 1, referencedWorkIds = Set(idA)),
+            work =
+              createWorkWith(idB, version = 1, referencedWorkIds = Set(idA)),
             affectedNodes = Set()
           )
 
@@ -88,7 +91,8 @@ class WorkGraphUpdaterTest
       val result =
         WorkGraphUpdater
           .update(
-            work = createWorkWith(idA, version = 2, referencedWorkIds = Set(idB)),
+            work =
+              createWorkWith(idA, version = 2, referencedWorkIds = Set(idB)),
             affectedNodes = Set(
               WorkNode(
                 idA,
@@ -101,7 +105,7 @@ class WorkGraphUpdaterTest
                 linkedIds = Nil,
                 componentId = ComponentId(idB))
             )
-        )
+          )
 
       result shouldBe Set(
         Set(
@@ -123,7 +127,8 @@ class WorkGraphUpdaterTest
       val result =
         WorkGraphUpdater
           .update(
-            work = createWorkWith(idA, version = 2, referencedWorkIds = Set(idB)),
+            work =
+              createWorkWith(idA, version = 2, referencedWorkIds = Set(idB)),
             affectedNodes = Set(
               WorkNode(
                 idA,
@@ -157,7 +162,8 @@ class WorkGraphUpdaterTest
       val result =
         WorkGraphUpdater
           .update(
-            work = createWorkWith(idB, version = 2, referencedWorkIds = Set(idC)),
+            work =
+              createWorkWith(idB, version = 2, referencedWorkIds = Set(idC)),
             affectedNodes = Set(
               WorkNode(
                 idA,
@@ -202,7 +208,8 @@ class WorkGraphUpdaterTest
       val result =
         WorkGraphUpdater
           .update(
-            work = createWorkWith(idB, version = 2, referencedWorkIds = Set(idC)),
+            work =
+              createWorkWith(idB, version = 2, referencedWorkIds = Set(idC)),
             affectedNodes = Set(
               WorkNode(
                 idA,
@@ -249,8 +256,10 @@ class WorkGraphUpdaterTest
       val result =
         WorkGraphUpdater
           .update(
-            work =
-              createWorkWith(idB, version = 2, referencedWorkIds = Set(idC, idD)),
+            work = createWorkWith(
+              idB,
+              version = 2,
+              referencedWorkIds = Set(idC, idD)),
             affectedNodes = Set(
               WorkNode(
                 idA,
@@ -305,7 +314,8 @@ class WorkGraphUpdaterTest
       val result =
         WorkGraphUpdater
           .update(
-            work = createWorkWith(idC, version = 2, referencedWorkIds = Set(idA)),
+            work =
+              createWorkWith(idC, version = 2, referencedWorkIds = Set(idA)),
             affectedNodes = Set(
               WorkNode(
                 idA,
@@ -470,14 +480,19 @@ class WorkGraphUpdaterTest
       val result =
         WorkGraphUpdater
           .update(
-            work = createWorkWith(idA, version = 2, referencedWorkIds = Set.empty),
+            work =
+              createWorkWith(idA, version = 2, referencedWorkIds = Set.empty),
             affectedNodes = Set(
               WorkNode(
                 idA,
                 version = 1,
                 linkedIds = List(idB),
                 componentId = "A+B"),
-              WorkNode(idB, version = 1, linkedIds = List(), componentId = "A+B"))
+              WorkNode(
+                idB,
+                version = 1,
+                linkedIds = List(),
+                componentId = "A+B"))
           )
 
       result shouldBe Set(
@@ -502,7 +517,8 @@ class WorkGraphUpdaterTest
       val result =
         WorkGraphUpdater
           .update(
-            work = createWorkWith(idA, version = 2, referencedWorkIds = Set.empty),
+            work =
+              createWorkWith(idA, version = 2, referencedWorkIds = Set.empty),
             affectedNodes = Set(
               WorkNode(
                 idA,
@@ -534,7 +550,8 @@ class WorkGraphUpdaterTest
       val result =
         WorkGraphUpdater
           .update(
-            work = createWorkWith(idB, version = 3, referencedWorkIds = Set.empty),
+            work =
+              createWorkWith(idB, version = 3, referencedWorkIds = Set.empty),
             affectedNodes = (
               Set(
                 WorkNode(
@@ -547,7 +564,11 @@ class WorkGraphUpdaterTest
                   version = 2,
                   linkedIds = List(idC),
                   componentId = "A+B+C"),
-                WorkNode(idC, version = 1, linkedIds = Nil, componentId = "A+B+C")
+                WorkNode(
+                  idC,
+                  version = 1,
+                  linkedIds = Nil,
+                  componentId = "A+B+C")
               )
             )
           )
@@ -579,7 +600,8 @@ class WorkGraphUpdaterTest
       val result =
         WorkGraphUpdater
           .update(
-            work = createWorkWith(idB, version = 3, referencedWorkIds = Set(idC)),
+            work =
+              createWorkWith(idB, version = 3, referencedWorkIds = Set(idC)),
             affectedNodes = Set(
               WorkNode(
                 idA,

--- a/pipeline/merger/src/test/scala/weco/pipeline/merger/MergerIntegrationTest.scala
+++ b/pipeline/merger/src/test/scala/weco/pipeline/merger/MergerIntegrationTest.scala
@@ -732,11 +732,11 @@ class MergerIntegrationTest
       identifiedWork(
         canonicalId = sierraSuppressedEbib.state.canonicalId,
         sourceIdentifier = sierraSuppressedEbib.state.sourceIdentifier
-      )
-        .withVersion(version = 2)
+      ).withVersion(version = 2)
         .items(
           List(
-            createUnidentifiableItemWith(locations = List(createDigitalLocation))
+            createUnidentifiableItemWith(
+              locations = List(createDigitalLocation))
           )
         )
 
@@ -746,7 +746,8 @@ class MergerIntegrationTest
         processWork(sierraSuppressedEbib)
         processWork(sierraUnsuppressedEbib)
 
-        context.getMerged(metsWork) should beRedirectedTo(sierraUnsuppressedEbib)
+        context.getMerged(metsWork) should beRedirectedTo(
+          sierraUnsuppressedEbib)
       }
     }
 
@@ -756,7 +757,8 @@ class MergerIntegrationTest
         processWork(metsWork)
         processWork(sierraUnsuppressedEbib)
 
-        context.getMerged(metsWork) should beRedirectedTo(sierraUnsuppressedEbib)
+        context.getMerged(metsWork) should beRedirectedTo(
+          sierraUnsuppressedEbib)
       }
     }
 
@@ -766,7 +768,8 @@ class MergerIntegrationTest
         processWork(sierraUnsuppressedEbib)
         processWork(metsWork)
 
-        context.getMerged(metsWork) should beRedirectedTo(sierraUnsuppressedEbib)
+        context.getMerged(metsWork) should beRedirectedTo(
+          sierraUnsuppressedEbib)
       }
     }
   }

--- a/pipeline/merger/src/test/scala/weco/pipeline/merger/MergerIntegrationTest.scala
+++ b/pipeline/merger/src/test/scala/weco/pipeline/merger/MergerIntegrationTest.scala
@@ -711,6 +711,7 @@ class MergerIntegrationTest
   Feature("Sierra e-bib/METS work merging is the same, regardless of order") {
     val sierraSuppressedEbib =
       sierraIdentifiedWork()
+        .withVersion(version = 1)
         .deleted(SuppressedFromSource("Sierra"))
 
     val metsIdentifier = sierraSuppressedEbib.sourceIdentifier.copy(
@@ -732,6 +733,7 @@ class MergerIntegrationTest
         canonicalId = sierraSuppressedEbib.state.canonicalId,
         sourceIdentifier = sierraSuppressedEbib.state.sourceIdentifier
       )
+        .withVersion(version = 2)
         .items(
           List(
             createUnidentifiableItemWith(locations = List(createDigitalLocation))


### PR DESCRIPTION
In particular, if you sent the works in this order:

1. The suppressed Sierra e-bib
2. The METS work
3. The unsuppressed Sierra e-bib

We wouldn't create a Sierra->METS link in step 2, so we wouldn't retrieve the METS work on step 3.

This is a side-effect of us attempting to be clever about how we put suppressed works in the store.

Now we give the same "component ID" (now a misnomer) to all the works that are written together, so if two works were written together they'll always be retrieved together.  We then have to rejig the rest of the matcher a bit so that individual components are written together, but overall it's simpler so hopefully we won't have more bugs like this in future.

---

~Still a WIP because I'm struggling to get tests passing locally – they pass individually, but not if you run the whole suite, which makes me think a test is leaking somewhere.~ Turns out these tests care quite a lot about the version of individual works, and I had to set those explicitly.

I'm looking for alternative names to "component ID". Maybe "group ID"?

Once this is merged and we rename component ID (separate PR), I'd quite like to do a reindex to get this change in, and flush out any other works affected by this issue.