### PR TITLE
Split InLibrary availability into ClosedStores and OpenShelves

### DIFF
--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/generators/ItemsGenerators.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/generators/ItemsGenerators.scala
@@ -49,6 +49,20 @@ trait ItemsGenerators extends IdentifiersGenerators with LocationGenerators {
   def createIdentifiedPhysicalItem: Item[IdState.Identified] =
     createIdentifiedItemWith(locations = List(createPhysicalLocation))
 
+  def createClosedStoresItem: Item[IdState.Identified] =
+    createIdentifiedItemWith(
+      locations = List(
+        createPhysicalLocationWith(locationType = LocationType.ClosedStores)
+      )
+    )
+
+  def createOpenShelvesItem: Item[IdState.Identified] =
+    createIdentifiedItemWith(
+      locations = List(
+        createPhysicalLocationWith(locationType = LocationType.OpenShelves)
+      )
+    )
+
   def createDigitalItem: Item[IdState.Unidentifiable.type] =
     createUnidentifiableItemWith(locations = List(createDigitalLocation))
 
@@ -62,7 +76,8 @@ trait ItemsGenerators extends IdentifiersGenerators with LocationGenerators {
             AccessCondition(
               method = AccessMethod.NotRequestable,
               status = accessStatus
-            ))
+            )
+          )
         )
       )
     )


### PR DESCRIPTION
Does what it says - distinguishing between physical items that need to be requested vs items that can be taken off the shelves