### PR TITLE
Add the 2021-12-21 pipeline

### DIFF
--- a/.wellcome_project
+++ b/.wellcome_project
@@ -81,10 +81,10 @@ reindexer:
 
 catalogue_pipeline:
   environments:
-    - id: "2021-11-25"
-      name: "2021-11-25"
     - id: "2021-11-29"
       name: "2021-11-29"
+    - id: "2021-12-21"
+      name: "2021-12-21"
   image_repositories:
     - id: id_minter
       services:

--- a/pipeline/terraform/locals.tf
+++ b/pipeline/terraform/locals.tf
@@ -10,6 +10,7 @@ locals {
   sierra_merged_items_topic_arn    = data.terraform_remote_state.sierra_adapter.outputs.merged_items_topic_arn
   sierra_merged_bibs_topic_arn     = data.terraform_remote_state.sierra_adapter.outputs.merged_bibs_topic_arn
   sierra_merged_holdings_topic_arn = data.terraform_remote_state.sierra_adapter.outputs.merged_holdings_topic_arn
+  sierra_merged_orders_topic_arn   = data.terraform_remote_state.sierra_adapter.outputs.merged_orders_topic_arn
 
   # Mets adapter VHS
   mets_adapter_read_policy = data.terraform_remote_state.mets_adapter.outputs.mets_dynamo_read_policy

--- a/pipeline/terraform/locals.tf
+++ b/pipeline/terraform/locals.tf
@@ -55,6 +55,4 @@ locals {
   traffic_filter_public_internet_id = local.shared_infra["ec_public_internet_traffic_filter_id"]
 
   logging_cluster_id = data.terraform_remote_state.shared_infra.outputs.logging_cluster_id
-
-  api_ec_version = data.terraform_remote_state.catalogue_api.outputs.catalogue_api_ec_version
 }

--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -4,7 +4,13 @@ module "catalogue_pipeline_2021-11-29" {
   pipeline_date = "2021-11-29"
   release_label = "2021-11-29"
 
-  is_reindexing = false
+  reindexing_state = {
+    connect_reindex_topics   = false
+    scale_up_tasks           = false
+    scale_up_elastic_cluster = false
+    scale_up_id_minter_db    = false
+    scale_up_matcher_db      = false
+  }
 
   # Boilerplate that shouldn't change between pipelines.
 
@@ -86,4 +92,100 @@ module "catalogue_pipeline_2021-11-29" {
 
   logging_cluster_id = local.logging_cluster_id
 }
+
+module "catalogue_pipeline_2021-12-21" {
+  source = "./stack"
+
+  pipeline_date = "2021-12-21"
+  release_label = "2021-12-21"
+
+  reindexing_state = {
+    connect_reindex_topics   = true
+    scale_up_tasks           = true
+    scale_up_elastic_cluster = true
+    scale_up_id_minter_db    = true
+    scale_up_matcher_db      = true
+  }
+
+  # Boilerplate that shouldn't change between pipelines.
+
+  adapters = {
+    sierra = {
+      topics = [
+        local.sierra_merged_bibs_topic_arn,
+        local.sierra_merged_items_topic_arn,
+        local.sierra_merged_holdings_topic_arn,
+      ]
+      reindex_topic = local.sierra_reindexer_topic_arn
+    }
+
+    miro = {
+      topics = [
+        local.miro_updates_topic_arn,
+      ]
+      reindex_topic = local.miro_reindexer_topic_arn,
+    }
+
+    mets = {
+      topics = [
+        local.mets_adapter_topic_arn,
+      ],
+      reindex_topic = local.mets_reindexer_topic_arn,
+    }
+
+    calm = {
+      topics = [
+        local.calm_adapter_topic_arn,
+        local.calm_deletions_topic_arn,
+      ],
+      reindex_topic = local.calm_reindexer_topic_arn,
+    }
+
+    tei = {
+      topics = [
+        local.tei_adapter_topic_arn,
+      ],
+      reindex_topic = local.tei_reindexer_topic_arn,
+    }
+  }
+
+  vpc_id  = local.vpc_id
+  subnets = local.private_subnets
+
+  dlq_alarm_arn = local.dlq_alarm_arn
+
+  rds_cluster_id        = local.rds_cluster_id
+  rds_subnet_group_name = local.rds_subnet_group_name
+
+  # Security groups
+  rds_ids_access_security_group_id = local.rds_access_security_group_id
+  ec_privatelink_security_group_id = local.ec_platform_privatelink_security_group_id
+
+  traffic_filter_platform_vpce_id   = local.traffic_filter_platform_vpce_id
+  traffic_filter_catalogue_vpce_id  = local.traffic_filter_catalogue_vpce_id
+  traffic_filter_public_internet_id = local.traffic_filter_public_internet_id
+
+  # Adapter VHS
+  vhs_miro_read_policy   = local.vhs_miro_read_policy
+  vhs_sierra_read_policy = local.vhs_sierra_read_policy
+  vhs_calm_read_policy   = local.vhs_calm_read_policy
+
+  # Inferrer data
+  inferrer_model_data_bucket_name = aws_s3_bucket.inferrer_model_core_data.id
+
+  tei_adapter_bucket_name = local.tei_adapter_bucket_name
+
+  shared_logging_secrets = data.terraform_remote_state.shared_infra.outputs.shared_secrets_logging
+
+  storage_bucket_name = local.storage_bucket
+
+  api_ec_version = local.api_ec_version
+
+  providers = {
+    aws.catalogue = aws.catalogue
+  }
+
+  logging_cluster_id = local.logging_cluster_id
+}
+
 

--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -99,11 +99,11 @@ module "catalogue_pipeline_2021-12-21" {
   release_label = "2021-12-21"
 
   reindexing_state = {
-    connect_reindex_topics   = true
-    scale_up_tasks           = true
-    scale_up_elastic_cluster = true
-    scale_up_id_minter_db    = true
-    scale_up_matcher_db      = true
+    connect_reindex_topics   = false
+    scale_up_tasks           = false
+    scale_up_elastic_cluster = false
+    scale_up_id_minter_db    = false
+    scale_up_matcher_db      = false
   }
 
   # Boilerplate that shouldn't change between pipelines.
@@ -185,5 +185,3 @@ module "catalogue_pipeline_2021-12-21" {
 
   logging_cluster_id = local.logging_cluster_id
 }
-
-

--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -84,8 +84,6 @@ module "catalogue_pipeline_2021-11-29" {
 
   storage_bucket_name = local.storage_bucket
 
-  api_ec_version = local.api_ec_version
-
   providers = {
     aws.catalogue = aws.catalogue
   }
@@ -178,8 +176,6 @@ module "catalogue_pipeline_2021-12-21" {
   shared_logging_secrets = data.terraform_remote_state.shared_infra.outputs.shared_secrets_logging
 
   storage_bucket_name = local.storage_bucket
-
-  api_ec_version = local.api_ec_version
 
   providers = {
     aws.catalogue = aws.catalogue

--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -20,6 +20,7 @@ module "catalogue_pipeline_2021-11-29" {
         local.sierra_merged_bibs_topic_arn,
         local.sierra_merged_items_topic_arn,
         local.sierra_merged_holdings_topic_arn,
+        local.sierra_merged_orders_topic_arn,
       ]
       reindex_topic = local.sierra_reindexer_topic_arn
     }
@@ -113,6 +114,7 @@ module "catalogue_pipeline_2021-12-21" {
         local.sierra_merged_bibs_topic_arn,
         local.sierra_merged_items_topic_arn,
         local.sierra_merged_holdings_topic_arn,
+        local.sierra_merged_orders_topic_arn,
       ]
       reindex_topic = local.sierra_reindexer_topic_arn
     }

--- a/pipeline/terraform/stack/cluster.tf
+++ b/pipeline/terraform/stack/cluster.tf
@@ -1,22 +1,22 @@
 resource "aws_ecs_cluster" "cluster" {
-  name               = local.namespace_hyphen
+  name               = local.namespace
   capacity_providers = [module.inference_capacity_provider.name]
 }
 
 module "inference_capacity_provider" {
   source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/ec2_capacity_provider?ref=v3.5.1"
 
-  name = "${local.namespace_hyphen}_inferrer"
+  name = "${local.namespace}_inferrer"
 
   // Setting this variable from aws_ecs_cluster.cluster.name creates a cycle
   // The cluster name is required for the instance user data script
   // This is a known issue https://github.com/terraform-providers/terraform-provider-aws/issues/12739
-  cluster_name = local.namespace_hyphen
+  cluster_name = local.namespace
 
   # When we're not reindexing, we halve the size of these instances and
   # the corresponding tasks, because they won't be getting as many updates.
-  instance_type           = var.is_reindexing ? "c5.2xlarge" : "c5.xlarge"
-  max_instances           = var.is_reindexing ? 12 : 1
+  instance_type           = var.reindexing_state.scale_up_tasks ? "c5.2xlarge" : "c5.xlarge"
+  max_instances           = var.reindexing_state.scale_up_tasks ? 12 : 1
   use_spot_purchasing     = true
   scaling_action_cooldown = 240
 

--- a/pipeline/terraform/stack/dynamo.tf
+++ b/pipeline/terraform/stack/dynamo.tf
@@ -13,13 +13,13 @@
 # https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/switching.capacitymode.html
 
 locals {
-  graph_table_billing_mode = var.is_reindexing ? "PROVISIONED" : "PAY_PER_REQUEST"
-  lock_table_billing_mode  = var.is_reindexing ? "PROVISIONED" : "PAY_PER_REQUEST"
+  graph_table_billing_mode = var.reindexing_state.scale_up_matcher_db ? "PROVISIONED" : "PAY_PER_REQUEST"
+  lock_table_billing_mode  = var.reindexing_state.scale_up_matcher_db ? "PROVISIONED" : "PAY_PER_REQUEST"
 }
 
 # Graph table
 locals {
-  graph_table_name = "${local.namespace_hyphen}_works-graph"
+  graph_table_name = "${local.namespace}_works-graph"
 }
 
 resource "aws_dynamodb_table" "matcher_graph_table" {
@@ -94,7 +94,7 @@ data "aws_iam_policy_document" "graph_table_readwrite" {
 # Lock table
 
 locals {
-  lock_table_name = "${local.namespace_hyphen}_matcher-lock-table"
+  lock_table_name = "${local.namespace}_matcher-lock-table"
 }
 
 resource "aws_dynamodb_table" "matcher_lock_table" {

--- a/pipeline/terraform/stack/dynamo.tf
+++ b/pipeline/terraform/stack/dynamo.tf
@@ -32,7 +32,7 @@ resource "aws_dynamodb_table" "matcher_graph_table" {
   }
 
   attribute {
-    name = "componentId"
+    name = "subgraphId"
     type = "S"
   }
 
@@ -45,7 +45,7 @@ resource "aws_dynamodb_table" "matcher_graph_table" {
 
   global_secondary_index {
     name            = "work-sets-index"
-    hash_key        = "componentId"
+    hash_key        = "subgraphId"
     projection_type = "ALL"
 
     read_capacity  = local.graph_table_billing_mode == "PROVISIONED" ? 600 : 1
@@ -58,9 +58,7 @@ resource "aws_dynamodb_table" "matcher_graph_table" {
 
   lifecycle {
     ignore_changes = [
-      global_secondary_index,
-      /*read_capacity,*/
-      /*write_capacity*/
+      /*global_secondary_index,*/
     ]
   }
 }

--- a/pipeline/terraform/stack/elastic_pipeline.tf
+++ b/pipeline/terraform/stack/elastic_pipeline.tf
@@ -3,14 +3,14 @@ data "ec_deployment" "logging" {
 }
 
 locals {
-  es_memory = var.is_reindexing ? "58g" : "8g"
+  es_memory = var.reindexing_state.scale_up_elastic_cluster ? "58g" : "8g"
 
   # When we're reindexing, this cluster isn't depended on for anything.
   # It's ephemeral data (and at 58GB of memory, expensive).
   #
   # Once we stop reindexing and make the pipeline live, we want it to be
   # highly available, to avoid issues with cross-cluster replication.
-  es_node_count = var.is_reindexing ? 1 : 2
+  es_node_count = var.reindexing_state.scale_up_elastic_cluster ? 1 : 2
 }
 
 resource "ec_deployment" "pipeline" {

--- a/pipeline/terraform/stack/elastic_pipeline.tf
+++ b/pipeline/terraform/stack/elastic_pipeline.tf
@@ -16,27 +16,7 @@ locals {
 resource "ec_deployment" "pipeline" {
   name = "pipeline-${var.pipeline_date}"
 
-  # Currently we do cross-cluster replication from the pipeline cluster
-  # to the API cluster.
-  #
-  # The Elasticsearch documentation is very clear [1]
-  #
-  #     The cluster containing follower indices must be running the same
-  #     or newer version of Elasticsearch as the remote cluster
-  #
-  # This even applies across patch versions, e.g. this configuration
-  # is no good:
-  #
-  #     pipeline = v7.14.1
-  #     api      = v7.14.0
-  #
-  # Using the same version as the API cluster means we'll never get CCR
-  # versioning in a muddle.  If you want a newer version, upgrade the
-  # API first.
-  #
-  # [1]: https://www.elastic.co/guide/en/elasticsearch/reference/current/xpack-ccr.html
-  #
-  version = var.api_ec_version
+  version = "7.16.2"
 
   region                 = "eu-west-1"
   deployment_template_id = "aws-io-optimized-v2"

--- a/pipeline/terraform/stack/locals.tf
+++ b/pipeline/terraform/stack/locals.tf
@@ -1,6 +1,5 @@
 locals {
-  namespace        = "catalogue-${var.pipeline_date}"
-  namespace_hyphen = replace(local.namespace, "_", "-")
+  namespace = "catalogue-${var.pipeline_date}"
 
   es_works_source_index       = "works-source-${var.pipeline_date}"
   es_works_merged_index       = "works-merged-${var.pipeline_date}"
@@ -34,7 +33,7 @@ locals {
   #
   # We also want to avoid running more ingestors when not reindexing
   # than when we are!
-  max_capacity = var.is_reindexing ? var.max_capacity : min(1, var.max_capacity)
+  max_capacity = var.reindexing_state.scale_up_tasks ? var.max_capacity : min(1, var.max_capacity)
 
   # If we're reindexing, our services will scale up to max capacity,
   # work through everything on the reindex queues, and then suddenly
@@ -47,8 +46,8 @@ locals {
   # Note: if the scale down adjustment is greater than the number of tasks,
   # ECS will just stop every task.  e.g. if scale_down_adjustment = -5 and
   # there are 3 tasks running, ECS will scale the tasks down to zero.
-  scale_down_adjustment = var.is_reindexing ? -5 : -1
-  scale_up_adjustment   = var.is_reindexing ? 5 : 1
+  scale_down_adjustment = var.reindexing_state.scale_up_tasks ? -5 : -1
+  scale_up_adjustment   = var.reindexing_state.scale_up_tasks ? 5 : 1
 
   services = [
     "ingestor_works",
@@ -71,11 +70,11 @@ locals {
     "transformer_calm",
   ]
 
-  sierra_adapter_topic_arns = var.is_reindexing ? concat(var.adapters["sierra"].topics, [var.adapters["sierra"].reindex_topic]) : var.adapters["sierra"].topics
-  miro_adapter_topic_arns   = var.is_reindexing ? concat(var.adapters["miro"].topics, [var.adapters["miro"].reindex_topic]) : var.adapters["miro"].topics
-  mets_adapter_topic_arns   = var.is_reindexing ? concat(var.adapters["mets"].topics, [var.adapters["mets"].reindex_topic]) : var.adapters["mets"].topics
-  tei_adapter_topic_arns    = var.is_reindexing ? concat(var.adapters["tei"].topics, [var.adapters["tei"].reindex_topic]) : var.adapters["tei"].topics
-  calm_adapter_topic_arns   = var.is_reindexing ? concat(var.adapters["calm"].topics, [var.adapters["calm"].reindex_topic]) : var.adapters["calm"].topics
+  sierra_adapter_topic_arns = var.reindexing_state.connect_reindex_topics ? concat(var.adapters["sierra"].topics, [var.adapters["sierra"].reindex_topic]) : var.adapters["sierra"].topics
+  miro_adapter_topic_arns   = var.reindexing_state.connect_reindex_topics ? concat(var.adapters["miro"].topics, [var.adapters["miro"].reindex_topic]) : var.adapters["miro"].topics
+  mets_adapter_topic_arns   = var.reindexing_state.connect_reindex_topics ? concat(var.adapters["mets"].topics, [var.adapters["mets"].reindex_topic]) : var.adapters["mets"].topics
+  tei_adapter_topic_arns    = var.reindexing_state.connect_reindex_topics ? concat(var.adapters["tei"].topics, [var.adapters["tei"].reindex_topic]) : var.adapters["tei"].topics
+  calm_adapter_topic_arns   = var.reindexing_state.connect_reindex_topics ? concat(var.adapters["calm"].topics, [var.adapters["calm"].reindex_topic]) : var.adapters["calm"].topics
 
   logging_cluster_id = var.logging_cluster_id
 }

--- a/pipeline/terraform/stack/rds_id_minter.tf
+++ b/pipeline/terraform/stack/rds_id_minter.tf
@@ -1,5 +1,5 @@
 locals {
-  extra_rds_instances = var.is_reindexing ? 2 : 0
+  extra_rds_instances = var.reindexing_state.scale_up_id_minter_db ? 2 : 0
 }
 
 resource "aws_rds_cluster_instance" "extra_instances" {

--- a/pipeline/terraform/stack/service_image_inferrer.tf
+++ b/pipeline/terraform/stack/service_image_inferrer.tf
@@ -22,12 +22,12 @@ locals {
 
   # When we're not reindexing, we halve the size of these tasks, because
   # they won't be getting as many updates.
-  total_cpu           = var.is_reindexing ? local.base_2x_total_cpu : local.base_1x_total_cpu
-  total_memory        = var.is_reindexing ? local.base_2x_total_memory : local.base_1x_total_memory
-  manager_memory      = var.is_reindexing ? local.base_manager_memory : floor(local.base_manager_memory / 2)
-  manager_cpu         = var.is_reindexing ? local.base_manager_cpu : floor(local.base_manager_cpu / 2)
-  aspect_ratio_cpu    = var.is_reindexing ? local.base_aspect_ratio_cpu : floor(local.base_aspect_ratio_cpu / 2)
-  aspect_ratio_memory = var.is_reindexing ? local.base_aspect_ratio_memory : floor(local.base_aspect_ratio_memory / 2)
+  total_cpu           = var.reindexing_state.scale_up_tasks ? local.base_2x_total_cpu : local.base_1x_total_cpu
+  total_memory        = var.reindexing_state.scale_up_tasks ? local.base_2x_total_memory : local.base_1x_total_memory
+  manager_memory      = var.reindexing_state.scale_up_tasks ? local.base_manager_memory : floor(local.base_manager_memory / 2)
+  manager_cpu         = var.reindexing_state.scale_up_tasks ? local.base_manager_cpu : floor(local.base_manager_cpu / 2)
+  aspect_ratio_cpu    = var.reindexing_state.scale_up_tasks ? local.base_aspect_ratio_cpu : floor(local.base_aspect_ratio_cpu / 2)
+  aspect_ratio_memory = var.reindexing_state.scale_up_tasks ? local.base_aspect_ratio_memory : floor(local.base_aspect_ratio_memory / 2)
 
   inferrer_cpu    = floor(0.5 * (local.total_cpu - local.manager_cpu - local.aspect_ratio_cpu))
   inferrer_memory = floor(0.5 * (local.total_memory - local.manager_memory - local.aspect_ratio_memory))

--- a/pipeline/terraform/stack/service_ingestor_images.tf
+++ b/pipeline/terraform/stack/service_ingestor_images.tf
@@ -26,7 +26,7 @@ module "ingestor_images" {
 
     es_images_index    = local.es_images_index
     es_augmented_index = local.es_images_augmented_index
-    es_is_reindexing   = var.is_reindexing
+    es_is_reindexing   = var.reindexing_state.scale_up_tasks
 
     ingest_flush_interval_seconds = local.ingestor_images_flush_interval_seconds
 

--- a/pipeline/terraform/stack/service_ingestor_works.tf
+++ b/pipeline/terraform/stack/service_ingestor_works.tf
@@ -27,7 +27,7 @@ module "ingestor_works" {
 
     es_works_index        = local.es_works_index
     es_denormalised_index = local.es_works_denormalised_index
-    es_is_reindexing      = var.is_reindexing
+    es_is_reindexing      = var.reindexing_state.scale_up_tasks
 
     ingest_flush_interval_seconds = local.ingestor_works_flush_interval_seconds
 
@@ -50,7 +50,7 @@ module "ingestor_works" {
     # To avoid this happening, we reduce the batch size when we're not
     # reindexing.  A smaller batch size is a bit less efficient, but
     # we don't process many messages when not reindexing so this is fine.
-    ingest_batch_size = var.is_reindexing ? 100 : 10
+    ingest_batch_size = var.reindexing_state.scale_up_tasks ? 100 : 10
   }
 
   secret_env_vars = local.pipeline_storage_es_service_secrets["work_ingestor"]

--- a/pipeline/terraform/stack/task_definition_image_training.tf
+++ b/pipeline/terraform/stack/task_definition_image_training.tf
@@ -1,5 +1,5 @@
 locals {
-  name   = "${local.namespace_hyphen}_image_training"
+  name   = "${local.namespace}_image_training"
   cpu    = 4096
   memory = 8192
 

--- a/pipeline/terraform/stack/variables.tf
+++ b/pipeline/terraform/stack/variables.tf
@@ -2,10 +2,6 @@ variable "pipeline_date" {
   type = string
 }
 
-variable "api_ec_version" {
-  type = string
-}
-
 variable "min_capacity" {
   type    = number
   default = 0

--- a/pipeline/terraform/stack/variables.tf
+++ b/pipeline/terraform/stack/variables.tf
@@ -35,9 +35,14 @@ variable "rds_subnet_group_name" {
   type = string
 }
 
-variable "is_reindexing" {
-  type        = bool
-  description = "Are you reindexing through this pipeline right now?"
+variable "reindexing_state" {
+  type = object({
+    connect_reindex_topics   = bool
+    scale_up_tasks           = bool
+    scale_up_elastic_cluster = bool
+    scale_up_id_minter_db    = bool
+    scale_up_matcher_db      = bool
+  })
 }
 
 variable "rds_ids_access_security_group_id" {}

--- a/pipeline/terraform/stack/variables.tf
+++ b/pipeline/terraform/stack/variables.tf
@@ -9,7 +9,7 @@ variable "min_capacity" {
 
 variable "max_capacity" {
   type        = number
-  default     = 20
+  default     = 15
   description = "The max capacity of every ECS service will be less than or equal to this value"
 }
 

--- a/pipeline/terraform/terraform.tf
+++ b/pipeline/terraform/terraform.tf
@@ -35,17 +35,6 @@ terraform {
   }
 }
 
-data "terraform_remote_state" "catalogue_api" {
-  backend = "s3"
-
-  config = {
-    role_arn = "arn:aws:iam::756629837203:role/catalogue-read_only"
-    bucket   = "wellcomecollection-catalogue-infra-delta"
-    key      = "terraform/catalogue/api/shared.tfstate"
-    region   = "eu-west-1"
-  }
-}
-
 data "terraform_remote_state" "catalogue_infra_critical" {
   backend = "s3"
 

--- a/sierra_adapter/terraform/outputs.tf
+++ b/sierra_adapter/terraform/outputs.tf
@@ -10,6 +10,10 @@ output "merged_holdings_topic_arn" {
   value = module.sierra-adapter-20200604.merged_holdings_topic_arn
 }
 
+output "merged_orders_topic_arn" {
+  value = module.sierra-adapter-20200604.merged_orders_topic_arn
+}
+
 output "vhs_table_name" {
   value = module.sierra-adapter-20200604.vhs_table_name
 }

--- a/sierra_adapter/terraform/stack/outputs.tf
+++ b/sierra_adapter/terraform/stack/outputs.tf
@@ -10,6 +10,10 @@ output "merged_holdings_topic_arn" {
   value = module.holdings_merger.topic_arn
 }
 
+output "merged_orders_topic_arn" {
+  value = module.orders_merger.topic_arn
+}
+
 output "vhs_table_name" {
   value = module.vhs_sierra.table_name
 }


### PR DESCRIPTION
The big change is that we have more fine-grained control over the resource scaling:

```hcl
  reindexing_state = {
    connect_reindex_topics   = false
    scale_up_tasks           = false
    scale_up_elastic_cluster = false
    scale_up_id_minter_db    = false
    scale_up_matcher_db      = false
  }
```

One of the most expensive bits of a reindex is the ~$100 we spend on having two DynamoDB tables with lots of capacity for the matcher – but the matcher/merger finishes pretty quickly. We can turn down that table while the ingestors/inferrers are running, and save a bit of money.

It also makes it more obvious what this is toggling – there's quite a bit of stuff that changes based on a reindex.