### PR TITLE
Add some models to use in the works ingestor

### DIFF
--- a/pipeline/ingestor/ingestor_images/src/main/scala/weco/pipeline/ingestor/images/models/IndexedImage.scala
+++ b/pipeline/ingestor/ingestor_images/src/main/scala/weco/pipeline/ingestor/images/models/IndexedImage.scala
@@ -11,6 +11,5 @@ case class IndexedImage(
   locations: List[DigitalLocation],
   source: ImageSource,
   modifiedTime: Instant,
-
   display: DisplayImage
 )

--- a/pipeline/ingestor/ingestor_images/src/main/scala/weco/pipeline/ingestor/images/models/IndexedImage.scala
+++ b/pipeline/ingestor/ingestor_images/src/main/scala/weco/pipeline/ingestor/images/models/IndexedImage.scala
@@ -1,0 +1,16 @@
+package weco.pipeline.ingestor.images.models
+
+import java.time.Instant
+
+import weco.catalogue.internal_model.image.{ImageSource, ImageState}
+import weco.catalogue.internal_model.locations.DigitalLocation
+
+case class IndexedImage(
+  version: Int,
+  state: ImageState.Indexed,
+  locations: List[DigitalLocation],
+  source: ImageSource,
+  modifiedTime: Instant,
+
+  display: DisplayImage
+)

--- a/pipeline/ingestor/ingestor_images/src/main/scala/weco/pipeline/ingestor/images/models/IndexedImage.scala
+++ b/pipeline/ingestor/ingestor_images/src/main/scala/weco/pipeline/ingestor/images/models/IndexedImage.scala
@@ -1,7 +1,8 @@
 package weco.pipeline.ingestor.images.models
 
-import java.time.Instant
+import io.circe.Json
 
+import java.time.Instant
 import weco.catalogue.internal_model.image.{ImageSource, ImageState}
 import weco.catalogue.internal_model.locations.DigitalLocation
 
@@ -11,5 +12,5 @@ case class IndexedImage(
   locations: List[DigitalLocation],
   source: ImageSource,
   modifiedTime: Instant,
-  display: DisplayImage
+  display: Json
 )

--- a/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/DebugInformation.scala
+++ b/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/DebugInformation.scala
@@ -1,0 +1,38 @@
+package weco.pipeline.ingestor.works.models
+
+import weco.catalogue.internal_model.identifiers.IdState
+import weco.catalogue.internal_model.work.{DeletedReason, InvisibilityReason}
+
+/** This is information we put in the Elasticsearch index because it's
+ * useful when we're debugging the pipeline, but not something we'd
+ * want to display in public API responses.
+ *
+ */
+sealed trait DebugInformation {
+
+  // Note: this is the version of the source record in the adapter; we
+  // include it for tracing a Work back to the source, but because of
+  // merging in the pipeline we can't rely on it for ordering.
+  val version: Int
+}
+
+object DebugInformation {
+  case class Visible(
+    version: Int,
+    redirectSources: Seq[IdState.Identified]
+  ) extends DebugInformation
+
+  case class Invisible(
+    version: Int,
+    invisibilityReasons: List[InvisibilityReason]
+  ) extends DebugInformation
+
+  case class Redirected(
+    version: Int
+  ) extends DebugInformation
+
+  case class Deleted(
+    version: Int,
+    deletedReason: DeletedReason
+  ) extends DebugInformation
+}

--- a/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/DebugInformation.scala
+++ b/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/DebugInformation.scala
@@ -1,6 +1,6 @@
 package weco.pipeline.ingestor.works.models
 
-import weco.catalogue.internal_model.identifiers.IdState
+import weco.catalogue.internal_model.identifiers.{IdState, SourceIdentifier}
 import weco.catalogue.internal_model.work.{DeletedReason, InvisibilityReason}
 
 /** This is information we put in the Elasticsearch index because it's
@@ -9,29 +9,30 @@ import weco.catalogue.internal_model.work.{DeletedReason, InvisibilityReason}
  *
  */
 sealed trait DebugInformation {
-
-  // Note: this is the version of the source record in the adapter; we
-  // include it for tracing a Work back to the source, but because of
-  // merging in the pipeline we can't rely on it for ordering.
+  val sourceIdentifier: SourceIdentifier
   val sourceVersion: Int
 }
 
 object DebugInformation {
   case class Visible(
+    sourceIdentifier: SourceIdentifier,
     sourceVersion: Int,
     redirectSources: Seq[IdState.Identified]
   ) extends DebugInformation
 
   case class Invisible(
+    sourceIdentifier: SourceIdentifier,
     sourceVersion: Int,
     invisibilityReasons: List[InvisibilityReason]
   ) extends DebugInformation
 
   case class Redirected(
+    sourceIdentifier: SourceIdentifier,
     sourceVersion: Int
   ) extends DebugInformation
 
   case class Deleted(
+    sourceIdentifier: SourceIdentifier,
     sourceVersion: Int,
     deletedReason: DeletedReason
   ) extends DebugInformation

--- a/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/DebugInformation.scala
+++ b/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/DebugInformation.scala
@@ -6,11 +6,10 @@ import weco.catalogue.internal_model.identifiers.{IdState, SourceIdentifier}
 import weco.catalogue.internal_model.work.{DeletedReason, InvisibilityReason}
 
 /** This is information we put in the Elasticsearch index because it's
- * useful when we're debugging the pipeline, but not something we'd
- * want to display in public API responses.
- *
- */
-
+  * useful when we're debugging the pipeline, but not something we'd
+  * want to display in public API responses.
+  *
+  */
 case class SourceWorkDebugInformation(
   identifier: SourceIdentifier,
   version: Int,

--- a/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/DebugInformation.scala
+++ b/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/DebugInformation.scala
@@ -13,26 +13,26 @@ sealed trait DebugInformation {
   // Note: this is the version of the source record in the adapter; we
   // include it for tracing a Work back to the source, but because of
   // merging in the pipeline we can't rely on it for ordering.
-  val version: Int
+  val sourceVersion: Int
 }
 
 object DebugInformation {
   case class Visible(
-    version: Int,
+    sourceVersion: Int,
     redirectSources: Seq[IdState.Identified]
   ) extends DebugInformation
 
   case class Invisible(
-    version: Int,
+    sourceVersion: Int,
     invisibilityReasons: List[InvisibilityReason]
   ) extends DebugInformation
 
   case class Redirected(
-    version: Int
+    sourceVersion: Int
   ) extends DebugInformation
 
   case class Deleted(
-    version: Int,
+    sourceVersion: Int,
     deletedReason: DeletedReason
   ) extends DebugInformation
 }

--- a/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/DebugInformation.scala
+++ b/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/DebugInformation.scala
@@ -1,5 +1,7 @@
 package weco.pipeline.ingestor.works.models
 
+import java.time.Instant
+
 import weco.catalogue.internal_model.identifiers.{IdState, SourceIdentifier}
 import weco.catalogue.internal_model.work.{DeletedReason, InvisibilityReason}
 
@@ -8,32 +10,45 @@ import weco.catalogue.internal_model.work.{DeletedReason, InvisibilityReason}
  * want to display in public API responses.
  *
  */
+
+case class SourceWorkDebugInformation(
+  identifier: SourceIdentifier,
+  version: Int,
+  modifiedTime: Instant
+)
+
 sealed trait DebugInformation {
-  val sourceIdentifier: SourceIdentifier
-  val sourceVersion: Int
+  val source: SourceWorkDebugInformation
+
+  val mergedTime: Instant
+  val indexedTime: Instant
 }
 
 object DebugInformation {
   case class Visible(
-    sourceIdentifier: SourceIdentifier,
-    sourceVersion: Int,
+    source: SourceWorkDebugInformation,
+    mergedTime: Instant,
+    indexedTime: Instant,
     redirectSources: Seq[IdState.Identified]
   ) extends DebugInformation
 
   case class Invisible(
-    sourceIdentifier: SourceIdentifier,
-    sourceVersion: Int,
+    source: SourceWorkDebugInformation,
+    mergedTime: Instant,
+    indexedTime: Instant,
     invisibilityReasons: List[InvisibilityReason]
   ) extends DebugInformation
 
   case class Redirected(
-    sourceIdentifier: SourceIdentifier,
-    sourceVersion: Int
+    source: SourceWorkDebugInformation,
+    mergedTime: Instant,
+    indexedTime: Instant,
   ) extends DebugInformation
 
   case class Deleted(
-    sourceIdentifier: SourceIdentifier,
-    sourceVersion: Int,
+    source: SourceWorkDebugInformation,
+    mergedTime: Instant,
+    indexedTime: Instant,
     deletedReason: DeletedReason
   ) extends DebugInformation
 }

--- a/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/IndexedWork.scala
+++ b/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/IndexedWork.scala
@@ -1,0 +1,36 @@
+package weco.pipeline.ingestor.works.models
+
+import weco.catalogue.internal_model.identifiers.{DataState, IdState}
+import weco.catalogue.internal_model.work.{WorkData, WorkState}
+
+sealed trait IndexedWork
+
+object IndexedWork {
+  case class Visible(
+    data: WorkData[DataState.Identified],
+    state: WorkState.Indexed,
+
+    debug: DebugInformation.Visible,
+    display: DisplayWork
+  ) extends IndexedWork
+
+  case class Redirected(
+    redirectTarget: IdState.Identified,
+    state: WorkState.Indexed,
+
+    debug: DebugInformation.Redirected
+  ) extends IndexedWork
+
+  case class Invisible(
+    data: WorkData[DataState.Identified],
+    state: WorkState.Indexed,
+
+    debug: DebugInformation.Invisible
+  ) extends IndexedWork
+
+  case class Deleted(
+    state: WorkState.Indexed,
+
+    debug: DebugInformation.Deleted
+  ) extends IndexedWork
+}

--- a/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/IndexedWork.scala
+++ b/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/IndexedWork.scala
@@ -7,30 +7,26 @@ sealed trait IndexedWork
 
 object IndexedWork {
   case class Visible(
-    data: WorkData[DataState.Identified],
-    state: WorkState.Indexed,
-
     debug: DebugInformation.Visible,
+    state: WorkState.Indexed,
+    data: WorkData[DataState.Identified],
     display: DisplayWork
   ) extends IndexedWork
 
   case class Redirected(
-    redirectTarget: IdState.Identified,
+    debug: DebugInformation.Redirected,
     state: WorkState.Indexed,
-
-    debug: DebugInformation.Redirected
+    redirectTarget: IdState.Identified
   ) extends IndexedWork
 
   case class Invisible(
-    data: WorkData[DataState.Identified],
+    debug: DebugInformation.Invisible,
     state: WorkState.Indexed,
-
-    debug: DebugInformation.Invisible
+    data: WorkData[DataState.Identified]
   ) extends IndexedWork
 
   case class Deleted(
-    state: WorkState.Indexed,
-
-    debug: DebugInformation.Deleted
+    debug: DebugInformation.Deleted,
+    state: WorkState.Indexed
   ) extends IndexedWork
 }

--- a/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/IndexedWork.scala
+++ b/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/IndexedWork.scala
@@ -1,5 +1,6 @@
 package weco.pipeline.ingestor.works.models
 
+import io.circe.Json
 import weco.catalogue.internal_model.identifiers.{DataState, IdState}
 import weco.catalogue.internal_model.work.{WorkData, WorkState}
 
@@ -10,7 +11,7 @@ object IndexedWork {
     debug: DebugInformation.Visible,
     state: WorkState.Indexed,
     data: WorkData[DataState.Identified],
-    display: DisplayWork
+    display: Json
   ) extends IndexedWork
 
   case class Redirected(


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5449

This is a suggestion for models for the first pass of this work. It's a forked version of `Work[WorkState.Indexed]`, starting to rearrange the fields towards something closer to what we want.

* The new `DebugInformation` case class contains information meant for devs to read, but which is of no value for displaying/searching works (e.g. the source identifier/version, or why a record was deleted). This will be stored in the `"debug"` field.

   Currently the API is serialising these fields when it gets a document from Elasticsearch (and I think we index them), but I think it should completely ignored by applications.

   For now I'm going to define/construct it in the ingestor to keep this patch manageable, but there's no reason we couldn't move it forward in future (because everything it contains will be written by the transformer, and doesn't change after that except maybe when merging).

* The `display` field points to a `Json` model; this is an exact representation of how it should be emitted by the API, e.g. no nulls.

* The `IndexedWork` type mirrors the `Work[WorkState.Indexed]` type, but I've moved some of the top-level fields into the `debug` field. The `data` and `state` fields are left as-is, so the meat of the existing API should continue to work.

* The `IndexedImage` type mirrors the `Image[ImageState.Indexed]` type, with the new `display` field. I haven't added a `debug` field yet because I'm not as savvy about what goes into images and what we'd need there.

   (We probably want to review how we do images more thoroughly; the only reason I've included them is so I get the DisplayImage logic in at the same time – it behaves a little differently with some of the includes, and I want to make sure I don't over-delete display code.)