### PR TITLE
Rejig the WorkNode model so we can simplify the way we retrieve changing graphs

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/SourceIdentifier.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/SourceIdentifier.scala
@@ -10,5 +10,5 @@ case class SourceIdentifier(
     value == value.trim,
     s"SourceIdentifier value has trailing/leading whitespace: <$value>")
 
-  override def toString = s"$ontologyType<${identifierType.id}/$value>"
+  override def toString = s"$ontologyType[${identifierType.id}/$value]"
 }

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/identifiers/SourceIdentifierTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/identifiers/SourceIdentifierTest.scala
@@ -11,7 +11,7 @@ class SourceIdentifierTest extends AnyFunSpec with Matchers {
       ontologyType = "Work"
     )
 
-    sourceIdentifier.toString shouldBe "Work<miro-image-number/A0001234>"
+    sourceIdentifier.toString shouldBe "Work[miro-image-number/A0001234]"
   }
 
   it("fails creating a sourceIdentifier with trailing spaces in the value") {

--- a/pipeline/matcher/src/main/scala/weco/pipeline/matcher/matcher/WorkMatcher.scala
+++ b/pipeline/matcher/src/main/scala/weco/pipeline/matcher/matcher/WorkMatcher.scala
@@ -53,11 +53,11 @@ class WorkMatcher(
               works = toMatchedIdentifiers(afterNodes),
               createdTime = Instant.now()))
         } else {
-          val affectedComponentIds =
+          val affectedSubgraphIds =
             (beforeNodes ++ afterNodes)
-              .map { _.componentId }
+              .map { _.subgraphId }
 
-          withLocks(work, ids = affectedComponentIds) {
+          withLocks(work, ids = affectedSubgraphIds) {
             workGraphStore
               .put(afterNodes)
               .map(
@@ -91,7 +91,7 @@ class WorkMatcher(
   private def toMatchedIdentifiers(
     nodes: Set[WorkNode]): Set[MatchedIdentifiers] =
     nodes
-      .groupBy { _.componentId }
+      .groupBy { _.subgraphId }
       .map {
         case (_, workNodes) =>
           // The matcher graph may include nodes for Works it hasn't seen yet, or which
@@ -102,8 +102,8 @@ class WorkMatcher(
           val identifiers =
             workNodes
               .collect {
-                case WorkNode(id, Some(version), _, _, _) =>
-                  WorkIdentifier(id, version)
+                case WorkNode(id, _, _, Some(sourceWorkData)) =>
+                  WorkIdentifier(id, sourceWorkData.version)
               }
 
           MatchedIdentifiers(identifiers)

--- a/pipeline/matcher/src/main/scala/weco/pipeline/matcher/matcher/WorkMatcher.scala
+++ b/pipeline/matcher/src/main/scala/weco/pipeline/matcher/matcher/WorkMatcher.scala
@@ -91,7 +91,7 @@ class WorkMatcher(
   private def toMatchedIdentifiers(
     nodes: Set[WorkNode]): Set[MatchedIdentifiers] =
     nodes
-      .groupBy { _.subgraphId }
+      .groupBy { _.componentIds }
       .map {
         case (_, workNodes) =>
           // The matcher graph may include nodes for Works it hasn't seen yet, or which

--- a/pipeline/matcher/src/main/scala/weco/pipeline/matcher/models/SubgraphId.scala
+++ b/pipeline/matcher/src/main/scala/weco/pipeline/matcher/models/SubgraphId.scala
@@ -3,13 +3,13 @@ package weco.pipeline.matcher.models
 import org.apache.commons.codec.digest.DigestUtils
 import weco.catalogue.internal_model.identifiers.CanonicalId
 
-object ComponentId {
+object SubgraphId {
 
-  /** This is shared by all the Works in the same component -- i.e., all the
-    * Works that are matched together.
+  /** This is shared by all the Works in the same subgraph -- all the Works that
+    * should be processed together.
     *
     * Note that this is based on the *unversioned* identifiers.  This means the
-    * component identifier is stable across different versions of a Work.
+    * subgraph identifier is stable across different versions of a Work.
     */
   def apply(ids: CanonicalId*): String =
     DigestUtils.sha256Hex(ids.sorted.map(_.underlying).mkString("+"))

--- a/pipeline/matcher/src/main/scala/weco/pipeline/matcher/models/SubgraphId.scala
+++ b/pipeline/matcher/src/main/scala/weco/pipeline/matcher/models/SubgraphId.scala
@@ -11,8 +11,14 @@ object SubgraphId {
     * Note that this is based on the *unversioned* identifiers.  This means the
     * subgraph identifier is stable across different versions of a Work.
     */
-  def apply(ids: CanonicalId*): String =
-    DigestUtils.sha256Hex(ids.sorted.map(_.underlying).mkString("+"))
+  def apply(ids: CanonicalId*): String = {
+    require(
+      ids.toSet.size == ids.size,
+      s"Passed duplicate IDs in SubgraphId: $ids"
+    )
 
-  def apply(ids: List[CanonicalId]): String = apply(ids: _*)
+    DigestUtils.sha256Hex(ids.sorted.map(_.underlying).mkString("+"))
+  }
+
+  def apply(ids: Set[CanonicalId]): String = apply(ids.toList: _*)
 }

--- a/pipeline/matcher/src/main/scala/weco/pipeline/matcher/models/WorkNode.scala
+++ b/pipeline/matcher/src/main/scala/weco/pipeline/matcher/models/WorkNode.scala
@@ -12,8 +12,15 @@ case class WorkNode(
 }
 
 case object WorkNode {
-  def apply(id: CanonicalId, subgraphId: String, componentIds: List[CanonicalId], sourceWork: SourceWorkData): WorkNode =
-    WorkNode(id = id, subgraphId = subgraphId, componentIds = componentIds, sourceWork = Some(sourceWork))
+  def apply(id: CanonicalId,
+            subgraphId: String,
+            componentIds: List[CanonicalId],
+            sourceWork: SourceWorkData): WorkNode =
+    WorkNode(
+      id = id,
+      subgraphId = subgraphId,
+      componentIds = componentIds,
+      sourceWork = Some(sourceWork))
 }
 
 case class SourceWorkData(

--- a/pipeline/matcher/src/main/scala/weco/pipeline/matcher/models/WorkNode.scala
+++ b/pipeline/matcher/src/main/scala/weco/pipeline/matcher/models/WorkNode.scala
@@ -4,25 +4,22 @@ import weco.catalogue.internal_model.identifiers.CanonicalId
 
 case class WorkNode(
   id: CanonicalId,
-  version: Option[Int],
-  linkedIds: List[CanonicalId],
-  componentId: String,
-  // Records whether this work is suppressed in a source system -- if so,
-  // we shouldn't be using it to construct matcher graphs.
-  suppressed: Boolean = false
-)
+  subgraphId: String,
+  componentIds: List[CanonicalId],
+  sourceWork: Option[SourceWorkData] = None,
+) {
+  require(componentIds.sorted == componentIds)
+}
 
-object WorkNode {
-  def apply(id: CanonicalId,
-            version: Int,
-            linkedIds: List[CanonicalId],
-            componentId: String): WorkNode =
-    WorkNode(id, Some(version), linkedIds, componentId)
+case object WorkNode {
+  def apply(id: CanonicalId, subgraphId: String, componentIds: List[CanonicalId], sourceWork: SourceWorkData): WorkNode =
+    WorkNode(id = id, subgraphId = subgraphId, componentIds = componentIds, sourceWork = Some(sourceWork))
+}
 
-  def apply(id: CanonicalId,
-            version: Int,
-            linkedIds: List[CanonicalId],
-            componentId: String,
-            suppressed: Boolean): WorkNode =
-    WorkNode(id, Some(version), linkedIds, componentId, suppressed)
+case class SourceWorkData(
+  version: Int,
+  suppressed: Boolean = false,
+  mergeCandidateIds: List[CanonicalId] = List(),
+) {
+  require(mergeCandidateIds.sorted == mergeCandidateIds)
 }

--- a/pipeline/matcher/src/main/scala/weco/pipeline/matcher/models/WorkNode.scala
+++ b/pipeline/matcher/src/main/scala/weco/pipeline/matcher/models/WorkNode.scala
@@ -1,6 +1,6 @@
 package weco.pipeline.matcher.models
 
-import weco.catalogue.internal_model.identifiers.CanonicalId
+import weco.catalogue.internal_model.identifiers.{CanonicalId, SourceIdentifier}
 
 case class WorkNode(
   id: CanonicalId,
@@ -17,6 +17,7 @@ case object WorkNode {
 }
 
 case class SourceWorkData(
+  id: SourceIdentifier,
   version: Int,
   suppressed: Boolean = false,
   mergeCandidateIds: List[CanonicalId] = List(),

--- a/pipeline/matcher/src/main/scala/weco/pipeline/matcher/models/WorkStub.scala
+++ b/pipeline/matcher/src/main/scala/weco/pipeline/matcher/models/WorkStub.scala
@@ -16,15 +16,16 @@ case class WorkStub(state: WorkState.Identified,
                     @JsonKey("type") workType: String) {
   lazy val id: CanonicalId = state.canonicalId
 
-  lazy val referencedWorkIds: Set[CanonicalId] =
+  lazy val mergeCandidateIds: Set[CanonicalId] =
     state.mergeCandidates
       .map { mergeCandidate =>
         mergeCandidate.id.canonicalId
       }
+      // TODO: Do we need this filterNot?  Will a work ever refer to itself?
       .filterNot { _ == id }
       .toSet
 
-  lazy val ids: Set[CanonicalId] = referencedWorkIds + id
+  lazy val ids: Set[CanonicalId] = mergeCandidateIds + id
 
   lazy val suppressed: Boolean = workType == "Deleted"
 }

--- a/pipeline/matcher/src/main/scala/weco/pipeline/matcher/storage/WorkGraphStore.scala
+++ b/pipeline/matcher/src/main/scala/weco/pipeline/matcher/storage/WorkGraphStore.scala
@@ -10,31 +10,9 @@ class WorkGraphStore(workNodeDao: WorkNodeDao)(implicit _ec: ExecutionContext) {
   def findAffectedWorks(ids: Set[CanonicalId]): Future[Set[WorkNode]] =
     for {
       directlyAffectedWorks <- workNodeDao.get(ids)
-      affectedComponentIds = directlyAffectedWorks.map(_.componentId)
-      affectedWorks <- workNodeDao.getByComponentIds(affectedComponentIds)
-      suppressedWorks <- getSuppressedWorksLinkedFrom(affectedWorks)
-    } yield affectedWorks ++ suppressedWorks
-
-  // Suppressed works are singletons in the matcher graph, so we don't find
-  // them when searching by component ID -- but we might refer to them in
-  // one of the affected works.
-  //
-  // We want to retrieve the copy of the suppressed node from the graph store,
-  // so we don't overwrite them when we store the updated graph.
-  //
-  // Suppressed works should never be linking to other works, so we only need
-  // to do this extra search pass once.
-  private def getSuppressedWorksLinkedFrom(
-    affectedWorks: Set[WorkNode]): Future[Set[WorkNode]] = {
-    val missingIds = affectedWorks.flatMap(_.linkedIds) -- affectedWorks.map(
-      _.id)
-
-    if (missingIds.isEmpty) {
-      Future.successful(Set())
-    } else {
-      workNodeDao.get(missingIds)
-    }
-  }
+      subgraphIds = directlyAffectedWorks.map(_.subgraphId)
+      affectedWorks <- workNodeDao.getBySubgraphIds(subgraphIds)
+    } yield affectedWorks
 
   def put(nodes: Set[WorkNode]): Future[Unit] =
     workNodeDao.put(nodes)

--- a/pipeline/matcher/src/main/scala/weco/pipeline/matcher/storage/WorkNodeDao.scala
+++ b/pipeline/matcher/src/main/scala/weco/pipeline/matcher/storage/WorkNodeDao.scala
@@ -28,29 +28,28 @@ class WorkNodeDao(dynamoClient: DynamoDbClient, dynamoConfig: DynamoConfig)(
         .exec { nodes.getAll("id" in ids) }
         .map {
           case Right(works) => works
-          case Left(scanamoError) => {
+          case Left(scanamoError) =>
             val exception = new RuntimeException(scanamoError.toString)
             error(
-              s"An error occurred while retrieving all workIds=$ids from DynamoDB",
+              s"An error occurred while retrieving ids=$ids from DynamoDB",
               exception)
             throw exception
-          }
         }
     }
 
-  def getByComponentIds(setIds: Set[String]): Future[Set[WorkNode]] =
-    Future.sequence(setIds.map(getByComponentId)).map(_.flatten)
+  def getBySubgraphIds(setIds: Set[String]): Future[Set[WorkNode]] =
+    Future.sequence(setIds.map(getSingleSubgraphId)).map(_.flatten)
 
-  private def getByComponentId(componentId: String) =
+  private def getSingleSubgraphId(subgraphId: String): Future[List[WorkNode]] =
     Future {
       scanamo
-        .exec { index.query("componentId" === componentId) }
+        .exec { index.query("subgraphId" === subgraphId) }
         .map {
           case Right(record) => record
           case Left(scanamoError) =>
             val exception = new RuntimeException(scanamoError.toString)
             error(
-              s"An error occurred while retrieving byComponentId=$componentId from DynamoDB",
+              s"An error occurred while retrieving subgraphId=$subgraphId",
               exception
             )
             throw exception

--- a/pipeline/matcher/src/main/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdater.scala
+++ b/pipeline/matcher/src/main/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdater.scala
@@ -108,7 +108,7 @@ private class WorkSubgraph(newWork: WorkNode,
     val workIds =
       sourceWorks
         .flatMap { case (id, work) => id +: work.mergeCandidateIds }
-        .toList
+        .toSet
 
     val g = Graph.from(edges = unsuppressedLinks, nodes = workIds)
 

--- a/pipeline/matcher/src/main/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdater.scala
+++ b/pipeline/matcher/src/main/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdater.scala
@@ -21,6 +21,7 @@ object WorkGraphUpdater extends Logging {
         componentIds = List(work.id),
         sourceWork = Some(
           SourceWorkData(
+            id = work.state.sourceIdentifier,
             version = work.version,
             suppressed = work.suppressed,
             mergeCandidateIds = work.mergeCandidateIds.toList.sorted
@@ -37,14 +38,14 @@ object WorkGraphUpdater extends Logging {
     work: WorkStub,
     affectedWorks: Map[CanonicalId, WorkNode]): Unit =
     affectedWorks.get(work.id).flatMap(_.sourceWork) match {
-      case Some(SourceWorkData(existingVersion, _, _))
+      case Some(SourceWorkData(_, existingVersion, _, _))
           if existingVersion > work.version =>
         val versionConflictMessage =
           s"update failed, work:${work.id} v${work.version} is not newer than existing work v$existingVersion"
         debug(versionConflictMessage)
         throw VersionExpectedConflictException(versionConflictMessage)
 
-      case Some(SourceWorkData(existingVersion, _, existingMergeCandidateIds))
+      case Some(SourceWorkData(_, existingVersion, _, existingMergeCandidateIds))
           if existingVersion == work.version && work.mergeCandidateIds != existingMergeCandidateIds.toSet =>
         val versionConflictMessage =
           s"update failed, work:${work.id} v${work.version} already exists with different content! update-ids:${work.mergeCandidateIds} != existing-ids:${existingMergeCandidateIds.toSet}"

--- a/pipeline/matcher/src/main/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdater.scala
+++ b/pipeline/matcher/src/main/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdater.scala
@@ -4,7 +4,14 @@ import grizzled.slf4j.Logging
 import scalax.collection.Graph
 import scalax.collection.GraphPredef._
 import weco.catalogue.internal_model.identifiers.CanonicalId
-import weco.pipeline.matcher.models.{SubgraphId, SourceWorkData, VersionExpectedConflictException, VersionUnexpectedConflictException, WorkNode, WorkStub}
+import weco.pipeline.matcher.models.{
+  SourceWorkData,
+  SubgraphId,
+  VersionExpectedConflictException,
+  VersionUnexpectedConflictException,
+  WorkNode,
+  WorkStub
+}
 
 object WorkGraphUpdater extends Logging {
   def update(work: WorkStub, affectedNodes: Set[WorkNode]): Set[WorkNode] = {
@@ -45,7 +52,8 @@ object WorkGraphUpdater extends Logging {
         debug(versionConflictMessage)
         throw VersionExpectedConflictException(versionConflictMessage)
 
-      case Some(SourceWorkData(_, existingVersion, _, existingMergeCandidateIds))
+      case Some(
+          SourceWorkData(_, existingVersion, _, existingMergeCandidateIds))
           if existingVersion == work.version && work.mergeCandidateIds != existingMergeCandidateIds.toSet =>
         val versionConflictMessage =
           s"update failed, work:${work.id} v${work.version} already exists with different content! update-ids:${work.mergeCandidateIds} != existing-ids:${existingMergeCandidateIds.toSet}"
@@ -66,7 +74,9 @@ private class WorkSubgraph(newWork: WorkNode,
 
   lazy val sourceWorks: Map[CanonicalId, SourceWorkData] =
     allWorks
-      .collect { case (id, WorkNode(_, _, _, Some(sourceWork))) => id -> sourceWork }
+      .collect {
+        case (id, WorkNode(_, _, _, Some(sourceWork))) => id -> sourceWork
+      }
 
   def create: Set[WorkNode] = {
     // Create a list of all the connections between works in the graph.
@@ -107,9 +117,7 @@ private class WorkSubgraph(newWork: WorkNode,
 
     // Get the IDs of all the works in this graph, and construct a Graph object.
     val workIds =
-      sourceWorks
-        .flatMap { case (id, work) => id +: work.mergeCandidateIds }
-        .toSet
+      sourceWorks.flatMap { case (id, work) => id +: work.mergeCandidateIds }.toSet
 
     val g = Graph.from(edges = unsuppressedLinks, nodes = workIds)
 

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/MatcherFeatureTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/MatcherFeatureTest.scala
@@ -84,7 +84,10 @@ class MatcherFeatureTest
               id = workV1.id,
               subgraphId = SubgraphId(workV1.id),
               componentIds = List(workV1.id),
-              sourceWork = SourceWorkData(version = existingWorkVersion),
+              sourceWork = SourceWorkData(
+                id = workV1.state.sourceIdentifier,
+                version = existingWorkVersion
+              ),
             )
 
             putTableItem[WorkNode](nodeV2, table = graphTable)

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/MatcherFeatureTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/MatcherFeatureTest.scala
@@ -3,6 +3,7 @@ package weco.pipeline.matcher
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+import org.scanamo.generic.auto._
 import weco.catalogue.internal_model.Implicits._
 import weco.catalogue.internal_model.index.IndexFixtures
 import weco.catalogue.internal_model.work.DeletedReason.SuppressedFromSource
@@ -22,6 +23,7 @@ import weco.pipeline_storage.Retriever
 import weco.pipeline_storage.memory.MemoryRetriever
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.language.higherKinds
 
 class MatcherFeatureTest
     extends AnyFunSpec
@@ -42,7 +44,7 @@ class MatcherFeatureTest
 
     withLocalSqsQueue() { queue =>
       withMatcherService(retriever, queue, messageSender) { _ =>
-        val work = createWorkWith(referencedWorkIds = Set.empty)
+        val work = createWorkWith(mergeCandidateIds = Set.empty)
 
         val expectedWorks =
           Set(
@@ -80,12 +82,12 @@ class MatcherFeatureTest
 
             val nodeV2 = WorkNode(
               id = workV1.id,
-              version = Some(existingWorkVersion),
-              linkedIds = Nil,
-              componentId = ComponentId(workV1.id)
+              subgraphId = SubgraphId(workV1.id),
+              componentIds = List(workV1.id),
+              sourceWork = SourceWorkData(version = existingWorkVersion),
             )
 
-            putTableItem(nodeV2, table = graphTable)
+            putTableItem[WorkNode](nodeV2, table = graphTable)
 
             sendWork(workV1, retriever, queue)
 

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/fixtures/LocalWorkGraphDynamoDb.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/fixtures/LocalWorkGraphDynamoDb.scala
@@ -29,7 +29,7 @@ trait LocalWorkGraphDynamoDb extends DynamoFixtures with RandomGenerators {
             .build(),
           AttributeDefinition
             .builder()
-            .attributeName("componentId")
+            .attributeName("subgraphId")
             .attributeType("S")
             .build()
         )
@@ -46,7 +46,7 @@ trait LocalWorkGraphDynamoDb extends DynamoFixtures with RandomGenerators {
             .keySchema(
               KeySchemaElement
                 .builder()
-                .attributeName("componentId")
+                .attributeName("subgraphId")
                 .keyType(KeyType.HASH)
                 .build()
             )

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/fixtures/MatcherFixtures.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/fixtures/MatcherFixtures.scala
@@ -1,20 +1,19 @@
 package weco.pipeline.matcher.fixtures
 
-import org.scanamo.generic.semiauto.deriveDynamoFormat
-import org.scanamo.DynamoFormat
+import org.scanamo.generic.auto._
 import weco.fixtures.TestWith
 import weco.messaging.fixtures.SQS
 import weco.messaging.memory.MemoryMessageSender
 import weco.messaging.sns.NotificationMessage
 import weco.pipeline.matcher.matcher.WorkMatcher
-import weco.pipeline.matcher.models.{MatcherResult, WorkNode, WorkStub}
+import weco.pipeline.matcher.models.{MatcherResult, WorkStub}
 import weco.pipeline.matcher.services.MatcherWorkerService
 import weco.pipeline.matcher.storage.{WorkGraphStore, WorkNodeDao}
 import weco.pipeline_storage.Retriever
 import weco.pipeline_storage.fixtures.PipelineStorageStreamFixtures
 import weco.pipeline_storage.memory.MemoryRetriever
 import weco.storage.fixtures.DynamoFixtures.Table
-import weco.storage.locking.dynamo.{DynamoLockDaoFixtures, ExpiringLock}
+import weco.storage.locking.dynamo.DynamoLockDaoFixtures
 import weco.storage.locking.memory.{MemoryLockDao, MemoryLockingService}
 
 import java.util.UUID
@@ -26,9 +25,6 @@ trait MatcherFixtures
     extends PipelineStorageStreamFixtures
     with DynamoLockDaoFixtures
     with LocalWorkGraphDynamoDb {
-
-  implicit val workNodeFormat: DynamoFormat[WorkNode] = deriveDynamoFormat
-  implicit val lockFormat: DynamoFormat[ExpiringLock] = deriveDynamoFormat
 
   def withWorkGraphTable[R](testWith: TestWith[Table, R]): R =
     withSpecifiedTable(createWorkGraphTable) { table =>

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/generators/WorkNodeGenerators.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/generators/WorkNodeGenerators.scala
@@ -1,5 +1,6 @@
 package weco.pipeline.matcher.generators
 
+import weco.catalogue.internal_model.identifiers.CanonicalId
 import weco.pipeline.matcher.models.{SourceWorkData, SubgraphId, WorkNode}
 
 trait WorkNodeGenerators extends WorkStubGenerators {
@@ -9,6 +10,9 @@ trait WorkNodeGenerators extends WorkStubGenerators {
   // examples whose meaning is hopefully obvious that reduces the amount of repetition
   // in our tests.
 
+  private def createSourceWork(id: CanonicalId): SourceWorkData =
+    SourceWorkData(id = sourceIdentifierFrom(id), version = 1)
+
   def createOneWork(pattern: String): WorkNode =
     pattern match {
       case "A" =>
@@ -16,35 +20,35 @@ trait WorkNodeGenerators extends WorkStubGenerators {
           id = idA,
           subgraphId = SubgraphId(idA),
           componentIds = List(idA),
-          sourceWork = SourceWorkData(version = 1),
+          sourceWork = createSourceWork(idA),
         )
       case "B" =>
         WorkNode(
           id = idB,
           subgraphId = SubgraphId(idB),
           componentIds = List(idB),
-          sourceWork = SourceWorkData(version = 1),
+          sourceWork = createSourceWork(idB),
         )
       case "B[suppressed]" =>
         WorkNode(
           id = idB,
           subgraphId = SubgraphId(idB),
           componentIds = List(idB),
-          sourceWork = SourceWorkData(version = 1, suppressed = true),
+          sourceWork = createSourceWork(idB).copy(suppressed = true),
         )
       case "C" =>
         WorkNode(
           id = idC,
           subgraphId = SubgraphId(idC),
           componentIds = List(idC),
-          sourceWork = SourceWorkData(version = 1),
+          sourceWork = createSourceWork(idC),
         )
       case "D" =>
         WorkNode(
           id = idD,
           subgraphId = SubgraphId(idD),
           componentIds = List(idD),
-          sourceWork = SourceWorkData(version = 1),
+          sourceWork = createSourceWork(idD),
         )
     }
 
@@ -56,13 +60,13 @@ trait WorkNodeGenerators extends WorkStubGenerators {
             id = idA,
             subgraphId = SubgraphId(idA, idB),
             componentIds = List(idA, idB),
-            sourceWork = SourceWorkData(version = 1, mergeCandidateIds = List(idB)),
+            sourceWork = createSourceWork(idA).copy(mergeCandidateIds = List(idB)),
           ),
           WorkNode(
             id = idB,
             subgraphId = SubgraphId(idA, idB),
             componentIds = List(idA, idB),
-            sourceWork = SourceWorkData(version = 1),
+            sourceWork = createSourceWork(idB),
           ),
         )
       case "C->D" =>
@@ -71,13 +75,13 @@ trait WorkNodeGenerators extends WorkStubGenerators {
             id = idC,
             subgraphId = SubgraphId(idC, idD),
             componentIds = List(idC, idD),
-            sourceWork = SourceWorkData(version = 1, mergeCandidateIds = List(idD)),
+            sourceWork = createSourceWork(idC).copy(mergeCandidateIds = List(idD)),
           ),
           WorkNode(
             id = idD,
             subgraphId = SubgraphId(idC, idD),
             componentIds = List(idC, idD),
-            sourceWork = SourceWorkData(version = 1),
+            sourceWork = createSourceWork(idD),
           ),
         )
     }
@@ -90,19 +94,19 @@ trait WorkNodeGenerators extends WorkStubGenerators {
             id = idA,
             subgraphId = SubgraphId(idA, idB, idC),
             componentIds = List(idA, idB, idC),
-            sourceWork = SourceWorkData(version = 1, mergeCandidateIds = List(idB)),
+            sourceWork = createSourceWork(idA).copy(mergeCandidateIds = List(idB)),
           ),
           WorkNode(
             id = idB,
             subgraphId = SubgraphId(idA, idB, idC),
             componentIds = List(idA, idB, idC),
-            sourceWork = SourceWorkData(version = 1, mergeCandidateIds = List(idC)),
+            sourceWork = createSourceWork(idB).copy(mergeCandidateIds = List(idC)),
           ),
           WorkNode(
             id = idC,
             subgraphId = SubgraphId(idA, idB, idC),
             componentIds = List(idA, idB, idC),
-            sourceWork = SourceWorkData(version = 1),
+            sourceWork = createSourceWork(idC),
           ),
         )
       case "A<->B->C" =>
@@ -111,19 +115,19 @@ trait WorkNodeGenerators extends WorkStubGenerators {
             id = idA,
             subgraphId = SubgraphId(idA, idB, idC),
             componentIds = List(idA, idB, idC),
-            sourceWork = SourceWorkData(version = 1, mergeCandidateIds = List(idB)),
+            sourceWork = createSourceWork(idA).copy(mergeCandidateIds = List(idB)),
           ),
           WorkNode(
             id = idB,
             subgraphId = SubgraphId(idA, idB, idC),
             componentIds = List(idA, idB, idC),
-            sourceWork = SourceWorkData(version = 1, mergeCandidateIds = List(idA, idC)),
+            sourceWork = createSourceWork(idB).copy(mergeCandidateIds = List(idA, idC)),
           ),
           WorkNode(
             id = idC,
             subgraphId = SubgraphId(idA, idB, idC),
             componentIds = List(idA, idB, idC),
-            sourceWork = SourceWorkData(version = 1),
+            sourceWork = createSourceWork(idC),
           ),
         )
     }
@@ -136,32 +140,43 @@ trait WorkNodeGenerators extends WorkStubGenerators {
             id = idA,
             subgraphId = SubgraphId(idA, idB, idC, idD, idE),
             componentIds = List(idA, idB, idC, idD, idE),
-            sourceWork = SourceWorkData(version = 1, mergeCandidateIds = List(idB)),
+            sourceWork = createSourceWork(idA).copy(mergeCandidateIds = List(idB)),
           ),
           WorkNode(
             id = idB,
             subgraphId = SubgraphId(idA, idB, idC, idD, idE),
             componentIds = List(idA, idB, idC, idD, idE),
-            sourceWork = SourceWorkData(version = 1, mergeCandidateIds = List(idC)),
+            sourceWork = createSourceWork(idB).copy(mergeCandidateIds = List(idC)),
           ),
           WorkNode(
             id = idC,
             subgraphId = SubgraphId(idA, idB, idC, idD, idE),
             componentIds = List(idA, idB, idC, idD, idE),
-            sourceWork = SourceWorkData(version = 1, mergeCandidateIds = List(idD)),
+            sourceWork = createSourceWork(idC).copy(mergeCandidateIds = List(idD)),
           ),
           WorkNode(
             id = idD,
             subgraphId = SubgraphId(idA, idB, idC, idD, idE),
             componentIds = List(idA, idB, idC, idD, idE),
-            sourceWork = SourceWorkData(version = 1, mergeCandidateIds = List(idE)),
+            sourceWork = createSourceWork(idD).copy(mergeCandidateIds = List(idE)),
           ),
           WorkNode(
             id = idE,
             subgraphId = SubgraphId(idA, idB, idC, idD, idE),
             componentIds = List(idA, idB, idC, idD, idE),
-            sourceWork = SourceWorkData(version = 1),
+            sourceWork = createSourceWork(idE),
           ),
         )
     }
+
+  implicit class WorkNodeOps(w: WorkNode) {
+    def updateSourceWork(version: Int, mergeCandidateIds: Set[CanonicalId] = Set(), suppressed: Boolean = false): WorkNode =
+      w.copy(
+        sourceWork = Some(w.sourceWork.get.copy(
+          version = version,
+          mergeCandidateIds = mergeCandidateIds.toList.sorted,
+          suppressed = suppressed
+        ))
+      )
+  }
 }

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/generators/WorkNodeGenerators.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/generators/WorkNodeGenerators.scala
@@ -60,7 +60,8 @@ trait WorkNodeGenerators extends WorkStubGenerators {
             id = idA,
             subgraphId = SubgraphId(idA, idB),
             componentIds = List(idA, idB),
-            sourceWork = createSourceWork(idA).copy(mergeCandidateIds = List(idB)),
+            sourceWork =
+              createSourceWork(idA).copy(mergeCandidateIds = List(idB)),
           ),
           WorkNode(
             id = idB,
@@ -75,7 +76,8 @@ trait WorkNodeGenerators extends WorkStubGenerators {
             id = idC,
             subgraphId = SubgraphId(idC, idD),
             componentIds = List(idC, idD),
-            sourceWork = createSourceWork(idC).copy(mergeCandidateIds = List(idD)),
+            sourceWork =
+              createSourceWork(idC).copy(mergeCandidateIds = List(idD)),
           ),
           WorkNode(
             id = idD,
@@ -94,13 +96,15 @@ trait WorkNodeGenerators extends WorkStubGenerators {
             id = idA,
             subgraphId = SubgraphId(idA, idB, idC),
             componentIds = List(idA, idB, idC),
-            sourceWork = createSourceWork(idA).copy(mergeCandidateIds = List(idB)),
+            sourceWork =
+              createSourceWork(idA).copy(mergeCandidateIds = List(idB)),
           ),
           WorkNode(
             id = idB,
             subgraphId = SubgraphId(idA, idB, idC),
             componentIds = List(idA, idB, idC),
-            sourceWork = createSourceWork(idB).copy(mergeCandidateIds = List(idC)),
+            sourceWork =
+              createSourceWork(idB).copy(mergeCandidateIds = List(idC)),
           ),
           WorkNode(
             id = idC,
@@ -115,13 +119,15 @@ trait WorkNodeGenerators extends WorkStubGenerators {
             id = idA,
             subgraphId = SubgraphId(idA, idB, idC),
             componentIds = List(idA, idB, idC),
-            sourceWork = createSourceWork(idA).copy(mergeCandidateIds = List(idB)),
+            sourceWork =
+              createSourceWork(idA).copy(mergeCandidateIds = List(idB)),
           ),
           WorkNode(
             id = idB,
             subgraphId = SubgraphId(idA, idB, idC),
             componentIds = List(idA, idB, idC),
-            sourceWork = createSourceWork(idB).copy(mergeCandidateIds = List(idA, idC)),
+            sourceWork =
+              createSourceWork(idB).copy(mergeCandidateIds = List(idA, idC)),
           ),
           WorkNode(
             id = idC,
@@ -132,7 +138,8 @@ trait WorkNodeGenerators extends WorkStubGenerators {
         )
     }
 
-  def createFiveWorks(pattern: String): (WorkNode, WorkNode, WorkNode, WorkNode, WorkNode) =
+  def createFiveWorks(
+    pattern: String): (WorkNode, WorkNode, WorkNode, WorkNode, WorkNode) =
     pattern match {
       case "A->B->C->D->E" =>
         (
@@ -140,25 +147,29 @@ trait WorkNodeGenerators extends WorkStubGenerators {
             id = idA,
             subgraphId = SubgraphId(idA, idB, idC, idD, idE),
             componentIds = List(idA, idB, idC, idD, idE),
-            sourceWork = createSourceWork(idA).copy(mergeCandidateIds = List(idB)),
+            sourceWork =
+              createSourceWork(idA).copy(mergeCandidateIds = List(idB)),
           ),
           WorkNode(
             id = idB,
             subgraphId = SubgraphId(idA, idB, idC, idD, idE),
             componentIds = List(idA, idB, idC, idD, idE),
-            sourceWork = createSourceWork(idB).copy(mergeCandidateIds = List(idC)),
+            sourceWork =
+              createSourceWork(idB).copy(mergeCandidateIds = List(idC)),
           ),
           WorkNode(
             id = idC,
             subgraphId = SubgraphId(idA, idB, idC, idD, idE),
             componentIds = List(idA, idB, idC, idD, idE),
-            sourceWork = createSourceWork(idC).copy(mergeCandidateIds = List(idD)),
+            sourceWork =
+              createSourceWork(idC).copy(mergeCandidateIds = List(idD)),
           ),
           WorkNode(
             id = idD,
             subgraphId = SubgraphId(idA, idB, idC, idD, idE),
             componentIds = List(idA, idB, idC, idD, idE),
-            sourceWork = createSourceWork(idD).copy(mergeCandidateIds = List(idE)),
+            sourceWork =
+              createSourceWork(idD).copy(mergeCandidateIds = List(idE)),
           ),
           WorkNode(
             id = idE,
@@ -170,13 +181,16 @@ trait WorkNodeGenerators extends WorkStubGenerators {
     }
 
   implicit class WorkNodeOps(w: WorkNode) {
-    def updateSourceWork(version: Int, mergeCandidateIds: Set[CanonicalId] = Set(), suppressed: Boolean = false): WorkNode =
+    def updateSourceWork(version: Int,
+                         mergeCandidateIds: Set[CanonicalId] = Set(),
+                         suppressed: Boolean = false): WorkNode =
       w.copy(
-        sourceWork = Some(w.sourceWork.get.copy(
-          version = version,
-          mergeCandidateIds = mergeCandidateIds.toList.sorted,
-          suppressed = suppressed
-        ))
+        sourceWork = Some(
+          w.sourceWork.get.copy(
+            version = version,
+            mergeCandidateIds = mergeCandidateIds.toList.sorted,
+            suppressed = suppressed
+          ))
       )
   }
 }

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/generators/WorkNodeGenerators.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/generators/WorkNodeGenerators.scala
@@ -1,6 +1,6 @@
 package weco.pipeline.matcher.generators
 
-import weco.pipeline.matcher.models.{ComponentId, WorkNode}
+import weco.pipeline.matcher.models.{SourceWorkData, SubgraphId, WorkNode}
 
 trait WorkNodeGenerators extends WorkStubGenerators {
   // These patterns are to make it easier to write simple tests.
@@ -14,30 +14,37 @@ trait WorkNodeGenerators extends WorkStubGenerators {
       case "A" =>
         WorkNode(
           id = idA,
-          version = 1,
-          linkedIds = Nil,
-          componentId = ComponentId(idA)
+          subgraphId = SubgraphId(idA),
+          componentIds = List(idA),
+          sourceWork = SourceWorkData(version = 1),
         )
       case "B" =>
         WorkNode(
           id = idB,
-          version = 1,
-          linkedIds = Nil,
-          componentId = ComponentId(idB)
+          subgraphId = SubgraphId(idB),
+          componentIds = List(idB),
+          sourceWork = SourceWorkData(version = 1),
+        )
+      case "B[suppressed]" =>
+        WorkNode(
+          id = idB,
+          subgraphId = SubgraphId(idB),
+          componentIds = List(idB),
+          sourceWork = SourceWorkData(version = 1, suppressed = true),
         )
       case "C" =>
         WorkNode(
           id = idC,
-          version = 1,
-          linkedIds = Nil,
-          componentId = ComponentId(idC)
+          subgraphId = SubgraphId(idC),
+          componentIds = List(idC),
+          sourceWork = SourceWorkData(version = 1),
         )
       case "D" =>
         WorkNode(
           id = idD,
-          version = 1,
-          linkedIds = Nil,
-          componentId = ComponentId(idD)
+          subgraphId = SubgraphId(idD),
+          componentIds = List(idD),
+          sourceWork = SourceWorkData(version = 1),
         )
     }
 
@@ -46,28 +53,32 @@ trait WorkNodeGenerators extends WorkStubGenerators {
       case "A->B" =>
         (
           WorkNode(
-            idA,
-            version = 1,
-            linkedIds = List(idB),
-            componentId = ComponentId(idA, idB)),
+            id = idA,
+            subgraphId = SubgraphId(idA, idB),
+            componentIds = List(idA, idB),
+            sourceWork = SourceWorkData(version = 1, mergeCandidateIds = List(idB)),
+          ),
           WorkNode(
-            idB,
-            version = 1,
-            linkedIds = Nil,
-            componentId = ComponentId(idA, idB))
+            id = idB,
+            subgraphId = SubgraphId(idA, idB),
+            componentIds = List(idA, idB),
+            sourceWork = SourceWorkData(version = 1),
+          ),
         )
       case "C->D" =>
         (
           WorkNode(
-            idC,
-            version = 1,
-            linkedIds = List(idD),
-            componentId = ComponentId(idC, idD)),
+            id = idC,
+            subgraphId = SubgraphId(idC, idD),
+            componentIds = List(idC, idD),
+            sourceWork = SourceWorkData(version = 1, mergeCandidateIds = List(idD)),
+          ),
           WorkNode(
-            idD,
-            version = 1,
-            linkedIds = Nil,
-            componentId = ComponentId(idC, idD))
+            id = idD,
+            subgraphId = SubgraphId(idC, idD),
+            componentIds = List(idC, idD),
+            sourceWork = SourceWorkData(version = 1),
+          ),
         )
     }
 
@@ -76,38 +87,81 @@ trait WorkNodeGenerators extends WorkStubGenerators {
       case "A->B->C" =>
         (
           WorkNode(
-            idA,
-            version = 1,
-            linkedIds = List(idB),
-            componentId = ComponentId(idA, idB, idC)),
+            id = idA,
+            subgraphId = SubgraphId(idA, idB, idC),
+            componentIds = List(idA, idB, idC),
+            sourceWork = SourceWorkData(version = 1, mergeCandidateIds = List(idB)),
+          ),
           WorkNode(
-            idB,
-            version = 1,
-            linkedIds = List(idC),
-            componentId = ComponentId(idA, idB, idC)),
+            id = idB,
+            subgraphId = SubgraphId(idA, idB, idC),
+            componentIds = List(idA, idB, idC),
+            sourceWork = SourceWorkData(version = 1, mergeCandidateIds = List(idC)),
+          ),
           WorkNode(
-            idC,
-            version = 1,
-            linkedIds = Nil,
-            componentId = ComponentId(idA, idB, idC)),
+            id = idC,
+            subgraphId = SubgraphId(idA, idB, idC),
+            componentIds = List(idA, idB, idC),
+            sourceWork = SourceWorkData(version = 1),
+          ),
         )
       case "A<->B->C" =>
         (
           WorkNode(
-            idA,
-            version = 1,
-            linkedIds = List(idB),
-            componentId = ComponentId(idA, idB, idC)),
+            id = idA,
+            subgraphId = SubgraphId(idA, idB, idC),
+            componentIds = List(idA, idB, idC),
+            sourceWork = SourceWorkData(version = 1, mergeCandidateIds = List(idB)),
+          ),
           WorkNode(
-            idB,
-            version = 1,
-            linkedIds = List(idA, idC),
-            componentId = ComponentId(idA, idB, idC)),
+            id = idB,
+            subgraphId = SubgraphId(idA, idB, idC),
+            componentIds = List(idA, idB, idC),
+            sourceWork = SourceWorkData(version = 1, mergeCandidateIds = List(idA, idC)),
+          ),
           WorkNode(
-            idC,
-            version = 1,
-            linkedIds = Nil,
-            componentId = ComponentId(idA, idB, idC)),
+            id = idC,
+            subgraphId = SubgraphId(idA, idB, idC),
+            componentIds = List(idA, idB, idC),
+            sourceWork = SourceWorkData(version = 1),
+          ),
+        )
+    }
+
+  def createFiveWorks(pattern: String): (WorkNode, WorkNode, WorkNode, WorkNode, WorkNode) =
+    pattern match {
+      case "A->B->C->D->E" =>
+        (
+          WorkNode(
+            id = idA,
+            subgraphId = SubgraphId(idA, idB, idC, idD, idE),
+            componentIds = List(idA, idB, idC, idD, idE),
+            sourceWork = SourceWorkData(version = 1, mergeCandidateIds = List(idB)),
+          ),
+          WorkNode(
+            id = idB,
+            subgraphId = SubgraphId(idA, idB, idC, idD, idE),
+            componentIds = List(idA, idB, idC, idD, idE),
+            sourceWork = SourceWorkData(version = 1, mergeCandidateIds = List(idC)),
+          ),
+          WorkNode(
+            id = idC,
+            subgraphId = SubgraphId(idA, idB, idC, idD, idE),
+            componentIds = List(idA, idB, idC, idD, idE),
+            sourceWork = SourceWorkData(version = 1, mergeCandidateIds = List(idD)),
+          ),
+          WorkNode(
+            id = idD,
+            subgraphId = SubgraphId(idA, idB, idC, idD, idE),
+            componentIds = List(idA, idB, idC, idD, idE),
+            sourceWork = SourceWorkData(version = 1, mergeCandidateIds = List(idE)),
+          ),
+          WorkNode(
+            id = idE,
+            subgraphId = SubgraphId(idA, idB, idC, idD, idE),
+            componentIds = List(idA, idB, idC, idD, idE),
+            sourceWork = SourceWorkData(version = 1),
+          ),
         )
     }
 }

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/generators/WorkStubGenerators.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/generators/WorkStubGenerators.scala
@@ -1,7 +1,11 @@
 package weco.pipeline.matcher.generators
 
 import weco.catalogue.internal_model.generators.IdentifiersGenerators
-import weco.catalogue.internal_model.identifiers.{CanonicalId, IdState, SourceIdentifier}
+import weco.catalogue.internal_model.identifiers.{
+  CanonicalId,
+  IdState,
+  SourceIdentifier
+}
 import weco.catalogue.internal_model.work.{MergeCandidate, Work, WorkState}
 import weco.elasticsearch.model.IndexId
 import weco.pipeline.matcher.models.WorkStub

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/generators/WorkStubGenerators.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/generators/WorkStubGenerators.scala
@@ -18,18 +18,18 @@ trait WorkStubGenerators extends IdentifiersGenerators {
 
   def createWorkStub: WorkStub =
     createWorkWith(
-      referencedWorkIds = collectionOf(min = 0) { createCanonicalId }.toSet
+      mergeCandidateIds = collectionOf(min = 0) { createCanonicalId }.toSet
     )
 
   def createWorkWith(id: CanonicalId = createCanonicalId,
                      version: Int = randomInt(from = 1, to = 10),
-                     referencedWorkIds: Set[CanonicalId] = Set(),
+                     mergeCandidateIds: Set[CanonicalId] = Set(),
                      workType: String = "Visible"): WorkStub =
     WorkStub(
       state = WorkState.Identified(
         sourceIdentifier = createSourceIdentifier,
         canonicalId = id,
-        mergeCandidates = referencedWorkIds
+        mergeCandidates = mergeCandidateIds
           .filterNot { _ == id }
           .map { canonicalId =>
             IdState.Identified(

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/generators/WorkStubGenerators.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/generators/WorkStubGenerators.scala
@@ -1,7 +1,7 @@
 package weco.pipeline.matcher.generators
 
 import weco.catalogue.internal_model.generators.IdentifiersGenerators
-import weco.catalogue.internal_model.identifiers.{CanonicalId, IdState}
+import weco.catalogue.internal_model.identifiers.{CanonicalId, IdState, SourceIdentifier}
 import weco.catalogue.internal_model.work.{MergeCandidate, Work, WorkState}
 import weco.elasticsearch.model.IndexId
 import weco.pipeline.matcher.models.WorkStub
@@ -16,25 +16,42 @@ trait WorkStubGenerators extends IdentifiersGenerators {
   val idD = CanonicalId("DDDDDDDD")
   val idE = CanonicalId("EEEEEEEE")
 
+  val sourceIdentifierA = createSourceIdentifierWith(value = "aaaaaaaa")
+  val sourceIdentifierB = createSourceIdentifierWith(value = "bbbbbbbb")
+  val sourceIdentifierC = createSourceIdentifierWith(value = "cccccccc")
+  val sourceIdentifierD = createSourceIdentifierWith(value = "dddddddd")
+  val sourceIdentifierE = createSourceIdentifierWith(value = "eeeeeeee")
+
+  protected def sourceIdentifierFrom(id: CanonicalId): SourceIdentifier =
+    id match {
+      case `idA` => sourceIdentifierA
+      case `idB` => sourceIdentifierB
+      case `idC` => sourceIdentifierC
+      case `idD` => sourceIdentifierD
+      case `idE` => sourceIdentifierE
+      case _     => createMiroSourceIdentifierWith(value = id.underlying)
+    }
+
   def createWorkStub: WorkStub =
     createWorkWith(
       mergeCandidateIds = collectionOf(min = 0) { createCanonicalId }.toSet
     )
 
-  def createWorkWith(id: CanonicalId = createCanonicalId,
+  def createWorkWith(id: CanonicalId = chooseFrom(idA, idB, idC, idD, idE),
                      version: Int = randomInt(from = 1, to = 10),
                      mergeCandidateIds: Set[CanonicalId] = Set(),
-                     workType: String = "Visible"): WorkStub =
+                     workType: String = "Visible"): WorkStub = {
+
     WorkStub(
       state = WorkState.Identified(
-        sourceIdentifier = createSourceIdentifier,
+        sourceIdentifier = sourceIdentifierFrom(id),
         canonicalId = id,
         mergeCandidates = mergeCandidateIds
           .filterNot { _ == id }
           .map { canonicalId =>
             IdState.Identified(
               canonicalId = canonicalId,
-              sourceIdentifier = createSourceIdentifier)
+              sourceIdentifier = sourceIdentifierFrom(canonicalId))
           }
           .map { id =>
             MergeCandidate(
@@ -48,6 +65,7 @@ trait WorkStubGenerators extends IdentifiersGenerators {
       version = version,
       workType = workType
     )
+  }
 
   implicit val indexId: IndexId[Work[WorkState.Identified]] =
     (w: Work[WorkState.Identified]) => w.id

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/matcher/WorkMatcherConcurrencyTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/matcher/WorkMatcherConcurrencyTest.scala
@@ -31,7 +31,7 @@ class WorkMatcherConcurrencyTest
 
         val workA = createWorkWith(
           id = idA,
-          referencedWorkIds = Set(idB)
+          mergeCandidateIds = Set(idB)
         )
 
         val workB = createWorkWith(id = idB)

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/matcher/WorkMatcherTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/matcher/WorkMatcherTest.scala
@@ -50,7 +50,7 @@ class WorkMatcherTest
                 id = work.id,
                 subgraphId = SubgraphId(work.id),
                 componentIds = List(work.id),
-                sourceWork = SourceWorkData(version = work.version),
+                sourceWork = SourceWorkData(id = work.state.sourceIdentifier, version = work.version),
               )
             )
           }
@@ -82,7 +82,11 @@ class WorkMatcherTest
                 id = idA,
                 subgraphId = SubgraphId(idA, idB),
                 componentIds = List(idA, idB),
-                sourceWork = SourceWorkData(version = work.version, mergeCandidateIds = List(idB)),
+                sourceWork = SourceWorkData(
+                  id = work.state.sourceIdentifier,
+                  version = work.version,
+                  mergeCandidateIds = List(idB)
+                ),
               ),
               WorkNode(
                 id = idB,
@@ -132,19 +136,22 @@ class WorkMatcherTest
               .toSet
 
             savedNodes shouldBe Set(
-              workA.copy(
-                subgraphId = SubgraphId(idA, idB, idC),
-                componentIds = List(idA, idB, idC),
-              ),
-              workB.copy(
-                subgraphId = SubgraphId(idA, idB, idC),
-                componentIds = List(idA, idB, idC),
-                sourceWork = Some(SourceWorkData(version = 2, mergeCandidateIds = List(idC))),
-              ),
-              workC.copy(
-                subgraphId = SubgraphId(idA, idB, idC),
-                componentIds = List(idA, idB, idC),
-              ),
+              workA
+                .copy(
+                  subgraphId = SubgraphId(idA, idB, idC),
+                  componentIds = List(idA, idB, idC),
+                ),
+              workB
+                .copy(
+                  subgraphId = SubgraphId(idA, idB, idC),
+                  componentIds = List(idA, idB, idC),
+                )
+                .updateSourceWork(version = 2, mergeCandidateIds = Set(idC)),
+              workC
+                .copy(
+                  subgraphId = SubgraphId(idA, idB, idC),
+                  componentIds = List(idA, idB, idC),
+                ),
             )
           }
         }

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/matcher/WorkMatcherTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/matcher/WorkMatcherTest.scala
@@ -50,7 +50,9 @@ class WorkMatcherTest
                 id = work.id,
                 subgraphId = SubgraphId(work.id),
                 componentIds = List(work.id),
-                sourceWork = SourceWorkData(id = work.state.sourceIdentifier, version = work.version),
+                sourceWork = SourceWorkData(
+                  id = work.state.sourceIdentifier,
+                  version = work.version),
               )
             )
           }

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/matcher/WorkMatcherTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/matcher/WorkMatcherTest.scala
@@ -4,24 +4,20 @@ import org.scalatest.EitherValues
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+import org.scanamo.generic.auto._
 import weco.catalogue.internal_model.identifiers.CanonicalId
-import weco.storage.locking.LockFailure
-import weco.storage.locking.memory.{MemoryLockDao, MemoryLockingService}
 import weco.fixtures.TimeAssertions
 import weco.pipeline.matcher.fixtures.MatcherFixtures
-import weco.pipeline.matcher.generators.WorkStubGenerators
-import weco.pipeline.matcher.models.{
-  ComponentId,
-  MatchedIdentifiers,
-  MatcherResult,
-  WorkIdentifier,
-  WorkNode
-}
+import weco.pipeline.matcher.generators.WorkNodeGenerators
+import weco.pipeline.matcher.models._
 import weco.pipeline.matcher.storage.{WorkGraphStore, WorkNodeDao}
+import weco.storage.locking.LockFailure
+import weco.storage.locking.memory.{MemoryLockDao, MemoryLockingService}
 
 import java.util.UUID
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
+import scala.language.higherKinds
 
 class WorkMatcherTest
     extends AnyFunSpec
@@ -29,7 +25,7 @@ class WorkMatcherTest
     with MatcherFixtures
     with ScalaFutures
     with EitherValues
-    with WorkStubGenerators
+    with WorkNodeGenerators
     with TimeAssertions {
 
   it(
@@ -52,9 +48,9 @@ class WorkMatcherTest
             savedLinkedWork shouldBe Some(
               WorkNode(
                 id = work.id,
-                version = work.version,
-                linkedIds = Nil,
-                componentId = ComponentId(work.id)
+                subgraphId = SubgraphId(work.id),
+                componentIds = List(work.id),
+                sourceWork = SourceWorkData(version = work.version),
               )
             )
           }
@@ -70,7 +66,7 @@ class WorkMatcherTest
         withWorkMatcher(workGraphStore) { workMatcher =>
           val work = createWorkWith(
             id = idA,
-            referencedWorkIds = Set(idB)
+            mergeCandidateIds = Set(idB)
           )
 
           whenReady(workMatcher.matchWork(work)) { matcherResult =>
@@ -84,16 +80,15 @@ class WorkMatcherTest
             savedWorkNodes should contain theSameElementsAs List(
               WorkNode(
                 id = idA,
-                version = work.version,
-                linkedIds = List(idB),
-                componentId = ComponentId(idA, idB)
+                subgraphId = SubgraphId(idA, idB),
+                componentIds = List(idA, idB),
+                sourceWork = SourceWorkData(version = work.version, mergeCandidateIds = List(idB)),
               ),
               WorkNode(
                 id = idB,
-                version = None,
-                linkedIds = Nil,
-                componentId = ComponentId(idA, idB)
-              )
+                subgraphId = SubgraphId(idA, idB),
+                componentIds = List(idA, idB),
+              ),
             )
           }
         }
@@ -106,34 +101,18 @@ class WorkMatcherTest
     withWorkGraphTable { graphTable =>
       withWorkGraphStore(graphTable) { workGraphStore =>
         withWorkMatcher(workGraphStore) { workMatcher =>
-          val existingWorkA = WorkNode(
-            id = idA,
-            version = 1,
-            linkedIds = List(idB),
-            componentId = ComponentId(idA, idB)
-          )
-          val existingWorkB = WorkNode(
-            id = idB,
-            version = 1,
-            linkedIds = Nil,
-            componentId = ComponentId(idA, idB)
-          )
-          val existingWorkC = WorkNode(
-            id = idC,
-            version = 1,
-            linkedIds = Nil,
-            componentId = ComponentId(idC)
-          )
+          val (workA, workB) = createTwoWorks("A->B")
+          val workC = createOneWork("C")
 
           putTableItems(
-            items = Seq(existingWorkA, existingWorkB, existingWorkC),
+            items = Seq(workA, workB, workC),
             table = graphTable
           )
 
           val work = createWorkWith(
             id = idB,
             version = 2,
-            referencedWorkIds = Set(idC)
+            mergeCandidateIds = Set(idC)
           )
 
           whenReady(workMatcher.matchWork(work)) { matcherResult =>
@@ -142,31 +121,30 @@ class WorkMatcherTest
               Set(
                 MatchedIdentifiers(
                   Set(
-                    WorkIdentifier(idA, 1),
-                    WorkIdentifier(idB, 2),
-                    WorkIdentifier(idC, 1))))
+                    WorkIdentifier(idA, version = 1),
+                    WorkIdentifier(idB, version = 2),
+                    WorkIdentifier(idC, version = 1))
+                )
+              )
 
             val savedNodes = scanTable[WorkNode](graphTable)
               .map(_.right.value)
+              .toSet
 
-            savedNodes should contain theSameElementsAs List(
-              WorkNode(
-                id = idA,
-                version = 1,
-                linkedIds = List(idB),
-                componentId = ComponentId(idA, idB, idC)
+            savedNodes shouldBe Set(
+              workA.copy(
+                subgraphId = SubgraphId(idA, idB, idC),
+                componentIds = List(idA, idB, idC),
               ),
-              WorkNode(
-                id = idB,
-                version = 2,
-                linkedIds = List(idC),
-                componentId = ComponentId(idA, idB, idC)
+              workB.copy(
+                subgraphId = SubgraphId(idA, idB, idC),
+                componentIds = List(idA, idB, idC),
+                sourceWork = Some(SourceWorkData(version = 2, mergeCandidateIds = List(idC))),
               ),
-              WorkNode(
-                id = idC,
-                version = 1,
-                linkedIds = Nil,
-                componentId = ComponentId(idA, idB, idC))
+              workC.copy(
+                subgraphId = SubgraphId(idA, idB, idC),
+                componentIds = List(idA, idB, idC),
+              ),
             )
           }
         }
@@ -208,17 +186,15 @@ class WorkMatcherTest
       withWorkGraphStore(graphTable) { workGraphStore =>
         val componentId = "ABC"
 
-        val future = workGraphStore.put(
-          Set(
-            WorkNode(idA, version = 0, linkedIds = List(idB), componentId),
-            WorkNode(idB, version = 0, linkedIds = List(idC), componentId),
-            WorkNode(idC, version = 0, linkedIds = Nil, componentId),
-          ))
+        val (workA, workB, workC) = createThreeWorks("A->B->C")
+
+        val future = workGraphStore.put(Set(workA, workB, workC))
 
         whenReady(future) { _ =>
           val work = createWorkWith(
             id = idA,
-            referencedWorkIds = Set(idB)
+            mergeCandidateIds = Set(idB),
+            version = workA.sourceWork.get.version + 1
           )
 
           implicit val lockDao: MemoryLockDao[String, UUID] =

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/matcher/WorkMatcherTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/matcher/WorkMatcherTest.scala
@@ -184,7 +184,7 @@ class WorkMatcherTest
 
     withWorkGraphTable { graphTable =>
       withWorkGraphStore(graphTable) { workGraphStore =>
-        val componentId = "ABC"
+        val subgraphId = SubgraphId(idA, idB, idC)
 
         val (workA, workB, workC) = createThreeWorks("A->B->C")
 
@@ -201,7 +201,7 @@ class WorkMatcherTest
             new MemoryLockDao[String, UUID] {
               override def lock(id: String, contextId: UUID): LockResult =
                 synchronized {
-                  if (id == componentId) {
+                  if (id == subgraphId) {
                     Left(LockFailure(id, e = expectedException))
                   } else {
                     super.lock(id, contextId)

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/models/SubgraphIdTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/models/SubgraphIdTest.scala
@@ -4,19 +4,19 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.pipeline.matcher.generators.WorkStubGenerators
 
-class ComponentIdTest extends AnyFunSpec with Matchers with WorkStubGenerators {
+class SubgraphIdTest extends AnyFunSpec with Matchers with WorkStubGenerators {
   it("creates a different component ID when the IDs change") {
-    ComponentId(idA) should not be ComponentId(idA, idB)
+    SubgraphId(idA) should not be SubgraphId(idA, idB)
   }
 
   it("gives the same component ID regardless of ordering") {
     val orderings = Set(
-      ComponentId(idA, idB, idC),
-      ComponentId(idA, idC, idB),
-      ComponentId(idB, idA, idC),
-      ComponentId(idB, idC, idA),
-      ComponentId(idC, idA, idB),
-      ComponentId(idC, idB, idA),
+      SubgraphId(idA, idB, idC),
+      SubgraphId(idA, idC, idB),
+      SubgraphId(idB, idA, idC),
+      SubgraphId(idB, idC, idA),
+      SubgraphId(idC, idA, idB),
+      SubgraphId(idC, idB, idA),
     )
 
     orderings should have size 1

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/services/MatcherWorkerServiceTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/services/MatcherWorkerServiceTest.scala
@@ -55,7 +55,7 @@ class MatcherWorkerServiceTest
     val workAv1 = createWorkWith(
       id = idA,
       version = 1,
-      referencedWorkIds = Set(idB)
+      mergeCandidateIds = Set(idB)
     )
 
     // Work Av1 matched to B (before B exists hence version is None)
@@ -112,7 +112,7 @@ class MatcherWorkerServiceTest
     val workAv2 = createWorkWith(
       id = idA,
       version = 2,
-      referencedWorkIds = Set(idB)
+      mergeCandidateIds = Set(idB)
     )
 
     val expectedWorksAv2 =
@@ -142,7 +142,7 @@ class MatcherWorkerServiceTest
     val workBv2 = createWorkWith(
       id = idB,
       version = 2,
-      referencedWorkIds = Set(idC)
+      mergeCandidateIds = Set(idC)
     )
 
     val expectedWorksBv2 =
@@ -203,7 +203,7 @@ class MatcherWorkerServiceTest
       createWorkWith(
         id = idA,
         version = 2,
-        referencedWorkIds = Set(idB)
+        mergeCandidateIds = Set(idB)
       )
 
     val expectedWorksAv2MatchedToB =
@@ -325,7 +325,7 @@ class MatcherWorkerServiceTest
             createWorkWith(
               id = idA,
               version = 2,
-              referencedWorkIds = Set(idB)
+              mergeCandidateIds = Set(idB)
             )
 
           sendWork(differentWorkAv2, retriever, queue)

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/storage/WorkNodeDaoTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/storage/WorkNodeDaoTest.scala
@@ -77,8 +77,7 @@ class WorkNodeDaoTest
 
           putTableItems(items = Seq(workA, workB), table = table)
 
-          whenReady(
-            matcherGraphDao.getBySubgraphIds(Set(SubgraphId(idA, idB)))) {
+          whenReady(matcherGraphDao.getBySubgraphIds(Set(SubgraphId(idA, idB)))) {
             _ shouldBe Set(workA, workB)
           }
         }
@@ -91,8 +90,7 @@ class WorkNodeDaoTest
         dynamoConfig = createDynamoConfigWith(nonExistentTable)
       )
 
-      whenReady(
-        workNodeDao.getBySubgraphIds(Set(SubgraphId(idA, idB))).failed) {
+      whenReady(workNodeDao.getBySubgraphIds(Set(SubgraphId(idA, idB))).failed) {
         _ shouldBe a[ResourceNotFoundException]
       }
     }
@@ -104,11 +102,15 @@ class WorkNodeDaoTest
                                subgraphId: String,
                                componentIds: Int)
           val badRecord: BadRecord =
-            BadRecord(id = idA, subgraphId = SubgraphId(idA, idB), componentIds = 123)
+            BadRecord(
+              id = idA,
+              subgraphId = SubgraphId(idA, idB),
+              componentIds = 123)
 
           putTableItem(badRecord, table = table)
 
-          val future = workNodeDao.getBySubgraphIds(setIds = Set(SubgraphId(idA, idB)))
+          val future =
+            workNodeDao.getBySubgraphIds(setIds = Set(SubgraphId(idA, idB)))
 
           whenReady(future.failed) {
             _ shouldBe a[RuntimeException]
@@ -141,7 +143,8 @@ class WorkNodeDaoTest
               id = id,
               subgraphId = SubgraphId(id),
               componentIds = List(id),
-              sourceWork = SourceWorkData(id = createSourceIdentifier, version = 1)
+              sourceWork =
+                SourceWorkData(id = createSourceIdentifier, version = 1)
             )
           }
 
@@ -162,7 +165,8 @@ class WorkNodeDaoTest
       withWorkGraphTable { table =>
         withWorkNodeDao(table) { workNodeDao =>
           case class BadRecord(id: CanonicalId, componentIds: String)
-          val badRecord: BadRecord = BadRecord(id = idA, componentIds = "1, 2, 3")
+          val badRecord: BadRecord =
+            BadRecord(id = idA, componentIds = "1, 2, 3")
 
           putTableItem(badRecord, table = table)
 

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/storage/WorkNodeDaoTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/storage/WorkNodeDaoTest.scala
@@ -141,7 +141,7 @@ class WorkNodeDaoTest
               id = id,
               subgraphId = SubgraphId(id),
               componentIds = List(id),
-              sourceWork = SourceWorkData(version = 1)
+              sourceWork = SourceWorkData(id = createSourceIdentifier, version = 1)
             )
           }
 

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/storage/WorkNodeDaoTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/storage/WorkNodeDaoTest.scala
@@ -101,9 +101,10 @@ class WorkNodeDaoTest
       withWorkGraphTable { table =>
         withWorkNodeDao(table) { workNodeDao =>
           case class BadRecord(id: CanonicalId,
-                               componentIds: String)
+                               subgraphId: String,
+                               componentIds: Int)
           val badRecord: BadRecord =
-            BadRecord(id = idA, componentIds = "1, 2, 3")
+            BadRecord(id = idA, subgraphId = SubgraphId(idA, idB), componentIds = 123)
 
           putTableItem(badRecord, table = table)
 

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/storage/elastic/ElasticWorkStubRetrieverTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/storage/elastic/ElasticWorkStubRetrieverTest.scala
@@ -70,7 +70,7 @@ class ElasticWorkStubRetrieverTest
       new ElasticWorkStubRetriever(elasticClient, index)
     )
 
-  override def createT: WorkStub = createWorkStub
+  override def createT: WorkStub = createWorkWith(id = createCanonicalId)
 
   override implicit val id: IndexId[WorkStub] =
     (work: WorkStub) => work.id.underlying

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdaterTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdaterTest.scala
@@ -3,7 +3,13 @@ package weco.pipeline.matcher.workgraph
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.pipeline.matcher.generators.WorkNodeGenerators
-import weco.pipeline.matcher.models.{SourceWorkData, SubgraphId, VersionExpectedConflictException, VersionUnexpectedConflictException, WorkNode}
+import weco.pipeline.matcher.models.{
+  SourceWorkData,
+  SubgraphId,
+  VersionExpectedConflictException,
+  VersionUnexpectedConflictException,
+  WorkNode
+}
 
 class WorkGraphUpdaterTest
     extends AnyFunSpec
@@ -24,7 +30,8 @@ class WorkGraphUpdaterTest
     }
 
     it("updating nothing with A->B gives A+B:A->B") {
-      val workStubA = createWorkWith(idA, version = 1, mergeCandidateIds = Set(idB))
+      val workStubA =
+        createWorkWith(idA, version = 1, mergeCandidateIds = Set(idB))
 
       val result = WorkGraphUpdater
         .update(
@@ -109,10 +116,12 @@ class WorkGraphUpdaterTest
           subgraphId = SubgraphId(idA, idB, idC),
           componentIds = List(idA, idB, idC),
         ),
-        workB.copy(
-          subgraphId = SubgraphId(idA, idB, idC),
-          componentIds = List(idA, idB, idC),
-        ).updateSourceWork(version = 2, mergeCandidateIds = Set(idC)),
+        workB
+          .copy(
+            subgraphId = SubgraphId(idA, idB, idC),
+            componentIds = List(idA, idB, idC),
+          )
+          .updateSourceWork(version = 2, mergeCandidateIds = Set(idC)),
         workC.copy(
           subgraphId = SubgraphId(idA, idB, idC),
           componentIds = List(idA, idB, idC),
@@ -136,10 +145,12 @@ class WorkGraphUpdaterTest
             subgraphId = SubgraphId(idA, idB, idC, idD),
             componentIds = List(idA, idB, idC, idD),
           ),
-          workB.copy(
-            subgraphId = SubgraphId(idA, idB, idC, idD),
-            componentIds = List(idA, idB, idC, idD),
-          ).updateSourceWork(version = 2, mergeCandidateIds = Set(idC)),
+          workB
+            .copy(
+              subgraphId = SubgraphId(idA, idB, idC, idD),
+              componentIds = List(idA, idB, idC, idD),
+            )
+            .updateSourceWork(version = 2, mergeCandidateIds = Set(idC)),
           workC.copy(
             subgraphId = SubgraphId(idA, idB, idC, idD),
             componentIds = List(idA, idB, idC, idD),
@@ -169,10 +180,12 @@ class WorkGraphUpdaterTest
             subgraphId = SubgraphId(idA, idB, idC, idD),
             componentIds = List(idA, idB, idC, idD),
           ),
-          workB.copy(
-            subgraphId = SubgraphId(idA, idB, idC, idD),
-            componentIds = List(idA, idB, idC, idD),
-          ).updateSourceWork(version = 2, mergeCandidateIds = Set(idC, idD)),
+          workB
+            .copy(
+              subgraphId = SubgraphId(idA, idB, idC, idD),
+              componentIds = List(idA, idB, idC, idD),
+            )
+            .updateSourceWork(version = 2, mergeCandidateIds = Set(idC, idD)),
           workC.copy(
             subgraphId = SubgraphId(idA, idB, idC, idD),
             componentIds = List(idA, idB, idC, idD),
@@ -222,7 +235,9 @@ class WorkGraphUpdaterTest
               subgraphId = SubgraphId(idA, idB),
               componentIds = List(idA, idB),
             )
-            .updateSourceWork(version = updateVersion, mergeCandidateIds = Set(idB)),
+            .updateSourceWork(
+              version = updateVersion,
+              mergeCandidateIds = Set(idB)),
           WorkNode(
             idB,
             subgraphId = SubgraphId(idA, idB),
@@ -256,7 +271,8 @@ class WorkGraphUpdaterTest
 
       val result = WorkGraphUpdater
         .update(
-          work = createWorkWith(idA, existingVersion, mergeCandidateIds = Set(idB)),
+          work =
+            createWorkWith(idA, existingVersion, mergeCandidateIds = Set(idB)),
           affectedNodes = Set(workA, workB)
         )
 
@@ -355,7 +371,10 @@ class WorkGraphUpdaterTest
           id = idA,
           subgraphId = SubgraphId(idA, idB),
           componentIds = List(idA),
-          sourceWork = SourceWorkData(id = workA.state.sourceIdentifier, version = 1, mergeCandidateIds = List(idB)),
+          sourceWork = SourceWorkData(
+            id = workA.state.sourceIdentifier,
+            version = 1,
+            mergeCandidateIds = List(idB)),
         ),
         workB.copy(
           subgraphId = SubgraphId(idA, idB),

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdaterTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdaterTest.scala
@@ -107,7 +107,7 @@ class WorkGraphUpdaterTest
         workB.copy(
           subgraphId = SubgraphId(idA, idB, idC),
           componentIds = List(idA, idB, idC),
-          sourceWork = Some(SourceWorkData(version = 1, mergeCandidateIds = List(idC))),
+          sourceWork = Some(SourceWorkData(version = 2, mergeCandidateIds = List(idC))),
         ),
         workC.copy(
           subgraphId = SubgraphId(idA, idB, idC),
@@ -361,10 +361,13 @@ class WorkGraphUpdaterTest
         WorkNode(
           id = idA,
           subgraphId = SubgraphId(idA, idB),
-          componentIds = List(idA, idB),
+          componentIds = List(idA),
           sourceWork = SourceWorkData(version = 1, mergeCandidateIds = List(idB)),
         ),
-        workB,
+        workB.copy(
+          subgraphId = SubgraphId(idA, idB),
+          componentIds = List(idB),
+        ),
       )
     }
 
@@ -382,8 +385,11 @@ class WorkGraphUpdaterTest
         )
 
       result shouldBe Set(
-        workA,
+        workA.copy(
+          componentIds = List(idA),
+        ),
         workB.copy(
+          componentIds = List(idB),
           sourceWork = Some(SourceWorkData(version = 2, suppressed = true))
         ),
       )
@@ -403,12 +409,21 @@ class WorkGraphUpdaterTest
 
       result shouldBe Set(
         workA.copy(
+          componentIds = List(idA, idB),
           sourceWork = Some(SourceWorkData(version = 2, mergeCandidateIds = List(idB)))
         ),
-        workB,
-        suppressedWorkC,
-        workD,
-        workE,
+        workB.copy(
+          componentIds = List(idA, idB),
+        ),
+        suppressedWorkC.copy(
+          componentIds = List(idC),
+        ),
+        workD.copy(
+          componentIds = List(idD, idE),
+        ),
+        workE.copy(
+          componentIds = List(idD, idE),
+        ),
       )
     }
 

--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdaterTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdaterTest.scala
@@ -3,12 +3,7 @@ package weco.pipeline.matcher.workgraph
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.pipeline.matcher.generators.WorkNodeGenerators
-import weco.pipeline.matcher.models.{
-  ComponentId,
-  VersionExpectedConflictException,
-  VersionUnexpectedConflictException,
-  WorkNode
-}
+import weco.pipeline.matcher.models.{SourceWorkData, SubgraphId, VersionExpectedConflictException, VersionUnexpectedConflictException, WorkNode}
 
 class WorkGraphUpdaterTest
     extends AnyFunSpec
@@ -21,7 +16,7 @@ class WorkGraphUpdaterTest
 
       val result = WorkGraphUpdater
         .update(
-          work = createWorkWith(idA, version = 1, referencedWorkIds = Set.empty),
+          work = createWorkWith(idA, version = 1, mergeCandidateIds = Set.empty),
           affectedNodes = Set()
         )
 
@@ -31,21 +26,23 @@ class WorkGraphUpdaterTest
     it("updating nothing with A->B gives A+B:A->B") {
       val result = WorkGraphUpdater
         .update(
-          work = createWorkWith(idA, version = 1, referencedWorkIds = Set(idB)),
+          work = createWorkWith(idA, version = 1, mergeCandidateIds = Set(idB)),
           affectedNodes = Set()
         )
 
       result shouldBe Set(
         WorkNode(
-          idA,
-          version = 1,
-          linkedIds = List(idB),
-          componentId = ComponentId(idA, idB)),
+          id = idA,
+          subgraphId = SubgraphId(idA, idB),
+          componentIds = List(idA, idB),
+          sourceWork = SourceWorkData(version = 1, mergeCandidateIds = List(idB)),
+        ),
         WorkNode(
-          idB,
-          version = None,
-          linkedIds = List(),
-          componentId = ComponentId(idA, idB))
+          id = idB,
+          subgraphId = SubgraphId(idA, idB),
+          componentIds = List(idA, idB),
+          sourceWork = None,
+        ),
       )
     }
   }
@@ -57,22 +54,21 @@ class WorkGraphUpdaterTest
 
       val result = WorkGraphUpdater
         .update(
-          work = createWorkWith(idA, version = 2, referencedWorkIds = Set(idB)),
+          work = createWorkWith(idA, version = 2, mergeCandidateIds = Set(idB)),
           affectedNodes = Set(workA, workB)
         )
 
-      result should contain theSameElementsAs
-        List(
-          WorkNode(
-            idA,
-            version = 2,
-            linkedIds = List(idB),
-            componentId = ComponentId(idA, idB)),
-          WorkNode(
-            idB,
-            version = 1,
-            linkedIds = List(),
-            componentId = ComponentId(idA, idB))
+      result shouldBe
+        Set(
+          workA.copy(
+            subgraphId = SubgraphId(idA, idB),
+            componentIds = List(idA, idB),
+            sourceWork = Some(SourceWorkData(version = 2, mergeCandidateIds = List(idB))),
+          ),
+          workB.copy(
+            subgraphId = SubgraphId(idA, idB),
+            componentIds = List(idA, idB),
+          ),
         )
     }
 
@@ -81,50 +77,42 @@ class WorkGraphUpdaterTest
 
       val result = WorkGraphUpdater
         .update(
-          work = createWorkWith(idA, version = 2, referencedWorkIds = Set(idB)),
+          work = createWorkWith(idA, version = 2, mergeCandidateIds = Set(idB)),
           affectedNodes = Set(workA, workB)
         )
 
       result shouldBe Set(
-        WorkNode(
-          idA,
-          version = 2,
-          linkedIds = List(idB),
-          componentId = ComponentId(idA, idB)),
-        WorkNode(
-          idB,
-          version = 1,
-          linkedIds = List(),
-          componentId = ComponentId(idA, idB))
+        workA.copy(
+          sourceWork = Some(SourceWorkData(version = 2, mergeCandidateIds = List(idB)))
+        ),
+        workB,
       )
     }
 
     it("updating A->B, B, C with B->C gives A+B+C:(A->B, B->C, C)") {
       val (workA, workB) = createTwoWorks("A->B")
-      val (workC) = createOneWork("C")
+      val workC = createOneWork("C")
 
       val result = WorkGraphUpdater
         .update(
-          work = createWorkWith(idB, version = 2, referencedWorkIds = Set(idC)),
+          work = createWorkWith(idB, version = 2, mergeCandidateIds = Set(idC)),
           affectedNodes = Set(workA, workB, workC)
         )
 
       result shouldBe Set(
-        WorkNode(
-          idA,
-          version = 1,
-          linkedIds = List(idB),
-          componentId = ComponentId(idA, idB, idC)),
-        WorkNode(
-          idB,
-          version = 2,
-          linkedIds = List(idC),
-          componentId = ComponentId(idA, idB, idC)),
-        WorkNode(
-          idC,
-          version = 1,
-          linkedIds = List(),
-          componentId = ComponentId(idA, idB, idC))
+        workA.copy(
+          subgraphId = SubgraphId(idA, idB, idC),
+          componentIds = List(idA, idB, idC),
+        ),
+        workB.copy(
+          subgraphId = SubgraphId(idA, idB, idC),
+          componentIds = List(idA, idB, idC),
+          sourceWork = Some(SourceWorkData(version = 1, mergeCandidateIds = List(idC))),
+        ),
+        workC.copy(
+          subgraphId = SubgraphId(idA, idB, idC),
+          componentIds = List(idA, idB, idC),
+        ),
       )
     }
 
@@ -134,32 +122,29 @@ class WorkGraphUpdaterTest
 
       val result = WorkGraphUpdater
         .update(
-          work = createWorkWith(idB, version = 2, referencedWorkIds = Set(idC)),
+          work = createWorkWith(idB, version = 2, mergeCandidateIds = Set(idC)),
           affectedNodes = Set(workA, workB, workC, workD)
         )
 
       result shouldBe
         Set(
-          WorkNode(
-            idA,
-            version = 1,
-            linkedIds = List(idB),
-            componentId = ComponentId(idA, idB, idC, idD)),
-          WorkNode(
-            idB,
-            version = 2,
-            linkedIds = List(idC),
-            componentId = ComponentId(idA, idB, idC, idD)),
-          WorkNode(
-            idC,
-            version = 1,
-            linkedIds = List(idD),
-            componentId = ComponentId(idA, idB, idC, idD)),
-          WorkNode(
-            idD,
-            version = 1,
-            linkedIds = List(),
-            componentId = ComponentId(idA, idB, idC, idD))
+          workA.copy(
+            subgraphId = SubgraphId(idA, idB, idC, idD),
+            componentIds = List(idA, idB, idC, idD),
+          ),
+          workB.copy(
+            subgraphId = SubgraphId(idA, idB, idC, idD),
+            componentIds = List(idA, idB, idC, idD),
+            sourceWork = Some(SourceWorkData(version = 2, mergeCandidateIds = List(idC)))
+          ),
+          workC.copy(
+            subgraphId = SubgraphId(idA, idB, idC, idD),
+            componentIds = List(idA, idB, idC, idD),
+          ),
+          workD.copy(
+            subgraphId = SubgraphId(idA, idB, idC, idD),
+            componentIds = List(idA, idB, idC, idD),
+          ),
         )
     }
 
@@ -171,32 +156,29 @@ class WorkGraphUpdaterTest
       val result = WorkGraphUpdater
         .update(
           work =
-            createWorkWith(idB, version = 2, referencedWorkIds = Set(idC, idD)),
+            createWorkWith(idB, version = 2, mergeCandidateIds = Set(idC, idD)),
           affectedNodes = Set(workA, workB, workC, workD)
         )
 
       result shouldBe
         Set(
-          WorkNode(
-            idA,
-            version = 1,
-            linkedIds = List(idB),
-            componentId = ComponentId(idA, idB, idC, idD)),
-          WorkNode(
-            idB,
-            version = 2,
-            linkedIds = List(idC, idD),
-            componentId = ComponentId(idA, idB, idC, idD)),
-          WorkNode(
-            idC,
-            version = 1,
-            linkedIds = List(),
-            componentId = ComponentId(idA, idB, idC, idD)),
-          WorkNode(
-            idD,
-            version = 1,
-            linkedIds = List(),
-            componentId = ComponentId(idA, idB, idC, idD))
+          workA.copy(
+            subgraphId = SubgraphId(idA, idB, idC, idD),
+            componentIds = List(idA, idB, idC, idD),
+          ),
+          workB.copy(
+            subgraphId = SubgraphId(idA, idB, idC, idD),
+            componentIds = List(idA, idB, idC, idD),
+            sourceWork = Some(SourceWorkData(version = 2, mergeCandidateIds = List(idC, idD)))
+          ),
+          workC.copy(
+            subgraphId = SubgraphId(idA, idB, idC, idD),
+            componentIds = List(idA, idB, idC, idD),
+          ),
+          workD.copy(
+            subgraphId = SubgraphId(idA, idB, idC, idD),
+            componentIds = List(idA, idB, idC, idD),
+          ),
         )
     }
 
@@ -205,26 +187,16 @@ class WorkGraphUpdaterTest
 
       val result = WorkGraphUpdater
         .update(
-          work = createWorkWith(idC, version = 2, referencedWorkIds = Set(idA)),
+          work = createWorkWith(idC, version = 2, mergeCandidateIds = Set(idA)),
           affectedNodes = Set(workA, workB, workC)
         )
 
       result shouldBe Set(
-        WorkNode(
-          idA,
-          version = 1,
-          linkedIds = List(idB),
-          componentId = ComponentId(idA, idB, idC)),
-        WorkNode(
-          idB,
-          version = 1,
-          linkedIds = List(idC),
-          componentId = ComponentId(idA, idB, idC)),
-        WorkNode(
-          idC,
-          version = 2,
-          linkedIds = List(idA),
-          componentId = ComponentId(idA, idB, idC))
+        workA,
+        workB,
+        workC.copy(
+          sourceWork = Some(SourceWorkData(version = 2, mergeCandidateIds = List(idA)))
+        ),
       )
     }
   }
@@ -233,42 +205,43 @@ class WorkGraphUpdaterTest
     it("processes an update for a newer version") {
       val workA = createOneWork("A")
 
-      val existingVersion = workA.version.get
+      val existingVersion = workA.sourceWork.get.version
       val updateVersion = existingVersion + 1
 
       val result = WorkGraphUpdater
         .update(
           work =
-            createWorkWith(idA, updateVersion, referencedWorkIds = Set(idB)),
+            createWorkWith(idA, updateVersion, mergeCandidateIds = Set(idB)),
           affectedNodes = Set(workA)
         )
 
-      result should contain theSameElementsAs
-        List(
+      result shouldBe
+        Set(
           WorkNode(
             idA,
-            updateVersion,
-            linkedIds = List(idB),
-            componentId = ComponentId(idA, idB)),
+            subgraphId = SubgraphId(idA, idB),
+            componentIds = List(idA, idB),
+            sourceWork = SourceWorkData(version = updateVersion, mergeCandidateIds = List(idB))
+          ),
           WorkNode(
             idB,
-            version = None,
-            linkedIds = List(),
-            componentId = ComponentId(idA, idB))
+            subgraphId = SubgraphId(idA, idB),
+            componentIds = List(idA, idB),
+          )
         )
     }
 
     it("doesn't process an update for a lower version") {
       val workA = createOneWork("A")
 
-      val existingVersion = workA.version.get
+      val existingVersion = workA.sourceWork.get.version
       val updateVersion = existingVersion - 1
 
       val thrown = intercept[VersionExpectedConflictException] {
         WorkGraphUpdater
           .update(
             work =
-              createWorkWith(idA, updateVersion, referencedWorkIds = Set(idB)),
+              createWorkWith(idA, updateVersion, mergeCandidateIds = Set(idB)),
             affectedNodes = Set(workA)
           )
       }
@@ -279,12 +252,12 @@ class WorkGraphUpdaterTest
       "processes an update for the same version if it's the same as the one stored") {
       val (workA, workB) = createTwoWorks("A->B")
 
-      val existingVersion = workA.version.get
+      val existingVersion = workA.sourceWork.get.version
 
       val result = WorkGraphUpdater
         .update(
           work =
-            createWorkWith(idA, existingVersion, referencedWorkIds = Set(idB)),
+            createWorkWith(idA, existingVersion, mergeCandidateIds = Set(idB)),
           affectedNodes = Set(workA, workB)
         )
 
@@ -295,7 +268,7 @@ class WorkGraphUpdaterTest
       "doesn't process an update for the same version if the work is different from the one stored") {
       val (workA, workB) = createTwoWorks("A->B")
 
-      val existingVersion = workA.version.get
+      val existingVersion = workA.sourceWork.get.version
 
       val thrown = intercept[VersionUnexpectedConflictException] {
         WorkGraphUpdater
@@ -303,7 +276,7 @@ class WorkGraphUpdaterTest
             work = createWorkWith(
               idA,
               existingVersion,
-              referencedWorkIds = Set(idC)),
+              mergeCandidateIds = Set(idC)),
             affectedNodes = Set(workA, workB)
           )
       }
@@ -317,21 +290,18 @@ class WorkGraphUpdaterTest
 
       val result = WorkGraphUpdater
         .update(
-          work = createWorkWith(idA, version = 2, referencedWorkIds = Set.empty),
+          work = createWorkWith(idA, version = 2, mergeCandidateIds = Set.empty),
           affectedNodes = Set(workA, workB)
         )
 
       result shouldBe Set(
-        WorkNode(
-          idA,
-          version = 2,
-          linkedIds = List(),
-          componentId = ComponentId(idA)),
-        WorkNode(
-          idB,
-          version = 1,
-          linkedIds = List(),
-          componentId = ComponentId(idB))
+        workA.copy(
+          componentIds = List(idA),
+          sourceWork = Some(SourceWorkData(version = 2)),
+        ),
+        workB.copy(
+          componentIds = List(idB),
+        ),
       )
     }
 
@@ -340,26 +310,21 @@ class WorkGraphUpdaterTest
 
       val result = WorkGraphUpdater
         .update(
-          work = createWorkWith(idB, version = 2, referencedWorkIds = Set.empty),
+          work = createWorkWith(idB, version = 2, mergeCandidateIds = Set.empty),
           affectedNodes = Set(workA, workB, workC)
         )
 
       result shouldBe Set(
-        WorkNode(
-          idA,
-          version = 1,
-          linkedIds = List(idB),
-          componentId = ComponentId(idA, idB)),
-        WorkNode(
-          idB,
-          version = 2,
-          linkedIds = Nil,
-          componentId = ComponentId(idA, idB)),
-        WorkNode(
-          idC,
-          version = 1,
-          linkedIds = Nil,
-          componentId = ComponentId(idC))
+        workA.copy(
+          componentIds = List(idA, idB)
+        ),
+        workB.copy(
+          componentIds = List(idA, idB),
+          sourceWork = Some(SourceWorkData(version = 2)),
+        ),
+        workC.copy(
+          componentIds = List(idC)
+        ),
       )
     }
 
@@ -368,17 +333,15 @@ class WorkGraphUpdaterTest
 
       val result = WorkGraphUpdater
         .update(
-          work = createWorkWith(idB, version = 2, referencedWorkIds = Set(idC)),
+          work = createWorkWith(idB, version = 2, mergeCandidateIds = Set(idC)),
           affectedNodes = Set(workA, workB, workC)
         )
 
       result shouldBe Set(
         workA,
-        WorkNode(
-          idB,
-          version = 2,
-          linkedIds = List(idC),
-          componentId = ComponentId(idA, idB, idC)),
+        workB.copy(
+          sourceWork = Some(SourceWorkData(version = 2, mergeCandidateIds = List(idC))),
+        ),
         workC,
       )
     }
@@ -386,134 +349,73 @@ class WorkGraphUpdaterTest
 
   describe("handling suppressed works") {
     it("A->B, but B is suppressed (updating A)") {
+      val workB = createOneWork("B[suppressed]")
+
       val result =
         WorkGraphUpdater.update(
-          work = createWorkWith(idA, version = 1, referencedWorkIds = Set(idB)),
-          affectedNodes = Set(
-            WorkNode(
-              id = idB,
-              version = 1,
-              linkedIds = List(),
-              componentId = ComponentId(idB),
-              suppressed = true)
-          )
+          work = createWorkWith(idA, version = 1, mergeCandidateIds = Set(idB)),
+          affectedNodes = Set(workB)
         )
 
       result shouldBe Set(
         WorkNode(
           id = idA,
-          version = 1,
-          linkedIds = List(idB),
-          componentId = ComponentId(idA)),
-        WorkNode(
-          id = idB,
-          version = 1,
-          linkedIds = List(),
-          componentId = ComponentId(idB),
-          suppressed = true)
+          subgraphId = SubgraphId(idA, idB),
+          componentIds = List(idA, idB),
+          sourceWork = SourceWorkData(version = 1, mergeCandidateIds = List(idB)),
+        ),
+        workB,
       )
     }
 
     it("A->B, but B is suppressed (updating B)") {
+      val (workA, workB) = createTwoWorks("A->B")
+
       val result =
         WorkGraphUpdater.update(
           work = createWorkWith(
             idB,
-            version = 1,
-            referencedWorkIds = Set(idB),
+            version = 2,
+            mergeCandidateIds = Set(idB),
             workType = "Deleted"),
-          affectedNodes = Set(
-            WorkNode(
-              id = idA,
-              version = 1,
-              linkedIds = List(idB),
-              componentId = ComponentId(idA, idB)),
-            WorkNode(
-              id = idB,
-              version = None,
-              linkedIds = List(),
-              componentId = ComponentId(idA, idB))
-          )
+          affectedNodes = Set(workA, workB)
         )
 
       result shouldBe Set(
-        WorkNode(
-          id = idA,
-          version = 1,
-          linkedIds = List(idB),
-          componentId = ComponentId(idA)),
-        WorkNode(
-          id = idB,
-          version = 1,
-          linkedIds = List(),
-          componentId = ComponentId(idB),
-          suppressed = true)
+        workA,
+        workB.copy(
+          sourceWork = Some(SourceWorkData(version = 2, suppressed = true))
+        ),
       )
     }
 
     it("A->B->C->D->E, but C is suppressed (updating A)") {
+      val (workA, workB, workC, workD, workE) = createFiveWorks("A->B->C->D->E")
+      val suppressedWorkC = workC.copy(
+        sourceWork = Some(workC.sourceWork.get.copy(suppressed = true))
+      )
+
       val result =
         WorkGraphUpdater.update(
-          work = createWorkWith(idA, version = 1, referencedWorkIds = Set(idB)),
-          affectedNodes = Set(
-            WorkNode(
-              id = idB,
-              version = 1,
-              linkedIds = List(idC),
-              componentId = ComponentId(idB)),
-            WorkNode(
-              id = idC,
-              version = 1,
-              linkedIds = List(idD),
-              componentId = ComponentId(idC),
-              suppressed = true),
-            WorkNode(
-              id = idD,
-              version = 1,
-              linkedIds = List(idE),
-              componentId = ComponentId(idD, idE)),
-            WorkNode(
-              id = idE,
-              version = 1,
-              linkedIds = List(),
-              componentId = ComponentId(idD, idE))
-          )
+          work = createWorkWith(idA, version = 2, mergeCandidateIds = Set(idB)),
+          affectedNodes = Set(workA, workB, suppressedWorkC, workD, workE)
         )
 
       result shouldBe Set(
-        WorkNode(
-          id = idA,
-          version = 1,
-          linkedIds = List(idB),
-          componentId = ComponentId(idA, idB)),
-        WorkNode(
-          id = idB,
-          version = 1,
-          linkedIds = List(idC),
-          componentId = ComponentId(idA, idB)),
-        WorkNode(
-          id = idC,
-          version = 1,
-          linkedIds = List(idD),
-          componentId = ComponentId(idC),
-          suppressed = true),
-        WorkNode(
-          id = idD,
-          version = 1,
-          linkedIds = List(idE),
-          componentId = ComponentId(idD, idE)),
-        WorkNode(
-          id = idE,
-          version = 1,
-          linkedIds = List(),
-          componentId = ComponentId(idD, idE))
+        workA.copy(
+          sourceWork = Some(SourceWorkData(version = 2, mergeCandidateIds = List(idB)))
+        ),
+        workB,
+        suppressedWorkC,
+        workD,
+        workE,
       )
     }
 
     it("A->B->C, B is suppressed, then B is updated as unsuppressed") {
       val graph1 =
         WorkGraphUpdater.update(
-          work = createWorkWith(idA, version = 1, referencedWorkIds = Set(idB)),
+          work = createWorkWith(idA, version = 1, mergeCandidateIds = Set(idB)),
           affectedNodes = Set()
         )
 
@@ -522,14 +424,14 @@ class WorkGraphUpdaterTest
           work = createWorkWith(
             idB,
             version = 1,
-            referencedWorkIds = Set(idC),
+            mergeCandidateIds = Set(idC),
             workType = "Deleted"),
           affectedNodes = graph1
         )
 
       val graph3 =
         WorkGraphUpdater.update(
-          work = createWorkWith(idC, version = 1, referencedWorkIds = Set()),
+          work = createWorkWith(idC, version = 1, mergeCandidateIds = Set()),
           affectedNodes = graph2
         )
 
@@ -544,12 +446,12 @@ class WorkGraphUpdaterTest
           work = createWorkWith(
             idB,
             version = 2,
-            referencedWorkIds = Set(idC),
+            mergeCandidateIds = Set(idC),
             workType = "Undeleted"),
           affectedNodes = graph3
         )
 
-      result.map(_.componentId) shouldBe Set(ComponentId(idA, idB, idC))
+      result.map(_.subgraphId) shouldBe Set(SubgraphId(idA, idB, idC))
     }
   }
 }

--- a/pipeline/merger/src/test/scala/weco/pipeline/merger/MergerIntegrationTest.scala
+++ b/pipeline/merger/src/test/scala/weco/pipeline/merger/MergerIntegrationTest.scala
@@ -167,9 +167,9 @@ class MergerIntegrationTest
       )
       val miro = miroIdentifiedWork()
       val sierraDigaidsPicture = sierraIdentifiedWork()
-        // Multiple physical items would prevent a Miro redirect in any other case,
-        // but we still expect to see it for the digaids works as the Miro item is
-        // a known duplicate of the METS item.
+      // Multiple physical items would prevent a Miro redirect in any other case,
+      // but we still expect to see it for the digaids works as the Miro item is
+      // a known duplicate of the METS item.
         .items(List(createIdentifiedPhysicalItem, createIdentifiedPhysicalItem))
         .format(Format.Pictures)
         .otherIdentifiers(List(createDigcodeIdentifier("digaids")))


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5389

The key is the new WorkNode model.

Before:

```scala
case class WorkNode(
  id: CanonicalId,
  version: Option[Int],
  linkedIds: List[CanonicalId],
  componentId: String,
  suppressed: Boolean = false
)
```

After:

```scala
case class WorkNode(
  id: CanonicalId,
  subgraphId: String,
  componentIds: List[CanonicalId],
  sourceWork: Option[SourceWorkData] = None,
)

case class SourceWorkData(
  id: SourceIdentifier,
  version: Int,
  suppressed: Boolean = false,
  mergeCandidateIds: List[CanonicalId] = List(),
)
```

Changes:

- The `subgraphId` records works that should be matched together; the `componentIds` record works that should be merged together.
- We now record the source identifier alongside the source work (which I've wanted for a while to make matcher analysis easier), and `linkedIds` has been renamed to `mergeCandidateIds`, which is what it actually is. I've also grouped all the source data, to make it more obvious whether a node corresponds to a known source work or not.

We use the new `subgraphId` to look up related works when matching, and it makes handling suppressed/unlinked works much simpler. If A and B are *ever* in the same matcher subgraph, they will *always* have the same subgraphId from that point forward, even if they're not in the same component. (Until the matcher database is reset.) It's a little inefficient, but much simpler and therefore less likely to be buggy.