### PR TITLE
Stop work availability in archives being inherited from child works

### DIFF
--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/StateTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/StateTest.scala
@@ -47,7 +47,8 @@ class StateTest
         ("preservedMember", "expectedValue"),
         (
           merged.state.relations,
-          Relations(ancestors = List(SeriesRelation("Mum")))),
+          Relations(ancestors = List(SeriesRelation("Mum")))
+        ),
         (merged.state.sourceIdentifier, sourceIdentifier),
         (merged.state.canonicalId, canonicalId),
         (merged.state.sourceModifiedTime, Instant.MIN)
@@ -60,12 +61,9 @@ class StateTest
   }
 
   private val denormalised = merged.transition[Denormalised](
-    (
-      Relations(
-        ancestors = List(SeriesRelation("Dad")),
-        siblingsPreceding = List(SeriesRelation("Big Brother"))
-      ),
-      Set()
+    Relations(
+      ancestors = List(SeriesRelation("Dad")),
+      siblingsPreceding = List(SeriesRelation("Big Brother"))
     )
   )
 
@@ -82,7 +80,8 @@ class StateTest
     }
 
     it(
-      "overwrites relations if they match by name, otherwise concatenating the relation lists in the normal manner") {
+      "overwrites relations if they match by name, otherwise concatenating the relation lists in the normal manner"
+    ) {
       val merged = Work.Visible[Merged](
         version = 0,
         state = Merged(
@@ -92,7 +91,8 @@ class StateTest
           mergedTime = Instant.MIN,
           availabilities = Set(),
           relations = Relations(
-            ancestors = List(SeriesRelation("Mum"), SeriesRelation("Dad")))
+            ancestors = List(SeriesRelation("Mum"), SeriesRelation("Dad"))
+          )
         ),
         data = WorkData(title = Some("My Title"))
       )
@@ -118,18 +118,16 @@ class StateTest
       )
 
       val denormalised = merged.transition[Denormalised](
-        (
-          Relations(
-            //Mum is already in the list, granny is new
-            ancestors = List(newMum, granny)
-          ),
-          Set()
+        Relations(
+          //Mum is already in the list, granny is new
+          ancestors = List(newMum, granny)
         )
       )
       denormalised.state.relations.ancestors shouldBe List(
         SeriesRelation("Dad"),
         newMum,
-        granny)
+        granny
+      )
     }
 
     it("Only overwrites unidentified relations from a previous stage.") {
@@ -152,7 +150,8 @@ class StateTest
           availabilities = Set(),
           relations = Relations(
             ancestors =
-              List(SeriesRelation("Granny"), SeriesRelation("Dad"), mum1))
+              List(SeriesRelation("Granny"), SeriesRelation("Dad"), mum1)
+          )
         ),
         data = WorkData(title = Some("My Title"))
       )
@@ -188,12 +187,9 @@ class StateTest
       )
 
       val denormalised = merged.transition[Denormalised](
-        (
-          Relations(
-            //Mum is already in the list, granny is new
-            ancestors = List(mumsMum, dadsMum, mum2)
-          ),
-          Set()
+        Relations(
+          //Mum is already in the list, granny is new
+          ancestors = List(mumsMum, dadsMum, mum2)
         )
       )
       denormalised.state.relations.ancestors shouldBe List(
@@ -235,11 +231,8 @@ class StateTest
       )
 
       val denormalised = merged.transition[Denormalised](
-        (
-          Relations(
-            ancestors = List(newAlbum)
-          ),
-          Set()
+        Relations(
+          ancestors = List(newAlbum)
         )
       )
       denormalised.state.relations.ancestors shouldBe List(newAlbum)

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/RelationEmbedderWorkerService.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/RelationEmbedderWorkerService.scala
@@ -42,27 +42,26 @@ class RelationEmbedderWorkerService[MsgDestination](
       .flatMap { batch =>
         info(
           s"Received batch for tree ${batch.rootPath} containing ${batch.selectors.size} selectors: ${batch.selectors
-            .mkString(", ")}")
+            .mkString(", ")}"
+        )
         relationsService
           .getRelationTree(batch)
           .runWith(Sink.seq)
           .map { relationWorks =>
             info(
-              s"Received ${relationWorks.size} relations for tree ${batch.rootPath}")
+              s"Received ${relationWorks.size} relations for tree ${batch.rootPath}"
+            )
             ArchiveRelationsCache(relationWorks)
           }
           .flatMap { relationsCache =>
             info(
-              s"Built cache for tree ${batch.rootPath}, containing ${relationsCache.size} relations (${relationsCache.numParents} works map to parent works).")
+              s"Built cache for tree ${batch.rootPath}, containing ${relationsCache.size} relations (${relationsCache.numParents} works map to parent works)."
+            )
             val denormalisedWorks = relationsService
               .getAffectedWorks(batch)
               .map { work =>
                 val relations = relationsCache(work)
-                val relationAvailabilities =
-                  relationsCache.getAvailabilities(work)
-                work.transition[Denormalised](
-                  (relations, relationAvailabilities)
-                )
+                work.transition[Denormalised](relations)
               }
 
             denormalisedWorks

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/models/ArchiveRelationsCache.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/models/ArchiveRelationsCache.scala
@@ -23,7 +23,8 @@ class ArchiveRelationsCache(works: Map[String, RelationWork]) extends Logging {
             info(s"Found no relations for work with path $path")
           else
             info(
-              s"Found relations for work with path $path: ${ancestors.size} ancestors, ${children.size} children, and ${siblingsPreceding.size + siblingsSucceeding.size} siblings")
+              s"Found relations for work with path $path: ${ancestors.size} ancestors, ${children.size} children, and ${siblingsPreceding.size + siblingsSucceeding.size} siblings"
+            )
           relations
       }
       .getOrElse {
@@ -32,43 +33,6 @@ class ArchiveRelationsCache(works: Map[String, RelationWork]) extends Logging {
       }
 
   private val paths: PathCollection = PathCollection(works.keySet)
-
-  /** Find the availabilities of this Work.
-    *
-    * The availabilities of an archive's Relations are the union of all the
-    * availabilities of its descendents, as well as its own.
-    *
-    * Note that this only covers *known* descendents.  e.g. if the works have
-    * paths (A, A/B/1), then A will not inherit availabilities from A/B/1 --
-    * the intermediate path A/B is missing.
-    *
-    * This preserves the original behaviour of the relation embedder, but it's
-    * not clear if it's intentional -- it was a side effect of the implementation,
-    * not something that was explicitly tested.
-    *
-    */
-  def getAvailabilities(work: Work[Merged]): Set[Availability] =
-    work.data.collectionPath match {
-      case Some(CollectionPath(workPath, _)) =>
-        val affectedPaths = paths.knownDescendentsOf(workPath) :+ workPath
-
-        works
-          .filter {
-            case (path, _) => affectedPaths.contains(path)
-          }
-          .flatMap { case (_, work) => work.state.availabilities }
-          .toSet
-
-      // We shouldn't be dealing with any works without a collectionPath field in the
-      // relation embedder; if we are then something has gone wrong.
-      case _ =>
-        assert(
-          assertion = false,
-          message =
-            s"Cannot get availabilities for work with empty collectionPath field: $work"
-        )
-        Set()
-    }
 
   def size: Int = works.size
 

--- a/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/ArchiveRelationsCacheTest.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/ArchiveRelationsCacheTest.scala
@@ -4,7 +4,7 @@ import org.apache.commons.io.IOUtils
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.Inspectors
-import weco.catalogue.internal_model.work.{Availability, Relation, Relations}
+import weco.catalogue.internal_model.work.{Relation, Relations}
 import weco.pipeline.relation_embedder.fixtures.RelationGenerators
 import weco.pipeline.relation_embedder.models.ArchiveRelationsCache
 
@@ -46,7 +46,8 @@ class ArchiveRelationsCacheTest
       .map(toRelationWork)
 
   it(
-    "Retrieves relations for the given path with children and siblings sorted correctly") {
+    "Retrieves relations for the given path with children and siblings sorted correctly"
+  ) {
     val relationsCache = ArchiveRelationsCache(works)
     relationsCache(work2) shouldBe Relations(
       ancestors = List(relA),
@@ -118,52 +119,6 @@ class ArchiveRelationsCacheTest
       siblingsPreceding = Nil,
       siblingsSucceeding = Nil
     )
-  }
-
-  describe("gets the availabilities for a work") {
-    val workA = work("a")
-    val work1 = work("a/1")
-    val workB = work("a/1/b")
-    val workB1 = work("a/1/b/1")
-    val workB11 = work("a/1/b/1/1", isAvailableOnline = true)
-    val workC = work("a/1/c", isAvailableOnline = true)
-
-    it("finds the availability on direct descendents") {
-      val relationsCache = ArchiveRelationsCache(
-        Seq(workA, work1, workB, workC).map(toRelationWork)
-      )
-
-      relationsCache.getAvailabilities(workA) shouldBe Set(Availability.Online)
-      relationsCache.getAvailabilities(work1) shouldBe Set(Availability.Online)
-      relationsCache.getAvailabilities(workB) shouldBe empty
-      relationsCache.getAvailabilities(workC) shouldBe Set(Availability.Online)
-    }
-
-    it("skips the availability on indirect descendents") {
-      val cacheWithDirectDescendents = ArchiveRelationsCache(
-        Seq(workB, workB1, workB11).map(toRelationWork)
-      )
-
-      val cacheWithoutDirectDescendents = ArchiveRelationsCache(
-        Seq(workB, workB11).map(toRelationWork)
-      )
-
-      cacheWithDirectDescendents.getAvailabilities(workB) shouldBe Set(
-        Availability.Online)
-      cacheWithoutDirectDescendents.getAvailabilities(workB) shouldBe empty
-    }
-  }
-
-  it("finds a work's availabilities") {
-    val relationsCache = ArchiveRelationsCache(works)
-
-    relationsCache.getAvailabilities(workA) should contain only Availability.Online
-    relationsCache.getAvailabilities(work1) should contain only Availability.Online
-    relationsCache.getAvailabilities(workC) should contain only Availability.Online
-
-    forEvery(List(workB, work2, workD, workE, workF, work3, work4)) { work =>
-      relationsCache.getAvailabilities(work).size shouldBe 0
-    }
   }
 
   // This is a real set of nearly 7000 paths from SAFPA.  This test is less focused on

--- a/pipeline/relation_embedder/router/src/main/scala/weco/pipeline/router/RouterWorkerService.scala
+++ b/pipeline/relation_embedder/router/src/main/scala/weco/pipeline/router/RouterWorkerService.scala
@@ -15,7 +15,9 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Success, Try}
 
 class RouterWorkerService[MsgDestination](
-  pipelineStream: PipelineStorageStream[NotificationMessage, Work[Denormalised], MsgDestination],
+  pipelineStream: PipelineStorageStream[NotificationMessage,
+                                        Work[Denormalised],
+                                        MsgDestination],
   pathsMsgSender: MessageSender[MsgDestination],
   workRetriever: Retriever[Work[Merged]]
 )(implicit ec: ExecutionContext, indexable: Indexable[Work[Denormalised]])

--- a/pipeline/relation_embedder/router/src/main/scala/weco/pipeline/router/RouterWorkerService.scala
+++ b/pipeline/relation_embedder/router/src/main/scala/weco/pipeline/router/RouterWorkerService.scala
@@ -15,11 +15,9 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Success, Try}
 
 class RouterWorkerService[MsgDestination](
-  pipelineStream: PipelineStorageStream[NotificationMessage,
-                                        Work[Denormalised],
-                                        MsgDestination],
+  pipelineStream: PipelineStorageStream[NotificationMessage, Work[Denormalised], MsgDestination],
   pathsMsgSender: MessageSender[MsgDestination],
-  workRetriever: Retriever[Work[Merged]],
+  workRetriever: Retriever[Work[Merged]]
 )(implicit ec: ExecutionContext, indexable: Indexable[Work[Denormalised]])
     extends Runnable {
   def run(): Future[Done] = {
@@ -30,16 +28,18 @@ class RouterWorkerService[MsgDestination](
         .via(
           processFlow(
             pipelineStream.config,
-            work => Future.fromTry(processMessage(work))))
+            work => Future.fromTry(processMessage(work))
+          )
+        )
     )
   }
 
   private def processMessage(
-    work: Work[Merged]): Try[List[Work[Denormalised]]] = {
+    work: Work[Merged]
+  ): Try[List[Work[Denormalised]]] = {
     work.data.collectionPath match {
       case None =>
-        Success(
-          List(work.transition[Denormalised]((Relations.none, Set.empty))))
+        Success(List(work.transition[Denormalised](Relations.none)))
       case Some(CollectionPath(path, _)) =>
         pathsMsgSender.send(path).map(_ => Nil)
 

--- a/pipeline/relation_embedder/router/src/test/scala/weco/pipeline/router/RouterWorkerServiceTest.scala
+++ b/pipeline/relation_embedder/router/src/test/scala/weco/pipeline/router/RouterWorkerServiceTest.scala
@@ -63,8 +63,8 @@ class RouterWorkerServiceTest
           worksMessageSender.messages.map(_.body) should contain(work.id)
           pathsMessageSender.messages shouldBe empty
           indexer.index should contain(
-            work.id -> work.transition[Denormalised](
-              (Relations.none, Set.empty)))
+            work.id -> work.transition[Denormalised](Relations.none)
+          )
         }
     }
   }
@@ -94,12 +94,14 @@ class RouterWorkerServiceTest
   }
 
   it(
-    "sends the message to the dlq and doesn't send anything on if indexing fails") {
+    "sends the message to the dlq and doesn't send anything on if indexing fails"
+  ) {
     val work = mergedWork()
     val failingIndexer = new Indexer[Work[Denormalised]] {
       override def init(): Future[Unit] = Future.successful(())
-      override def apply(documents: Seq[Work[Denormalised]])
-        : Future[Either[Seq[Work[Denormalised]], Seq[Work[Denormalised]]]] =
+      override def apply(
+        documents: Seq[Work[Denormalised]]
+      ): Future[Either[Seq[Work[Denormalised]], Seq[Work[Denormalised]]]] =
         Future.successful(Left(documents))
     }
 
@@ -120,10 +122,12 @@ class RouterWorkerServiceTest
     }
   }
 
-  def withWorkerService[R](indexer: Indexer[Work[Denormalised]],
-                           retriever: Retriever[Work[Merged]])(
-    testWith: TestWith[(QueuePair, MemoryMessageSender, MemoryMessageSender),
-                       R]): R =
+  def withWorkerService[R](
+    indexer: Indexer[Work[Denormalised]],
+    retriever: Retriever[Work[Merged]]
+  )(
+    testWith: TestWith[(QueuePair, MemoryMessageSender, MemoryMessageSender), R]
+  ): R =
     withLocalSqsQueuePair(visibilityTimeout = 1 second) {
       case q @ QueuePair(queue, _) =>
         val worksMessageSender = new MemoryMessageSender


### PR DESCRIPTION
Does what it says - this feature has caused more confusion than it has solved