### PR TITLE
Copy identifiers when a physical bib has an unrelated merge candidate

### DIFF
--- a/builds/run_sbt_task_in_docker.sh
+++ b/builds/run_sbt_task_in_docker.sh
@@ -25,7 +25,7 @@ docker run --tty --rm \
   --volume ~/.ivy2:/root/.ivy2 \
   --volume "$HOST_COURSIER_CACHE:/root/$LINUX_COURSIER_CACHE" \
   --volume /var/run/docker.sock:/var/run/docker.sock \
-  --volume "${DOCKER_CONFIG:-~/.docker}":/root/.docker \
+  --volume "${DOCKER_CONFIG:-$HOME/.docker}":/root/.docker \
   --net host \
   --volume "$ROOT:$ROOT" \
   --workdir "$ROOT" \

--- a/pipeline/matcher/scripts/graphAttributes.ts
+++ b/pipeline/matcher/scripts/graphAttributes.ts
@@ -4,7 +4,11 @@ import { dirname } from 'path';
 import { SourceIdentifier, SourceWork } from './models';
 
 // https://stackoverflow.com/a/51302466
-const downloadFile = async (url: string, path: string) => {
+const downloadFile = async (url: string | undefined, path: string) => {
+  if (typeof url === 'undefined') {
+    return;
+  }
+
   // Ensure the directory exists.  Theoretically can throw an error if the dir
   // pops into existence before we call mkdirSync(), but unlikely.
   if (!existsSync(dirname(path))) {

--- a/pipeline/merger/src/main/scala/weco/pipeline/merger/models/Sources.scala
+++ b/pipeline/merger/src/main/scala/weco/pipeline/merger/models/Sources.scala
@@ -24,17 +24,11 @@ object Sources {
       case t if isAudiovisual(t) =>
         None
 
-      // We've seen Sierra bib/e-bib pairs that go in both directions, i.e.
+      // Handle the case where the physical bib links to the e-bib.
       //
-      //      bib { 776 $w -> e-bib}
-      //
-      // and
-      //
-      //      e-bib { 776 $w -> bib }
-      //
-      // We need to handle both cases.
-      //
-      case t if physicalSierra(t) && t.state.mergeCandidates.nonEmpty =>
+      // Note: the physical bib may have merge candidates to other works, so
+      // we need to make sure we don't match this branch if that's the case.
+      case t if physicalSierra(t) && t.hasPhysicalDigitalMergeCandidate =>
         val digitisedLinkedIds = target.state.mergeCandidates
           .filter(_.reason.contains("Physical/digitised Sierra work"))
           .map(_.id.canonicalId)
@@ -42,6 +36,8 @@ object Sources {
         sources.find(source =>
           digitisedLinkedIds.contains(source.state.canonicalId))
 
+      // Handle the case where the e-bib links to the physical bib, but not
+      // the other way round.
       case t if physicalSierra(t) =>
         sources
           .filter { w =>
@@ -56,4 +52,9 @@ object Sources {
 
       case _ => None
     }
+
+  private implicit class TargetOps(target: Work.Visible[Identified]) {
+    def hasPhysicalDigitalMergeCandidate: Boolean =
+      target.state.mergeCandidates.exists(_.reason.contains("Physical/digitised Sierra work"))
+  }
 }

--- a/pipeline/merger/src/main/scala/weco/pipeline/merger/rules/OtherIdentifiersRule.scala
+++ b/pipeline/merger/src/main/scala/weco/pipeline/merger/rules/OtherIdentifiersRule.scala
@@ -118,16 +118,17 @@ object OtherIdentifiersRule extends FieldMergeRule with MergerLogging {
 
     val isDefinedForSource: WorkPredicate = sierraWork
 
-    // TODO: What if we don't get any matching source work?  Then we'd blat the
-    // otherIdentifiers already on the target work.  I can't think of a scenario
-    // in which it would happen in practice, so I can't test it, but noting in
-    // case we see this in future.
     def rule(target: Work.Visible[Identified],
-             sources: NonEmptyList[Work[Identified]]): FieldData =
-      findFirstLinkedDigitisedSierraWorkFor(target, sources.toList)
-        .map { w =>
-          target.data.otherIdentifiers ++ w.identifiers
+             sources: NonEmptyList[Work[Identified]]): FieldData = {
+      val sourceIdentifiers =
+        findFirstLinkedDigitisedSierraWorkFor(target, sources.toList) match {
+          case Some(digitisedWork) => target.data.otherIdentifiers ++ digitisedWork.identifiers
+          case None =>
+            warn(s"Unable to find other digitised Sierra identifiers for target work ${target.id}")
+            List()
         }
-        .getOrElse(Nil)
+
+      target.data.otherIdentifiers ++ sourceIdentifiers
+    }
   }
 }

--- a/pipeline/merger/src/test/scala/weco/pipeline/merger/models/SourcesTest.scala
+++ b/pipeline/merger/src/test/scala/weco/pipeline/merger/models/SourcesTest.scala
@@ -2,12 +2,8 @@ package weco.pipeline.merger.models
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import weco.catalogue.internal_model.work.generators.SierraWorkGenerators
+import weco.catalogue.internal_model.work.generators.{CalmWorkGenerators, MiroWorkGenerators, SierraWorkGenerators}
 import weco.catalogue.internal_model.identifiers.IdState
-import weco.catalogue.internal_model.work.generators.{
-  CalmWorkGenerators,
-  SierraWorkGenerators
-}
 import weco.catalogue.internal_model.work.{Format, MergeCandidate}
 import weco.pipeline.matcher.generators.MergeCandidateGenerators
 
@@ -15,6 +11,7 @@ class SourcesTest
     extends AnyFunSpec
     with Matchers
     with CalmWorkGenerators
+    with MiroWorkGenerators
     with SierraWorkGenerators
     with MergeCandidateGenerators {
   describe("findFirstLinkedDigitisedSierraWorkFor") {
@@ -164,6 +161,28 @@ class SourcesTest
           sources = Seq(digitisedWork))
 
       result shouldBe None
+    }
+
+    it("finds a merge candidate if the MC is on the e-bib, and the physical bib has an unrelated MC") {
+      val miroWork = miroIdentifiedWork()
+      val physicalWork =
+        sierraPhysicalIdentifiedWork()
+          .format(Format.Books)
+          .mergeCandidates(
+            List(createMiroSierraMergeCandidateFor(miroWork))
+          )
+
+      val digitisedWork =
+        sierraDigitalIdentifiedWork()
+          .mergeCandidates(
+            List(createSierraPairMergeCandidateFor(physicalWork))
+          )
+
+      val result = Sources.findFirstLinkedDigitisedSierraWorkFor(
+        physicalWork,
+        sources = Seq(digitisedWork, miroWork))
+
+      result shouldBe Some(digitisedWork)
     }
   }
 }

--- a/pipeline/merger/src/test/scala/weco/pipeline/merger/services/PlatformMergerTest.scala
+++ b/pipeline/merger/src/test/scala/weco/pipeline/merger/services/PlatformMergerTest.scala
@@ -922,6 +922,48 @@ class PlatformMergerTest
     redirectedWork.identifiers should contain theSameElementsAs (physicalWork.identifiers ++ electronicWork.identifiers)
   }
 
+  it("handles a Sierra physical/digitised pair where there's an irrelevant Miro work in the mix") {
+    // This is a regression test for an issue we saw where the identifiers were
+    // being dropped from a set of works where:
+    //
+    //    Sierra e-bib
+    //        ↓
+    //    Sierra physical bib
+    //        ↓
+    //    Miro work
+    //
+    // and the identifiers were being dropped from the merged work.
+    //
+    // See https://wellcome.slack.com/archives/C8X9YKM5X/p1645180445345339
+
+    val miroWork = miroIdentifiedWork()
+
+    val physicalWork =
+      sierraPhysicalIdentifiedWork()
+        .format(Format.Books)
+        .mergeCandidates(
+          List(createMiroSierraMergeCandidateFor(miroWork))
+        )
+
+    val digitisedWork =
+      sierraDigitalIdentifiedWork()
+        .mergeCandidates(
+          List(createSierraPairMergeCandidateFor(physicalWork))
+        )
+
+    val result = merger.merge(works = Seq(miroWork, physicalWork, digitisedWork))
+
+    val mergedWork =
+      result
+        .mergedWorksWithTime(now)
+        .collectFirst { case w: Work.Visible[Merged] => w }
+        .get
+
+    mergedWork.identifiers should contain theSameElementsAs(
+      physicalWork.identifiers ++ digitisedWork.identifiers
+    )
+  }
+
   describe("merging TEI works") {
     it("merges a physical sierra with a tei") {
       val merger = PlatformMerger


### PR DESCRIPTION
In particular, we want to handle the case where:

    Sierra e-bib
        ↓
    Sierra physical bib
        ↓
    Miro work

Previously we weren't finding the e-bib in "indFirstLinkedDigitisedSierraWorkFor", because we'd go down the wrong branch if there were *any* merge candidates, even if they weren't the ones we were looking for. This meant we weren't putting any identifiers on the merged work.

See https://wellcome.slack.com/archives/C8X9YKM5X/p1645180445345339