### PR TITLE
Allocate the right memory for image inferrer tasks

### DIFF
--- a/pipeline/terraform/stack/service_image_inferrer.tf
+++ b/pipeline/terraform/stack/service_image_inferrer.tf
@@ -9,8 +9,12 @@ locals {
   shared_storage_name      = "shared_storage"
   shared_storage_path      = "/data"
 
-  base_total_cpu           = 8192
-  base_total_memory        = 15463
+  base_2x_total_cpu = 8192
+  base_1x_total_cpu = 4096
+
+  base_2x_total_memory = 15463
+  base_1x_total_memory = 7623
+
   base_manager_memory      = 2048
   base_manager_cpu         = 1024
   base_aspect_ratio_cpu    = 2048
@@ -18,8 +22,8 @@ locals {
 
   # When we're not reindexing, we halve the size of these tasks, because
   # they won't be getting as many updates.
-  total_cpu           = var.is_reindexing ? local.base_total_cpu : floor(local.base_total_cpu / 2)
-  total_memory        = var.is_reindexing ? local.base_total_memory : floor(local.base_total_memory / 2)
+  total_cpu           = var.is_reindexing ? local.base_2x_total_cpu : local.base_1x_total_cpu
+  total_memory        = var.is_reindexing ? local.base_2x_total_memory : local.base_1x_total_memory
   manager_memory      = var.is_reindexing ? local.base_manager_memory : floor(local.base_manager_memory / 2)
   manager_cpu         = var.is_reindexing ? local.base_manager_cpu : floor(local.base_manager_cpu / 2)
   aspect_ratio_cpu    = var.is_reindexing ? local.base_aspect_ratio_cpu : floor(local.base_aspect_ratio_cpu / 2)


### PR DESCRIPTION
Should fix.

<img width="508" alt="Screenshot 2021-12-21 at 11 01 35" src="https://user-images.githubusercontent.com/301220/146919475-8e36113a-74cc-499f-a584-412af913cee2.png">
