### PR TITLE
Add support for Japanese language in the TEI transformer

### DIFF
--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/data/TeiLanguageData.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/data/TeiLanguageData.scala
@@ -43,6 +43,7 @@ object TeiLanguageData extends Logging {
       case ("eng", "English") => MarcLanguageCodeList.fromName("English")
       case ("en", "English")  => MarcLanguageCodeList.fromName("English")
       case ("hi", "Hindi")    => MarcLanguageCodeList.fromName("Hindi")
+      case ("ja", "Japanese") => MarcLanguageCodeList.fromName("Japanese")
       case ("jv", "Javanese") => MarcLanguageCodeList.fromName("Javanese")
       case ("pra", "Prakrit languages") =>
         MarcLanguageCodeList.fromName("Prakrit languages")


### PR DESCRIPTION
Should fix this error in the TEI transformer:

```
java.lang.Throwable: Unable to map TEI language to catalogue language: id=ja, label=Japanese
```