### PR TITLE
Do some refactoring in the matcher

### DIFF
--- a/pipeline/matcher/src/main/scala/weco/pipeline/matcher/matcher/WorkMatcher.scala
+++ b/pipeline/matcher/src/main/scala/weco/pipeline/matcher/matcher/WorkMatcher.scala
@@ -32,7 +32,7 @@ class WorkMatcher(
   def matchWork(work: WorkStub): Future[MatcherResult] =
     withLocks(work, work.ids.map(_.toString)) {
       for {
-        beforeNodes <- workGraphStore.findAffectedWorks(work)
+        beforeNodes <- workGraphStore.findAffectedWorks(work.ids)
         afterNodes = WorkGraphUpdater.update(work, beforeNodes)
 
         updatedNodes = afterNodes -- beforeNodes

--- a/pipeline/matcher/src/main/scala/weco/pipeline/matcher/storage/WorkGraphStore.scala
+++ b/pipeline/matcher/src/main/scala/weco/pipeline/matcher/storage/WorkGraphStore.scala
@@ -1,14 +1,15 @@
 package weco.pipeline.matcher.storage
 
-import weco.pipeline.matcher.models.{WorkNode, WorkStub}
+import weco.catalogue.internal_model.identifiers.CanonicalId
+import weco.pipeline.matcher.models.WorkNode
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class WorkGraphStore(workNodeDao: WorkNodeDao)(implicit _ec: ExecutionContext) {
 
-  def findAffectedWorks(w: WorkStub): Future[Set[WorkNode]] =
+  def findAffectedWorks(ids: Set[CanonicalId]): Future[Set[WorkNode]] =
     for {
-      directlyAffectedWorks <- workNodeDao.get(w.ids)
+      directlyAffectedWorks <- workNodeDao.get(ids)
       affectedComponentIds = directlyAffectedWorks.map(_.componentId)
       affectedWorks <- workNodeDao.getByComponentIds(affectedComponentIds)
       suppressedWorks <- getSuppressedWorksLinkedFrom(affectedWorks)

--- a/pipeline/matcher/src/main/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdater.scala
+++ b/pipeline/matcher/src/main/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdater.scala
@@ -30,12 +30,11 @@ object WorkGraphUpdater extends Logging {
         throw VersionExpectedConflictException(versionConflictMessage)
 
       case Some(WorkNode(_, Some(existingVersion), linkedIds, _, _))
-        if existingVersion == work.version && work.referencedWorkIds != linkedIds.toSet => {
+        if existingVersion == work.version && work.referencedWorkIds != linkedIds.toSet =>
           val versionConflictMessage =
             s"update failed, work:${work.id} v${work.version} already exists with different content! update-ids:${work.referencedWorkIds} != existing-ids:${linkedIds.toSet}"
           debug(versionConflictMessage)
           throw VersionUnexpectedConflictException(versionConflictMessage)
-        }
 
       case _ => ()
     }

--- a/pipeline/matcher/src/main/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdater.scala
+++ b/pipeline/matcher/src/main/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdater.scala
@@ -17,7 +17,19 @@ object WorkGraphUpdater extends Logging {
     val affectedWorks = affectedNodes.map { n => n.id -> n }.toMap
 
     checkVersionConflicts(work, affectedWorks)
-    doUpdate(work, affectedNodes)
+
+    val newSubgraph = new WorkSubgraph(
+      newWork = WorkNode(
+        id = work.id,
+        version = work.version,
+        linkedIds = work.referencedWorkIds.toList,
+        componentId = ComponentId(work.id),
+        suppressed = work.suppressed
+      ),
+      existingWorks = affectedWorks.filterNot { case (id, _) => id == work.id }
+    )
+
+    newSubgraph.create
   }
 
   private def checkVersionConflicts(work: WorkStub,
@@ -38,40 +50,15 @@ object WorkGraphUpdater extends Logging {
 
       case _ => ()
     }
+}
 
-  private def doUpdate(work: WorkStub,
-                       affectedNodes: Set[WorkNode]): Set[WorkNode] = {
+private class WorkSubgraph(newWork: WorkNode, existingWorks: Map[CanonicalId, WorkNode]) {
+  require(!existingWorks.contains(newWork.id))
 
-    // Find everything that's in the existing graph, but which isn't
-    // the node we're updating.
-    //
-    // e.g.     A   B
-    //           \ /
-    //            C
-    //           / \
-    //          D   E
-    //
-    // If we're updating work B, then this list will be (A C D E).
-    //
-    val linkedWorks =
-      affectedNodes.filterNot(_.id == work.id)
+  // This is a lookup of all the works in this update
+  val allWorks: Map[CanonicalId, WorkNode] = existingWorks + (newWork.id -> newWork)
 
-    // Create a map (work ID) -> (version) for every work in the graph.
-    //
-    // Every work in the existing graph will be in this list.
-    //
-    val workVersions: Map[CanonicalId, Int] =
-      linkedWorks.collect {
-        case WorkNode(id, Some(version), _, _, _) => (id, version)
-      }.toMap + (work.id -> work.version)
-
-    // Create a set of all Works that are suppressed at the source.  We shouldn't
-    // include any of these in the final graph.
-    val suppressedWorks: Set[CanonicalId] =
-      (linkedWorks.map(w => (w.id, w.suppressed)) ++ Set(
-        (work.id, work.suppressed)))
-        .collect { case (workId, true) => workId }
-
+  def create: Set[WorkNode] = {
     // Create a list of all the connections between works in the graph.
     //
     // e.g.     A → B → C
@@ -83,16 +70,10 @@ object WorkGraphUpdater extends Logging {
     //    updateLinks = (D → E)
     //    otherLinks  = (A → B, B → C, B → D)
     //
-    val updateLinks =
-      work.referencedWorkIds.map {
-        work.id ~> _
+    val links =
+      allWorks.flatMap { case (id, work) =>
+        work.linkedIds.map { id ~> _ }
       }
-
-    val otherLinks =
-      linkedWorks
-        .flatMap { node =>
-          node.linkedIds.map { node.id ~> _ }
-        }
 
     // Remove any links that come to/from works that are suppressed.
     // This means we won't match "through" these works.
@@ -107,18 +88,12 @@ object WorkGraphUpdater extends Logging {
     //          D → E
     //
     // We record information about suppressions in the matcher database.
-    val allLinks = updateLinks ++ otherLinks
-    val unsuppressedLinks = allLinks
-      .filterNot { lk =>
-        suppressedWorks.contains(lk.head) || suppressedWorks.contains(lk.to)
-      }
+    val unsuppressedLinks = links
+      .filterNot { link => link.head.isSuppressed || link.to.isSuppressed }
 
     // Get the IDs of all the works in this graph, and construct a Graph object.
     val workIds =
-      affectedNodes
-        .flatMap { node =>
-          node.id +: node.linkedIds
-        } + work.id
+      allWorks.flatMap { case (id, work) => id +: work.linkedIds }
 
     val g = Graph.from(edges = unsuppressedLinks, nodes = workIds)
 
@@ -134,9 +109,9 @@ object WorkGraphUpdater extends Logging {
     // being used for the matcher result.  e.g. linkedWorkIds(B) would be the same even
     // if work D was suppressed.
     //
-    def linkedWorkIds(n: g.NodeT): List[CanonicalId] =
-      allLinks
-        .collect { case link if link.head == n.value => link.to }
+    def linkedWorkIds(id: CanonicalId): List[CanonicalId] =
+      links
+        .collect { case link if link.head == id => link.to }
         .toList
         .sorted
 
@@ -153,15 +128,22 @@ object WorkGraphUpdater extends Logging {
       .flatMap(component => {
         val nodeIds = component.nodes.map(_.value).toList
         component.nodes.map(node => {
+          val id = node.value
+
           WorkNode(
-            id = node.value,
-            version = workVersions.get(node.value),
-            linkedIds = linkedWorkIds(node),
+            id = id,
+            version = allWorks.get(id).flatMap(_.version),
+            linkedIds = linkedWorkIds(id),
             componentId = ComponentId(nodeIds),
-            suppressed = suppressedWorks.contains(node.value)
+            suppressed = id.isSuppressed
           )
         })
       })
       .toSet
+  }
+
+  implicit class WorkOps(id: CanonicalId) {
+    def isSuppressed: Boolean =
+      allWorks.get(id).exists(_.suppressed)
   }
 }

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/generators/WorkNodeGenerators.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/generators/WorkNodeGenerators.scala
@@ -1,0 +1,91 @@
+package weco.pipeline.matcher.generators
+
+import weco.catalogue.internal_model.identifiers.IdState
+import weco.catalogue.internal_model.work.{MergeCandidate, WorkState}
+import weco.pipeline.matcher.models.{ComponentId, WorkNode, WorkStub}
+
+import java.time.Instant
+
+trait WorkNodeGenerators extends WorkStubGenerators  {
+  def createOneWork(pattern: String): WorkNode =
+    pattern match {
+      case "A" =>
+        WorkNode(
+          id = idA,
+          version = 0,
+          linkedIds = Nil,
+          componentId = ComponentId(idA)
+        )
+    }
+
+  def createTwoWorks(pattern: String): (WorkNode, WorkNode) =
+    pattern match {
+      case "A->B" =>
+        (
+          WorkNode(
+            idA,
+            version = 1,
+            linkedIds = List(idB),
+            componentId = ComponentId(idA, idB)),
+          WorkNode(
+            idB,
+            version = 1,
+            linkedIds = Nil,
+            componentId = ComponentId(idA, idB))
+        )
+    }
+
+  def createThreeWorks(pattern: String): (WorkNode, WorkNode, WorkNode) =
+    pattern match {
+      case "A->B->C" =>
+        (
+          WorkNode(
+            idA,
+            version = 1,
+            linkedIds = List(idB),
+            componentId = ComponentId(idA, idB, idC)),
+          WorkNode(
+            idB,
+            version = 1,
+            linkedIds = List(idC),
+            componentId = ComponentId(idA, idB, idC)),
+          WorkNode(
+            idC,
+            version = 1,
+            linkedIds = Nil,
+            componentId = ComponentId(idA, idB, idC)),
+        )
+    }
+
+  implicit class WorkNodeOps(n: WorkNode) {
+    def toStub: WorkStub =
+      WorkStub(
+        state = WorkState.Identified(
+          sourceIdentifier = createSourceIdentifier,
+          canonicalId = n.id,
+          mergeCandidates = n.linkedIds
+            .filterNot { _ == n.id }
+            .map { canonicalId =>
+              IdState.Identified(
+                canonicalId = canonicalId,
+                sourceIdentifier = createSourceIdentifier)
+            }
+            .map { id =>
+              MergeCandidate(
+                id = id,
+                reason = "Linked in the matcher tests"
+              )
+            }
+            .toList,
+          sourceModifiedTime = Instant.now()
+        ),
+        version = n.version.get,
+        workType = "Visible"
+      )
+  }
+
+//  def createThreeWorks(pattern: String) =
+//    pattern match {
+//      case "A->B->C"
+//    }
+}

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/generators/WorkNodeGenerators.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/generators/WorkNodeGenerators.scala
@@ -14,9 +14,30 @@ trait WorkNodeGenerators extends WorkStubGenerators {
       case "A" =>
         WorkNode(
           id = idA,
-          version = 0,
+          version = 1,
           linkedIds = Nil,
           componentId = ComponentId(idA)
+        )
+      case "B" =>
+        WorkNode(
+          id = idB,
+          version = 1,
+          linkedIds = Nil,
+          componentId = ComponentId(idB)
+        )
+      case "C" =>
+        WorkNode(
+          id = idC,
+          version = 1,
+          linkedIds = Nil,
+          componentId = ComponentId(idC)
+        )
+      case "D" =>
+        WorkNode(
+          id = idD,
+          version = 1,
+          linkedIds = Nil,
+          componentId = ComponentId(idD)
         )
     }
 
@@ -35,6 +56,19 @@ trait WorkNodeGenerators extends WorkStubGenerators {
             linkedIds = Nil,
             componentId = ComponentId(idA, idB))
         )
+      case "C->D" =>
+        (
+          WorkNode(
+            idC,
+            version = 1,
+            linkedIds = List(idD),
+            componentId = ComponentId(idC, idD)),
+          WorkNode(
+            idD,
+            version = 1,
+            linkedIds = Nil,
+            componentId = ComponentId(idC, idD))
+        )
     }
 
   def createThreeWorks(pattern: String): (WorkNode, WorkNode, WorkNode) =
@@ -50,6 +84,24 @@ trait WorkNodeGenerators extends WorkStubGenerators {
             idB,
             version = 1,
             linkedIds = List(idC),
+            componentId = ComponentId(idA, idB, idC)),
+          WorkNode(
+            idC,
+            version = 1,
+            linkedIds = Nil,
+            componentId = ComponentId(idA, idB, idC)),
+        )
+      case "A<->B->C" =>
+        (
+          WorkNode(
+            idA,
+            version = 1,
+            linkedIds = List(idB),
+            componentId = ComponentId(idA, idB, idC)),
+          WorkNode(
+            idB,
+            version = 1,
+            linkedIds = List(idA, idC),
             componentId = ComponentId(idA, idB, idC)),
           WorkNode(
             idC,

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/generators/WorkNodeGenerators.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/generators/WorkNodeGenerators.scala
@@ -1,12 +1,14 @@
 package weco.pipeline.matcher.generators
 
-import weco.catalogue.internal_model.identifiers.IdState
-import weco.catalogue.internal_model.work.{MergeCandidate, WorkState}
-import weco.pipeline.matcher.models.{ComponentId, WorkNode, WorkStub}
+import weco.pipeline.matcher.models.{ComponentId, WorkNode}
 
-import java.time.Instant
+trait WorkNodeGenerators extends WorkStubGenerators {
+  // These patterns are to make it easier to write simple tests.
+  //
+  // We're not writing arbitrary pattern parsing code; instead we have some hard-coded
+  // examples whose meaning is hopefully obvious that reduces the amount of repetition
+  // in our tests.
 
-trait WorkNodeGenerators extends WorkStubGenerators  {
   def createOneWork(pattern: String): WorkNode =
     pattern match {
       case "A" =>
@@ -56,36 +58,4 @@ trait WorkNodeGenerators extends WorkStubGenerators  {
             componentId = ComponentId(idA, idB, idC)),
         )
     }
-
-  implicit class WorkNodeOps(n: WorkNode) {
-    def toStub: WorkStub =
-      WorkStub(
-        state = WorkState.Identified(
-          sourceIdentifier = createSourceIdentifier,
-          canonicalId = n.id,
-          mergeCandidates = n.linkedIds
-            .filterNot { _ == n.id }
-            .map { canonicalId =>
-              IdState.Identified(
-                canonicalId = canonicalId,
-                sourceIdentifier = createSourceIdentifier)
-            }
-            .map { id =>
-              MergeCandidate(
-                id = id,
-                reason = "Linked in the matcher tests"
-              )
-            }
-            .toList,
-          sourceModifiedTime = Instant.now()
-        ),
-        version = n.version.get,
-        workType = "Visible"
-      )
-  }
-
-//  def createThreeWorks(pattern: String) =
-//    pattern match {
-//      case "A->B->C"
-//    }
 }

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/matcher/WorkMatcherTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/matcher/WorkMatcherTest.scala
@@ -4,19 +4,13 @@ import org.scalatest.EitherValues
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+import weco.catalogue.internal_model.identifiers.CanonicalId
 import weco.storage.locking.LockFailure
 import weco.storage.locking.memory.{MemoryLockDao, MemoryLockingService}
 import weco.fixtures.TimeAssertions
 import weco.pipeline.matcher.fixtures.MatcherFixtures
 import weco.pipeline.matcher.generators.WorkStubGenerators
-import weco.pipeline.matcher.models.{
-  ComponentId,
-  MatchedIdentifiers,
-  MatcherResult,
-  WorkIdentifier,
-  WorkNode,
-  WorkStub
-}
+import weco.pipeline.matcher.models.{ComponentId, MatchedIdentifiers, MatcherResult, WorkIdentifier, WorkNode}
 import weco.pipeline.matcher.storage.{WorkGraphStore, WorkNodeDao}
 
 import java.util.UUID
@@ -257,7 +251,7 @@ class WorkMatcherTest
     val expectedException = new RuntimeException("Failed to put")
 
     val brokenStore = new WorkGraphStore(workNodeDao) {
-      override def findAffectedWorks(w: WorkStub): Future[Set[WorkNode]] =
+      override def findAffectedWorks(ids: Set[CanonicalId]): Future[Set[WorkNode]] =
         Future.successful(Set[WorkNode]())
 
       override def put(nodes: Set[WorkNode]): Future[Unit] =

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/matcher/WorkMatcherTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/matcher/WorkMatcherTest.scala
@@ -10,7 +10,13 @@ import weco.storage.locking.memory.{MemoryLockDao, MemoryLockingService}
 import weco.fixtures.TimeAssertions
 import weco.pipeline.matcher.fixtures.MatcherFixtures
 import weco.pipeline.matcher.generators.WorkStubGenerators
-import weco.pipeline.matcher.models.{ComponentId, MatchedIdentifiers, MatcherResult, WorkIdentifier, WorkNode}
+import weco.pipeline.matcher.models.{
+  ComponentId,
+  MatchedIdentifiers,
+  MatcherResult,
+  WorkIdentifier,
+  WorkNode
+}
 import weco.pipeline.matcher.storage.{WorkGraphStore, WorkNodeDao}
 
 import java.util.UUID
@@ -251,7 +257,8 @@ class WorkMatcherTest
     val expectedException = new RuntimeException("Failed to put")
 
     val brokenStore = new WorkGraphStore(workNodeDao) {
-      override def findAffectedWorks(ids: Set[CanonicalId]): Future[Set[WorkNode]] =
+      override def findAffectedWorks(
+        ids: Set[CanonicalId]): Future[Set[WorkNode]] =
         Future.successful(Set[WorkNode]())
 
       override def put(nodes: Set[WorkNode]): Future[Unit] =

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/storage/WorkGraphStoreTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/storage/WorkGraphStoreTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.funspec.AnyFunSpec
 import weco.pipeline.matcher.fixtures.MatcherFixtures
-import weco.pipeline.matcher.generators.WorkStubGenerators
+import weco.pipeline.matcher.generators.WorkNodeGenerators
 import weco.pipeline.matcher.models.{ComponentId, WorkNode}
 import weco.pipeline.matcher.workgraph.WorkGraphUpdater
 
@@ -17,17 +17,13 @@ class WorkGraphStoreTest
     with Matchers
     with ScalaFutures
     with MatcherFixtures
-    with WorkStubGenerators {
+    with WorkNodeGenerators {
 
   describe("Get graph of linked works") {
     it("returns nothing if there are no matching graphs") {
       withWorkGraphTable { graphTable =>
         withWorkGraphStore(graphTable) { workGraphStore =>
-          val future = workGraphStore.findAffectedWorks(
-            createWorkWith(
-              id = createCanonicalId,
-              version = 0,
-              referencedWorkIds = Set.empty))
+          val future = workGraphStore.findAffectedWorks(ids = Set(createCanonicalId))
 
           whenReady(future) {
             _ shouldBe empty
@@ -40,17 +36,11 @@ class WorkGraphStoreTest
       "returns a WorkNode if it has no links and it's the only node in the setId") {
       withWorkGraphTable { graphTable =>
         withWorkGraphStore(graphTable) { workGraphStore =>
-          val work =
-            WorkNode(
-              id = idA,
-              version = 0,
-              linkedIds = Nil,
-              componentId = ComponentId(idA))
+          val work = createOneWork("A")
 
           putTableItem(work, table = graphTable)
 
-          val future =
-            workGraphStore.findAffectedWorks(createWorkWith(idA, 0, Set.empty))
+          val future = workGraphStore.findAffectedWorks(ids = Set(work.id))
 
           whenReady(future) {
             _ shouldBe Set(work)
@@ -62,23 +52,11 @@ class WorkGraphStoreTest
     it("returns a WorkNode and the links in the workUpdate") {
       withWorkGraphTable { graphTable =>
         withWorkGraphStore(graphTable) { workGraphStore =>
-          val workA =
-            WorkNode(
-              id = idA,
-              version = 0,
-              linkedIds = Nil,
-              componentId = ComponentId(idA))
-          val workB =
-            WorkNode(
-              id = idB,
-              version = 0,
-              linkedIds = Nil,
-              componentId = ComponentId(idB))
+          val (workA, workB) = createTwoWorks("A->B")
 
           putTableItems(items = Seq(workA, workB), table = graphTable)
 
-          val future =
-            workGraphStore.findAffectedWorks(createWorkWith(idA, 0, Set(idB)))
+          val future = workGraphStore.findAffectedWorks(ids = Set(workA.id))
 
           whenReady(future) {
             _ shouldBe Set(workA, workB)
@@ -90,24 +68,11 @@ class WorkGraphStoreTest
     it("returns a WorkNode and the links in the database") {
       withWorkGraphTable { graphTable =>
         withWorkGraphStore(graphTable) { workGraphStore =>
-          val workA =
-            WorkNode(
-              id = idA,
-              version = 0,
-              linkedIds = List(idB),
-              componentId = ComponentId(idA, idB))
-          val workB =
-            WorkNode(
-              id = idB,
-              version = 0,
-              linkedIds = Nil,
-              componentId = ComponentId(idA, idB))
+          val (workA, workB) = createTwoWorks("A->B")
 
           putTableItems(items = Seq(workA, workB), table = graphTable)
 
-          val future =
-            workGraphStore.findAffectedWorks(
-              createWorkWith(idA, version = 0, referencedWorkIds = Set.empty))
+          val future = workGraphStore.findAffectedWorks(ids = Set(workA.id))
 
           whenReady(future) {
             _ shouldBe Set(workA, workB)
@@ -116,70 +81,23 @@ class WorkGraphStoreTest
       }
     }
 
-    it(
-      "returns a WorkNode and the links in the database more than one level down") {
+    it("finds all the affected works, from anywhere in the component") {
       withWorkGraphTable { graphTable =>
         withWorkGraphStore(graphTable) { workGraphStore =>
-          val workA =
-            WorkNode(
-              id = idA,
-              version = 0,
-              linkedIds = List(idB),
-              componentId = ComponentId(idA, idB, idC))
-          val workB =
-            WorkNode(
-              id = idB,
-              version = 0,
-              linkedIds = List(idC),
-              componentId = ComponentId(idA, idB, idC))
-          val workC = WorkNode(
-            id = idC,
-            version = 0,
-            linkedIds = Nil,
-            componentId = ComponentId(idA, idB, idC))
+          val (workA, workB, workC) = createThreeWorks("A->B->C")
 
           putTableItems(items = Seq(workA, workB, workC), table = graphTable)
 
-          val future =
-            workGraphStore.findAffectedWorks(createWorkWith(idA, 0, Set.empty))
+          val works = Set(workA, workB, workC)
 
-          whenReady(future) {
-            _ shouldBe Set(workA, workB, workC)
-          }
-        }
-      }
-    }
+          works.foreach { w =>
+            println(s"Finding affected works for ${w.id}")
 
-    it(
-      "returns a WorkNode and the links in the database where an update joins two sets of works") {
-      withWorkGraphTable { graphTable =>
-        withWorkGraphStore(graphTable) { workGraphStore =>
-          val workA =
-            WorkNode(
-              id = idA,
-              version = 0,
-              linkedIds = List(idB),
-              componentId = ComponentId(idA, idB))
-          val workB =
-            WorkNode(
-              id = idB,
-              version = 0,
-              linkedIds = Nil,
-              componentId = ComponentId(idA, idB))
-          val workC =
-            WorkNode(
-              id = idC,
-              version = 0,
-              linkedIds = Nil,
-              componentId = ComponentId(idC))
+            val future = workGraphStore.findAffectedWorks(ids = Set(w.id))
 
-          putTableItems(items = Seq(workA, workB, workC), table = graphTable)
-
-          val work =
-            createWorkWith(idB, version = 0, referencedWorkIds = Set(idC))
-
-          whenReady(workGraphStore.findAffectedWorks(work)) {
-            _ shouldBe Set(workA, workB, workC)
+            whenReady(future) {
+              _ shouldBe works
+            }
           }
         }
       }
@@ -204,20 +122,20 @@ class WorkGraphStoreTest
           Await.ready(workGraphStore.put(nodesC), atMost = 1 second)
 
           // Then store B
-          whenReady(workGraphStore.findAffectedWorks(workB)) { affectedNodes =>
+          whenReady(workGraphStore.findAffectedWorks(ids = workB.ids)) { affectedNodes =>
             val updatedNodes = WorkGraphUpdater.update(workB, affectedNodes)
             Await.ready(workGraphStore.put(updatedNodes), atMost = 1 second)
           }
 
           // Then store A
-          whenReady(workGraphStore.findAffectedWorks(workA)) { affectedNodes =>
+          whenReady(workGraphStore.findAffectedWorks(ids = workA.ids)) { affectedNodes =>
             val updatedNodes = WorkGraphUpdater.update(workA, affectedNodes)
             Await.ready(workGraphStore.put(updatedNodes), atMost = 1 second)
           }
 
           getExistingTableItem[WorkNode](id = idC.underlying, graphTable).suppressed shouldBe true
 
-          whenReady(workGraphStore.findAffectedWorks(workA)) { affectedNodes =>
+          whenReady(workGraphStore.findAffectedWorks(ids = workA.ids)) { affectedNodes =>
             affectedNodes.map(_.id) should contain(workC.id)
           }
         }
@@ -229,23 +147,15 @@ class WorkGraphStoreTest
     it("puts a simple graph") {
       withWorkGraphTable { graphTable =>
         withWorkGraphStore(graphTable) { workGraphStore =>
-          val workNodeA = WorkNode(
-            idA,
-            version = 0,
-            linkedIds = List(idB),
-            componentId = ComponentId(idA, idB))
-          val workNodeB = WorkNode(
-            idB,
-            version = 0,
-            linkedIds = Nil,
-            componentId = ComponentId(idA, idB))
+          val (workA, workB) = createTwoWorks("A->B")
+          val works = Set(workA, workB)
 
-          whenReady(workGraphStore.put(Set(workNodeA, workNodeB))) { _ =>
+          val future = workGraphStore.put(works)
+
+          whenReady(future) { _ =>
             val savedWorks = scanTable[WorkNode](graphTable)
               .map(_.right.get)
-            savedWorks should contain theSameElementsAs List(
-              workNodeA,
-              workNodeB)
+            savedWorks should contain theSameElementsAs works
           }
         }
       }

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/storage/WorkGraphStoreTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/storage/WorkGraphStoreTest.scala
@@ -23,7 +23,8 @@ class WorkGraphStoreTest
     it("returns nothing if there are no matching graphs") {
       withWorkGraphTable { graphTable =>
         withWorkGraphStore(graphTable) { workGraphStore =>
-          val future = workGraphStore.findAffectedWorks(ids = Set(createCanonicalId))
+          val future =
+            workGraphStore.findAffectedWorks(ids = Set(createCanonicalId))
 
           whenReady(future) {
             _ shouldBe empty
@@ -105,21 +106,24 @@ class WorkGraphStoreTest
           Await.ready(workGraphStore.put(nodesC), atMost = 1 second)
 
           // Then store B
-          whenReady(workGraphStore.findAffectedWorks(ids = workB.ids)) { affectedNodes =>
-            val updatedNodes = WorkGraphUpdater.update(workB, affectedNodes)
-            Await.ready(workGraphStore.put(updatedNodes), atMost = 1 second)
+          whenReady(workGraphStore.findAffectedWorks(ids = workB.ids)) {
+            affectedNodes =>
+              val updatedNodes = WorkGraphUpdater.update(workB, affectedNodes)
+              Await.ready(workGraphStore.put(updatedNodes), atMost = 1 second)
           }
 
           // Then store A
-          whenReady(workGraphStore.findAffectedWorks(ids = workA.ids)) { affectedNodes =>
-            val updatedNodes = WorkGraphUpdater.update(workA, affectedNodes)
-            Await.ready(workGraphStore.put(updatedNodes), atMost = 1 second)
+          whenReady(workGraphStore.findAffectedWorks(ids = workA.ids)) {
+            affectedNodes =>
+              val updatedNodes = WorkGraphUpdater.update(workA, affectedNodes)
+              Await.ready(workGraphStore.put(updatedNodes), atMost = 1 second)
           }
 
           getExistingTableItem[WorkNode](id = idC.underlying, graphTable).suppressed shouldBe true
 
-          whenReady(workGraphStore.findAffectedWorks(ids = workA.ids)) { affectedNodes =>
-            affectedNodes.map(_.id) should contain(workC.id)
+          whenReady(workGraphStore.findAffectedWorks(ids = workA.ids)) {
+            affectedNodes =>
+              affectedNodes.map(_.id) should contain(workC.id)
           }
         }
       }

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdaterTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdaterTest.scala
@@ -47,25 +47,6 @@ class WorkGraphUpdaterTest
           componentId = ComponentId(idA, idB))
       )
     }
-
-    it("updating nothing with B->A gives A+B:B->A") {
-      WorkGraphUpdater
-        .update(
-          work = createWorkWith(idB, version = 1, referencedWorkIds = Set(idA)),
-          affectedNodes = Set()
-        ) shouldBe Set(
-        WorkNode(
-          idB,
-          version = 1,
-          linkedIds = List(idA),
-          componentId = ComponentId(idA, idB)),
-        WorkNode(
-          idA,
-          version = None,
-          linkedIds = List(),
-          componentId = ComponentId(idA, idB))
-      )
-    }
   }
 
   describe("Adding links to existing works") {

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdaterTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdaterTest.scala
@@ -2,39 +2,35 @@ package weco.pipeline.matcher.workgraph
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import weco.pipeline.matcher.generators.WorkStubGenerators
-import weco.pipeline.matcher.models.{
-  ComponentId,
-  VersionExpectedConflictException,
-  VersionUnexpectedConflictException,
-  WorkNode
-}
+import weco.pipeline.matcher.generators.WorkNodeGenerators
+import weco.pipeline.matcher.models.{ComponentId, VersionExpectedConflictException, VersionUnexpectedConflictException, WorkNode}
 
 class WorkGraphUpdaterTest
     extends AnyFunSpec
     with Matchers
-    with WorkStubGenerators {
+    with WorkNodeGenerators {
 
   describe("Adding links without existing works") {
     it("updating nothing with A gives A:A") {
-      WorkGraphUpdater
+      val workA = createOneWork("A")
+
+      val result = WorkGraphUpdater
         .update(
           work = createWorkWith(idA, version = 1, referencedWorkIds = Set.empty),
           affectedNodes = Set()
-        ) shouldBe Set(
-        WorkNode(
-          idA,
-          version = 1,
-          linkedIds = List(),
-          componentId = ComponentId(idA)))
+        )
+
+      result shouldBe Set(workA)
     }
 
     it("updating nothing with A->B gives A+B:A->B") {
-      WorkGraphUpdater
+      val result = WorkGraphUpdater
         .update(
           work = createWorkWith(idA, version = 1, referencedWorkIds = Set(idB)),
           affectedNodes = Set()
-        ) shouldBe Set(
+        )
+
+      result shouldBe Set(
         WorkNode(
           idA,
           version = 1,
@@ -51,22 +47,16 @@ class WorkGraphUpdaterTest
 
   describe("Adding links to existing works") {
     it("updating A, B with A->B gives A+B:(A->B, B)") {
-      WorkGraphUpdater
+      val workA = createOneWork("A")
+      val workB = createOneWork("B")
+
+      val result = WorkGraphUpdater
         .update(
           work = createWorkWith(idA, version = 2, referencedWorkIds = Set(idB)),
-          affectedNodes = Set(
-            WorkNode(
-              idA,
-              version = 1,
-              linkedIds = Nil,
-              componentId = ComponentId(idA)),
-            WorkNode(
-              idB,
-              version = 1,
-              linkedIds = Nil,
-              componentId = ComponentId(idB))
-          )
-        ) should contain theSameElementsAs
+          affectedNodes = Set(workA, workB)
+        )
+
+      result should contain theSameElementsAs
         List(
           WorkNode(
             idA,
@@ -82,21 +72,15 @@ class WorkGraphUpdaterTest
     }
 
     it("updating A->B with A->B gives A+B:(A->B, B)") {
-      WorkGraphUpdater
+      val (workA, workB) = createTwoWorks("A->B")
+
+      val result = WorkGraphUpdater
         .update(
           work = createWorkWith(idA, version = 2, referencedWorkIds = Set(idB)),
-          affectedNodes = Set(
-            WorkNode(
-              idA,
-              version = 1,
-              linkedIds = List(idB),
-              componentId = ComponentId(idA, idB)),
-            WorkNode(
-              idB,
-              version = 1,
-              linkedIds = Nil,
-              componentId = ComponentId(idA, idB)))
-        ) shouldBe Set(
+          affectedNodes = Set(workA, workB)
+        )
+
+      result shouldBe Set(
         WorkNode(
           idA,
           version = 2,
@@ -111,30 +95,19 @@ class WorkGraphUpdaterTest
     }
 
     it("updating A->B, B, C with B->C gives A+B+C:(A->B, B->C, C)") {
-      WorkGraphUpdater
+      val (workA, workB) = createTwoWorks("A->B")
+      val (workC) = createOneWork("C")
+
+      val result = WorkGraphUpdater
         .update(
           work = createWorkWith(idB, version = 2, referencedWorkIds = Set(idC)),
-          affectedNodes = Set(
-            WorkNode(
-              idA,
-              version = 2,
-              linkedIds = List(idB),
-              componentId = "A+B"),
-            WorkNode(
-              idB,
-              version = 1,
-              linkedIds = Nil,
-              componentId = ComponentId(idA, idB)),
-            WorkNode(
-              idC,
-              version = 1,
-              linkedIds = Nil,
-              componentId = ComponentId(idC))
-          )
-        ) shouldBe Set(
+          affectedNodes = Set(workA, workB, workC)
+        )
+
+      result shouldBe Set(
         WorkNode(
           idA,
-          version = 2,
+          version = 1,
           linkedIds = List(idB),
           componentId = ComponentId(idA, idB, idC)),
         WorkNode(
@@ -151,24 +124,16 @@ class WorkGraphUpdaterTest
     }
 
     it("updating A->B, C->D with B->C gives A+B+C+D:(A->B, B->C, C->D, D)") {
-      WorkGraphUpdater
+      val (workA, workB) = createTwoWorks("A->B")
+      val (workC, workD) = createTwoWorks("C->D")
+
+      val result = WorkGraphUpdater
         .update(
           work = createWorkWith(idB, version = 2, referencedWorkIds = Set(idC)),
-          affectedNodes = Set(
-            WorkNode(
-              idA,
-              version = 1,
-              linkedIds = List(idB),
-              componentId = "A+B"),
-            WorkNode(
-              idC,
-              version = 1,
-              linkedIds = List(idD),
-              componentId = "C+D"),
-            WorkNode(idB, version = 1, linkedIds = Nil, componentId = "A+B"),
-            WorkNode(idD, version = 1, linkedIds = Nil, componentId = "C+D")
-          )
-        ) shouldBe
+          affectedNodes = Set(workA, workB, workC, workD)
+        )
+
+      result shouldBe
         Set(
           WorkNode(
             idA,
@@ -194,37 +159,22 @@ class WorkGraphUpdaterTest
     }
 
     it("updating A->B with B->[C,D] gives A+B+C+D:(A->B, B->C&D, C, D") {
-      WorkGraphUpdater
+      val (workA, workB) = createTwoWorks("A->B")
+      val workC = createOneWork("C")
+      val workD = createOneWork("D")
+
+      val result = WorkGraphUpdater
         .update(
           work =
             createWorkWith(idB, version = 2, referencedWorkIds = Set(idC, idD)),
-          affectedNodes = Set(
-            WorkNode(
-              idA,
-              version = 2,
-              linkedIds = List(idB),
-              componentId = "A+B"),
-            WorkNode(
-              idB,
-              version = 1,
-              linkedIds = Nil,
-              componentId = ComponentId(idA, idB)),
-            WorkNode(
-              idC,
-              version = 1,
-              linkedIds = Nil,
-              componentId = ComponentId(idC)),
-            WorkNode(
-              idD,
-              version = 1,
-              linkedIds = Nil,
-              componentId = ComponentId(idD))
-          )
-        ) shouldBe
+          affectedNodes = Set(workA, workB, workC, workD)
+        )
+
+      result shouldBe
         Set(
           WorkNode(
             idA,
-            version = 2,
+            version = 1,
             linkedIds = List(idB),
             componentId = ComponentId(idA, idB, idC, idD)),
           WorkNode(
@@ -245,32 +195,24 @@ class WorkGraphUpdaterTest
         )
     }
 
-    it("updating A->B->C with A->C gives A+B+C:(A->B, B->C, C->A") {
-      WorkGraphUpdater
+    it("updating A->B->C with C->A gives A+B+C:(A->B, B->C, C->A") {
+      val (workA, workB, workC) = createThreeWorks("A->B->C")
+
+      val result = WorkGraphUpdater
         .update(
           work = createWorkWith(idC, version = 2, referencedWorkIds = Set(idA)),
-          affectedNodes = Set(
-            WorkNode(
-              idA,
-              version = 2,
-              linkedIds = List(idB),
-              componentId = "A+B+C"),
-            WorkNode(
-              idB,
-              version = 2,
-              linkedIds = List(idC),
-              componentId = "A+B+C"),
-            WorkNode(idC, version = 1, linkedIds = Nil, componentId = "A+B+C")
-          )
-        ) shouldBe Set(
+          affectedNodes = Set(workA, workB, workC)
+        )
+
+      result shouldBe Set(
         WorkNode(
           idA,
-          version = 2,
+          version = 1,
           linkedIds = List(idB),
           componentId = ComponentId(idA, idB, idC)),
         WorkNode(
           idB,
-          version = 2,
+          version = 1,
           linkedIds = List(idC),
           componentId = ComponentId(idA, idB, idC)),
         WorkNode(
@@ -284,19 +226,19 @@ class WorkGraphUpdaterTest
 
   describe("Update version") {
     it("processes an update for a newer version") {
-      val existingVersion = 1
-      val updateVersion = 2
-      WorkGraphUpdater
+      val workA = createOneWork("A")
+
+      val existingVersion = workA.version.get
+      val updateVersion = existingVersion + 1
+
+      val result = WorkGraphUpdater
         .update(
           work =
             createWorkWith(idA, updateVersion, referencedWorkIds = Set(idB)),
-          affectedNodes = Set(
-            WorkNode(
-              idA,
-              existingVersion,
-              linkedIds = Nil,
-              componentId = ComponentId(idA)))
-        ) should contain theSameElementsAs
+          affectedNodes = Set(workA)
+        )
+
+      result should contain theSameElementsAs
         List(
           WorkNode(
             idA,
@@ -312,102 +254,67 @@ class WorkGraphUpdaterTest
     }
 
     it("doesn't process an update for a lower version") {
-      val existingVersion = 3
-      val updateVersion = 1
+      val workA = createOneWork("A")
+
+      val existingVersion = workA.version.get
+      val updateVersion = existingVersion - 1
 
       val thrown = intercept[VersionExpectedConflictException] {
         WorkGraphUpdater
           .update(
             work =
               createWorkWith(idA, updateVersion, referencedWorkIds = Set(idB)),
-            affectedNodes = Set(
-              WorkNode(
-                idA,
-                existingVersion,
-                linkedIds = Nil,
-                componentId = ComponentId(idA)))
+            affectedNodes = Set(workA)
           )
       }
-      thrown.message shouldBe s"update failed, work:$idA v1 is not newer than existing work v3"
+      thrown.message shouldBe s"update failed, work:$idA v$updateVersion is not newer than existing work v$existingVersion"
     }
 
     it(
       "processes an update for the same version if it's the same as the one stored") {
-      val existingVersion = 2
-      val updateVersion = 2
+      val (workA, workB) = createTwoWorks("A->B")
 
-      WorkGraphUpdater
+      val existingVersion = workA.version.get
+
+      val result = WorkGraphUpdater
         .update(
           work =
-            createWorkWith(idA, updateVersion, referencedWorkIds = Set(idB)),
-          affectedNodes = Set(
-            WorkNode(
-              idA,
-              existingVersion,
-              linkedIds = List(idB),
-              componentId = ComponentId(idA, idB)),
-            WorkNode(
-              idB,
-              version = 0,
-              linkedIds = List(),
-              componentId = ComponentId(idA, idB))
-          )
-        ) should contain theSameElementsAs
-        List(
-          WorkNode(
-            idA,
-            updateVersion,
-            linkedIds = List(idB),
-            componentId = ComponentId(idA, idB)),
-          WorkNode(
-            idB,
-            version = 0,
-            linkedIds = List(),
-            componentId = ComponentId(idA, idB))
+            createWorkWith(idA, existingVersion, referencedWorkIds = Set(idB)),
+          affectedNodes = Set(workA, workB)
         )
+
+      result shouldBe Set(workA, workB)
     }
 
     it(
       "doesn't process an update for the same version if the work is different from the one stored") {
-      val existingVersion = 2
-      val updateVersion = 2
+      val (workA, workB) = createTwoWorks("A->B")
+
+      val existingVersion = workA.version.get
 
       val thrown = intercept[VersionUnexpectedConflictException] {
         WorkGraphUpdater
           .update(
             work =
-              createWorkWith(idA, updateVersion, referencedWorkIds = Set(idC)),
-            affectedNodes = Set(
-              WorkNode(
-                idA,
-                existingVersion,
-                linkedIds = List(idB),
-                componentId = ComponentId(idA, idB)),
-              WorkNode(
-                idB,
-                version = 0,
-                linkedIds = List(),
-                componentId = ComponentId(idA, idB))
-            )
+              createWorkWith(idA, existingVersion, referencedWorkIds = Set(idC)),
+            affectedNodes = Set(workA, workB)
           )
       }
-      thrown.getMessage shouldBe s"update failed, work:$idA v2 already exists with different content! update-ids:Set($idC) != existing-ids:Set($idB)"
+      thrown.getMessage shouldBe s"update failed, work:$idA v$existingVersion already exists with different content! update-ids:Set($idC) != existing-ids:Set($idB)"
     }
   }
 
   describe("Removing links") {
-    it("updating  A->B with A gives A:A and B:B") {
-      WorkGraphUpdater
+    it("updating A->B with A gives A:A and B:B") {
+      val (workA, workB) = createTwoWorks("A->B")
+
+      val result = WorkGraphUpdater
         .update(
           work = createWorkWith(idA, version = 2, referencedWorkIds = Set.empty),
-          affectedNodes = Set(
-            WorkNode(
-              idA,
-              version = 1,
-              linkedIds = List(idB),
-              componentId = "A+B"),
-            WorkNode(idB, version = 1, linkedIds = List(), componentId = "A+B"))
-        ) shouldBe Set(
+          affectedNodes = Set(workA, workB)
+        )
+
+      result shouldBe Set(
         WorkNode(
           idA,
           version = 2,
@@ -422,33 +329,23 @@ class WorkGraphUpdaterTest
     }
 
     it("updating A->B->C with B gives A+B:(A->B, B) and C:C") {
-      WorkGraphUpdater
+      val (workA, workB, workC) = createThreeWorks("A->B->C")
+
+      val result = WorkGraphUpdater
         .update(
-          work = createWorkWith(idB, version = 3, referencedWorkIds = Set.empty),
-          affectedNodes = (
-            Set(
-              WorkNode(
-                idA,
-                version = 2,
-                linkedIds = List(idB),
-                componentId = "A+B+C"),
-              WorkNode(
-                idB,
-                version = 2,
-                linkedIds = List(idC),
-                componentId = "A+B+C"),
-              WorkNode(idC, version = 1, linkedIds = Nil, componentId = "A+B+C")
-            )
-          )
-        ) shouldBe Set(
+          work = createWorkWith(idB, version = 2, referencedWorkIds = Set.empty),
+          affectedNodes = Set(workA, workB, workC)
+        )
+
+      result shouldBe Set(
         WorkNode(
           idA,
-          version = 2,
+          version = 1,
           linkedIds = List(idB),
           componentId = ComponentId(idA, idB)),
         WorkNode(
           idB,
-          version = 3,
+          version = 2,
           linkedIds = Nil,
           componentId = ComponentId(idA, idB)),
         WorkNode(
@@ -460,44 +357,28 @@ class WorkGraphUpdaterTest
     }
 
     it("updating A<->B->C with B->C gives A+B+C:(A->B, B->C, C)") {
-      WorkGraphUpdater
+      val (workA, workB, workC) = createThreeWorks("A<->B->C")
+
+      val result = WorkGraphUpdater
         .update(
-          work = createWorkWith(idB, version = 3, referencedWorkIds = Set(idC)),
-          affectedNodes = Set(
-            WorkNode(
-              idA,
-              version = 2,
-              linkedIds = List(idB),
-              componentId = "A+B+C"),
-            WorkNode(
-              idB,
-              version = 2,
-              linkedIds = List(idA, idC),
-              componentId = "A+B+C"),
-            WorkNode(idC, version = 1, linkedIds = Nil, componentId = "A+B+C")
-          )
-        ) shouldBe Set(
-        WorkNode(
-          idA,
-          version = 2,
-          linkedIds = List(idB),
-          componentId = ComponentId(idA, idB, idC)),
+          work = createWorkWith(idB, version = 2, referencedWorkIds = Set(idC)),
+          affectedNodes = Set(workA, workB, workC)
+        )
+
+      result shouldBe Set(
+        workA,
         WorkNode(
           idB,
-          version = 3,
+          version = 2,
           linkedIds = List(idC),
           componentId = ComponentId(idA, idB, idC)),
-        WorkNode(
-          idC,
-          version = 1,
-          linkedIds = Nil,
-          componentId = ComponentId(idA, idB, idC))
+        workC,
       )
     }
   }
 
   describe("handling suppressed works") {
-    it("A → B, but B is suppressed (updating A)") {
+    it("A->B, but B is suppressed (updating A)") {
       val result =
         WorkGraphUpdater.update(
           work = createWorkWith(idA, version = 1, referencedWorkIds = Set(idB)),
@@ -526,7 +407,7 @@ class WorkGraphUpdaterTest
       )
     }
 
-    it("A → B, but B is suppressed (updating B)") {
+    it("A->B, but B is suppressed (updating B)") {
       val result =
         WorkGraphUpdater.update(
           work = createWorkWith(
@@ -563,7 +444,7 @@ class WorkGraphUpdaterTest
       )
     }
 
-    it("A → B → C → D → E, but C is suppressed (updating A)") {
+    it("A->B->C->D->E, but C is suppressed (updating A)") {
       val result =
         WorkGraphUpdater.update(
           work = createWorkWith(idA, version = 1, referencedWorkIds = Set(idB)),
@@ -622,7 +503,7 @@ class WorkGraphUpdaterTest
       )
     }
 
-    it("A → B → C, B is suppressed, then B is updated as unsuppressed") {
+    it("A->B->C, B is suppressed, then B is updated as unsuppressed") {
       val graph1 =
         WorkGraphUpdater.update(
           work = createWorkWith(idA, version = 1, referencedWorkIds = Set(idB)),

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdaterTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdaterTest.scala
@@ -3,7 +3,12 @@ package weco.pipeline.matcher.workgraph
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.pipeline.matcher.generators.WorkNodeGenerators
-import weco.pipeline.matcher.models.{ComponentId, VersionExpectedConflictException, VersionUnexpectedConflictException, WorkNode}
+import weco.pipeline.matcher.models.{
+  ComponentId,
+  VersionExpectedConflictException,
+  VersionUnexpectedConflictException,
+  WorkNode
+}
 
 class WorkGraphUpdaterTest
     extends AnyFunSpec
@@ -295,8 +300,10 @@ class WorkGraphUpdaterTest
       val thrown = intercept[VersionUnexpectedConflictException] {
         WorkGraphUpdater
           .update(
-            work =
-              createWorkWith(idA, existingVersion, referencedWorkIds = Set(idC)),
+            work = createWorkWith(
+              idA,
+              existingVersion,
+              referencedWorkIds = Set(idC)),
             affectedNodes = Set(workA, workB)
           )
       }

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdaterTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdaterTest.scala
@@ -440,31 +440,6 @@ class WorkGraphUpdaterTest
       )
     }
 
-    it("updating A->B with A but NO B (*should* not occur) gives A:A and B:B") {
-      WorkGraphUpdater
-        .update(
-          work = createWorkWith(idA, version = 2, referencedWorkIds = Set.empty),
-          affectedNodes = Set(
-            WorkNode(
-              idA,
-              version = 1,
-              linkedIds = List(idB),
-              componentId = "A+B")
-          )
-        ) shouldBe Set(
-        WorkNode(
-          idA,
-          version = 2,
-          linkedIds = Nil,
-          componentId = ComponentId(idA)),
-        WorkNode(
-          idB,
-          version = None,
-          linkedIds = Nil,
-          componentId = ComponentId(idB))
-      )
-    }
-
     it("updating A->B->C with B gives A+B:(A->B, B) and C:C") {
       WorkGraphUpdater
         .update(


### PR DESCRIPTION
Some no-op refactoring for https://github.com/wellcomecollection/platform/issues/5389

In particular:

* Reducing the amount of boilerplate in the tests, so when I change WorkNode there are less places to update. This also helped me spot several identical or redundant tests we can remove. In particular we can now do things like:

    ```scala
    val workA = createOneWork("A")

    val (workA, workB) = createTwoWorks("A->B")
    ```

    and it creates the correct set of WorkNode values for you.

* Simplifying WorkGraphUpdater by creating a `Map[CanonicalId, WorkNode]` which contains all the state. This makes it much easier to look up the state of an existing node (e.g. version, suppressed)