### PR TITLE
Use Fargate Spot for the Sierra adapter

### DIFF
--- a/sierra_adapter/terraform/.terraform.lock.hcl
+++ b/sierra_adapter/terraform/.terraform.lock.hcl
@@ -5,6 +5,17 @@ provider "registry.terraform.io/hashicorp/aws" {
   version = "3.67.0"
   hashes = [
     "h1:p7CyS0dxRoxAMVeCBy7VS6yLm4hWkvl3ojhOvaog1n4=",
+    "zh:0bf1ecb4fe3ff79da63c82454a5dd9e12f867d5372b6bb30e560376537dc7a53",
+    "zh:0d5bedecf10ef6d8f8669661fe67b6ef572c7619a2322a825b9003ab2e93a396",
+    "zh:1a58d45c692071b566dccdb480c7ef968e034292f82f48d8948ff8d75a0a1198",
+    "zh:58bc36e36fffdc4e211d11101434941257e667fe7fb53514e3852ceaeaca55a6",
+    "zh:63bb67c92fd0eb938a02930be0af26f11f9ecad3c56870987a2ddac85613dff7",
+    "zh:7172053f58cdee02256dd4726196c22a80a256ff3bf46b60378c89463b1d9340",
+    "zh:804ca483b2bf451fc2278855cfaa97ad0179d43bf67259d1c36c50e9310c0c5c",
+    "zh:854e22be11c992042b31d728af049912da0eda70172d975ac8a94c3d2edb3326",
+    "zh:a9b18d34edb1a1beb6ed5a083de832ddd0019c594f5fed6554d1be659cebfe61",
+    "zh:b3dd0c0d77c25ad1c61665eb5ddde3ed1b3d525c5b99cfbbeaf245e0faa6a6bb",
+    "zh:dacf8f3a7408ac6439b01ef2774854837bb27fe7412fc9050b4f892d912873a5",
   ]
 }
 

--- a/sierra_adapter/terraform/sierra_indexer/main.tf
+++ b/sierra_adapter/terraform/sierra_indexer/main.tf
@@ -51,4 +51,6 @@ module "service" {
   elastic_cloud_vpce_sg_id = var.elastic_cloud_vpce_sg_id
 
   shared_logging_secrets = var.shared_logging_secrets
+
+  use_fargate_spot = true
 }

--- a/sierra_adapter/terraform/sierra_reader/main.tf
+++ b/sierra_adapter/terraform/sierra_reader/main.tf
@@ -41,4 +41,6 @@ module "sierra_reader_service" {
   elastic_cloud_vpce_sg_id = var.elastic_cloud_vpce_sg_id
 
   shared_logging_secrets = var.shared_logging_secrets
+
+  use_fargate_spot = true
 }


### PR DESCRIPTION
This looks like a simple oversight; I spotted it because we had some charges for non-Spot Fargate in the February bill, but there's nothing in the platform account that needs to be continuously up.