### PR TITLE
Three-zone deployment for Elastic instances serving API traffic

### DIFF
--- a/pipeline/terraform/stack/elastic_pipeline.tf
+++ b/pipeline/terraform/stack/elastic_pipeline.tf
@@ -9,8 +9,8 @@ locals {
   # It's ephemeral data (and at 58GB of memory, expensive).
   #
   # Once we stop reindexing and make the pipeline live, we want it to be
-  # highly available, to avoid issues with cross-cluster replication.
-  es_node_count = var.reindexing_state.scale_up_elastic_cluster ? 1 : 2
+  # highly available, because it's serving API traffic.
+  es_node_count = var.reindexing_state.scale_up_elastic_cluster ? 1 : 3
 }
 
 data "ec_stack" "latest_patch" {


### PR DESCRIPTION
This is something Jonathan spotted; it was 2-zone when we were only using it as a CCR source (so there was never any break in uptime, which broke CCR), but it should be 3-zone now it's serving live traffic.

I've made this change manually in the console for the 2022-04-28 cluster so as not to interfere with Paul's work in this configuration, and then it should be picked up by his pipeline when it goes live.