### PR TITLE
Create JSON examples of what's in the API index that can be consumed by the API repo

### DIFF
--- a/fixtures/list-of-works.0.json
+++ b/fixtures/list-of-works.0.json
@@ -1,0 +1,136 @@
+{
+  "description" : "one of a list of works",
+  "createdAt" : "2022-04-28T13:28:29.048Z",
+  "id" : "equ81tpb",
+  "document" : {
+    "debug" : {
+      "source" : {
+        "identifier" : {
+          "identifierType" : {
+            "id" : "miro-image-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "dgZfc8BAUa"
+        },
+        "version" : 46,
+        "modifiedTime" : "2022-03-31T19:22:48Z"
+      },
+      "mergedTime" : "2022-03-31T19:22:48Z",
+      "indexedTime" : "2022-04-28T13:28:28.506Z",
+      "redirectSources" : [
+      ]
+    },
+    "state" : {
+      "sourceIdentifier" : {
+        "identifierType" : {
+          "id" : "miro-image-number"
+        },
+        "ontologyType" : "Work",
+        "value" : "dgZfc8BAUa"
+      },
+      "canonicalId" : "equ81tpb",
+      "mergedTime" : "2022-03-31T19:22:48Z",
+      "sourceModifiedTime" : "2022-03-31T19:22:48Z",
+      "indexedTime" : "2022-04-28T13:28:28.506Z",
+      "availabilities" : [
+      ],
+      "derivedData" : {
+        "contributorAgents" : [
+        ]
+      },
+      "relations" : {
+        "ancestors" : [
+        ],
+        "children" : [
+        ],
+        "siblingsPreceding" : [
+        ],
+        "siblingsSucceeding" : [
+        ]
+      }
+    },
+    "data" : {
+      "title" : "title-2TWOPFt15v",
+      "otherIdentifiers" : [
+      ],
+      "alternativeTitles" : [
+      ],
+      "format" : null,
+      "description" : null,
+      "physicalDescription" : null,
+      "lettering" : null,
+      "createdDate" : null,
+      "subjects" : [
+      ],
+      "genres" : [
+      ],
+      "contributors" : [
+      ],
+      "thumbnail" : null,
+      "production" : [
+      ],
+      "languages" : [
+      ],
+      "edition" : null,
+      "notes" : [
+      ],
+      "duration" : null,
+      "items" : [
+      ],
+      "holdings" : [
+      ],
+      "collectionPath" : null,
+      "referenceNumber" : null,
+      "imageData" : [
+      ],
+      "workType" : "Standard"
+    },
+    "display" : {
+      "id" : "equ81tpb",
+      "title" : "title-2TWOPFt15v",
+      "alternativeTitles" : [
+      ],
+      "contributors" : [
+      ],
+      "identifiers" : [
+        {
+          "identifierType" : {
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
+            "type" : "IdentifierType"
+          },
+          "value" : "dgZfc8BAUa",
+          "type" : "Identifier"
+        }
+      ],
+      "subjects" : [
+      ],
+      "genres" : [
+      ],
+      "items" : [
+      ],
+      "holdings" : [
+      ],
+      "availabilities" : [
+      ],
+      "production" : [
+      ],
+      "languages" : [
+      ],
+      "notes" : [
+      ],
+      "images" : [
+      ],
+      "parts" : [
+      ],
+      "partOf" : [
+      ],
+      "precededBy" : [
+      ],
+      "succeededBy" : [
+      ],
+      "type" : "Work"
+    },
+    "type" : "Visible"
+  }
+}

--- a/fixtures/list-of-works.1.json
+++ b/fixtures/list-of-works.1.json
@@ -1,0 +1,136 @@
+{
+  "description" : "one of a list of works",
+  "createdAt" : "2022-04-28T13:28:29.052Z",
+  "id" : "jtwv1ndp",
+  "document" : {
+    "debug" : {
+      "source" : {
+        "identifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "B7ZuKSWpBe"
+        },
+        "version" : 35,
+        "modifiedTime" : "2022-04-26T04:13:40Z"
+      },
+      "mergedTime" : "2022-04-26T04:13:40Z",
+      "indexedTime" : "2022-04-28T13:28:29.049Z",
+      "redirectSources" : [
+      ]
+    },
+    "state" : {
+      "sourceIdentifier" : {
+        "identifierType" : {
+          "id" : "sierra-system-number"
+        },
+        "ontologyType" : "Work",
+        "value" : "B7ZuKSWpBe"
+      },
+      "canonicalId" : "jtwv1ndp",
+      "mergedTime" : "2022-04-26T04:13:40Z",
+      "sourceModifiedTime" : "2022-04-26T04:13:40Z",
+      "indexedTime" : "2022-04-28T13:28:29.049Z",
+      "availabilities" : [
+      ],
+      "derivedData" : {
+        "contributorAgents" : [
+        ]
+      },
+      "relations" : {
+        "ancestors" : [
+        ],
+        "children" : [
+        ],
+        "siblingsPreceding" : [
+        ],
+        "siblingsSucceeding" : [
+        ]
+      }
+    },
+    "data" : {
+      "title" : "title-H7sjiP63hv",
+      "otherIdentifiers" : [
+      ],
+      "alternativeTitles" : [
+      ],
+      "format" : null,
+      "description" : null,
+      "physicalDescription" : null,
+      "lettering" : null,
+      "createdDate" : null,
+      "subjects" : [
+      ],
+      "genres" : [
+      ],
+      "contributors" : [
+      ],
+      "thumbnail" : null,
+      "production" : [
+      ],
+      "languages" : [
+      ],
+      "edition" : null,
+      "notes" : [
+      ],
+      "duration" : null,
+      "items" : [
+      ],
+      "holdings" : [
+      ],
+      "collectionPath" : null,
+      "referenceNumber" : null,
+      "imageData" : [
+      ],
+      "workType" : "Standard"
+    },
+    "display" : {
+      "id" : "jtwv1ndp",
+      "title" : "title-H7sjiP63hv",
+      "alternativeTitles" : [
+      ],
+      "contributors" : [
+      ],
+      "identifiers" : [
+        {
+          "identifierType" : {
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
+            "type" : "IdentifierType"
+          },
+          "value" : "B7ZuKSWpBe",
+          "type" : "Identifier"
+        }
+      ],
+      "subjects" : [
+      ],
+      "genres" : [
+      ],
+      "items" : [
+      ],
+      "holdings" : [
+      ],
+      "availabilities" : [
+      ],
+      "production" : [
+      ],
+      "languages" : [
+      ],
+      "notes" : [
+      ],
+      "images" : [
+      ],
+      "parts" : [
+      ],
+      "partOf" : [
+      ],
+      "precededBy" : [
+      ],
+      "succeededBy" : [
+      ],
+      "type" : "Work"
+    },
+    "type" : "Visible"
+  }
+}

--- a/fixtures/list-of-works.2.json
+++ b/fixtures/list-of-works.2.json
@@ -1,0 +1,136 @@
+{
+  "description" : "one of a list of works",
+  "createdAt" : "2022-04-28T13:28:29.055Z",
+  "id" : "suihraob",
+  "document" : {
+    "debug" : {
+      "source" : {
+        "identifier" : {
+          "identifierType" : {
+            "id" : "miro-image-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "r589wyJzS2"
+        },
+        "version" : 97,
+        "modifiedTime" : "2022-05-10T13:16:29Z"
+      },
+      "mergedTime" : "2022-05-10T13:16:29Z",
+      "indexedTime" : "2022-04-28T13:28:29.052Z",
+      "redirectSources" : [
+      ]
+    },
+    "state" : {
+      "sourceIdentifier" : {
+        "identifierType" : {
+          "id" : "miro-image-number"
+        },
+        "ontologyType" : "Work",
+        "value" : "r589wyJzS2"
+      },
+      "canonicalId" : "suihraob",
+      "mergedTime" : "2022-05-10T13:16:29Z",
+      "sourceModifiedTime" : "2022-05-10T13:16:29Z",
+      "indexedTime" : "2022-04-28T13:28:29.052Z",
+      "availabilities" : [
+      ],
+      "derivedData" : {
+        "contributorAgents" : [
+        ]
+      },
+      "relations" : {
+        "ancestors" : [
+        ],
+        "children" : [
+        ],
+        "siblingsPreceding" : [
+        ],
+        "siblingsSucceeding" : [
+        ]
+      }
+    },
+    "data" : {
+      "title" : "title-2RuvBbFbQP",
+      "otherIdentifiers" : [
+      ],
+      "alternativeTitles" : [
+      ],
+      "format" : null,
+      "description" : null,
+      "physicalDescription" : null,
+      "lettering" : null,
+      "createdDate" : null,
+      "subjects" : [
+      ],
+      "genres" : [
+      ],
+      "contributors" : [
+      ],
+      "thumbnail" : null,
+      "production" : [
+      ],
+      "languages" : [
+      ],
+      "edition" : null,
+      "notes" : [
+      ],
+      "duration" : null,
+      "items" : [
+      ],
+      "holdings" : [
+      ],
+      "collectionPath" : null,
+      "referenceNumber" : null,
+      "imageData" : [
+      ],
+      "workType" : "Standard"
+    },
+    "display" : {
+      "id" : "suihraob",
+      "title" : "title-2RuvBbFbQP",
+      "alternativeTitles" : [
+      ],
+      "contributors" : [
+      ],
+      "identifiers" : [
+        {
+          "identifierType" : {
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
+            "type" : "IdentifierType"
+          },
+          "value" : "r589wyJzS2",
+          "type" : "Identifier"
+        }
+      ],
+      "subjects" : [
+      ],
+      "genres" : [
+      ],
+      "items" : [
+      ],
+      "holdings" : [
+      ],
+      "availabilities" : [
+      ],
+      "production" : [
+      ],
+      "languages" : [
+      ],
+      "notes" : [
+      ],
+      "images" : [
+      ],
+      "parts" : [
+      ],
+      "partOf" : [
+      ],
+      "precededBy" : [
+      ],
+      "succeededBy" : [
+      ],
+      "type" : "Work"
+    },
+    "type" : "Visible"
+  }
+}

--- a/fixtures/list-of-works.3.json
+++ b/fixtures/list-of-works.3.json
@@ -1,0 +1,136 @@
+{
+  "description" : "one of a list of works",
+  "createdAt" : "2022-04-28T13:28:29.057Z",
+  "id" : "vbi1ii19",
+  "document" : {
+    "debug" : {
+      "source" : {
+        "identifier" : {
+          "identifierType" : {
+            "id" : "miro-image-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "CzLNHBFHuR"
+        },
+        "version" : 38,
+        "modifiedTime" : "2022-04-13T20:28:09Z"
+      },
+      "mergedTime" : "2022-04-13T20:28:09Z",
+      "indexedTime" : "2022-04-28T13:28:29.055Z",
+      "redirectSources" : [
+      ]
+    },
+    "state" : {
+      "sourceIdentifier" : {
+        "identifierType" : {
+          "id" : "miro-image-number"
+        },
+        "ontologyType" : "Work",
+        "value" : "CzLNHBFHuR"
+      },
+      "canonicalId" : "vbi1ii19",
+      "mergedTime" : "2022-04-13T20:28:09Z",
+      "sourceModifiedTime" : "2022-04-13T20:28:09Z",
+      "indexedTime" : "2022-04-28T13:28:29.055Z",
+      "availabilities" : [
+      ],
+      "derivedData" : {
+        "contributorAgents" : [
+        ]
+      },
+      "relations" : {
+        "ancestors" : [
+        ],
+        "children" : [
+        ],
+        "siblingsPreceding" : [
+        ],
+        "siblingsSucceeding" : [
+        ]
+      }
+    },
+    "data" : {
+      "title" : "title-WjGGR8UNWu",
+      "otherIdentifiers" : [
+      ],
+      "alternativeTitles" : [
+      ],
+      "format" : null,
+      "description" : null,
+      "physicalDescription" : null,
+      "lettering" : null,
+      "createdDate" : null,
+      "subjects" : [
+      ],
+      "genres" : [
+      ],
+      "contributors" : [
+      ],
+      "thumbnail" : null,
+      "production" : [
+      ],
+      "languages" : [
+      ],
+      "edition" : null,
+      "notes" : [
+      ],
+      "duration" : null,
+      "items" : [
+      ],
+      "holdings" : [
+      ],
+      "collectionPath" : null,
+      "referenceNumber" : null,
+      "imageData" : [
+      ],
+      "workType" : "Standard"
+    },
+    "display" : {
+      "id" : "vbi1ii19",
+      "title" : "title-WjGGR8UNWu",
+      "alternativeTitles" : [
+      ],
+      "contributors" : [
+      ],
+      "identifiers" : [
+        {
+          "identifierType" : {
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
+            "type" : "IdentifierType"
+          },
+          "value" : "CzLNHBFHuR",
+          "type" : "Identifier"
+        }
+      ],
+      "subjects" : [
+      ],
+      "genres" : [
+      ],
+      "items" : [
+      ],
+      "holdings" : [
+      ],
+      "availabilities" : [
+      ],
+      "production" : [
+      ],
+      "languages" : [
+      ],
+      "notes" : [
+      ],
+      "images" : [
+      ],
+      "parts" : [
+      ],
+      "partOf" : [
+      ],
+      "precededBy" : [
+      ],
+      "succeededBy" : [
+      ],
+      "type" : "Work"
+    },
+    "type" : "Visible"
+  }
+}

--- a/fixtures/list-of-works.4.json
+++ b/fixtures/list-of-works.4.json
@@ -1,0 +1,136 @@
+{
+  "description" : "one of a list of works",
+  "createdAt" : "2022-04-28T13:28:29.060Z",
+  "id" : "whfyqts0",
+  "document" : {
+    "debug" : {
+      "source" : {
+        "identifier" : {
+          "identifierType" : {
+            "id" : "calm-record-id"
+          },
+          "ontologyType" : "Work",
+          "value" : "FRZvWebpA5"
+        },
+        "version" : 27,
+        "modifiedTime" : "2022-04-05T05:55:25Z"
+      },
+      "mergedTime" : "2022-04-05T05:55:25Z",
+      "indexedTime" : "2022-04-28T13:28:29.057Z",
+      "redirectSources" : [
+      ]
+    },
+    "state" : {
+      "sourceIdentifier" : {
+        "identifierType" : {
+          "id" : "calm-record-id"
+        },
+        "ontologyType" : "Work",
+        "value" : "FRZvWebpA5"
+      },
+      "canonicalId" : "whfyqts0",
+      "mergedTime" : "2022-04-05T05:55:25Z",
+      "sourceModifiedTime" : "2022-04-05T05:55:25Z",
+      "indexedTime" : "2022-04-28T13:28:29.057Z",
+      "availabilities" : [
+      ],
+      "derivedData" : {
+        "contributorAgents" : [
+        ]
+      },
+      "relations" : {
+        "ancestors" : [
+        ],
+        "children" : [
+        ],
+        "siblingsPreceding" : [
+        ],
+        "siblingsSucceeding" : [
+        ]
+      }
+    },
+    "data" : {
+      "title" : "title-coJXQqPyux",
+      "otherIdentifiers" : [
+      ],
+      "alternativeTitles" : [
+      ],
+      "format" : null,
+      "description" : null,
+      "physicalDescription" : null,
+      "lettering" : null,
+      "createdDate" : null,
+      "subjects" : [
+      ],
+      "genres" : [
+      ],
+      "contributors" : [
+      ],
+      "thumbnail" : null,
+      "production" : [
+      ],
+      "languages" : [
+      ],
+      "edition" : null,
+      "notes" : [
+      ],
+      "duration" : null,
+      "items" : [
+      ],
+      "holdings" : [
+      ],
+      "collectionPath" : null,
+      "referenceNumber" : null,
+      "imageData" : [
+      ],
+      "workType" : "Standard"
+    },
+    "display" : {
+      "id" : "whfyqts0",
+      "title" : "title-coJXQqPyux",
+      "alternativeTitles" : [
+      ],
+      "contributors" : [
+      ],
+      "identifiers" : [
+        {
+          "identifierType" : {
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
+            "type" : "IdentifierType"
+          },
+          "value" : "FRZvWebpA5",
+          "type" : "Identifier"
+        }
+      ],
+      "subjects" : [
+      ],
+      "genres" : [
+      ],
+      "items" : [
+      ],
+      "holdings" : [
+      ],
+      "availabilities" : [
+      ],
+      "production" : [
+      ],
+      "languages" : [
+      ],
+      "notes" : [
+      ],
+      "images" : [
+      ],
+      "parts" : [
+      ],
+      "partOf" : [
+      ],
+      "precededBy" : [
+      ],
+      "succeededBy" : [
+      ],
+      "type" : "Work"
+    },
+    "type" : "Visible"
+  }
+}

--- a/pipeline/ingestor/ingestor_common/src/test/scala/weco/pipeline/ingestor/fixtures/ApiFixtures.scala
+++ b/pipeline/ingestor/ingestor_common/src/test/scala/weco/pipeline/ingestor/fixtures/ApiFixtures.scala
@@ -1,0 +1,25 @@
+package weco.pipeline.ingestor.fixtures
+
+import io.circe.Json
+import io.circe.syntax._
+import weco.fixtures.RandomGenerators
+import weco.json.JsonUtil._
+
+import java.io.{File, PrintWriter}
+import java.time.Instant
+import scala.util.Random
+
+trait ApiFixtures extends RandomGenerators {
+  case class Fixture(description: String, createdAt: Instant = Instant.now(), id: String, document: Json)
+
+  override protected lazy val random: Random =
+    new Random(0)
+
+  def saveFixtures(fixtures: List[(String, Fixture)]): Unit =
+    fixtures.foreach { case (id, fixture) =>
+      val file = new File(s"fixtures/$id.json")
+      val pw = new PrintWriter(file)
+      pw.write(fixture.asJson.spaces2)
+      pw.close()
+    }
+}

--- a/pipeline/ingestor/ingestor_common/src/test/scala/weco/pipeline/ingestor/fixtures/ApiFixtures.scala
+++ b/pipeline/ingestor/ingestor_common/src/test/scala/weco/pipeline/ingestor/fixtures/ApiFixtures.scala
@@ -10,16 +10,20 @@ import java.time.Instant
 import scala.util.Random
 
 trait ApiFixtures extends RandomGenerators {
-  case class Fixture(description: String, createdAt: Instant = Instant.now(), id: String, document: Json)
+  case class Fixture(description: String,
+                     createdAt: Instant = Instant.now(),
+                     id: String,
+                     document: Json)
 
   override protected lazy val random: Random =
     new Random(0)
 
   def saveFixtures(fixtures: List[(String, Fixture)]): Unit =
-    fixtures.foreach { case (id, fixture) =>
-      val file = new File(s"fixtures/$id.json")
-      val pw = new PrintWriter(file)
-      pw.write(fixture.asJson.spaces2)
-      pw.close()
+    fixtures.foreach {
+      case (id, fixture) =>
+        val file = new File(s"fixtures/$id.json")
+        val pw = new PrintWriter(file)
+        pw.write(fixture.asJson.spaces2)
+        pw.close()
     }
 }

--- a/pipeline/ingestor/ingestor_works/src/test/scala/weco/pipeline/ingestor/works/CreateApiFixturesTest.scala
+++ b/pipeline/ingestor/ingestor_works/src/test/scala/weco/pipeline/ingestor/works/CreateApiFixturesTest.scala
@@ -1,0 +1,25 @@
+package weco.pipeline.ingestor.works
+
+import io.circe.syntax._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import weco.catalogue.internal_model.work.generators.WorkGenerators
+import weco.json.JsonUtil._
+import weco.pipeline.ingestor.fixtures.ApiFixtures
+
+class CreateApiFixturesTest extends AnyFunSpec with Matchers with WorkGenerators with ApiFixtures {
+  it("creates the fixtures") {
+    val fixtures = denormalisedWorks(count = 5)
+      .sortBy { _.state.canonicalId }
+      .zipWithIndex
+      .map { case (work, index) =>
+        s"list-of-works.$index" -> Fixture(
+          description = "one of a list of works",
+          id = work.id,
+          document = WorkTransformer.deriveData(work).asJson
+        )
+      }
+
+    saveFixtures(fixtures)
+  }
+}

--- a/pipeline/ingestor/ingestor_works/src/test/scala/weco/pipeline/ingestor/works/CreateApiFixturesTest.scala
+++ b/pipeline/ingestor/ingestor_works/src/test/scala/weco/pipeline/ingestor/works/CreateApiFixturesTest.scala
@@ -7,17 +7,22 @@ import weco.catalogue.internal_model.work.generators.WorkGenerators
 import weco.json.JsonUtil._
 import weco.pipeline.ingestor.fixtures.ApiFixtures
 
-class CreateApiFixturesTest extends AnyFunSpec with Matchers with WorkGenerators with ApiFixtures {
+class CreateApiFixturesTest
+    extends AnyFunSpec
+    with Matchers
+    with WorkGenerators
+    with ApiFixtures {
   it("creates the fixtures") {
     val fixtures = denormalisedWorks(count = 5)
       .sortBy { _.state.canonicalId }
       .zipWithIndex
-      .map { case (work, index) =>
-        s"list-of-works.$index" -> Fixture(
-          description = "one of a list of works",
-          id = work.id,
-          document = WorkTransformer.deriveData(work).asJson
-        )
+      .map {
+        case (work, index) =>
+          s"list-of-works.$index" -> Fixture(
+            description = "one of a list of works",
+            id = work.id,
+            document = WorkTransformer.deriveData(work).asJson
+          )
       }
 
     saveFixtures(fixtures)


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5449

We've drastically changed the structure of the API index, and the way the API should use it – so rather than continuing to replicate internal model between the pipeline/API repos, I want to investigate breaking that link.

This PR introduces a new trait `ApiFixtures`, with a model that defines what a JSON fixture looks like:

```scala
case class Fixture(
  description: String,
  createdAt: Instant = Instant.now(),
  id: String,
  document: Json
)
```

These fixtures get serialised as JSON in the `fixtures` folder (name tbc), and then in the API tests there are helpers that will index these JSON files into Elasticsearch (specifically, the `document` property).

We'll need way more fixtures than this to get the API tests passing, but hopefully this is enough to illustrate the idea. I want to get a sense of whether others think this is a sensible approach before digging into it.

