### PR TITLE
Fix: Router seems unreliable

### DIFF
--- a/common/pipeline_storage/src/main/scala/weco/pipeline_storage/PipelineStorageStream.scala
+++ b/common/pipeline_storage/src/main/scala/weco/pipeline_storage/PipelineStorageStream.scala
@@ -14,6 +14,39 @@ import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future, TimeoutException}
 import scala.util.Try
 
+/**
+ * Configuration for the processing of messages in batches.
+ *
+ * Messages will be processed when either batchSize or flushInterval are reached.
+ *
+ * The intended use for this is where it can be significantly more efficient to process
+ * multiple messages together, rather than one at a time.  For example where
+ * downloading all the data to service a bundle of messages incurs less overhead than
+ * making individual requests for the data to service each message.
+ *
+ * ==Setting batchSize and flushInterval==
+ *
+ * The numbers for batchSize and flushInterval should be chosen based on how responsive
+ * you want the service to be and how many message the service can realistically handle
+ * in one go, as well as the expected frequency with which messages are likely to be received.
+ *
+ * In normal running, where this activity is triggered by a few real humans manually modifying
+ * a few records at a time, you might expect the flush interval to be reached most of the time.
+ *
+ * On the other hand, when this activity is triggered by some kind of computer-initiated batch
+ * update, you might expect the batch size to be the threshold that normally triggers processing.
+
+ * @note The values for batchSize and flushInterval are related to the duration set externally
+ * for the expiry of the messages being consumed (visibility timeout in SQS).
+ *
+ * `((Message Expiry) - (Flush Interval))` must be long enough to allow
+ * `(Batch Size - 1)` messages to be processed, otherwise those messages will
+ * expire and either be re-queued or fail completely.
+ *
+ * @param batchSize The maximum number of messages to process in one batch.
+ * @param flushInterval The maximum duration to wait before processing messages.
+ * @param parallelism
+ */
 case class PipelineStorageConfig(batchSize: Int,
                                  flushInterval: FiniteDuration,
                                  parallelism: Int)

--- a/common/pipeline_storage/src/main/scala/weco/pipeline_storage/PipelineStorageStream.scala
+++ b/common/pipeline_storage/src/main/scala/weco/pipeline_storage/PipelineStorageStream.scala
@@ -27,7 +27,7 @@ import scala.util.Try
   * ==Setting batchSize and flushInterval==
   *
   * The numbers for batchSize and flushInterval should be chosen based on how responsive
-  * you want the service to be and how many message the service can realistically handle
+  * you want the service to be and how many messages the service can realistically handle
   * in one go, as well as the expected frequency with which messages are likely to be received.
   *
   * In normal running, where this activity is triggered by a few real humans manually modifying

--- a/common/pipeline_storage/src/main/scala/weco/pipeline_storage/PipelineStorageStream.scala
+++ b/common/pipeline_storage/src/main/scala/weco/pipeline_storage/PipelineStorageStream.scala
@@ -15,38 +15,38 @@ import scala.concurrent.{ExecutionContext, Future, TimeoutException}
 import scala.util.Try
 
 /**
- * Configuration for the processing of messages in batches.
- *
- * Messages will be processed when either batchSize or flushInterval are reached.
- *
- * The intended use for this is where it can be significantly more efficient to process
- * multiple messages together, rather than one at a time.  For example where
- * downloading all the data to service a bundle of messages incurs less overhead than
- * making individual requests for the data to service each message.
- *
- * ==Setting batchSize and flushInterval==
- *
- * The numbers for batchSize and flushInterval should be chosen based on how responsive
- * you want the service to be and how many message the service can realistically handle
- * in one go, as well as the expected frequency with which messages are likely to be received.
- *
- * In normal running, where this activity is triggered by a few real humans manually modifying
- * a few records at a time, you might expect the flush interval to be reached most of the time.
- *
- * On the other hand, when this activity is triggered by some kind of computer-initiated batch
- * update, you might expect the batch size to be the threshold that normally triggers processing.
+  * Configuration for the processing of messages in batches.
+  *
+  * Messages will be processed when either batchSize or flushInterval are reached.
+  *
+  * The intended use for this is where it can be significantly more efficient to process
+  * multiple messages together, rather than one at a time.  For example where
+  * downloading all the data to service a bundle of messages incurs less overhead than
+  * making individual requests for the data to service each message.
+  *
+  * ==Setting batchSize and flushInterval==
+  *
+  * The numbers for batchSize and flushInterval should be chosen based on how responsive
+  * you want the service to be and how many message the service can realistically handle
+  * in one go, as well as the expected frequency with which messages are likely to be received.
+  *
+  * In normal running, where this activity is triggered by a few real humans manually modifying
+  * a few records at a time, you might expect the flush interval to be reached most of the time.
+  *
+  * On the other hand, when this activity is triggered by some kind of computer-initiated batch
+  * update, you might expect the batch size to be the threshold that normally triggers processing.
 
- * @note The values for batchSize and flushInterval are related to the duration set externally
- * for the expiry of the messages being consumed (visibility timeout in SQS).
- *
- * `((Message Expiry) - (Flush Interval))` must be long enough to allow
- * `(Batch Size - 1)` messages to be processed, otherwise those messages will
- * expire and either be re-queued or fail completely.
- *
- * @param batchSize The maximum number of messages to process in one batch.
- * @param flushInterval The maximum duration to wait before processing messages.
- * @param parallelism
- */
+  * @note The values for batchSize and flushInterval are related to the duration set externally
+  * for the expiry of the messages being consumed (visibility timeout in SQS).
+  *
+  * `((Message Expiry) - (Flush Interval))` must be long enough to allow
+  * `(Batch Size - 1)` messages to be processed, otherwise those messages will
+  * expire and either be re-queued or fail completely.
+  *
+  * @param batchSize The maximum number of messages to process in one batch.
+  * @param flushInterval The maximum duration to wait before processing messages.
+  * @param parallelism
+  */
 case class PipelineStorageConfig(batchSize: Int,
                                  flushInterval: FiniteDuration,
                                  parallelism: Int)

--- a/pipeline/relation_embedder/router/README.md
+++ b/pipeline/relation_embedder/router/README.md
@@ -1,0 +1,41 @@
+# Relation Embedder Router
+## What does it do?
+
+The router extracts any collectionPath values from incoming documents and notifies the embedder that there is a 
+collectionPath to process.
+
+```mermaid
+sequenceDiagram
+    participant Upstream
+    participant Router
+    participant Embedder
+    participant Downstream
+
+    Upstream ->> Router: A doc with collectionPath
+    Router ->> Embedder: Here's a collectionPath for you
+    Note over Embedder: modify all docs within that path's sphere of influence 
+    Embedder ->> Downstream: process all these docs
+```
+
+If a document has no collectionPath, it is simply passed on to the works topic.
+```mermaid
+
+sequenceDiagram
+    participant Upstream
+    participant Router
+    participant Embedder
+    participant Downstream
+
+    Upstream ->> Router: A doc with no collectionPath
+    Note over Embedder: I'm not involved
+    Router ->> Downstream: process this doc
+
+```
+
+## Why?
+
+Unlike other pipeline stages, the relation embedder does not operate on the document currently 
+passing through the pipeline, but on *all* documents with which that document has a relationship.
+
+Because of this, the message sent to the embedder is the *content of the collectionPath*, rather 
+than a way to identify the document in question.

--- a/pipeline/relation_embedder/router/README.md
+++ b/pipeline/relation_embedder/router/README.md
@@ -37,5 +37,8 @@ sequenceDiagram
 Unlike other pipeline stages, the relation embedder does not operate on the document currently 
 passing through the pipeline, but on *all* documents with which that document has a relationship.
 
-Because of this, the message sent to the embedder is the *content of the collectionPath*, rather 
+This is an expensive process, so it is best to bypass the relation embedder entirely if it is not
+needed for a given record.
+
+Because of these, the message sent to the embedder is the *content of the collectionPath*, rather 
 than a way to identify the document in question.

--- a/pipeline/terraform/stack/service_work_router.tf
+++ b/pipeline/terraform/stack/service_work_router.tf
@@ -31,7 +31,7 @@ module "router" {
     es_merged_index        = local.es_works_merged_index
     es_denormalised_index  = local.es_works_denormalised_index
     batch_size             = 100
-    flush_interval_seconds = 30
+    flush_interval_seconds = 20
   }
 
   secret_env_vars = local.pipeline_storage_es_service_secrets["router"]

--- a/pipeline/terraform/stack/service_work_router.tf
+++ b/pipeline/terraform/stack/service_work_router.tf
@@ -31,6 +31,11 @@ module "router" {
     es_merged_index        = local.es_works_merged_index
     es_denormalised_index  = local.es_works_denormalised_index
     batch_size             = 100
+    # The flush interval must be sufficiently lower than the message timeout
+    # to allow the messages to be processed after the flush inteval but before
+    # they expire.  The upstream queue timeout is not set by us, leaving it
+    # at the default 30 seconds.
+    # See https://github.com/wellcomecollection/platform/issues/5463
     flush_interval_seconds = 20
   }
 

--- a/pipeline/terraform/stack/service_work_router.tf
+++ b/pipeline/terraform/stack/service_work_router.tf
@@ -28,9 +28,9 @@ module "router" {
     paths_topic_arn = module.router_path_output_topic.arn
     works_topic_arn = module.router_work_output_topic.arn
 
-    es_merged_index        = local.es_works_merged_index
-    es_denormalised_index  = local.es_works_denormalised_index
-    batch_size             = 100
+    es_merged_index       = local.es_works_merged_index
+    es_denormalised_index = local.es_works_denormalised_index
+    batch_size            = 100
     # The flush interval must be sufficiently lower than the message timeout
     # to allow the messages to be processed after the flush inteval but before
     # they expire.  The upstream queue timeout is not set by us, leaving it


### PR DESCRIPTION
See: https://github.com/wellcomecollection/platform/issues/5463

The manifestation of this problem is that the router_input_dlq grows.

The cause is that the queue message timeout and the batch flush interval are the same, so it only succeeds when it's busy, and fails when it's quiet.