### PR TITLE
Use the new URL for the Calm API

### DIFF
--- a/calm_adapter/terraform/locals.tf
+++ b/calm_adapter/terraform/locals.tf
@@ -14,7 +14,7 @@ locals {
   reindex_jobs_topic_arn          = data.terraform_remote_state.reindexer.outputs.topic_arn
   calm_deletion_checker_topic_arn = data.terraform_remote_state.reindexer.outputs.calm_deletion_checker_topic_arn
   calm_reporting_topic_arn        = data.terraform_remote_state.reindexer.outputs.calm_reporting_topic_arn
-  calm_api_url                    = "https://archives.wellcome.ac.uk/CalmAPI/ContentService.asmx"
+  calm_api_url                    = "https://archives.wellcome.org/CalmAPI/ContentService.asmx"
 
   deletion_checking_enabled = true
 

--- a/calm_adapter/terraform/topics.tf
+++ b/calm_adapter/terraform/topics.tf
@@ -8,38 +8,14 @@ module "calm_deletions_topic" {
   name   = "calm-deletions"
 }
 
-data "aws_iam_policy_document" "publish_to_adapter_topic" {
-  statement {
-    actions = [
-      "sns:Publish",
-    ]
-
-    resources = [
-      module.calm_adapter_topic.arn
-    ]
-  }
-}
-
-data "aws_iam_policy_document" "publish_to_deletions_topic" {
-  statement {
-    actions = [
-      "sns:Publish",
-    ]
-
-    resources = [
-      module.calm_deletions_topic.arn
-    ]
-  }
-}
-
 resource "aws_iam_role_policy" "adapter_policy" {
   role   = module.adapter_worker.task_role_name
-  policy = data.aws_iam_policy_document.publish_to_adapter_topic.json
+  policy = module.calm_adapter_topic.publish_policy
 }
 
 resource "aws_iam_role_policy" "deletion_checker_policy" {
   role   = module.deletion_checker_worker.task_role_name
-  policy = data.aws_iam_policy_document.publish_to_deletions_topic.json
+  policy = module.calm_deletions_topic.publish_policy
 }
 
 resource "aws_sns_topic" "calm_windows_topic" {


### PR DESCRIPTION
Not the cause of https://github.com/wellcomecollection/platform/issues/5388, but came up while discussing it – Louise asked us to swap the URL over to the new domain.