### PR TITLE
Sierra hierarchy snags

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Relations.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Relations.scala
@@ -65,7 +65,12 @@ object RelationSet {
     // For hierarches, this could be determined by depth, but in the case of Series links,
     // the order is determined by the order in the source data.
     val indexMap = relations.map(_.title).distinct.zipWithIndex.toMap
-    relations.groupBy(_.title).values.map(_.maxBy(_.id)).toList.sortBy(relation => indexMap(relation.title))
+    relations
+      .groupBy(_.title)
+      .values
+      .map(_.maxBy(_.id))
+      .toList
+      .sortBy(relation => indexMap(relation.title))
   }
 }
 

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Relations.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Relations.scala
@@ -28,35 +28,36 @@ case class Relations(
     Relations(
       ancestors = RelationSet(this.ancestors ::: that.ancestors),
       children = RelationSet(this.children ::: that.children),
-      siblingsPreceding = RelationSet(this.siblingsPreceding ::: that.siblingsPreceding),
-      siblingsSucceeding = RelationSet(this.siblingsSucceeding ::: that.siblingsSucceeding)
+      siblingsPreceding =
+        RelationSet(this.siblingsPreceding ::: that.siblingsPreceding),
+      siblingsSucceeding =
+        RelationSet(this.siblingsSucceeding ::: that.siblingsSucceeding)
     )
   }
 }
 
 /**
- * Lists of Relations are unique by title, with identified relations taking
- * priority over unidentified ones.
- *
- * The situation can arise where an early stage sets up some relations
- * but only knows the title of a given relation, but a later stage then
- * then finds that same relation using an identifier.
- * In that case, the newer, identifier-based one supersedes
- * the older name-only one.
- *
- * Sometimes, that early name-only relation is not identified, so should
- * be preserved.
- *
- * A concrete example of this is where a Sierra document contains a 773
- * field.  During transformation, we do not know whether this will result
- * in it becoming a member of a Series or a Hierarchy, because that distinction
- * is driven by the presence of a reciprocal 774 relationship on the parent.
- *
- * So, during the transformer phase, a candidate Series ancestor is created.
- * If, during the relation embedder phase, the other end is found, then the
- * Series ancestor is to be discarded.
- */
-
+  * Lists of Relations are unique by title, with identified relations taking
+  * priority over unidentified ones.
+  *
+  * The situation can arise where an early stage sets up some relations
+  * but only knows the title of a given relation, but a later stage then
+  * then finds that same relation using an identifier.
+  * In that case, the newer, identifier-based one supersedes
+  * the older name-only one.
+  *
+  * Sometimes, that early name-only relation is not identified, so should
+  * be preserved.
+  *
+  * A concrete example of this is where a Sierra document contains a 773
+  * field.  During transformation, we do not know whether this will result
+  * in it becoming a member of a Series or a Hierarchy, because that distinction
+  * is driven by the presence of a reciprocal 774 relationship on the parent.
+  *
+  * So, during the transformer phase, a candidate Series ancestor is created.
+  * If, during the relation embedder phase, the other end is found, then the
+  * Series ancestor is to be discarded.
+  */
 object RelationSet {
   def apply(relations: List[Relation]): List[Relation] = {
     relations.groupBy(_.title).values.map(_.maxBy(_.id)).toList

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Relations.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Relations.scala
@@ -60,7 +60,12 @@ case class Relations(
   */
 object RelationSet {
   def apply(relations: List[Relation]): List[Relation] = {
-    relations.groupBy(_.title).values.map(_.maxBy(_.id)).toList
+    // Store the original first positions, in order to preserve order.
+    // Order is significant in RelationSets, e.g. in a hierarchy, ancestors = parent,grandparent,great grandparent etc.
+    // For hierarches, this could be determined by depth, but in the case of Series links,
+    // the order is determined by the order in the source data.
+    val indexMap = relations.map(_.title).distinct.zipWithIndex.toMap
+    relations.groupBy(_.title).values.map(_.maxBy(_.id)).toList.sortBy(relation => indexMap(relation.title))
   }
 }
 

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/StateTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/StateTest.scala
@@ -126,7 +126,10 @@ class StateTest
           Set()
         )
       )
-      denormalised.state.relations.ancestors shouldBe List(newMum, SeriesRelation("Dad"), granny)
+      denormalised.state.relations.ancestors shouldBe List(
+        newMum,
+        SeriesRelation("Dad"),
+        granny)
     }
 
     it("preserves existing state members") {

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/StateTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/StateTest.scala
@@ -81,7 +81,8 @@ class StateTest
       )
     }
 
-    it("overwrites relations if they match by name, otherwise concatenating the relation lists in the normal manner") {
+    it(
+      "overwrites relations if they match by name, otherwise concatenating the relation lists in the normal manner") {
       val merged = Work.Visible[Merged](
         version = 0,
         state = Merged(
@@ -90,7 +91,8 @@ class StateTest
           sourceModifiedTime = Instant.MIN,
           mergedTime = Instant.MIN,
           availabilities = Set(),
-          relations = Relations(ancestors = List(SeriesRelation("Mum"), SeriesRelation("Dad")))
+          relations = Relations(
+            ancestors = List(SeriesRelation("Mum"), SeriesRelation("Dad")))
         ),
         data = WorkData(title = Some("My Title"))
       )
@@ -99,13 +101,21 @@ class StateTest
         id = Some(CanonicalId("deadbeef")),
         title = Some("Mum"),
         collectionPath = Some(CollectionPath("cafed00d/deadbeef")),
-        workType = WorkType.Standard, depth = 0, numChildren = 1, numDescendents = 1)
+        workType = WorkType.Standard,
+        depth = 0,
+        numChildren = 1,
+        numDescendents = 1
+      )
 
       val granny = new Relation(
         id = Some(CanonicalId("baadf00d")),
         title = Some("granny"),
         collectionPath = Some(CollectionPath("cafed00d/deadbeef/baadf00d")),
-        workType = WorkType.Standard, depth = 0, numChildren = 1, numDescendents = 1)
+        workType = WorkType.Standard,
+        depth = 0,
+        numChildren = 1,
+        numDescendents = 1
+      )
 
       val denormalised = merged.transition[Denormalised](
         (

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/StateTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/StateTest.scala
@@ -20,7 +20,7 @@ class StateTest
     SourceIdentifier(SierraIdentifier, "otype", "id")
   private val workData = WorkData(title = Some("My Title"))
   private val canonicalId = CanonicalId("baadf00d")
-  private val merged = Work.Visible[Identified](
+  private val identified = Work.Visible[Identified](
     version = 0,
     state = Identified(
       sourceIdentifier = sourceIdentifier,
@@ -30,27 +30,27 @@ class StateTest
     ),
     data = WorkData(title = Some("My Title"))
   )
-  private val identified = merged.transition[Merged](Instant.MAX)
+  private val merged = identified.transition[Merged](Instant.MAX)
 
   describe("transition from identified to merged") {
 
     it("preserves the Work data as-is") {
-      identified.data shouldBe workData
+      merged.data shouldBe workData
     }
 
     it("assigns a new mergedTime") {
-      identified.state.mergedTime shouldBe Instant.MAX
+      merged.state.mergedTime shouldBe Instant.MAX
     }
 
     it("preserves existing state members") {
       val preservedMembers = Table(
         ("preservedMember", "expectedValue"),
         (
-          identified.state.relations,
+          merged.state.relations,
           Relations(ancestors = List(SeriesRelation("Mum")))),
-        (identified.state.sourceIdentifier, sourceIdentifier),
-        (identified.state.canonicalId, canonicalId),
-        (identified.state.sourceModifiedTime, Instant.MIN)
+        (merged.state.sourceIdentifier, sourceIdentifier),
+        (merged.state.canonicalId, canonicalId),
+        (merged.state.sourceModifiedTime, Instant.MIN)
       )
       forAll(preservedMembers) {
         case (preservedMember, expectedValue) =>
@@ -59,7 +59,7 @@ class StateTest
     }
   }
 
-  private val denormalised = identified.transition[Denormalised](
+  private val denormalised = merged.transition[Denormalised](
     (
       Relations(
         ancestors = List(SeriesRelation("Dad")),
@@ -78,6 +78,45 @@ class StateTest
       denormalised.state.relations shouldBe Relations(
         ancestors = List(SeriesRelation("Mum"), SeriesRelation("Dad")),
         siblingsPreceding = List(SeriesRelation("Big Brother"))
+      )
+    }
+
+    it("overwrites relations if they match by name, otherwise concatenating the relation lists in the normal manner") {
+      val merged = Work.Visible[Merged](
+        version = 0,
+        state = Merged(
+          sourceIdentifier = sourceIdentifier,
+          canonicalId = canonicalId,
+          sourceModifiedTime = Instant.MIN,
+          mergedTime = Instant.MIN,
+          availabilities = Set(),
+          relations = Relations(ancestors = List(SeriesRelation("Mum"), SeriesRelation("Dad")))
+        ),
+        data = WorkData(title = Some("My Title"))
+      )
+
+      val newMum = new Relation(
+        id = Some(CanonicalId("deadbeef")),
+        title = Some("Mum"),
+        collectionPath = Some(CollectionPath("cafed00d/deadbeef")),
+        workType = WorkType.Standard, depth = 0, numChildren = 1, numDescendents = 1)
+
+      val granny = new Relation(
+        id = Some(CanonicalId("baadf00d")),
+        title = Some("granny"),
+        collectionPath = Some(CollectionPath("cafed00d/deadbeef/baadf00d")),
+        workType = WorkType.Standard, depth = 0, numChildren = 1, numDescendents = 1)
+
+      val denormalised = merged.transition[Denormalised](
+        (
+          Relations(
+            ancestors = List(newMum, granny)
+          ),
+          Set()
+        )
+      )
+      denormalised.state.relations shouldBe Relations(
+        ancestors = List(newMum, SeriesRelation("Dad"), granny)
       )
     }
 

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/StateTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/StateTest.scala
@@ -126,11 +126,7 @@ class StateTest
           Set()
         )
       )
-      denormalised.state.relations shouldBe Relations(
-        // Only one Mum, the original has been dropped.
-        // Dad is preserved, Granny is added.
-        ancestors = List(newMum, SeriesRelation("Dad"), granny)
-      )
+      denormalised.state.relations.ancestors shouldBe List(newMum, SeriesRelation("Dad"), granny)
     }
 
     it("preserves existing state members") {

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/StateTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/StateTest.scala
@@ -120,12 +120,15 @@ class StateTest
       val denormalised = merged.transition[Denormalised](
         (
           Relations(
+            //Mum is already in the list, granny is new
             ancestors = List(newMum, granny)
           ),
           Set()
         )
       )
       denormalised.state.relations shouldBe Relations(
+        // Only one Mum, the original has been dropped.
+        // Dad is preserved, Granny is added.
         ancestors = List(newMum, SeriesRelation("Dad"), granny)
       )
     }


### PR DESCRIPTION
This fixes the problem where a child in the hierarchy also gets a series link tag in the UI.

(requires a reindex to actually fix)