### PR TITLE
Use an OpenJDK image from ECR Public, not Docker Hub

### DIFF
--- a/pipeline/relation_embedder/path_concatenator/Dockerfile
+++ b/pipeline/relation_embedder/path_concatenator/Dockerfile
@@ -1,4 +1,4 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+FROM public.ecr.aws/docker/library/openjdk:11
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5545, which includes a discussion of the benefits.