### PR TITLE
Update the rules for requesting

### DIFF
--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/RulesForRequestingResult.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/RulesForRequestingResult.scala
@@ -28,8 +28,6 @@ object NotRequestable {
 
   case class RequestTopItem(message: String) extends NotRequestable
 
-  case class BelongsInStrongroom(message: String) extends NotRequestable
-
   // This is used for items that are prevented from requesting, and the rule
   // doesn't include a message to display to users.
   //

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala
@@ -33,8 +33,8 @@ import weco.sierra.models.data.SierraItemData
   *   -   Variable length fields on items
   *       https://documentation.iii.com/sierrahelp/Content/sril/sril_records_varfld_types_item.html
   *
-  * This is based on a copy of the Rules for Requesting as sent from LS&S
-  * on 19 November 2021.
+  * This was last checked against Sierra based on a set of rules sent from
+  * Liz Richens on 31 January 2022.
   *
   */
 object SierraRulesForRequesting {

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala
@@ -41,15 +41,6 @@ object SierraRulesForRequesting {
   def apply(itemData: SierraItemData): RulesForRequestingResult =
     itemData match {
 
-      // This is the line:
-      //
-      //    q|i||97||=|x||This item belongs in the Strongroom
-      //
-      // This rule means "if fixed field 97 on the item has the value 'x'".
-      case i if i.fixedField("97").contains("x") =>
-        NotRequestable.BelongsInStrongroom(
-          "This item belongs in the Strongroom")
-
       // These cases cover the lines:
       //
       //    q|i||88||=|m||This item is missing.
@@ -385,13 +376,6 @@ object SierraRulesForRequesting {
       case i if i.fixedField("79").containsAnyOf("rm001", "rmdda") =>
         NotRequestable.NoPublicMessage(
           s"fixed field 79 = ${i.fixedField("79").get}")
-
-      // This case covers the line:
-      //
-      //    q|i||97||=|j||
-      //
-      case i if i.fixedField("97").contains("j") =>
-        NotRequestable.NoPublicMessage("fixed field 97 = j")
 
       case _ => Requestable
     }

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequestingTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequestingTest.scala
@@ -12,23 +12,6 @@ class SierraRulesForRequestingTest
     with Matchers
     with SierraDataGenerators
     with TableDrivenPropertyChecks {
-  it("blocks an item from the strong room") {
-    val item = createSierraItemDataWith(
-      fixedFields = Map("97" -> FixedField(label = "IMESSAGE", value = "x"))
-    )
-
-    SierraRulesForRequesting(item) shouldBe NotRequestable.BelongsInStrongroom(
-      "This item belongs in the Strongroom")
-  }
-
-  it("blocks an item with fixed field 97 (imessage) = j") {
-    val item = createSierraItemDataWith(
-      fixedFields = Map("97" -> FixedField(label = "IMESSAGE", value = "j"))
-    )
-
-    SierraRulesForRequesting(item) shouldBe a[NotRequestable.NoPublicMessage]
-  }
-
   it("blocks an item based on the status") {
     val testCases = Table(
       ("status", "expectedMessage"),


### PR DESCRIPTION
Quoting an email from Liz:

> The two rules relate to field 97 (in Sierra, the IMessage field). I have removed these two rules:
>
> q|i||97||=|x||This item belongs in the Strongroom
> #Line above for item message `x=restricted' added 18/03/10 by msj for strongroom project
> 
> #to remove request button when variable field is present
> q|i||97||=|j||
