### PR TITLE
Optional relation ids

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Relations.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Relations.scala
@@ -65,13 +65,13 @@ object Relation {
     )
 
   /**
-   * A Relation created with just a String is a Series.  The string is the title.
-   * A Series is not an entity in its own right, so does not have an id of its own.
-   *
-   * Practically, a Series does not exist in a hierarchy, so does not have depth or
-   * children or descendents, even though (obviously) there are objects that are "partOf"
-   * the series.
-   */
+    * A Relation created with just a String is a Series.  The string is the title.
+    * A Series is not an entity in its own right, so does not have an id of its own.
+    *
+    * Practically, a Series does not exist in a hierarchy, so does not have depth or
+    * children or descendents, even though (obviously) there are objects that are "partOf"
+    * the series.
+    */
   def apply(series: String): Relation =
     new Relation(None, Some(series), None, WorkType.Series, 0, 0, 0)
 

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Relations.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Relations.scala
@@ -55,7 +55,7 @@ object Relation {
     numDescendents: Int
   ): Relation =
     Relation(
-      id = Option(id),
+      id = Some(id),
       title = data.title,
       collectionPath = data.collectionPath,
       workType = data.workType,

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Relations.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Relations.scala
@@ -37,7 +37,7 @@ object Relations {
 }
 
 case class Relation(
-  id: CanonicalId,
+  id: Option[CanonicalId],
   title: Option[String],
   collectionPath: Option[CollectionPath],
   workType: WorkType,
@@ -55,7 +55,7 @@ object Relation {
     numDescendents: Int
   ): Relation =
     Relation(
-      id = id,
+      id = Option(id),
       title = data.title,
       collectionPath = data.collectionPath,
       workType = data.workType,

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Relations.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Relations.scala
@@ -47,14 +47,14 @@ case class Relation(
 )
 
 /**
- * A Relation can be created with just a String representing the title of a Series.
- * A Series is not an entity in its own right, so does not have an id of its own.
- *
- * Practically, a Series does not exist in a hierarchy, so does not have depth or
- * children or descendants, nor does it have a collectionPath, even though (obviously)
- * there are objects that are "partOf" the series.
- */
-object SeriesRelation{
+  * A Relation can be created with just a String representing the title of a Series.
+  * A Series is not an entity in its own right, so does not have an id of its own.
+  *
+  * Practically, a Series does not exist in a hierarchy, so does not have depth or
+  * children or descendants, nor does it have a collectionPath, even though (obviously)
+  * there are objects that are "partOf" the series.
+  */
+object SeriesRelation {
   def apply(series: String): Relation =
     Relation(
       id = None,
@@ -66,7 +66,6 @@ object SeriesRelation{
       numDescendents = 0
     )
 }
-
 
 object Relation {
   private def apply(

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Relations.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Relations.scala
@@ -46,6 +46,28 @@ case class Relation(
   numDescendents: Int,
 )
 
+/**
+ * A Relation can be created with just a String representing the title of a Series.
+ * A Series is not an entity in its own right, so does not have an id of its own.
+ *
+ * Practically, a Series does not exist in a hierarchy, so does not have depth or
+ * children or descendants, nor does it have a collectionPath, even though (obviously)
+ * there are objects that are "partOf" the series.
+ */
+object SeriesRelation{
+  def apply(series: String): Relation =
+    Relation(
+      id = None,
+      title = Some(series),
+      collectionPath = None,
+      workType = WorkType.Series,
+      depth = 0,
+      numChildren = 0,
+      numDescendents = 0
+    )
+}
+
+
 object Relation {
   private def apply(
     id: CanonicalId,
@@ -63,17 +85,6 @@ object Relation {
       numChildren = numChildren,
       numDescendents = numDescendents,
     )
-
-  /**
-    * A Relation created with just a String is a Series.  The string is the title.
-    * A Series is not an entity in its own right, so does not have an id of its own.
-    *
-    * Practically, a Series does not exist in a hierarchy, so does not have depth or
-    * children or descendants, even though (obviously) there are objects that are "partOf"
-    * the series.
-    */
-  def apply(series: String): Relation =
-    Relation(None, Some(series), None, WorkType.Series, 0, 0, 0)
 
   def apply[State <: WorkState](work: Work[State],
                                 depth: Int,

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Relations.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Relations.scala
@@ -69,7 +69,7 @@ object Relation {
     * A Series is not an entity in its own right, so does not have an id of its own.
     *
     * Practically, a Series does not exist in a hierarchy, so does not have depth or
-    * children or descendents, even though (obviously) there are objects that are "partOf"
+    * children or descendants, even though (obviously) there are objects that are "partOf"
     * the series.
     */
   def apply(series: String): Relation =

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Relations.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Relations.scala
@@ -64,6 +64,17 @@ object Relation {
       numDescendents = numDescendents,
     )
 
+  /**
+   * A Relation created with just a String is a Series.  The string is the title.
+   * A Series is not an entity in its own right, so does not have an id of its own.
+   *
+   * Practically, a Series does not exist in a hierarchy, so does not have depth or
+   * children or descendents, even though (obviously) there are objects that are "partOf"
+   * the series.
+   */
+  def apply(series: String): Relation =
+    new Relation(None, Some(series), None, WorkType.Series, 0, 0, 0)
+
   def apply[State <: WorkState](work: Work[State],
                                 depth: Int,
                                 numChildren: Int,

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Relations.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Relations.scala
@@ -73,7 +73,7 @@ object Relation {
     * the series.
     */
   def apply(series: String): Relation =
-    new Relation(None, Some(series), None, WorkType.Series, 0, 0, 0)
+    Relation(None, Some(series), None, WorkType.Series, 0, 0, 0)
 
   def apply[State <: WorkState](work: Work[State],
                                 depth: Int,

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/RelationsTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/RelationsTest.scala
@@ -1,0 +1,49 @@
+package weco.catalogue.internal_model.work
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import weco.catalogue.internal_model.work.generators.WorkGenerators
+
+class RelationsTest extends AnyFunSpec with Matchers {
+  it("Has zero size when empty") {
+    Relations.none.size shouldBe 0
+  }
+
+  it("Shows the total number of known relations when populated") {
+    Relations(
+      List(Relation("Granny"), Relation("Grandpa")),
+      List(Relation("Baby")),
+      List(Relation("Big Sister")),
+      List(Relation("Little Brother"))
+    ).size shouldBe 5
+  }
+}
+
+class RelationTest extends AnyFunSpec
+  with Matchers
+  with WorkGenerators {
+
+  it("Creates a Relation by extracting relevant properties from a Work") {
+    val work = indexedWork()
+    val relation = Relation(work, 1, 2, 3)
+    relation.id.get shouldBe work.state.canonicalId
+    relation.title shouldBe work.data.title
+    relation.collectionPath shouldBe work.data.collectionPath
+    relation.depth shouldBe 1
+    relation.numChildren shouldBe 2
+    relation.numDescendents shouldBe 3
+  }
+
+  it("Creates a Series Relation from a title") {
+    val relation = Relation("hello")
+    relation.title.get shouldBe "hello"
+    relation.workType shouldBe WorkType.Series
+
+    relation.collectionPath shouldBe None
+    relation.id shouldBe None
+    relation.depth shouldBe 0
+    relation.numChildren shouldBe 0
+    relation.numDescendents shouldBe 0
+  }
+
+}

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/RelationsTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/RelationsTest.scala
@@ -11,20 +11,20 @@ class RelationsTest extends AnyFunSpec with Matchers {
 
   it("Shows the total number of known relations when populated") {
     Relations(
-      List(Relation("Granny"), Relation("Grandpa")),
-      List(Relation("Baby")),
-      List(Relation("Big Sister")),
-      List(Relation("Little Brother"))
+      ancestors = List(SeriesRelation("Granny"), SeriesRelation("Grandpa")),
+      children = List(SeriesRelation("Baby")),
+      siblingsPreceding = List(SeriesRelation("Big Sister")),
+      siblingsSucceeding = List(SeriesRelation("Little Brother"))
     ).size shouldBe 5
   }
 
   it(
     "Shows the total number of known relations even when not all relation lists are populated") {
     Relations(
-      List(Relation("Granny"), Relation("Grandpa"), Relation("Mum")),
-      List(Relation("Baby")),
-      Nil,
-      List(Relation("Little Brother"), Relation("Little Sister"))
+      ancestors = List(SeriesRelation("Granny"), SeriesRelation("Grandpa"), SeriesRelation("Mum")),
+      children = List(SeriesRelation("Baby")),
+      siblingsPreceding = Nil,
+      siblingsSucceeding = List(SeriesRelation("Little Brother"), SeriesRelation("Little Sister"))
     ).size shouldBe 6
   }
 }
@@ -33,7 +33,7 @@ class RelationTest extends AnyFunSpec with Matchers with WorkGenerators {
 
   it("Creates a Relation by extracting relevant properties from a Work") {
     val work = indexedWork()
-    val relation = Relation(work, 1, 2, 3)
+    val relation = Relation(work = work, depth = 1, numChildren = 2, numDescendents = 3)
     relation.id.get shouldBe work.state.canonicalId
     relation.title shouldBe work.data.title
     relation.collectionPath shouldBe work.data.collectionPath
@@ -43,7 +43,7 @@ class RelationTest extends AnyFunSpec with Matchers with WorkGenerators {
   }
 
   it("Creates a Series Relation from a title") {
-    val relation = Relation("hello")
+    val relation = SeriesRelation("hello")
     relation.title.get shouldBe "hello"
     relation.workType shouldBe WorkType.Series
 

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/RelationsTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/RelationsTest.scala
@@ -21,10 +21,14 @@ class RelationsTest extends AnyFunSpec with Matchers {
   it(
     "Shows the total number of known relations even when not all relation lists are populated") {
     Relations(
-      ancestors = List(SeriesRelation("Granny"), SeriesRelation("Grandpa"), SeriesRelation("Mum")),
+      ancestors = List(
+        SeriesRelation("Granny"),
+        SeriesRelation("Grandpa"),
+        SeriesRelation("Mum")),
       children = List(SeriesRelation("Baby")),
       siblingsPreceding = Nil,
-      siblingsSucceeding = List(SeriesRelation("Little Brother"), SeriesRelation("Little Sister"))
+      siblingsSucceeding =
+        List(SeriesRelation("Little Brother"), SeriesRelation("Little Sister"))
     ).size shouldBe 6
   }
 }
@@ -33,7 +37,8 @@ class RelationTest extends AnyFunSpec with Matchers with WorkGenerators {
 
   it("Creates a Relation by extracting relevant properties from a Work") {
     val work = indexedWork()
-    val relation = Relation(work = work, depth = 1, numChildren = 2, numDescendents = 3)
+    val relation =
+      Relation(work = work, depth = 1, numChildren = 2, numDescendents = 3)
     relation.id.get shouldBe work.state.canonicalId
     relation.title shouldBe work.data.title
     relation.collectionPath shouldBe work.data.collectionPath

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/RelationsTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/RelationsTest.scala
@@ -5,7 +5,7 @@ import org.scalatest.matchers.should.Matchers
 import weco.catalogue.internal_model.work.generators.WorkGenerators
 
 class RelationsTest extends AnyFunSpec with Matchers {
-  it("Has zero size when empty") {
+  it("has zero size when empty") {
     Relations.none.size shouldBe 0
   }
 

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/RelationsTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/RelationsTest.scala
@@ -19,9 +19,7 @@ class RelationsTest extends AnyFunSpec with Matchers {
   }
 }
 
-class RelationTest extends AnyFunSpec
-  with Matchers
-  with WorkGenerators {
+class RelationTest extends AnyFunSpec with Matchers with WorkGenerators {
 
   it("Creates a Relation by extracting relevant properties from a Work") {
     val work = indexedWork()

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/RelationsTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/RelationsTest.scala
@@ -18,7 +18,8 @@ class RelationsTest extends AnyFunSpec with Matchers {
     ).size shouldBe 5
   }
 
-  it("Shows the total number of known relations even when not all relation lists are populated") {
+  it(
+    "Shows the total number of known relations even when not all relation lists are populated") {
     Relations(
       List(Relation("Granny"), Relation("Grandpa"), Relation("Mum")),
       List(Relation("Baby")),

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/RelationsTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/RelationsTest.scala
@@ -17,6 +17,15 @@ class RelationsTest extends AnyFunSpec with Matchers {
       List(Relation("Little Brother"))
     ).size shouldBe 5
   }
+
+  it("Shows the total number of known relations even when not all relation lists are populated") {
+    Relations(
+      List(Relation("Granny"), Relation("Grandpa"), Relation("Mum")),
+      List(Relation("Baby")),
+      Nil,
+      List(Relation("Little Brother"), Relation("Little Sister"))
+    ).size shouldBe 6
+  }
 }
 
 class RelationTest extends AnyFunSpec with Matchers with WorkGenerators {

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/models/RelationWork.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/models/RelationWork.scala
@@ -13,7 +13,7 @@ case class RelationWork(
 
   def toRelation(depth: Int, numChildren: Int, numDescendents: Int) =
     Relation(
-      id = state.canonicalId,
+      id = Some(state.canonicalId),
       title = data.title,
       collectionPath = data.collectionPath,
       workType = data.workType,


### PR DESCRIPTION
This introduces the possibility that a Relation can exist without an id.  It *does not* actually make that happen.

This creates a breaking change in internal_model that is resolved in the API with this pull (once the internal_model hash has been updated) https://github.com/wellcomecollection/catalogue-api/pull/360/files

Because the API loads the data from Elasticsearch, and there are no actual Relations without ids, the change  won't  break the API until we actually start producing Relations without ids.

Part of https://github.com/wellcomecollection/platform/issues/5408