### PR TITLE
Copy "Reserves Notes" into AccessCondition.note for items on exhibition

### DIFF
--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -310,11 +310,17 @@ object SierraItemAccess extends SierraQueryOps with Logging {
       // When an item is on display in an exhibition, it is not available for request.
       // In this case, the Reserves Note(s) should give some more detail.
       case (_, _, _, _, Some(LocationType.OnExhibition))
-          if itemData.varFields.withFieldTag("r").nonEmpty =>
+        if itemData.varFields.withFieldTag("r").nonEmpty =>
+        val sanitiseReservesNote = for (
+          source_str <- itemData.varFields.withFieldTag("r").contents
+        ) yield source_str.replaceFirst(
+          "^\\d\\d-\\d\\d-\\d\\d (ON|OFF) RESERVE FOR ", ""
+        ).replaceAll(" CIRCED \\d+ TIMES", "")
+
         AccessCondition(
           method = AccessMethod.NotRequestable,
           note = Some(
-            itemData.varFields.withFieldTag("r").contents.mkString("<br />"))
+            sanitiseReservesNote.mkString("<br />"))
         )
 
       // If we can't work out how this item should be handled, then let's mark it

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -309,10 +309,12 @@ object SierraItemAccess extends SierraQueryOps with Logging {
 
       // When an item is on display in an exhibition, it is not available for request.
       // In this case, the Reserves Note(s) should give some more detail.
-      case (_, _, _, _, Some(LocationType.OnExhibition)) if itemData.varFields.withFieldTag("r").nonEmpty =>
+      case (_, _, _, _, Some(LocationType.OnExhibition))
+          if itemData.varFields.withFieldTag("r").nonEmpty =>
         AccessCondition(
           method = AccessMethod.NotRequestable,
-          note = Some(itemData.varFields.withFieldTag("r").contents.mkString("<br />"))
+          note = Some(
+            itemData.varFields.withFieldTag("r").contents.mkString("<br />"))
         )
 
       // If we can't work out how this item should be handled, then let's mark it

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -307,6 +307,14 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           note = Some(noteText)
         )
 
+      // When an item is on display in an exhibition, it is not available for request.
+      // In this case, the Reserves Note(s) should give some more detail.
+      case (_, _, _, _, Some(LocationType.OnExhibition)) if itemData.varFields.withFieldTag("r").nonEmpty =>
+        AccessCondition(
+          method = AccessMethod.NotRequestable,
+          note = Some(itemData.varFields.withFieldTag("r").contents.mkString("<br />"))
+        )
+
       // If we can't work out how this item should be handled, then let's mark it
       // as unavailable for now.
       //

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -848,7 +848,8 @@ class SierraItemAccessTest
   }
   describe("an item on exhibition") {
     it("has a note based on its Reserves Note") {
-      val displayreservation = "Locked filing cabinet, disused lavatory with a sign saying 'Beware of The Leopard'"
+      val displayreservation =
+        "Locked filing cabinet, disused lavatory with a sign saying 'Beware of The Leopard'"
       val itemData = createSierraItemDataWith(
         fixedFields = Map(
           "79" -> FixedField(
@@ -882,7 +883,9 @@ class SierraItemAccessTest
         varFields = List(
           VarField(fieldTag = "r", "in the bottom of a locked filing cabinet"),
           VarField(fieldTag = "r", "stuck in a disused lavatory"),
-          VarField(fieldTag = "r", "with a sign on the door saying 'Beware of The Leopard'")
+          VarField(
+            fieldTag = "r",
+            "with a sign on the door saying 'Beware of The Leopard'")
         ),
       )
 
@@ -895,12 +898,13 @@ class SierraItemAccessTest
         method = AccessMethod.NotRequestable,
         note = Some(
           "in the bottom of a locked filing cabinet<br />" +
-          "stuck in a disused lavatory<br />" +
-          "with a sign on the door saying 'Beware of The Leopard'"
+            "stuck in a disused lavatory<br />" +
+            "with a sign on the door saying 'Beware of The Leopard'"
         )
       )
     }
-    it("has the default 'contact the library' note if there are no Reserves Notes") {
+    it(
+      "has the default 'contact the library' note if there are no Reserves Notes") {
       val itemData = createSierraItemDataWith(
         fixedFields = Map(
           "79" -> FixedField(

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -928,6 +928,7 @@ class SierraItemAccessTest
       //  - Something that is On Exhibition is not expected to have an off reserve entry.
       //  - Something that has both an on and an off reserve entry is not expected to be On Exhibition.
       // However, it is something that *could* happen.
+      // If these duplicate lines are encountered in real life, we should get the record corrected in Sierra.
       ac shouldBe AccessCondition(
         method = AccessMethod.NotRequestable,
         note = Some(

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -846,7 +846,85 @@ class SierraItemAccessTest
       )
     }
   }
+  describe("an item on exhibition") {
+    it("has a note based on its Reserves Note") {
+      val displayreservation = "Locked filing cabinet, disused lavatory with a sign saying 'Beware of The Leopard'"
+      val itemData = createSierraItemDataWith(
+        fixedFields = Map(
+          "79" -> FixedField(
+            label = "LOCATION",
+            value = "exres",
+            display = "On Exhibition")
+        ),
+        varFields = List(
+          VarField(fieldTag = "r", displayreservation)
+        )
+      )
 
+      val (ac, _) = SierraItemAccess(
+        location = Some(LocationType.OnExhibition),
+        itemData = itemData
+      )
+
+      ac shouldBe AccessCondition(
+        method = AccessMethod.NotRequestable,
+        note = Some(displayreservation)
+      )
+    }
+    it("can show multiple Reserves Notes") {
+      val itemData = createSierraItemDataWith(
+        fixedFields = Map(
+          "79" -> FixedField(
+            label = "LOCATION",
+            value = "exres",
+            display = "On Exhibition")
+        ),
+        varFields = List(
+          VarField(fieldTag = "r", "in the bottom of a locked filing cabinet"),
+          VarField(fieldTag = "r", "stuck in a disused lavatory"),
+          VarField(fieldTag = "r", "with a sign on the door saying 'Beware of The Leopard'")
+        ),
+      )
+
+      val (ac, _) = SierraItemAccess(
+        location = Some(LocationType.OnExhibition),
+        itemData = itemData
+      )
+
+      ac shouldBe AccessCondition(
+        method = AccessMethod.NotRequestable,
+        note = Some(
+          "in the bottom of a locked filing cabinet<br />" +
+          "stuck in a disused lavatory<br />" +
+          "with a sign on the door saying 'Beware of The Leopard'"
+        )
+      )
+    }
+    it("has the default 'contact the library' note if there are no Reserves Notes") {
+      val itemData = createSierraItemDataWith(
+        fixedFields = Map(
+          "79" -> FixedField(
+            label = "LOCATION",
+            value = "exres",
+            display = "On Exhibition")
+        ),
+        varFields = List(
+          VarField(fieldTag = "p", "GBP850")
+        )
+      )
+
+      val (ac, _) = SierraItemAccess(
+        location = Some(LocationType.OnExhibition),
+        itemData = itemData
+      )
+
+      ac shouldBe AccessCondition(
+        method = AccessMethod.NotRequestable,
+        note = Some(
+          s"""This item cannot be requested online. Please contact <a href="mailto:library@wellcomecollection.org">library@wellcomecollection.org</a> for more information.""")
+      )
+    }
+  }
   it("handles the case where we can't map the access data") {
     val itemData = createSierraItemDataWith(
       fixedFields = Map(

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -903,6 +903,37 @@ class SierraItemAccessTest
         )
       )
     }
+    it("Only shows substantive content from Reserves Notes") {
+      val itemData = createSierraItemDataWith(
+        fixedFields = Map(
+          "79" -> FixedField(
+            label = "LOCATION",
+            value = "exres",
+            display = "On Exhibition")
+        ),
+        varFields = List(
+          VarField(fieldTag = "r", "25-12-22 ON RESERVE FOR Beware of the Leopard"),
+          VarField(fieldTag = "r", "25-12-22 OFF RESERVE FOR Beware of the Leopard CIRCED 2 TIMES"),
+          VarField(fieldTag = "r", "In a locked filing cabinet")
+        )
+      )
+
+      val (ac, _) = SierraItemAccess(
+        location = Some(LocationType.OnExhibition),
+        itemData = itemData
+      )
+      // To avoid confusion for staff, and in the interest of completeness, notes that are identical
+      // after removing the non-interesting content are preserved.
+      // This scenario *should* not be encountered.  Something that is
+      ac shouldBe AccessCondition(
+        method = AccessMethod.NotRequestable,
+        note = Some(
+          "Beware of the Leopard<br />" +
+            "Beware of the Leopard<br />" +
+            "In a locked filing cabinet"
+        )
+      )
+    }
     it(
       "has the default 'contact the library' note if there are no Reserves Notes") {
       val itemData = createSierraItemDataWith(

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -924,7 +924,10 @@ class SierraItemAccessTest
       )
       // To avoid confusion for staff, and in the interest of completeness, notes that are identical
       // after removing the non-interesting content are preserved.
-      // This scenario *should* not be encountered.  Something that is
+      // This scenario *should* not be encountered.
+      //  - Something that is On Exhibition is not expected to have an off reserve entry.
+      //  - Something that has both an on and an off reserve entry is not expected to be On Exhibition.
+      // However, it is something that *could* happen.
       ac shouldBe AccessCondition(
         method = AccessMethod.NotRequestable,
         note = Some(


### PR DESCRIPTION
Fixes issue https://github.com/wellcomecollection/platform/issues/5401

Items on exhibition have useful details in the reserves notes.