### PR TITLE
Enable calm indexer buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -70,6 +70,8 @@ steps:
     label: "Calm adapter"
   - command: .buildkite/scripts/run_job.py calm_deletion_checker
     label: "Calm deletion checker"
+  - command: .buildkite/scripts/run_job.py calm_indexer
+    label: "Calm indexer"
   - command: .buildkite/scripts/run_job.py inference_manager
     label: "inference manager"
   - command: .buildkite/scripts/run_job.py tei_id_extractor

--- a/calm_adapter/calm_indexer/src/main/scala/weco/pipeline/calm_indexer/Main.scala
+++ b/calm_adapter/calm_indexer/src/main/scala/weco/pipeline/calm_indexer/Main.scala
@@ -24,7 +24,7 @@ object Main extends WellcomeTypesafeApp {
     implicit val elasticClient: ElasticClient =
       ElasticBuilder.buildElasticClient(config)
 
-    implicit val s3Client: AmazonS3 = S3Builder.buildS3Client(config)
+    implicit val s3Client: AmazonS3 = S3Builder.buildS3Client
 
     new Worker(
       sqsStream = SQSBuilder.buildSQSStream(config),


### PR DESCRIPTION
I noticed that calm_indexer had a bug that prevented compilation, and that buildkite was not complaining.

This PR introduces calm_indexer to the buildkite pipeline and fixes the compilation bug.