### PR TITLE
Extract hierarchies from Sierra data

### DIFF
--- a/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/RelationsServiceTest.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/RelationsServiceTest.scala
@@ -233,9 +233,9 @@ class RelationsServiceTest
 
     it("handles gaps in a tree") {
       /*
-      * If a path is specified where not all nodes correspond to a record,
-      * A tree containing all the existing records should still be created.
-      * */
+       * If a path is specified where not all nodes correspond to a record,
+       * A tree containing all the existing records should still be created.
+       * */
       val works = List(
         work("x"),
         work("x/y/z")

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/SierraTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/SierraTransformer.scala
@@ -143,7 +143,8 @@ class SierraTransformer(sierraTransformable: SierraTransformable, version: Int)
           SierraItems(bibId, bibData, itemDataEntries) ++
           SierraElectronicResources(bibId, varFields = bibData.varFields),
       holdings = SierraHoldings(bibId, holdingsDataMap),
-      referenceNumber = SierraReferenceNumber(bibData)
+      referenceNumber = SierraReferenceNumber(bibData),
+      collectionPath = SierraCollectionPath(bibData)
     )
 
   lazy val bibId = sierraTransformable.sierraId

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraCollectionPath.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraCollectionPath.scala
@@ -7,65 +7,68 @@ import weco.sierra.models.data.SierraBibData
 import weco.sierra.models.marc.{VarField}
 
 /**
- * Convert links between identified Sierra entries into a hierarchical path.
- *
- * The Sierra linking fields 773 and 774, when specified with the identifier subfield
- * "$w - Record control number" represent a part-whole relationship akin to those found
- * in CALM or TEI resources.
- *
- * - [773 - Host Item Entry](https://www.loc.gov/marc/bibliographic/bd773.html)
- * - [774 - Constituent Unit Entry](https://www.loc.gov/marc/bibliographic/bd774.html)
- *
- * When the identifier is not present, `773` fields represent membership of a Series, see
- * SierraParents.  Such fields are ignored here.
- *
- * At this point, the records are not 'Identified', moreover, the identifiers used in these
- * two fields are Worldcat ids (e.g. (Wcat)29062i), which do not get resolved by the id minter.
- *
- * Therefore, at this point we can only create the "link" via a common collection path,
- * to be later resolved by the relation embedder.
- *
- * A feature of these fields is that they often refer (via the $g - Related Parts subfield)
- * to a subsection of the whole. This subsection is not in itself an entity that exists and
- * can be identified or linked to.
- *
- * e.g. the following fields from two records, corresponding to both "ends" of the relationship
- *  - 773 0  |tBasil Hood. Photograph album,|gpage 5.|w(Wcat)9175i
- *  - 774 0  |gPage 5 :|tCharing Cross Hospital: a portrait of house surgeons. Photograph, 1906.|w(Wcat)28914i
- *  They each refer to the other, but there is no "page 5" object.
- *  So, although page 5 might look like it should be a node in the collectionPath, it cannot be.
- *
- *  Notable challenges in the data include:
- *  - punctuation must be stripped ("Page 5 :" should match "page 5.")
- *  - case must be normalised ("Page 5" should match "page 5")
- *  - the (Wcat) prefix must be stripped ("(Wcat)9175i" should match "9175i")
- *  - the value must be turned into something the relation embedder expects
- *      (evidence points to this being underscores for spaces).
- *
- *  The hierarchy of Sierra-based data is flatter than other systems. A node is expected to *either* be a host or a
- *  constituent. It is possible for record that is a "host" to also be part of a series, but that relationship
- *  would not contain the $w subfield, so is to be ignored here.
- *
- *  A constituent has exactly one host
- *  A host may have many constituents, but for the purpose of defining a CollectionPath, it only matters that one
- *  exists, not how many there are.
- *  */
-
+  * Convert links between identified Sierra entries into a hierarchical path.
+  *
+  * The Sierra linking fields 773 and 774, when specified with the identifier subfield
+  * "$w - Record control number" represent a part-whole relationship akin to those found
+  * in CALM or TEI resources.
+  *
+  * - [773 - Host Item Entry](https://www.loc.gov/marc/bibliographic/bd773.html)
+  * - [774 - Constituent Unit Entry](https://www.loc.gov/marc/bibliographic/bd774.html)
+  *
+  * When the identifier is not present, `773` fields represent membership of a Series, see
+  * SierraParents.  Such fields are ignored here.
+  *
+  * At this point, the records are not 'Identified', moreover, the identifiers used in these
+  * two fields are Worldcat ids (e.g. (Wcat)29062i), which do not get resolved by the id minter.
+  *
+  * Therefore, at this point we can only create the "link" via a common collection path,
+  * to be later resolved by the relation embedder.
+  *
+  * A feature of these fields is that they often refer (via the $g - Related Parts subfield)
+  * to a subsection of the whole. This subsection is not in itself an entity that exists and
+  * can be identified or linked to.
+  *
+  * e.g. the following fields from two records, corresponding to both "ends" of the relationship
+  *  - 773 0  |tBasil Hood. Photograph album,|gpage 5.|w(Wcat)9175i
+  *  - 774 0  |gPage 5 :|tCharing Cross Hospital: a portrait of house surgeons. Photograph, 1906.|w(Wcat)28914i
+  *  They each refer to the other, but there is no "page 5" object.
+  *  So, although page 5 might look like it should be a node in the collectionPath, it cannot be.
+  *
+  *  Notable challenges in the data include:
+  *  - punctuation must be stripped ("Page 5 :" should match "page 5.")
+  *  - case must be normalised ("Page 5" should match "page 5")
+  *  - the (Wcat) prefix must be stripped ("(Wcat)9175i" should match "9175i")
+  *  - the value must be turned into something the relation embedder expects
+  *      (evidence points to this being underscores for spaces).
+  *
+  *  The hierarchy of Sierra-based data is flatter than other systems. A node is expected to *either* be a host or a
+  *  constituent. It is possible for record that is a "host" to also be part of a series, but that relationship
+  *  would not contain the $w subfield, so is to be ignored here.
+  *
+  *  A constituent has exactly one host
+  *  A host may have many constituents, but for the purpose of defining a CollectionPath, it only matters that one
+  *  exists, not how many there are.
+  *  */
 object SierraCollectionPath extends SierraQueryOps with Logging {
   def apply(bibData: SierraBibData): Option[CollectionPath] = {
     bibData.varfieldsWithTag("774") match {
       case Nil => pathFromHostEntryField(bibData)
       case _ =>
         Some(CollectionPath(bibData.varfieldsWithTag("001").head.content.get))
-      }
-}
-  private def pathFromHostEntryField(bibData: SierraBibData): Option[CollectionPath] = {
-    val maybeIdentifiedHostEntryField: Option[VarField] = bibData.varfieldsWithTag("773").find(_.subfieldsWithTag("w").nonEmpty)
-    if(maybeIdentifiedHostEntryField.isDefined) {
+    }
+  }
+  private def pathFromHostEntryField(
+    bibData: SierraBibData): Option[CollectionPath] = {
+    val maybeIdentifiedHostEntryField: Option[VarField] =
+      bibData.varfieldsWithTag("773").find(_.subfieldsWithTag("w").nonEmpty)
+    if (maybeIdentifiedHostEntryField.isDefined) {
       val identifiedHostEntryField = maybeIdentifiedHostEntryField.get
-      Some(CollectionPath(
-        f"${identifiedHostEntryField.content}/${getRelatedPart(identifiedHostEntryField)}${bibData.varfieldsWithTag("001").head.content}"
-      ))
+      Some(
+        CollectionPath(
+          f"${identifiedHostEntryField.content}/${getRelatedPart(
+            identifiedHostEntryField)}${bibData.varfieldsWithTag("001").head.content}"
+        ))
     }
     None
   }
@@ -74,7 +77,7 @@ object SierraCollectionPath extends SierraQueryOps with Logging {
     val gFields = hostEntryField.subfieldsWithTag("g")
     gFields match {
       case Nil => ""
-      case _ => gFields.head.content
+      case _   => gFields.head.content
     }
   }
 

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraCollectionPath.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraCollectionPath.scala
@@ -62,8 +62,9 @@ object SierraCollectionPath extends SierraQueryOps with Logging {
       None
     else {
       (getControlNumber(bibData), bibData.varfieldsWithTag("774")) match {
-        case(None, _) =>
-          warn(f"Attempt to create CollectionPath for Sierra document without a control number field ${bibData}")
+        case (None, _) =>
+          warn(
+            f"Attempt to create CollectionPath for Sierra document without a control number field ${bibData}")
           None
         case (Some(bibId), Nil) =>
           HostEntryFieldCollectionPath(bibData, bibId)
@@ -98,7 +99,9 @@ object SierraCollectionPath extends SierraQueryOps with Logging {
   * field, and that field has a $w subtag, or it would have multiple 773 fields,
   * and none of them have a $w subtag.
   */
-private object HostEntryFieldCollectionPath extends SierraQueryOps with Logging {
+private object HostEntryFieldCollectionPath
+    extends SierraQueryOps
+    with Logging {
   val nonTokenCharacters = new Regex("[^0-9a-zA-Z_]")
 
   def apply(bibData: SierraBibData, bibId: String): Option[CollectionPath] = {
@@ -115,7 +118,9 @@ private object HostEntryFieldCollectionPath extends SierraQueryOps with Logging 
     else {
       // Should not be possible to reach this point, SierraCollectionPath.apply will have
       // ensured that an appropriate 773 entry exists somewhere in the document.
-      warn(f"Could not find a varfield suitable for making a collectionPath ${bibData.varfieldsWithTag("773")}")
+      warn(
+        f"Could not find a varfield suitable for making a collectionPath ${bibData
+          .varfieldsWithTag("773")}")
       None
     }
   }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraCollectionPath.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraCollectionPath.scala
@@ -118,7 +118,8 @@ private object HostEntryFieldCollectionPath
     else {
       // Should not be possible to reach this point, SierraCollectionPath.apply will have
       // ensured that an appropriate 773 entry exists somewhere in the document.
-      warn(f"Could not find a varfield suitable for making a collectionPath ${bibData}")
+      warn(
+        f"Could not find a varfield suitable for making a collectionPath ${bibData}")
       None
     }
   }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraCollectionPath.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraCollectionPath.scala
@@ -4,81 +4,142 @@ import grizzled.slf4j.Logging
 import weco.catalogue.internal_model.work.CollectionPath
 import weco.sierra.models.SierraQueryOps
 import weco.sierra.models.data.SierraBibData
-import weco.sierra.models.marc.{VarField}
+import weco.sierra.models.marc.VarField
+
+import scala.util.matching.Regex
 
 /**
-  * Convert links between identified Sierra entries into a hierarchical path.
-  *
-  * The Sierra linking fields 773 and 774, when specified with the identifier subfield
-  * "$w - Record control number" represent a part-whole relationship akin to those found
-  * in CALM or TEI resources.
-  *
-  * - [773 - Host Item Entry](https://www.loc.gov/marc/bibliographic/bd773.html)
-  * - [774 - Constituent Unit Entry](https://www.loc.gov/marc/bibliographic/bd774.html)
-  *
-  * When the identifier is not present, `773` fields represent membership of a Series, see
-  * SierraParents.  Such fields are ignored here.
-  *
-  * At this point, the records are not 'Identified', moreover, the identifiers used in these
-  * two fields are Worldcat ids (e.g. (Wcat)29062i), which do not get resolved by the id minter.
-  *
-  * Therefore, at this point we can only create the "link" via a common collection path,
-  * to be later resolved by the relation embedder.
-  *
-  * A feature of these fields is that they often refer (via the $g - Related Parts subfield)
-  * to a subsection of the whole. This subsection is not in itself an entity that exists and
-  * can be identified or linked to.
-  *
-  * e.g. the following fields from two records, corresponding to both "ends" of the relationship
-  *  - 773 0  |tBasil Hood. Photograph album,|gpage 5.|w(Wcat)9175i
-  *  - 774 0  |gPage 5 :|tCharing Cross Hospital: a portrait of house surgeons. Photograph, 1906.|w(Wcat)28914i
-  *  They each refer to the other, but there is no "page 5" object.
-  *  So, although page 5 might look like it should be a node in the collectionPath, it cannot be.
-  *
-  *  Notable challenges in the data include:
-  *  - punctuation must be stripped ("Page 5 :" should match "page 5.")
-  *  - case must be normalised ("Page 5" should match "page 5")
-  *  - the (Wcat) prefix must be stripped ("(Wcat)9175i" should match "9175i")
-  *  - the value must be turned into something the relation embedder expects
-  *      (evidence points to this being underscores for spaces).
-  *
-  *  The hierarchy of Sierra-based data is flatter than other systems. A node is expected to *either* be a host or a
-  *  constituent. It is possible for record that is a "host" to also be part of a series, but that relationship
-  *  would not contain the $w subfield, so is to be ignored here.
-  *
-  *  A constituent has exactly one host
-  *  A host may have many constituents, but for the purpose of defining a CollectionPath, it only matters that one
-  *  exists, not how many there are.
-  *  */
+ * Convert links between identified Sierra entries into a hierarchical path.
+ *
+ * The Sierra linking fields 773 and 774, when specified with the identifier subfield
+ * "$w - Record control number" represent a part-whole relationship akin to those found
+ * in CALM or TEI resources.
+ *
+ * - [773 - Host Item Entry](https://www.loc.gov/marc/bibliographic/bd773.html)
+ * - [774 - Constituent Unit Entry](https://www.loc.gov/marc/bibliographic/bd774.html)
+ *
+ * When the identifier is not present, `773` fields represent membership of a Series, see
+ * SierraParents.  Such fields are ignored here.
+ *
+ * At this point, the records are not 'Identified', moreover, the identifiers used in these
+ * two fields are Worldcat ids (e.g. (Wcat)29062i), which do not get resolved by the id minter.
+ *
+ * Therefore, at this point we can only create the "link" via a common collection path,
+ * to be later resolved by the relation embedder.
+ *
+ * A feature of these fields is that they often refer (via the $g - Related Parts subfield)
+ * to a subsection of the whole. This subsection is not in itself an entity that exists and
+ * can be identified or linked to.
+ *
+ * e.g. the following fields from two records, corresponding to both "ends" of the relationship
+ *  - 773 0  |tBasil Hood. Photograph album,|gpage 5.|w(Wcat)9175i
+ *  - 774 0  |gPage 5 :|tCharing Cross Hospital: a portrait of house surgeons. Photograph, 1906.|w(Wcat)28914i
+ *    They each refer to the other, but there is no "page 5" object.
+ *    So, although page 5 might look like it should be a node in the collectionPath, it cannot be.
+ *
+ * Notable challenges in the data include:
+ *  - punctuation must be stripped ("Page 5 :" should match "page 5.")
+ *  - case must be normalised ("Page 5" should match "page 5")
+ *  - the (Wcat) prefix must be stripped ("(Wcat)9175i" should match "9175i")
+ *  - the value must be turned into something the relation embedder expects
+ *    (evidence points to this being underscores for spaces).
+ *
+ * The hierarchy of Sierra-based data is flatter than other systems. A node is expected to *either* be a host or a
+ * constituent. It is possible for record that is a "host" to also be part of a series, but that relationship
+ * would not contain the $w subfield, so is to be ignored here.
+ *
+ * A constituent has exactly one host
+ * A host may have many constituents, but for the purpose of defining a CollectionPath, it only matters that one
+ * exists, not how many there are.
+ * */
 object SierraCollectionPath extends SierraQueryOps with Logging {
+
   def apply(bibData: SierraBibData): Option[CollectionPath] = {
-    bibData.varfieldsWithTag("774") match {
-      case Nil => pathFromHostEntryField(bibData)
-      case _ =>
-        Some(CollectionPath(bibData.varfieldsWithTag("001").head.content.get))
+    if (bibData.subfieldsWithTags(("773", "w"), ("774", "w")).isEmpty)
+      None
+    else {
+      (getOwnId(bibData), bibData.varfieldsWithTag("774")) match {
+        case (Some(bibId), Nil) =>
+          HostEntryFieldCollectionPath(bibData, bibId)
+        case (Some(bibId), _) =>
+          Some(CollectionPath(path = bibId, label = None))
+      }
     }
-  }
-  private def pathFromHostEntryField(
-    bibData: SierraBibData): Option[CollectionPath] = {
-    val maybeIdentifiedHostEntryField: Option[VarField] =
-      bibData.varfieldsWithTag("773").find(_.subfieldsWithTag("w").nonEmpty)
-    if (maybeIdentifiedHostEntryField.isDefined) {
-      val identifiedHostEntryField = maybeIdentifiedHostEntryField.get
-      Some(
-        CollectionPath(
-          f"${identifiedHostEntryField.content}/${getRelatedPart(
-            identifiedHostEntryField)}${bibData.varfieldsWithTag("001").head.content}"
-        ))
-    }
-    None
   }
 
+  private def getOwnId(bibData: SierraBibData): Option[String] = {
+    bibData.varfieldsWithTag("001").headOption.flatMap(_.content)
+  }
+}
+
+
+/**
+ * Return an optional CollectionPath for a bib with host entry fields.
+ *
+ * The host entry field (773) has been used both for the identified
+ * relationship with a reciprocal 774 on the other record, and for
+ * unidentified Series membership.
+ *
+ * As such, a bib may have many host entry fields (773),
+ * but at most, only one of them is expected to result in a CollectionPath.
+ * This will be the one with a $w tag
+ *
+ * It is possible, but unlikely that a bib would have a mixture of both
+ * The more common scenario is that it would have either exactly one 773
+ * field, and that field has a $w subtag, or it would have multiple 773 fields,
+ * and none of them have a $w subtag.
+ */
+object HostEntryFieldCollectionPath extends SierraQueryOps with Logging {
+  val nonTokenCharacters = new Regex("[^0-9a-zA-Z_]")
+
+  def apply(bibData: SierraBibData, bibId: String): Option[CollectionPath] = {
+    // not bibData.subFieldsWithTag, because we later need to get the $g subtag
+    // from *the same* varfield as the one with the $w subtag
+    val hostEntryField: Option[VarField] =
+    bibData.varfieldsWithTag("773").find(_.subfieldsWithTag("w").nonEmpty)
+
+    if (hostEntryField.nonEmpty && bibId.nonEmpty)
+      Some(CollectionPath(path = collectionPathString(hostEntryField.get, bibId), label = None))
+    else
+      None
+  }
+
+  /**
+   * Return the path from the parent to this record as a / separated string.
+   *
+   * Being flat, the paths generated from 774/773 relationships consist of exactly two nodes.
+   *
+   * The $g - related part value is included, if present, as part of the node corresponding to
+   * this record, this allows for alphanumeric sorting to put everything in (roughly) the correct order
+   *
+   * $g is not included as a node of its own, because it refers to something that does not exist
+   * as an entity in its own right.
+   *
+   */
+  private def collectionPathString(hostEntryField: VarField, ownId: String): String = {
+    f"${getHostId(hostEntryField)}/${getRelatedPart(hostEntryField)}${ownId}"
+  }
+
+  /**
+   * Extract the Related Part value from a host entry field, if any.
+   * The Related Part ($g) subfield contains a free-text name of
+   * the part of the host to which this record belongs.
+   * This may be something like a page or volume number,
+   * with or without text like "vol." or  "page: " etc.
+   * The source data may contain punctuation, spaces etc,
+   * all of which are removed or replaced
+   * to make a token similar to those the Relation Embedder receives from
+   * CALM and TEI
+   */
   private def getRelatedPart(hostEntryField: VarField): String = {
     val gFields = hostEntryField.subfieldsWithTag("g")
     gFields match {
       case Nil => ""
-      case _   => gFields.head.content
+      case _ => nonTokenCharacters.replaceAllIn(gFields.head.content.replaceAll(" ", "_"), "") + "_"
     }
   }
 
+  private def getHostId(varField: VarField): String = {
+    varField.subfieldsWithTag("w").head.content.stripPrefix("(Wcat)")
+  }
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraCollectionPath.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraCollectionPath.scala
@@ -6,41 +6,39 @@ import weco.sierra.models.SierraQueryOps
 import weco.sierra.models.data.SierraBibData
 
 /**
- * Convert links between identified Sierra entries into a hierarchical path.
- *
- * The Sierra linking fields 773 and 774, when specified with the identifier subfield
- * "$w - Record control number" represent a part-whole relationship akin to those found
- * in CALM or TEI resources.
- *
- * - [773 - Host Item Entry](https://www.loc.gov/marc/bibliographic/bd773.html)
- * - [774 - Constituent Unit Entry](https://www.loc.gov/marc/bibliographic/bd774.html)
- *
- * When the identifier is not present, `773` fields represent membership of a Series, see
- * SierraParents.
- *
- * At this point, the records are not 'Identified', moreover, the identifiers used in these
- * two fields are Worldcat ids (e.g. (Wcat)29062i), which do not get resolved by the id minter.
- *
- * Therefore, at this point we can only create the "link" via a collection path, to be later
- * resolved by the relation embedder.
- *
- * A feature of these fields is that they often refer (via the $g - Related Parts subfield)
- * to a subsection of the whole. This subsection is not in itself an entity that exists and
- * can be identified or linked to.
- *
- * e.g. the following fields from two records, corresponding to both "ends" of the relationship
- *  - 774 0  |gPage 5 :|tCharing Cross Hospital: a portrait of house surgeons. Photograph, 1906.|w(Wcat)28914i
- *  - 773 0  |tBasil Hood. Photograph album,|gpage 5.|w(Wcat)9175i
- *  They each refer to the other, but there is no "page 5" object.
- *  So, although page 5 might look like it should be a node in the collectionPath, it cannot be.,
- *  */
-
+  * Convert links between identified Sierra entries into a hierarchical path.
+  *
+  * The Sierra linking fields 773 and 774, when specified with the identifier subfield
+  * "$w - Record control number" represent a part-whole relationship akin to those found
+  * in CALM or TEI resources.
+  *
+  * - [773 - Host Item Entry](https://www.loc.gov/marc/bibliographic/bd773.html)
+  * - [774 - Constituent Unit Entry](https://www.loc.gov/marc/bibliographic/bd774.html)
+  *
+  * When the identifier is not present, `773` fields represent membership of a Series, see
+  * SierraParents.
+  *
+  * At this point, the records are not 'Identified', moreover, the identifiers used in these
+  * two fields are Worldcat ids (e.g. (Wcat)29062i), which do not get resolved by the id minter.
+  *
+  * Therefore, at this point we can only create the "link" via a collection path, to be later
+  * resolved by the relation embedder.
+  *
+  * A feature of these fields is that they often refer (via the $g - Related Parts subfield)
+  * to a subsection of the whole. This subsection is not in itself an entity that exists and
+  * can be identified or linked to.
+  *
+  * e.g. the following fields from two records, corresponding to both "ends" of the relationship
+  *  - 774 0  |gPage 5 :|tCharing Cross Hospital: a portrait of house surgeons. Photograph, 1906.|w(Wcat)28914i
+  *  - 773 0  |tBasil Hood. Photograph album,|gpage 5.|w(Wcat)9175i
+  *  They each refer to the other, but there is no "page 5" object.
+  *  So, although page 5 might look like it should be a node in the collectionPath, it cannot be.,
+  *  */
 object SierraCollectionPath extends SierraQueryOps with Logging {
   def apply(bibData: SierraBibData): Option[CollectionPath] = {
     bibData.varfieldsWithTags("773", "774")
     Some(CollectionPath("banana"))
     None
   }
-
 
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraCollectionPath.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraCollectionPath.scala
@@ -118,9 +118,7 @@ private object HostEntryFieldCollectionPath
     else {
       // Should not be possible to reach this point, SierraCollectionPath.apply will have
       // ensured that an appropriate 773 entry exists somewhere in the document.
-      warn(
-        f"Could not find a varfield suitable for making a collectionPath ${bibData
-          .varfieldsWithTag("773")}")
+      warn(f"Could not find a varfield suitable for making a collectionPath ${bibData}")
       None
     }
   }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraCollectionPath.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraCollectionPath.scala
@@ -1,0 +1,46 @@
+package weco.pipeline.transformer.sierra.transformers
+
+import grizzled.slf4j.Logging
+import weco.catalogue.internal_model.work.CollectionPath
+import weco.sierra.models.SierraQueryOps
+import weco.sierra.models.data.SierraBibData
+
+/**
+ * Convert links between identified Sierra entries into a hierarchical path.
+ *
+ * The Sierra linking fields 773 and 774, when specified with the identifier subfield
+ * "$w - Record control number" represent a part-whole relationship akin to those found
+ * in CALM or TEI resources.
+ *
+ * - [773 - Host Item Entry](https://www.loc.gov/marc/bibliographic/bd773.html)
+ * - [774 - Constituent Unit Entry](https://www.loc.gov/marc/bibliographic/bd774.html)
+ *
+ * When the identifier is not present, `773` fields represent membership of a Series, see
+ * SierraParents.
+ *
+ * At this point, the records are not 'Identified', moreover, the identifiers used in these
+ * two fields are Worldcat ids (e.g. (Wcat)29062i), which do not get resolved by the id minter.
+ *
+ * Therefore, at this point we can only create the "link" via a collection path, to be later
+ * resolved by the relation embedder.
+ *
+ * A feature of these fields is that they often refer (via the $g - Related Parts subfield)
+ * to a subsection of the whole. This subsection is not in itself an entity that exists and
+ * can be identified or linked to.
+ *
+ * e.g. the following fields from two records, corresponding to both "ends" of the relationship
+ *  - 774 0  |gPage 5 :|tCharing Cross Hospital: a portrait of house surgeons. Photograph, 1906.|w(Wcat)28914i
+ *  - 773 0  |tBasil Hood. Photograph album,|gpage 5.|w(Wcat)9175i
+ *  They each refer to the other, but there is no "page 5" object.
+ *  So, although page 5 might look like it should be a node in the collectionPath, it cannot be.,
+ *  */
+
+object SierraCollectionPath extends SierraQueryOps with Logging {
+  def apply(bibData: SierraBibData): Option[CollectionPath] = {
+    bibData.varfieldsWithTags("773", "774")
+    Some(CollectionPath("banana"))
+    None
+  }
+
+
+}

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraCollectionPath.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraCollectionPath.scala
@@ -4,41 +4,78 @@ import grizzled.slf4j.Logging
 import weco.catalogue.internal_model.work.CollectionPath
 import weco.sierra.models.SierraQueryOps
 import weco.sierra.models.data.SierraBibData
+import weco.sierra.models.marc.{VarField}
 
 /**
-  * Convert links between identified Sierra entries into a hierarchical path.
-  *
-  * The Sierra linking fields 773 and 774, when specified with the identifier subfield
-  * "$w - Record control number" represent a part-whole relationship akin to those found
-  * in CALM or TEI resources.
-  *
-  * - [773 - Host Item Entry](https://www.loc.gov/marc/bibliographic/bd773.html)
-  * - [774 - Constituent Unit Entry](https://www.loc.gov/marc/bibliographic/bd774.html)
-  *
-  * When the identifier is not present, `773` fields represent membership of a Series, see
-  * SierraParents.
-  *
-  * At this point, the records are not 'Identified', moreover, the identifiers used in these
-  * two fields are Worldcat ids (e.g. (Wcat)29062i), which do not get resolved by the id minter.
-  *
-  * Therefore, at this point we can only create the "link" via a collection path, to be later
-  * resolved by the relation embedder.
-  *
-  * A feature of these fields is that they often refer (via the $g - Related Parts subfield)
-  * to a subsection of the whole. This subsection is not in itself an entity that exists and
-  * can be identified or linked to.
-  *
-  * e.g. the following fields from two records, corresponding to both "ends" of the relationship
-  *  - 774 0  |gPage 5 :|tCharing Cross Hospital: a portrait of house surgeons. Photograph, 1906.|w(Wcat)28914i
-  *  - 773 0  |tBasil Hood. Photograph album,|gpage 5.|w(Wcat)9175i
-  *  They each refer to the other, but there is no "page 5" object.
-  *  So, although page 5 might look like it should be a node in the collectionPath, it cannot be.,
-  *  */
+ * Convert links between identified Sierra entries into a hierarchical path.
+ *
+ * The Sierra linking fields 773 and 774, when specified with the identifier subfield
+ * "$w - Record control number" represent a part-whole relationship akin to those found
+ * in CALM or TEI resources.
+ *
+ * - [773 - Host Item Entry](https://www.loc.gov/marc/bibliographic/bd773.html)
+ * - [774 - Constituent Unit Entry](https://www.loc.gov/marc/bibliographic/bd774.html)
+ *
+ * When the identifier is not present, `773` fields represent membership of a Series, see
+ * SierraParents.  Such fields are ignored here.
+ *
+ * At this point, the records are not 'Identified', moreover, the identifiers used in these
+ * two fields are Worldcat ids (e.g. (Wcat)29062i), which do not get resolved by the id minter.
+ *
+ * Therefore, at this point we can only create the "link" via a common collection path,
+ * to be later resolved by the relation embedder.
+ *
+ * A feature of these fields is that they often refer (via the $g - Related Parts subfield)
+ * to a subsection of the whole. This subsection is not in itself an entity that exists and
+ * can be identified or linked to.
+ *
+ * e.g. the following fields from two records, corresponding to both "ends" of the relationship
+ *  - 773 0  |tBasil Hood. Photograph album,|gpage 5.|w(Wcat)9175i
+ *  - 774 0  |gPage 5 :|tCharing Cross Hospital: a portrait of house surgeons. Photograph, 1906.|w(Wcat)28914i
+ *  They each refer to the other, but there is no "page 5" object.
+ *  So, although page 5 might look like it should be a node in the collectionPath, it cannot be.
+ *
+ *  Notable challenges in the data include:
+ *  - punctuation must be stripped ("Page 5 :" should match "page 5.")
+ *  - case must be normalised ("Page 5" should match "page 5")
+ *  - the (Wcat) prefix must be stripped ("(Wcat)9175i" should match "9175i")
+ *  - the value must be turned into something the relation embedder expects
+ *      (evidence points to this being underscores for spaces).
+ *
+ *  The hierarchy of Sierra-based data is flatter than other systems. A node is expected to *either* be a host or a
+ *  constituent. It is possible for record that is a "host" to also be part of a series, but that relationship
+ *  would not contain the $w subfield, so is to be ignored here.
+ *
+ *  A constituent has exactly one host
+ *  A host may have many constituents, but for the purpose of defining a CollectionPath, it only matters that one
+ *  exists, not how many there are.
+ *  */
+
 object SierraCollectionPath extends SierraQueryOps with Logging {
   def apply(bibData: SierraBibData): Option[CollectionPath] = {
-    bibData.varfieldsWithTags("773", "774")
-    Some(CollectionPath("banana"))
+    bibData.varfieldsWithTag("774") match {
+      case Nil => pathFromHostEntryField(bibData)
+      case _ =>
+        Some(CollectionPath(bibData.varfieldsWithTag("001").head.content.get))
+      }
+}
+  private def pathFromHostEntryField(bibData: SierraBibData): Option[CollectionPath] = {
+    val maybeIdentifiedHostEntryField: Option[VarField] = bibData.varfieldsWithTag("773").find(_.subfieldsWithTag("w").nonEmpty)
+    if(maybeIdentifiedHostEntryField.isDefined) {
+      val identifiedHostEntryField = maybeIdentifiedHostEntryField.get
+      Some(CollectionPath(
+        f"${identifiedHostEntryField.content}/${getRelatedPart(identifiedHostEntryField)}${bibData.varfieldsWithTag("001").head.content}"
+      ))
+    }
     None
+  }
+
+  private def getRelatedPart(hostEntryField: VarField): String = {
+    val gFields = hostEntryField.subfieldsWithTag("g")
+    gFields match {
+      case Nil => ""
+      case _ => gFields.head.content
+    }
   }
 
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraCollectionPath.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraCollectionPath.scala
@@ -9,49 +9,49 @@ import weco.sierra.models.marc.VarField
 import scala.util.matching.Regex
 
 /**
- * Convert links between identified Sierra entries into a hierarchical path.
- *
- * The Sierra linking fields 773 and 774, when specified with the identifier subfield
- * "$w - Record control number" represent a part-whole relationship akin to those found
- * in CALM or TEI resources.
- *
- * - [773 - Host Item Entry](https://www.loc.gov/marc/bibliographic/bd773.html)
- * - [774 - Constituent Unit Entry](https://www.loc.gov/marc/bibliographic/bd774.html)
- *
- * When the identifier is not present, `773` fields represent membership of a Series, see
- * SierraParents.  Such fields are ignored here.
- *
- * At this point, the records are not 'Identified', moreover, the identifiers used in these
- * two fields are Worldcat ids (e.g. (Wcat)29062i), which do not get resolved by the id minter.
- *
- * Therefore, at this point we can only create the "link" via a common collection path,
- * to be later resolved by the relation embedder.
- *
- * A feature of these fields is that they often refer (via the $g - Related Parts subfield)
- * to a subsection of the whole. This subsection is not in itself an entity that exists and
- * can be identified or linked to.
- *
- * e.g. the following fields from two records, corresponding to both "ends" of the relationship
- *  - 773 0  |tBasil Hood. Photograph album,|gpage 5.|w(Wcat)9175i
- *  - 774 0  |gPage 5 :|tCharing Cross Hospital: a portrait of house surgeons. Photograph, 1906.|w(Wcat)28914i
- *    They each refer to the other, but there is no "page 5" object.
- *    So, although page 5 might look like it should be a node in the collectionPath, it cannot be.
- *
- * Notable challenges in the data include:
- *  - punctuation must be stripped ("Page 5 :" should match "page 5.")
- *  - case must be normalised ("Page 5" should match "page 5")
- *  - the (Wcat) prefix must be stripped ("(Wcat)9175i" should match "9175i")
- *  - the value must be turned into something the relation embedder expects
- *    (evidence points to this being underscores for spaces).
- *
- * The hierarchy of Sierra-based data is flatter than other systems. A node is expected to *either* be a host or a
- * constituent. It is possible for record that is a "host" to also be part of a series, but that relationship
- * would not contain the $w subfield, so is to be ignored here.
- *
- * A constituent has exactly one host
- * A host may have many constituents, but for the purpose of defining a CollectionPath, it only matters that one
- * exists, not how many there are.
- * */
+  * Convert links between identified Sierra entries into a hierarchical path.
+  *
+  * The Sierra linking fields 773 and 774, when specified with the identifier subfield
+  * "$w - Record control number" represent a part-whole relationship akin to those found
+  * in CALM or TEI resources.
+  *
+  * - [773 - Host Item Entry](https://www.loc.gov/marc/bibliographic/bd773.html)
+  * - [774 - Constituent Unit Entry](https://www.loc.gov/marc/bibliographic/bd774.html)
+  *
+  * When the identifier is not present, `773` fields represent membership of a Series, see
+  * SierraParents.  Such fields are ignored here.
+  *
+  * At this point, the records are not 'Identified', moreover, the identifiers used in these
+  * two fields are Worldcat ids (e.g. (Wcat)29062i), which do not get resolved by the id minter.
+  *
+  * Therefore, at this point we can only create the "link" via a common collection path,
+  * to be later resolved by the relation embedder.
+  *
+  * A feature of these fields is that they often refer (via the $g - Related Parts subfield)
+  * to a subsection of the whole. This subsection is not in itself an entity that exists and
+  * can be identified or linked to.
+  *
+  * e.g. the following fields from two records, corresponding to both "ends" of the relationship
+  *  - 773 0  |tBasil Hood. Photograph album,|gpage 5.|w(Wcat)9175i
+  *  - 774 0  |gPage 5 :|tCharing Cross Hospital: a portrait of house surgeons. Photograph, 1906.|w(Wcat)28914i
+  *    They each refer to the other, but there is no "page 5" object.
+  *    So, although page 5 might look like it should be a node in the collectionPath, it cannot be.
+  *
+  * Notable challenges in the data include:
+  *  - punctuation must be stripped ("Page 5 :" should match "page 5.")
+  *  - case must be normalised ("Page 5" should match "page 5")
+  *  - the (Wcat) prefix must be stripped ("(Wcat)9175i" should match "9175i")
+  *  - the value must be turned into something the relation embedder expects
+  *    (evidence points to this being underscores for spaces).
+  *
+  * The hierarchy of Sierra-based data is flatter than other systems. A node is expected to *either* be a host or a
+  * constituent. It is possible for record that is a "host" to also be part of a series, but that relationship
+  * would not contain the $w subfield, so is to be ignored here.
+  *
+  * A constituent has exactly one host
+  * A host may have many constituents, but for the purpose of defining a CollectionPath, it only matters that one
+  * exists, not how many there are.
+  * */
 object SierraCollectionPath extends SierraQueryOps with Logging {
 
   def apply(bibData: SierraBibData): Option[CollectionPath] = {
@@ -72,23 +72,22 @@ object SierraCollectionPath extends SierraQueryOps with Logging {
   }
 }
 
-
 /**
- * Return an optional CollectionPath for a bib with host entry fields.
- *
- * The host entry field (773) has been used both for the identified
- * relationship with a reciprocal 774 on the other record, and for
- * unidentified Series membership.
- *
- * As such, a bib may have many host entry fields (773),
- * but at most, only one of them is expected to result in a CollectionPath.
- * This will be the one with a $w tag
- *
- * It is possible, but unlikely that a bib would have a mixture of both
- * The more common scenario is that it would have either exactly one 773
- * field, and that field has a $w subtag, or it would have multiple 773 fields,
- * and none of them have a $w subtag.
- */
+  * Return an optional CollectionPath for a bib with host entry fields.
+  *
+  * The host entry field (773) has been used both for the identified
+  * relationship with a reciprocal 774 on the other record, and for
+  * unidentified Series membership.
+  *
+  * As such, a bib may have many host entry fields (773),
+  * but at most, only one of them is expected to result in a CollectionPath.
+  * This will be the one with a $w tag
+  *
+  * It is possible, but unlikely that a bib would have a mixture of both
+  * The more common scenario is that it would have either exactly one 773
+  * field, and that field has a $w subtag, or it would have multiple 773 fields,
+  * and none of them have a $w subtag.
+  */
 object HostEntryFieldCollectionPath extends SierraQueryOps with Logging {
   val nonTokenCharacters = new Regex("[^0-9a-zA-Z_]")
 
@@ -96,46 +95,53 @@ object HostEntryFieldCollectionPath extends SierraQueryOps with Logging {
     // not bibData.subFieldsWithTag, because we later need to get the $g subtag
     // from *the same* varfield as the one with the $w subtag
     val hostEntryField: Option[VarField] =
-    bibData.varfieldsWithTag("773").find(_.subfieldsWithTag("w").nonEmpty)
+      bibData.varfieldsWithTag("773").find(_.subfieldsWithTag("w").nonEmpty)
 
     if (hostEntryField.nonEmpty && bibId.nonEmpty)
-      Some(CollectionPath(path = collectionPathString(hostEntryField.get, bibId), label = None))
+      Some(
+        CollectionPath(
+          path = collectionPathString(hostEntryField.get, bibId),
+          label = None))
     else
       None
   }
 
   /**
-   * Return the path from the parent to this record as a / separated string.
-   *
-   * Being flat, the paths generated from 774/773 relationships consist of exactly two nodes.
-   *
-   * The $g - related part value is included, if present, as part of the node corresponding to
-   * this record, this allows for alphanumeric sorting to put everything in (roughly) the correct order
-   *
-   * $g is not included as a node of its own, because it refers to something that does not exist
-   * as an entity in its own right.
-   *
-   */
-  private def collectionPathString(hostEntryField: VarField, ownId: String): String = {
+    * Return the path from the parent to this record as a / separated string.
+    *
+    * Being flat, the paths generated from 774/773 relationships consist of exactly two nodes.
+    *
+    * The $g - related part value is included, if present, as part of the node corresponding to
+    * this record, this allows for alphanumeric sorting to put everything in (roughly) the correct order
+    *
+    * $g is not included as a node of its own, because it refers to something that does not exist
+    * as an entity in its own right.
+    *
+    */
+  private def collectionPathString(hostEntryField: VarField,
+                                   ownId: String): String = {
     f"${getHostId(hostEntryField)}/${getRelatedPart(hostEntryField)}${ownId}"
   }
 
   /**
-   * Extract the Related Part value from a host entry field, if any.
-   * The Related Part ($g) subfield contains a free-text name of
-   * the part of the host to which this record belongs.
-   * This may be something like a page or volume number,
-   * with or without text like "vol." or  "page: " etc.
-   * The source data may contain punctuation, spaces etc,
-   * all of which are removed or replaced
-   * to make a token similar to those the Relation Embedder receives from
-   * CALM and TEI
-   */
+    * Extract the Related Part value from a host entry field, if any.
+    * The Related Part ($g) subfield contains a free-text name of
+    * the part of the host to which this record belongs.
+    * This may be something like a page or volume number,
+    * with or without text like "vol." or  "page: " etc.
+    * The source data may contain punctuation, spaces etc,
+    * all of which are removed or replaced
+    * to make a token similar to those the Relation Embedder receives from
+    * CALM and TEI
+    */
   private def getRelatedPart(hostEntryField: VarField): String = {
     val gFields = hostEntryField.subfieldsWithTag("g")
     gFields match {
       case Nil => ""
-      case _ => nonTokenCharacters.replaceAllIn(gFields.head.content.replaceAll(" ", "_"), "") + "_"
+      case _ =>
+        nonTokenCharacters.replaceAllIn(
+          gFields.head.content.replaceAll(" ", "_"),
+          "") + "_"
     }
   }
 

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraCollectionPath.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraCollectionPath.scala
@@ -58,7 +58,7 @@ object SierraCollectionPath extends SierraQueryOps with Logging {
     if (bibData.subfieldsWithTags(("773", "w"), ("774", "w")).isEmpty)
       None
     else {
-      (getOwnId(bibData), bibData.varfieldsWithTag("774")) match {
+      (getControlNumber(bibData), bibData.varfieldsWithTag("774")) match {
         case (Some(bibId), Nil) =>
           HostEntryFieldCollectionPath(bibData, bibId)
         case (Some(bibId), _) =>
@@ -67,7 +67,11 @@ object SierraCollectionPath extends SierraQueryOps with Logging {
     }
   }
 
-  private def getOwnId(bibData: SierraBibData): Option[String] = {
+  /**
+   * Return the String value of the control number field, if present
+   * https://www.loc.gov/marc/bibliographic/bd001.html
+   */
+  private def getControlNumber(bibData: SierraBibData): Option[String] = {
     bibData.varfieldsWithTag("001").headOption.flatMap(_.content)
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraCollectionPath.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraCollectionPath.scala
@@ -68,9 +68,9 @@ object SierraCollectionPath extends SierraQueryOps with Logging {
   }
 
   /**
-   * Return the String value of the control number field, if present
-   * https://www.loc.gov/marc/bibliographic/bd001.html
-   */
+    * Return the String value of the control number field, if present
+    * https://www.loc.gov/marc/bibliographic/bd001.html
+    */
   private def getControlNumber(bibData: SierraBibData): Option[String] = {
     bibData.varfieldsWithTag("001").headOption.flatMap(_.content)
   }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraCollectionPath.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraCollectionPath.scala
@@ -158,7 +158,7 @@ private object HostEntryFieldCollectionPath
       case Nil => ""
       case _ =>
         nonTokenCharacters.replaceAllIn(
-          gFields.head.content.replaceAll(" ", "_"),
+          gFields.head.content.replace(' ', '_'),
           "") + "_"
     }
   }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraCollectionPathTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraCollectionPathTest.scala
@@ -52,7 +52,10 @@ class SierraCollectionPathTest
           marcTag = Some(marcTag),
           subfields = List(
             Subfield(tag = "t", content = "A Constituent"),
-            Subfield(tag = "w", content = "This value does not matter, it just matters that it exists")
+            Subfield(
+              tag = "w",
+              content =
+                "This value does not matter, it just matters that it exists")
           )
         )
       )
@@ -70,14 +73,18 @@ class SierraCollectionPathTest
         marcTag = Some("774"),
         subfields = List(
           Subfield(tag = "t", content = "A Constituent"),
-          Subfield(tag = "w", content = "This value does not matter, it just matters that it exists")
+          Subfield(
+            tag = "w",
+            content =
+              "This value does not matter, it just matters that it exists")
         )
       )
     )
     getCollectionPath(varFields).get shouldBe CollectionPath(path = "12345i")
   }
 
-  it("constructs a value from a 773 field, consisting of $w and the document's own id") {
+  it(
+    "constructs a value from a 773 field, consisting of $w and the document's own id") {
     val varFields = List(
       VarField(
         marcTag = Some("001"),
@@ -91,7 +98,8 @@ class SierraCollectionPathTest
         )
       )
     )
-    getCollectionPath(varFields).get shouldBe CollectionPath(path = "12345i/56789i")
+    getCollectionPath(varFields).get shouldBe CollectionPath(
+      path = "12345i/56789i")
   }
 
   it("constructs a value from a 773 field, including $g if present") {
@@ -113,8 +121,8 @@ class SierraCollectionPathTest
       path = "12345i/page_4_56789i")
   }
 
-
-  it("constructs a value from the correct 773 field, even when there are multiple") {
+  it(
+    "constructs a value from the correct 773 field, even when there are multiple") {
     val varFields = List(
       VarField(
         marcTag = Some("001"),
@@ -141,9 +149,9 @@ class SierraCollectionPathTest
           Subfield(tag = "g", content = "vol. 4")
         )
       )
-
     )
-    getCollectionPath(varFields).get shouldBe CollectionPath(path = "12345i/vol_4_56789i")
+    getCollectionPath(varFields).get shouldBe CollectionPath(
+      path = "12345i/vol_4_56789i")
   }
 
   private def getCollectionPath(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraCollectionPathTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraCollectionPathTest.scala
@@ -23,7 +23,7 @@ class SierraCollectionPathTest
     getCollectionPath(varFields) shouldBe None
   }
 
-  it("returns None, if a relevant field does not have the $w subfield") {
+  it("returns None, if no 773/774 fields have the $w subfield") {
     forAll(
       Table(
         "marcTag",
@@ -33,7 +33,27 @@ class SierraCollectionPathTest
       val varFields = List(
         VarField(
           marcTag = Some(marcTag),
-          content = Some("banana")
+          content = Some("title-only reference to the other document")
+        )
+      )
+      getCollectionPath(varFields) shouldBe None
+    }
+  }
+
+  it("returns None, if an otherwise matching document has no 001 field") {
+    forAll(
+      Table(
+        "marcTag",
+        "773",
+        "774"
+      )) { (marcTag) =>
+      val varFields = List(
+        VarField(
+          marcTag = Some(marcTag),
+          subfields = List(
+            Subfield(tag = "t", content = "A Constituent"),
+            Subfield(tag = "w", content = "This value does not matter, it just matters that it exists")
+          )
         )
       )
       getCollectionPath(varFields) shouldBe None
@@ -50,15 +70,31 @@ class SierraCollectionPathTest
         marcTag = Some("774"),
         subfields = List(
           Subfield(tag = "t", content = "A Constituent"),
-          Subfield(tag = "w", content = "(Wcat)28931i")
+          Subfield(tag = "w", content = "This value does not matter, it just matters that it exists")
         )
       )
     )
     getCollectionPath(varFields).get shouldBe CollectionPath(path = "12345i")
   }
 
-  it(
-    "constructs a value from a 773 field, consisting of $w, $g and the document's own id") {
+  it("constructs a value from a 773 field, consisting of $w and the document's own id") {
+    val varFields = List(
+      VarField(
+        marcTag = Some("001"),
+        content = Some("56789i")
+      ),
+      VarField(
+        marcTag = Some("773"),
+        subfields = List(
+          Subfield(tag = "t", content = "A Host"),
+          Subfield(tag = "w", content = "(Wcat)12345i")
+        )
+      )
+    )
+    getCollectionPath(varFields).get shouldBe CollectionPath(path = "12345i/56789i")
+  }
+
+  it("constructs a value from a 773 field, including $g if present") {
     val varFields = List(
       VarField(
         marcTag = Some("001"),
@@ -73,20 +109,12 @@ class SierraCollectionPathTest
         )
       )
     )
-    getCollectionPath(varFields) shouldBe CollectionPath(
-      path = "12345i/page4_56789i")
-    // CollectionPath is path (ids) and label (concat the $g and title?),
-    // In CALM records, they match,
-    // In TEI records, the path object does not necessarily have a label
-    //
-    // 001   28914i
-    // 245 00 Charing Cross Hospital: a portrait of house surgeons. Photograph, 1906.
-    // 773   Basil Hood. Photograph album,|gpage 5.|w(Wcat)9175i
-    // path: 9175i/page_5_28914i
-    // label: Basil Hood. Photograph album/page 5.
+    getCollectionPath(varFields).get shouldBe CollectionPath(
+      path = "12345i/page_4_56789i")
   }
 
-  it("constructs a value from a 773 field, without a $g") {
+
+  it("constructs a value from the correct 773 field, even when there are multiple") {
     val varFields = List(
       VarField(
         marcTag = Some("001"),
@@ -95,16 +123,27 @@ class SierraCollectionPathTest
       VarField(
         marcTag = Some("773"),
         subfields = List(
-          Subfield(tag = "t", content = "A Host"),
-          Subfield(tag = "w", content = "(Wcat)12345i")
+          Subfield(tag = "t", content = "Not this one"),
+        )
+      ),
+      VarField(
+        marcTag = Some("773"),
+        subfields = List(
+          Subfield(tag = "t", content = "Or this one"),
+          Subfield(tag = "g", content = "Not this page either")
+        )
+      ),
+      VarField(
+        marcTag = Some("773"),
+        subfields = List(
+          Subfield(tag = "t", content = "This one"),
+          Subfield(tag = "w", content = "(Wcat)12345i"),
+          Subfield(tag = "g", content = "vol. 4")
         )
       )
-    )
-    getCollectionPath(varFields) shouldBe CollectionPath(path = "12345i/56789i")
-  }
 
-  it("removes field-final punctuation from the $t subfield") {
-    fail()
+    )
+    getCollectionPath(varFields).get shouldBe CollectionPath(path = "12345i/vol_4_56789i")
   }
 
   private def getCollectionPath(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraCollectionPathTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraCollectionPathTest.scala
@@ -63,7 +63,7 @@ class SierraCollectionPathTest
     }
   }
 
-  it("returns the document's own id for a 774 field") {
+  it("returns the document's own id when a 774 field is found") {
     val varFields = List(
       VarField(
         marcTag = Some("001"),
@@ -94,7 +94,7 @@ class SierraCollectionPathTest
         marcTag = Some("773"),
         subfields = List(
           Subfield(tag = "t", content = "A Host"),
-          Subfield(tag = "w", content = "(Wcat)12345i")
+          Subfield(tag = "w", content = "12345i")
         )
       )
     )
@@ -102,6 +102,24 @@ class SierraCollectionPathTest
       path = "12345i/56789i")
   }
 
+  it(
+    "removes the (Wcat) prefix, from the $w subfield, if present") {
+    val varFields = List(
+      VarField(
+        marcTag = Some("001"),
+        content = Some("56789i")
+      ),
+      VarField(
+        marcTag = Some("773"),
+        subfields = List(
+          Subfield(tag = "t", content = "A Host"),
+          Subfield(tag = "w", content = "(Wcat)12345i")
+        )
+      )
+    )
+    getCollectionPath(varFields).get shouldBe CollectionPath(
+      path = "12345i/56789i")
+  }
   it("constructs a value from a 773 field, including $g if present") {
     val varFields = List(
       VarField(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraCollectionPathTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraCollectionPathTest.scala
@@ -9,12 +9,12 @@ import weco.sierra.models.marc
 import weco.sierra.models.marc.{Subfield, VarField}
 
 class SierraCollectionPathTest
-  extends AnyFunSpec
+    extends AnyFunSpec
     with Matchers
     with SierraDataGenerators
     with TableDrivenPropertyChecks {
 
-  it("returns None, if there are no 773 or 774 fields"){
+  it("returns None, if there are no 773 or 774 fields") {
     val varFields = List(
       VarField(
         marcTag = Some("999"),
@@ -24,7 +24,7 @@ class SierraCollectionPathTest
     getCollectionPath(varFields) shouldBe None
   }
 
-  it("returns None, if a relevant field does not have the $w subfield"){
+  it("returns None, if a relevant field does not have the $w subfield") {
     forAll(
       Table(
         "marcTag",
@@ -41,7 +41,7 @@ class SierraCollectionPathTest
     }
   }
 
-  it("returns the document's own id for a 774 field"){
+  it("returns the document's own id for a 774 field") {
     val varFields = List(
       VarField(
         marcTag = Some("001"),
@@ -55,10 +55,11 @@ class SierraCollectionPathTest
         )
       )
     )
-    getCollectionPath(varFields) shouldBe CollectionPath(path="12345i")
+    getCollectionPath(varFields) shouldBe CollectionPath(path = "12345i")
   }
 
-  it("constructs a value from a 773 field, consisting of $w, $g and the document's own id"){
+  it(
+    "constructs a value from a 773 field, consisting of $w, $g and the document's own id") {
     val varFields = List(
       VarField(
         marcTag = Some("001"),
@@ -73,7 +74,8 @@ class SierraCollectionPathTest
         )
       )
     )
-    getCollectionPath(varFields) shouldBe CollectionPath(path="12345i/page4_56789i")
+    getCollectionPath(varFields) shouldBe CollectionPath(
+      path = "12345i/page4_56789i")
     // CollectionPath is path (ids) and label (concat the $g and title?),
     // In CALM records, they match,
     // In TEI records, the path object does not necessarily have a label
@@ -85,7 +87,7 @@ class SierraCollectionPathTest
     // label: Basil Hood. Photograph album/page 5.
   }
 
-  it("constructs a value from a 773 field, without a $g"){
+  it("constructs a value from a 773 field, without a $g") {
     val varFields = List(
       VarField(
         marcTag = Some("001"),
@@ -99,13 +101,14 @@ class SierraCollectionPathTest
         )
       )
     )
-    getCollectionPath(varFields) shouldBe CollectionPath(path="12345i/56789i")
+    getCollectionPath(varFields) shouldBe CollectionPath(path = "12345i/56789i")
   }
 
-  it("removes field-final punctuation from the $t subfield"){
+  it("removes field-final punctuation from the $t subfield") {
     fail()
   }
 
-  private def getCollectionPath(varFields: List[VarField]): Option[CollectionPath] =
+  private def getCollectionPath(
+    varFields: List[VarField]): Option[CollectionPath] =
     SierraCollectionPath(createSierraBibDataWith(varFields = varFields))
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraCollectionPathTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraCollectionPathTest.scala
@@ -1,0 +1,111 @@
+package weco.pipeline.transformer.sierra.transformers
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks
+import weco.catalogue.internal_model.work.CollectionPath
+import weco.sierra.generators.SierraDataGenerators
+import weco.sierra.models.marc
+import weco.sierra.models.marc.{Subfield, VarField}
+
+class SierraCollectionPathTest
+  extends AnyFunSpec
+    with Matchers
+    with SierraDataGenerators
+    with TableDrivenPropertyChecks {
+
+  it("returns None, if there are no 773 or 774 fields"){
+    val varFields = List(
+      VarField(
+        marcTag = Some("999"),
+        content = Some("banana")
+      )
+    )
+    getCollectionPath(varFields) shouldBe None
+  }
+
+  it("returns None, if a relevant field does not have the $w subfield"){
+    forAll(
+      Table(
+        "marcTag",
+        "773",
+        "774"
+      )) { (marcTag) =>
+      val varFields = List(
+        VarField(
+          marcTag = Some(marcTag),
+          content = Some("banana")
+        )
+      )
+      getCollectionPath(varFields) shouldBe None
+    }
+  }
+
+  it("returns the document's own id for a 774 field"){
+    val varFields = List(
+      VarField(
+        marcTag = Some("001"),
+        content = Some("12345i")
+      ),
+      VarField(
+        marcTag = Some("774"),
+        subfields = List(
+          Subfield(tag = "t", content = "A Constituent"),
+          Subfield(tag = "w", content = "(Wcat)28931i")
+        )
+      )
+    )
+    getCollectionPath(varFields) shouldBe CollectionPath(path="12345i")
+  }
+
+  it("constructs a value from a 773 field, consisting of $w, $g and the document's own id"){
+    val varFields = List(
+      VarField(
+        marcTag = Some("001"),
+        content = Some("56789i")
+      ),
+      VarField(
+        marcTag = Some("773"),
+        subfields = List(
+          Subfield(tag = "t", content = "A Host"),
+          Subfield(tag = "w", content = "(Wcat)12345i"),
+          Subfield(tag = "g", content = "page 4")
+        )
+      )
+    )
+    getCollectionPath(varFields) shouldBe CollectionPath(path="12345i/page4_56789i")
+    // CollectionPath is path (ids) and label (concat the $g and title?),
+    // In CALM records, they match,
+    // In TEI records, the path object does not necessarily have a label
+    //
+    // 001   28914i
+    // 245 00 Charing Cross Hospital: a portrait of house surgeons. Photograph, 1906.
+    // 773   Basil Hood. Photograph album,|gpage 5.|w(Wcat)9175i
+    // path: 9175i/page_5_28914i
+    // label: Basil Hood. Photograph album/page 5.
+  }
+
+  it("constructs a value from a 773 field, without a $g"){
+    val varFields = List(
+      VarField(
+        marcTag = Some("001"),
+        content = Some("56789i")
+      ),
+      VarField(
+        marcTag = Some("773"),
+        subfields = List(
+          Subfield(tag = "t", content = "A Host"),
+          Subfield(tag = "w", content = "(Wcat)12345i")
+        )
+      )
+    )
+    getCollectionPath(varFields) shouldBe CollectionPath(path="12345i/56789i")
+  }
+
+  it("removes field-final punctuation from the $t subfield"){
+    fail()
+  }
+
+  private def getCollectionPath(varFields: List[VarField]): Option[CollectionPath] =
+    SierraCollectionPath(createSierraBibDataWith(varFields = varFields))
+}

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraCollectionPathTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraCollectionPathTest.scala
@@ -102,8 +102,7 @@ class SierraCollectionPathTest
       path = "12345i/56789i")
   }
 
-  it(
-    "removes the (Wcat) prefix, from the $w subfield, if present") {
+  it("removes the (Wcat) prefix, from the $w subfield, if present") {
     val varFields = List(
       VarField(
         marcTag = Some("001"),

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraCollectionPathTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraCollectionPathTest.scala
@@ -5,7 +5,6 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
 import weco.catalogue.internal_model.work.CollectionPath
 import weco.sierra.generators.SierraDataGenerators
-import weco.sierra.models.marc
 import weco.sierra.models.marc.{Subfield, VarField}
 
 class SierraCollectionPathTest
@@ -55,7 +54,7 @@ class SierraCollectionPathTest
         )
       )
     )
-    getCollectionPath(varFields) shouldBe CollectionPath(path = "12345i")
+    getCollectionPath(varFields).get shouldBe CollectionPath(path = "12345i")
   }
 
   it(


### PR DESCRIPTION
This change sets a CollectionPath to make use of the relation embedder, in order to turn 773 and 774 fields into hierarchical partOf relationships.

