### PR TITLE
Add the index config to support querying by subject identifier

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksIndexConfig.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksIndexConfig.scala
@@ -227,6 +227,14 @@ object WorksIndexConfig extends IndexConfigFields {
       // to index it -- it's just an arbitrary blob of JSON.
       val display = objectField("display").withEnabled(false)
 
+      // This field contains the values we're actually going to query in search.
+      val query = objectField("query")
+        .fields(
+          keywordField("subjects.id"),
+          keywordField("subjects.identifiers.value"),
+          keywordField("subjects.label")
+        )
+
       // This field contains the display documents used by aggregations.
       //
       // The values are JSON documents that can be included in an AggregationBucket from
@@ -254,6 +262,7 @@ object WorksIndexConfig extends IndexConfigFields {
         objectField("redirectTarget").withDynamic("false"),
         debug,
         display,
+        query,
         aggregatableValues
       )
     },

--- a/common/internal_model/src/test/resources/WorksIndexConfig.json
+++ b/common/internal_model/src/test/resources/WorksIndexConfig.json
@@ -958,6 +958,20 @@
         "type" : "object",
         "enabled": false
       },
+      "query": {
+        "type": "object",
+        "properties": {
+          "subjects.id": {
+            "type": "keyword"
+          },
+          "subjects.identifiers.value": {
+            "type": "keyword"
+          },
+          "subjects.label": {
+            "type": "keyword"
+          }
+        }
+      },
       "aggregatableValues" : {
         "type" : "object",
         "properties" : {

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/generators/SubjectGenerators.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/generators/SubjectGenerators.scala
@@ -22,7 +22,7 @@ trait SubjectGenerators extends RandomGenerators {
   def createSubject: Subject[IdState.Minted] =
     createSubjectWith()
 
-  private def createConcepts(
+  protected def createConcepts(
     conceptStrings: List[String] = List.fill(3)(randomAlphanumeric(15))
   ): List[AbstractRootConcept[IdState.Minted]] =
     conceptStrings.map(Concept(_))

--- a/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/WorkTransformer.scala
+++ b/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/WorkTransformer.scala
@@ -8,7 +8,8 @@ import weco.pipeline.ingestor.works.models.{
   DebugInformation,
   IndexedWork,
   SourceWorkDebugInformation,
-  WorkAggregatableValues
+  WorkAggregatableValues,
+  WorkQueryableValues
 }
 import weco.catalogue.display_model.Implicits._
 
@@ -44,6 +45,7 @@ trait WorkTransformer {
             state = state,
             data = data,
             display = display,
+            query = WorkQueryableValues(w.data),
             aggregatableValues = WorkAggregatableValues(
               w.data,
               availabilities = state.availabilities)

--- a/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/IndexedWork.scala
+++ b/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/IndexedWork.scala
@@ -16,6 +16,7 @@ object IndexedWork {
     state: WorkState.Indexed,
     data: WorkData[DataState.Identified],
     display: Json,
+    query: WorkQueryableValues,
     aggregatableValues: WorkAggregatableValues
   ) extends IndexedWork
 

--- a/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/WorkQueryableValues.scala
+++ b/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/WorkQueryableValues.scala
@@ -33,4 +33,3 @@ case object WorkQueryableValues {
         .toList
   }
 }
-

--- a/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/WorkQueryableValues.scala
+++ b/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/WorkQueryableValues.scala
@@ -1,0 +1,36 @@
+package weco.pipeline.ingestor.works.models
+
+import io.circe.generic.extras.JsonKey
+import weco.catalogue.internal_model.identifiers.{DataState, IdState}
+import weco.catalogue.internal_model.work.WorkData
+
+case class WorkQueryableValues(
+  @JsonKey("subjects.id") subjectIds: List[String],
+  @JsonKey("subjects.identifiers.value") subjectIdentifiers: List[String],
+  @JsonKey("subjects.label") subjectLabels: List[String]
+)
+
+case object WorkQueryableValues {
+  def apply(workData: WorkData[DataState.Identified]): WorkQueryableValues =
+    WorkQueryableValues(
+      subjectIds = workData.subjects.map(_.id).canonicalIds,
+      subjectIdentifiers = workData.subjects.map(_.id).sourceIdentifiers,
+      subjectLabels = workData.subjects.map(_.label)
+    )
+
+  implicit class IdStateOps(ids: Seq[IdState.Minted]) {
+    def canonicalIds: List[String] =
+      ids.flatMap(_.maybeCanonicalId).map(_.underlying).toList
+
+    def sourceIdentifiers: List[String] =
+      ids
+        .collect {
+          case IdState.Identified(_, sourceIdentifier, otherIdentifiers) =>
+            sourceIdentifier +: otherIdentifiers
+        }
+        .flatten
+        .map(_.value)
+        .toList
+  }
+}
+

--- a/pipeline/ingestor/ingestor_works/src/test/scala/weco/pipeline/ingestor/works/CreateTestWorkDocuments.scala
+++ b/pipeline/ingestor/ingestor_works/src/test/scala/weco/pipeline/ingestor/works/CreateTestWorkDocuments.scala
@@ -6,24 +6,11 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.catalogue.internal_model.Implicits._
 import weco.catalogue.internal_model.generators.ImageGenerators
-import weco.catalogue.internal_model.identifiers.IdState
+import weco.catalogue.internal_model.identifiers.{CanonicalId, IdState, IdentifierType, SourceIdentifier}
 import weco.catalogue.internal_model.languages.Language
 import weco.catalogue.internal_model.locations.AccessStatus.LicensedResources
-import weco.catalogue.internal_model.locations.{
-  AccessCondition,
-  AccessMethod,
-  AccessStatus,
-  DigitalLocationType,
-  License,
-  LocationType,
-  PhysicalLocationType
-}
-import weco.catalogue.internal_model.work.Format.{
-  Audio,
-  Books,
-  Journals,
-  Pictures
-}
+import weco.catalogue.internal_model.locations.{AccessCondition, AccessMethod, AccessStatus, DigitalLocationType, License, LocationType, PhysicalLocationType}
+import weco.catalogue.internal_model.work.Format.{Audio, Books, Journals, Pictures}
 import weco.catalogue.internal_model.work._
 import weco.catalogue.internal_model.work.generators._
 import weco.json.JsonUtil._
@@ -516,10 +503,43 @@ class CreateTestWorkDocuments
   }
 
   it("creates examples for the subject filter tests") {
-    val sanitation = createSubjectWith("Sanitation.")
+    val sanitation =
+      Subject(
+        id = IdState.Identified(
+          canonicalId = CanonicalId("sanitati"),
+          sourceIdentifier = SourceIdentifier(
+            identifierType = IdentifierType.LCSubjects,
+            value = "lcsh-sanitation",
+            ontologyType = "Subject"
+          ),
+          otherIdentifiers = List(
+            SourceIdentifier(
+              identifierType = IdentifierType.MESH,
+              value = "mesh-sanitation",
+              ontologyType = "Subject"
+            )
+          )
+        ),
+        label = "Sanitation.",
+        concepts = createConcepts()
+      )
+
     val london = createSubjectWith("London (England)")
     val psychology = createSubjectWith("Psychology, Pathological")
-    val darwin = createSubjectWith("Darwin \"Jones\", Charles")
+
+    val darwin =
+      Subject(
+        id = IdState.Identified(
+          canonicalId = CanonicalId("darwin01"),
+          sourceIdentifier = SourceIdentifier(
+            identifierType = IdentifierType.LCNames,
+            value = "lcnames-darwin",
+            ontologyType = "Subject"
+          )
+        ),
+        label = "Darwin \"Jones\", Charles",
+        concepts = createConcepts()
+      )
 
     val sanitationWork = denormalisedWork().subjects(List(sanitation))
     val londonWork = denormalisedWork().subjects(List(london))

--- a/pipeline/ingestor/ingestor_works/src/test/scala/weco/pipeline/ingestor/works/CreateTestWorkDocuments.scala
+++ b/pipeline/ingestor/ingestor_works/src/test/scala/weco/pipeline/ingestor/works/CreateTestWorkDocuments.scala
@@ -6,11 +6,29 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.catalogue.internal_model.Implicits._
 import weco.catalogue.internal_model.generators.ImageGenerators
-import weco.catalogue.internal_model.identifiers.{CanonicalId, IdState, IdentifierType, SourceIdentifier}
+import weco.catalogue.internal_model.identifiers.{
+  CanonicalId,
+  IdState,
+  IdentifierType,
+  SourceIdentifier
+}
 import weco.catalogue.internal_model.languages.Language
 import weco.catalogue.internal_model.locations.AccessStatus.LicensedResources
-import weco.catalogue.internal_model.locations.{AccessCondition, AccessMethod, AccessStatus, DigitalLocationType, License, LocationType, PhysicalLocationType}
-import weco.catalogue.internal_model.work.Format.{Audio, Books, Journals, Pictures}
+import weco.catalogue.internal_model.locations.{
+  AccessCondition,
+  AccessMethod,
+  AccessStatus,
+  DigitalLocationType,
+  License,
+  LocationType,
+  PhysicalLocationType
+}
+import weco.catalogue.internal_model.work.Format.{
+  Audio,
+  Books,
+  Journals,
+  Pictures
+}
 import weco.catalogue.internal_model.work._
 import weco.catalogue.internal_model.work.generators._
 import weco.json.JsonUtil._

--- a/pipeline/ingestor/ingestor_works/src/test/scala/weco/pipeline/ingestor/works/fixtures/WorksIngestorFixtures.scala
+++ b/pipeline/ingestor/ingestor_works/src/test/scala/weco/pipeline/ingestor/works/fixtures/WorksIngestorFixtures.scala
@@ -14,7 +14,11 @@ import weco.fixtures.{TestWith, TimeAssertions}
 import weco.messaging.fixtures.SQS.Queue
 import weco.pipeline.ingestor.fixtures.IngestorFixtures
 import weco.pipeline.ingestor.works.WorkTransformer
-import weco.pipeline.ingestor.works.models.{IndexedWork, WorkAggregatableValues}
+import weco.pipeline.ingestor.works.models.{
+  IndexedWork,
+  WorkAggregatableValues,
+  WorkQueryableValues
+}
 import weco.pipeline_storage.elastic.{ElasticIndexer, ElasticSourceRetriever}
 import weco.json.JsonUtil._
 
@@ -46,9 +50,10 @@ trait WorksIngestorFixtures
       val expectedWork = WorkTransformer.deriveData(work)
 
       storedWork match {
-        case w @ IndexedWork.Visible(_, _, _, _, _) =>
+        case w @ IndexedWork.Visible(_, _, _, _, storedQuery, storedAggregations) =>
           w.data shouldBe expectedWork.asInstanceOf[IndexedWork.Visible].data
-          w.aggregatableValues shouldBe WorkAggregatableValues(
+          storedQuery shouldBe WorkQueryableValues(work.data)
+          storedAggregations shouldBe WorkAggregatableValues(
             work.data,
             work.state.availabilities)
         case _ => ()

--- a/pipeline/ingestor/ingestor_works/src/test/scala/weco/pipeline/ingestor/works/fixtures/WorksIngestorFixtures.scala
+++ b/pipeline/ingestor/ingestor_works/src/test/scala/weco/pipeline/ingestor/works/fixtures/WorksIngestorFixtures.scala
@@ -50,7 +50,13 @@ trait WorksIngestorFixtures
       val expectedWork = WorkTransformer.deriveData(work)
 
       storedWork match {
-        case w @ IndexedWork.Visible(_, _, _, _, storedQuery, storedAggregations) =>
+        case w @ IndexedWork.Visible(
+              _,
+              _,
+              _,
+              _,
+              storedQuery,
+              storedAggregations) =>
           w.data shouldBe expectedWork.asInstanceOf[IndexedWork.Visible].data
           storedQuery shouldBe WorkQueryableValues(work.data)
           storedAggregations shouldBe WorkAggregatableValues(

--- a/pipeline/ingestor/ingestor_works/src/test/scala/weco/pipeline/ingestor/works/models/WorkQueryableValuesTest.scala
+++ b/pipeline/ingestor/ingestor_works/src/test/scala/weco/pipeline/ingestor/works/models/WorkQueryableValuesTest.scala
@@ -1,0 +1,71 @@
+package weco.pipeline.ingestor.works.models
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import weco.catalogue.internal_model.identifiers.{
+  CanonicalId,
+  DataState,
+  IdState,
+  IdentifierType,
+  SourceIdentifier
+}
+import weco.catalogue.internal_model.work.{Concept, Subject, WorkData}
+import weco.catalogue.internal_model.work.generators.{
+  SubjectGenerators,
+  WorkGenerators
+}
+
+class WorkQueryableValuesTest extends AnyFunSpec with Matchers with SubjectGenerators with WorkGenerators {
+  it("populates subjects correctly") {
+    val data = WorkData[DataState.Identified](
+      title = Some(s"title-${randomAlphanumeric(length = 10)}"),
+      subjects = List(
+        Subject(
+          label = "Silly sausages",
+          concepts = List(Concept("silliness"), Concept("cylinders"))
+        ),
+        Subject(
+          label = "Straight scythes",
+          concepts = List(Concept("tools"))
+        ),
+        Subject(
+          id = IdState.Identified(
+            canonicalId = CanonicalId("ssssssss"),
+            sourceIdentifier = SourceIdentifier(
+              identifierType = IdentifierType.LCSubjects,
+              value = "lcs-soggy",
+              ontologyType = "Subject"
+            ),
+            otherIdentifiers = List(
+              SourceIdentifier(
+                identifierType = IdentifierType.MESH,
+                value = "mesh-soggy",
+                ontologyType = "Subject"
+              )
+            )
+          ),
+          label = "Soggy sponges",
+          concepts = List()
+        ),
+        Subject(
+          id = IdState.Identified(
+            canonicalId = CanonicalId("SSSSSSSS"),
+            sourceIdentifier = SourceIdentifier(
+              identifierType = IdentifierType.LCNames,
+              value = "lcs-simon",
+              ontologyType = "Subject"
+            )
+          ),
+          label = "Sam Smithington",
+          concepts = List()
+        )
+      )
+    )
+
+    val q = WorkQueryableValues(data)
+
+    q.subjectIds shouldBe List("ssssssss", "SSSSSSSS")
+    q.subjectIdentifiers shouldBe List("lcs-soggy", "mesh-soggy", "lcs-simon")
+    q.subjectLabels shouldBe List("Silly sausages", "Straight scythes", "Soggy sponges", "Sam Smithington")
+  }
+}

--- a/pipeline/ingestor/ingestor_works/src/test/scala/weco/pipeline/ingestor/works/models/WorkQueryableValuesTest.scala
+++ b/pipeline/ingestor/ingestor_works/src/test/scala/weco/pipeline/ingestor/works/models/WorkQueryableValuesTest.scala
@@ -15,7 +15,11 @@ import weco.catalogue.internal_model.work.generators.{
   WorkGenerators
 }
 
-class WorkQueryableValuesTest extends AnyFunSpec with Matchers with SubjectGenerators with WorkGenerators {
+class WorkQueryableValuesTest
+    extends AnyFunSpec
+    with Matchers
+    with SubjectGenerators
+    with WorkGenerators {
   it("populates subjects correctly") {
     val data = WorkData[DataState.Identified](
       title = Some(s"title-${randomAlphanumeric(length = 10)}"),
@@ -66,6 +70,10 @@ class WorkQueryableValuesTest extends AnyFunSpec with Matchers with SubjectGener
 
     q.subjectIds shouldBe List("ssssssss", "SSSSSSSS")
     q.subjectIdentifiers shouldBe List("lcs-soggy", "mesh-soggy", "lcs-simon")
-    q.subjectLabels shouldBe List("Silly sausages", "Straight scythes", "Soggy sponges", "Sam Smithington")
+    q.subjectLabels shouldBe List(
+      "Silly sausages",
+      "Straight scythes",
+      "Soggy sponges",
+      "Sam Smithington")
   }
 }

--- a/pipeline/ingestor/test_documents/work.visible.everything.0.json
+++ b/pipeline/ingestor/test_documents/work.visible.everything.0.json
@@ -1024,6 +1024,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["ArEtlVdV0j", "hG54NzomzM"]
+    },
     "aggregatableValues" : {
       "workType" : [
       ],

--- a/pipeline/ingestor/test_documents/work.visible.everything.1.json
+++ b/pipeline/ingestor/test_documents/work.visible.everything.1.json
@@ -1064,6 +1064,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["5LLMVvWxgX", "PSF4EIy1m2"]
+    },
     "aggregatableValues" : {
       "workType" : [
       ],

--- a/pipeline/ingestor/test_documents/work.visible.everything.2.json
+++ b/pipeline/ingestor/test_documents/work.visible.everything.2.json
@@ -1037,6 +1037,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["osW8hKQNGv", "h5tlAUKxcP"]
+    },
     "aggregatableValues" : {
       "workType" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.0.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.0.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["6IZ2DrUzFk"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"a\",\"label\":\"Books\",\"type\":\"Format\"}"

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.1.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.1.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["6IZ2DrUzFk"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"q\",\"label\":\"Digital Images\",\"type\":\"Format\"}"

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.10.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.10.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["Vo8KntFwFf"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"i\",\"label\":\"Audio\",\"type\":\"Format\"}"

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.11.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.11.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["Vo8KntFwFf"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"g\",\"label\":\"Videos\",\"type\":\"Format\"}"

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.12.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.12.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["v4BHmwGTZr"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"h\",\"label\":\"Archives and manuscripts\",\"type\":\"Format\"}"

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.13.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.13.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["v4BHmwGTZr"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"n\",\"label\":\"Film\",\"type\":\"Format\"}"

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.14.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.14.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["v4BHmwGTZr"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"b\",\"label\":\"Manuscripts\",\"type\":\"Format\"}"

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.15.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.15.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["v4BHmwGTZr"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"c\",\"label\":\"Music\",\"type\":\"Format\"}"

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.16.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.16.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["v4BHmwGTZr"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"u\",\"label\":\"Standing order\",\"type\":\"Format\"}"

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.17.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.17.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["v4BHmwGTZr"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"z\",\"label\":\"Web sites\",\"type\":\"Format\"}"

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.18.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.18.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["9hdRJC6PIO"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"v\",\"label\":\"E-books\",\"type\":\"Format\"}"

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.19.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.19.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["9hdRJC6PIO"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"s\",\"label\":\"E-sound\",\"type\":\"Format\"}"

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.2.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.2.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["6IZ2DrUzFk"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"l\",\"label\":\"Ephemera\",\"type\":\"Format\"}"

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.20.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.20.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["9hdRJC6PIO"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"j\",\"label\":\"E-journals\",\"type\":\"Format\"}"

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.21.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.21.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["9hdRJC6PIO"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"f\",\"label\":\"E-videos\",\"type\":\"Format\"}"

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.22.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.22.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["9hdRJC6PIO"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"x\",\"label\":\"Manuscripts\",\"type\":\"Format\"}"

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.3.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.3.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["6IZ2DrUzFk"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"e\",\"label\":\"Maps\",\"type\":\"Format\"}"

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.4.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.4.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["6IZ2DrUzFk"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"k\",\"label\":\"Pictures\",\"type\":\"Format\"}"

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.5.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.5.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["6IZ2DrUzFk"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"w\",\"label\":\"Student dissertations\",\"type\":\"Format\"}"

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.6.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.6.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["Vo8KntFwFf"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"r\",\"label\":\"3-D Objects\",\"type\":\"Format\"}"

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.7.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.7.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["Vo8KntFwFf"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"m\",\"label\":\"CD-Roms\",\"type\":\"Format\"}"

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.8.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.8.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["Vo8KntFwFf"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"d\",\"label\":\"Journals\",\"type\":\"Format\"}"

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.9.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.9.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["Vo8KntFwFf"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"p\",\"label\":\"Mixed materials\",\"type\":\"Format\"}"

--- a/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.0.json
+++ b/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.0.json
@@ -1,7 +1,7 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-05-10T09:08:11.347Z",
   "id" : "x3ofwne6",
+  "createdAt" : "2022-05-30T11:06:49.175Z",
   "document" : {
     "debug" : {
       "source" : {
@@ -63,7 +63,24 @@
       "subjects" : [
         {
           "id" : {
-            "type" : "Unidentifiable"
+            "canonicalId" : "sanitati",
+            "sourceIdentifier" : {
+              "identifierType" : {
+                "id" : "lc-subjects"
+              },
+              "ontologyType" : "Subject",
+              "value" : "lcsh-sanitation"
+            },
+            "otherIdentifiers" : [
+              {
+                "identifierType" : {
+                  "id" : "nlm-mesh"
+                },
+                "ontologyType" : "Subject",
+                "value" : "mesh-sanitation"
+              }
+            ],
+            "type" : "Identified"
           },
           "label" : "Sanitation.",
           "concepts" : [
@@ -134,6 +151,27 @@
       ],
       "subjects" : [
         {
+          "id" : "sanitati",
+          "identifiers" : [
+            {
+              "identifierType" : {
+                "id" : "lc-subjects",
+                "label" : "Library of Congress Subject Headings (LCSH)",
+                "type" : "IdentifierType"
+              },
+              "value" : "lcsh-sanitation",
+              "type" : "Identifier"
+            },
+            {
+              "identifierType" : {
+                "id" : "nlm-mesh",
+                "label" : "Medical Subject Headings (MESH) identifier",
+                "type" : "IdentifierType"
+              },
+              "value" : "mesh-sanitation",
+              "type" : "Identifier"
+            }
+          ],
           "label" : "Sanitation.",
           "concepts" : [
             {
@@ -178,6 +216,18 @@
       ],
       "type" : "Work"
     },
+    "query" : {
+      "subjects.id" : [
+        "sanitati"
+      ],
+      "subjects.identifiers.value" : [
+        "lcsh-sanitation",
+        "mesh-sanitation"
+      ],
+      "subjects.label" : [
+        "Sanitation."
+      ]
+    },
     "aggregatableValues" : {
       "workType" : [
       ],
@@ -186,7 +236,7 @@
       "production.dates" : [
       ],
       "subjects.label" : [
-        "{\"label\":\"Sanitation.\",\"concepts\":[],\"type\":\"Subject\"}"
+        "{\"id\":\"sanitati\",\"label\":\"Sanitation.\",\"concepts\":[],\"type\":\"Subject\"}"
       ],
       "languages" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.1.json
+++ b/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.1.json
@@ -1,7 +1,7 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-05-10T09:08:11.347Z",
   "id" : "rdbnpfc2",
+  "createdAt" : "2022-05-30T11:06:49.176Z",
   "document" : {
     "debug" : {
       "source" : {
@@ -177,6 +177,15 @@
       "succeededBy" : [
       ],
       "type" : "Work"
+    },
+    "query" : {
+      "subjects.id" : [
+      ],
+      "subjects.identifiers.value" : [
+      ],
+      "subjects.label" : [
+        "London (England)"
+      ]
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.2.json
+++ b/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.2.json
@@ -1,7 +1,7 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-05-10T09:08:11.347Z",
   "id" : "fjor9vqa",
+  "createdAt" : "2022-05-30T11:06:49.177Z",
   "document" : {
     "debug" : {
       "source" : {
@@ -177,6 +177,15 @@
       "succeededBy" : [
       ],
       "type" : "Work"
+    },
+    "query" : {
+      "subjects.id" : [
+      ],
+      "subjects.identifiers.value" : [
+      ],
+      "subjects.label" : [
+        "Psychology, Pathological"
+      ]
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.3.json
+++ b/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.3.json
@@ -1,7 +1,7 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-05-10T09:08:11.348Z",
   "id" : "h18d0cbf",
+  "createdAt" : "2022-05-30T11:06:49.177Z",
   "document" : {
     "debug" : {
       "source" : {
@@ -63,7 +63,17 @@
       "subjects" : [
         {
           "id" : {
-            "type" : "Unidentifiable"
+            "canonicalId" : "darwin01",
+            "sourceIdentifier" : {
+              "identifierType" : {
+                "id" : "lc-names"
+              },
+              "ontologyType" : "Subject",
+              "value" : "lcnames-darwin"
+            },
+            "otherIdentifiers" : [
+            ],
+            "type" : "Identified"
           },
           "label" : "Darwin \"Jones\", Charles",
           "concepts" : [
@@ -134,6 +144,18 @@
       ],
       "subjects" : [
         {
+          "id" : "darwin01",
+          "identifiers" : [
+            {
+              "identifierType" : {
+                "id" : "lc-names",
+                "label" : "Library of Congress Name authority records",
+                "type" : "IdentifierType"
+              },
+              "value" : "lcnames-darwin",
+              "type" : "Identifier"
+            }
+          ],
           "label" : "Darwin \"Jones\", Charles",
           "concepts" : [
             {
@@ -178,6 +200,17 @@
       ],
       "type" : "Work"
     },
+    "query" : {
+      "subjects.id" : [
+        "darwin01"
+      ],
+      "subjects.identifiers.value" : [
+        "lcnames-darwin"
+      ],
+      "subjects.label" : [
+        "Darwin \"Jones\", Charles"
+      ]
+    },
     "aggregatableValues" : {
       "workType" : [
       ],
@@ -186,7 +219,7 @@
       "production.dates" : [
       ],
       "subjects.label" : [
-        "{\"label\":\"Darwin \\\"Jones\\\", Charles\",\"concepts\":[],\"type\":\"Subject\"}"
+        "{\"id\":\"darwin01\",\"label\":\"Darwin \\\"Jones\\\", Charles\",\"concepts\":[],\"type\":\"Subject\"}"
       ],
       "languages" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.4.json
+++ b/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.4.json
@@ -121,7 +121,17 @@
         },
         {
           "id" : {
-            "type" : "Unidentifiable"
+            "canonicalId" : "darwin01",
+            "sourceIdentifier" : {
+              "identifierType" : {
+                "id" : "lc-names"
+              },
+              "ontologyType" : "Subject",
+              "value" : "lcnames-darwin"
+            },
+            "otherIdentifiers" : [
+            ],
+            "type" : "Identified"
           },
           "label" : "Darwin \"Jones\", Charles",
           "concepts" : [
@@ -272,6 +282,19 @@
       ],
       "type" : "Work"
     },
+    "query" : {
+      "subjects.id" : [
+        "darwin01"
+      ],
+      "subjects.identifiers.value" : [
+        "lcnames-darwin"
+      ],
+      "subjects.label" : [
+        "London (England)",
+        "Psychology, Pathological",
+        "Darwin \"Jones\", Charles"
+      ]
+    },
     "aggregatableValues" : {
       "workType" : [
       ],
@@ -282,7 +305,7 @@
       "subjects.label" : [
         "{\"label\":\"London (England)\",\"concepts\":[],\"type\":\"Subject\"}",
         "{\"label\":\"Psychology, Pathological\",\"concepts\":[],\"type\":\"Subject\"}",
-        "{\"label\":\"Darwin \\\"Jones\\\", Charles\",\"concepts\":[],\"type\":\"Subject\"}"
+        "{\"id\":\"darwin01\",\"label\":\"Darwin \\\"Jones\\\", Charles\",\"concepts\":[],\"type\":\"Subject\"}"
       ],
       "languages" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.5.json
+++ b/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.5.json
@@ -131,77 +131,14 @@
       ],
       "type" : "Work"
     },
-    "type" : "Visible"
-  },
-  "work" : {
-    "version" : 74,
-    "data" : {
-      "title" : "title-66qqlbcmHn",
-      "otherIdentifiers" : [
+    "query" : {
+      "subjects.id" : [
       ],
-      "alternativeTitles" : [
+      "subjects.identifiers.value" : [
       ],
-      "format" : null,
-      "description" : null,
-      "physicalDescription" : null,
-      "lettering" : null,
-      "createdDate" : null,
-      "subjects" : [
-      ],
-      "genres" : [
-      ],
-      "contributors" : [
-      ],
-      "thumbnail" : null,
-      "production" : [
-      ],
-      "languages" : [
-      ],
-      "edition" : null,
-      "notes" : [
-      ],
-      "duration" : null,
-      "items" : [
-      ],
-      "holdings" : [
-      ],
-      "collectionPath" : null,
-      "referenceNumber" : null,
-      "imageData" : [
-      ],
-      "workType" : "Standard"
+      "subjects.label" : [
+      ]
     },
-    "state" : {
-      "sourceIdentifier" : {
-        "identifierType" : {
-          "id" : "miro-image-number"
-        },
-        "ontologyType" : "Work",
-        "value" : "sAZ5Ju5hoU"
-      },
-      "canonicalId" : "h5zhfqrb",
-      "mergedTime" : "2022-05-08T03:03:37Z",
-      "sourceModifiedTime" : "2022-05-08T03:03:37Z",
-      "indexedTime" : "2022-05-10T09:08:11.348Z",
-      "availabilities" : [
-      ],
-      "derivedData" : {
-        "contributorAgents" : [
-        ]
-      },
-      "relations" : {
-        "ancestors" : [
-        ],
-        "children" : [
-        ],
-        "siblingsPreceding" : [
-        ],
-        "siblingsSucceeding" : [
-        ]
-      }
-    },
-    "redirectSources" : [
-    ],
     "type" : "Visible"
   }
 }


### PR DESCRIPTION
The new `WorkQueryableValues` is where we'll store values we want to query on the work. It does flatten it out, but this is very similar to what Elasticsearch is already doing internally – e.g. we lose the connection between a subject ID and its label, but we'll keep it in the `display` field, and we can't query across them right now.

I'm torn about how to name the fields. `subjects.label` seems pretty clear cut, but the ID and identifiers field less so.

1. `subjects.id` and `subjects.identifiers.value` is more explicit about where we get that value on the work
2. `subjects` and `subjects.identifiers` matches what we do in API filters

I'm drawn to (1) because we'll use this object for anything we want to query, including values that don't support filtering (e.g. `title`), so I don't want it to be driven by the needs of filtering – but maybe having them match means the API can have even less knowledge of filtering, and just prepend `query.*` to user queries?

Suggestions welcome.