### PR TITLE
Provide a better message for an "impossible" scenario in the ID minter

### DIFF
--- a/builds/publish_image_with_weco_deploy.sh
+++ b/builds/publish_image_with_weco_deploy.sh
@@ -43,7 +43,7 @@ docker run --tty --rm \
   --env AWS_PROFILE \
   --volume ~/.aws:/root/.aws \
   --volume /var/run/docker.sock:/var/run/docker.sock \
-  --volume "${DOCKER_CONFIG:-~/.docker}:/root/.docker" \
+  --volume "${DOCKER_CONFIG:-$HOME/.docker}:/root/.docker" \
   --volume "$ROOT:$ROOT" \
   --workdir "$ROOT" \
   "$ECR_REGISTRY/$WECO_DEPLOY_IMAGE" \

--- a/pipeline/id_minter/README.md
+++ b/pipeline/id_minter/README.md
@@ -66,3 +66,7 @@ Then, it adds a `canonicalId` field with the ID to the JSON:
 ```
 
 It updates all SourceIdentifier objects in the JSON, even if they're deeply nested; e.g. it also adds canonical IDs to items and subjects.
+
+## Connecting to the ID minter database
+
+If you need to connect to the ID minter database, there are [some notes on how to do so](./connect-to-the-database.md).

--- a/pipeline/id_minter/connect_to_the_database.md
+++ b/pipeline/id_minter/connect_to_the_database.md
@@ -1,0 +1,67 @@
+# Connecting to the ID minter database
+
+Occasionally it's useful to connect to the ID minter database to correct a record, but we do it very sparingly.
+
+You can't connect to the ID minter directly from the outside world – you have to use a bastion host.
+
+These are some loose notes I wrote the last time I had to do it; there may be gaps in these instructions because I didn't have time to test them fully, but hopefully they're a useful guide.
+
+1.  Launch an EC2 instance which can connect to the ID minter database (the "bastion instance").
+
+    This means launching the smallest EC2 instance you can get, with the following settings:
+
+    -   In the catalogue VPC
+    -   In a private subnet
+    -   In the `id_minter_bastion_ssh_access`, `id_minter_instance_ssh_access` and `identifiers_database_sg` security groups
+    -   An SSH key that you have access to
+
+2.  Launch an EC2 instance which you can connect to (the "externally visible instance").
+
+    This means launching the smallest EC2 instance you can get, with the following settings:
+
+    -   In the catalogue VPC
+    -   In a public subnet and public IP
+    -   The same security groups as the previous step
+    -   An SSH key that you have access to
+
+3.  Update the security group `id_minter_instance_ssh_access` to allow traffic on port 22 from your local IP address.
+
+    Update the security group `identifiers_database_sg` to allow traffic on port 22 from your private instance.
+
+4.  Connect to the externally visible host using your SSH key.
+    Upload your SSH key to this host, e.g.
+
+    ```console
+    $ scp -i ~/.ssh/wellcomedigitalplatform ec2-user@ec2-54-229-72-34.eu-west-1.compute.amazonaws.com:~/.ssh/wellcomedigitalplatform
+    $ ssh -i ~/.ssh/wellcomedigitalplatform ec2-user@ec2-54-229-72-34.eu-west-1.compute.amazonaws.com
+    ```
+
+5.  Connect to the bastion host using your SSH key, e.g.
+
+    ```console
+    $ ssh -i ~/.ssh/wellcomedigitalplatform ec2-user@ip-172-31-180-161.eu-west-1.compute.internal
+    ```
+
+6.  Install MySQL and connect to the RDS instance:
+
+    ```console
+    $ sudo yum install -y mysql
+    $ mysql --host=$HOST --port=3306 --user=$USERNAME --password=$PASSWORD
+    ```
+
+    You can get the host/usernamepassword values from the RDS and Secrets Manager consoles, respectively.
+
+## Modifying the ID minter database
+
+Here are some useful commands:
+
+```mysql
+USE identifiers;
+
+SELECT * FROM identifiers WHERE CanonicalId = 'w62ubcaw';
+
+UPDATE identifiers SET SourceId = 'b20442506/FILE_0518_OBJECTS'
+WHERE SourceId = 'B20442506/FILE_0518_OBJECTS'
+AND OntologyType = 'Image'
+AND SourceSystem = 'mets-image';
+```

--- a/pipeline/id_minter/docker-compose.yml
+++ b/pipeline/id_minter/docker-compose.yml
@@ -1,12 +1,13 @@
-mysql:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/library/mysql:5.6"
-  ports:
-    - "3307:3306"
-  environment:
-      - "MYSQL_ROOT_PASSWORD=password"
-localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack"
-  environment:
-    - SERVICES=sqs
-  ports:
-    - "4566:4566"
+services:
+  mysql:
+    image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/library/mysql:5.6"
+    ports:
+      - "3307:3306"
+    environment:
+        - "MYSQL_ROOT_PASSWORD=password"
+  localstack:
+    image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack"
+    environment:
+      - SERVICES=sqs
+    ports:
+      - "4566:4566"

--- a/pipeline/id_minter/src/main/scala/weco/pipeline/id_minter/database/IdentifiersDao.scala
+++ b/pipeline/id_minter/src/main/scala/weco/pipeline/id_minter/database/IdentifiersDao.scala
@@ -91,9 +91,9 @@ class IdentifiersDao(identifiers: IdentifiersTable) extends Logging {
 
                       val errorMessage = if (distinctIdentifiers.contains(similarIdentifier)) {
                         s"""
-                           |The query returned a METS sourceIdentifier ($sourceIdentifier) which we weren't looking for,
+                           |The query returned a source identifier ($sourceIdentifier) which we weren't looking for,
                            |but it did return a similar identifier ($similarIdentifier).
-                           |Somebody may have fixed the case of the b number in the source METS file;
+                           |If this is a METS identifier, may have fixed the case of the b number in the source file;
                            |if so, you'll need to update the associated records in the ID minter database.
                            |See https://github.com/wellcomecollection/catalogue-pipeline/blob/main/pipeline/id_minter/connect_to_the_database.md
                            |""".stripMargin

--- a/pipeline/id_minter/src/main/scala/weco/pipeline/id_minter/database/IdentifiersDao.scala
+++ b/pipeline/id_minter/src/main/scala/weco/pipeline/id_minter/database/IdentifiersDao.scala
@@ -89,22 +89,24 @@ class IdentifiersDao(identifiers: IdentifiersTable) extends Logging {
                         value = "^B".r.replaceAllIn(sourceIdentifier.value, "b")
                       )
 
-                      val errorMessage = if (distinctIdentifiers.contains(similarIdentifier)) {
-                        s"""
+                      val errorMessage =
+                        if (distinctIdentifiers.contains(similarIdentifier)) {
+                          s"""
                            |The query returned a source identifier ($sourceIdentifier) which we weren't looking for,
                            |but it did return a similar identifier ($similarIdentifier).
                            |If this is a METS identifier, may have fixed the case of the b number in the source file;
                            |if so, you'll need to update the associated records in the ID minter database.
                            |See https://github.com/wellcomecollection/catalogue-pipeline/blob/main/pipeline/id_minter/connect_to_the_database.md
                            |""".stripMargin
-                      } else {
-                        s"""
+                        } else {
+                          s"""
                            |The query returned a sourceIdentifier ($sourceIdentifier) which we weren't looking for
                            |($distinctIdentifiers)
                            |""".stripMargin
-                      }
+                        }
 
-                      throw new RuntimeException(errorMessage.replace("\n", " "))
+                      throw new RuntimeException(
+                        errorMessage.replace("\n", " "))
                     }
                   })
                   .list


### PR DESCRIPTION
The ID minter is the app that creates the canonical IDs we use in works URLs, e.g. in /works/k6sy9zz3, the canonical ID is `k6sy9zz3`. Each canonical ID has a 1:1 correspondence with an ID from a source system. The canonical–source ID mappings are stored in an RDS database.

When it runs, the ID minter asks the database _"please give me any canonical IDs you know about for X, Y, Z"_. It uses any that already exist, then creates new canonical IDs for any source IDs that haven't been seen before. So far, so simple.

What happens when the database hands back canonical IDs for P, Q, and R? This should be impossible in practice (and we wrote a comment to that effect), but it is in fact possible – because the database queries are case insensitive. Consider:

> ID minter: Please give me the canonical ID for "METS b12345678"
> Database: Here's the canonical ID for "METS B12345678"
> ID minter: This isn't what I asked for 😱 💥 

Although in general we use lowercase b-identifiers for METS files, there are a handful where we've used uppercase B in the past. When these get corrected, the ID minter is unhappy.

It's rare enough that I don't (yet) want to put in proper logic to fix this automatically, but I can put in a better error message so it's easier for the next person to debug.

I've also put in some notes about how to connect to the ID minter database, which is a thing I do relatively infrequently and have to re-derive from scratch every time. These instructions probably have some gaps, but they're a starting point.

This fixes the issue Ashley was having in Slack: https://wellcome.slack.com/archives/C8X9YKM5X/p1646995044309189