### PR TITLE
Use localstack/localstack instead of scality/s3server to mock S3 in tests

### DIFF
--- a/sierra_adapter/sierra_reader/docker-compose.yml
+++ b/sierra_adapter/sierra_reader/docker-compose.yml
@@ -1,10 +1,8 @@
-s3:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/scality/s3server:mem-latest"
-  ports:
-    - "33333:8000"
-localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack"
-  environment:
-    - SERVICES=sqs
-  ports:
-    - "4566:4566"
+version: "3"
+services:
+  localstack:
+    image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack"
+    environment:
+      - SERVICES=sqs,s3
+    ports:
+      - "4566:4566"

--- a/sierra_adapter/sierra_reader/src/test/scala/weco/pipeline/sierra_reader/fixtures/WorkerServiceFixture.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/weco/pipeline/sierra_reader/fixtures/WorkerServiceFixture.scala
@@ -1,6 +1,7 @@
 package weco.pipeline.sierra_reader.fixtures
 
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse, Uri}
+import com.amazonaws.services.s3.AmazonS3
 import weco.akka.fixtures.Akka
 import weco.fixtures.TestWith
 import weco.messaging.fixtures.SQS
@@ -16,8 +17,12 @@ import weco.sierra.models.identifiers.SierraRecordTypes
 import scala.concurrent.ExecutionContext.Implicits.global
 
 trait WorkerServiceFixture extends Akka with SQS with S3Fixtures {
+  override val s3Port: Int = 4566
 
   val sierraUri = "http://sierra:1234"
+
+  override implicit val s3Client: AmazonS3 =
+    createS3ClientWithEndpoint(s"http://localhost:$s3Port")
 
   def createClient(responses: Seq[(HttpRequest, HttpResponse)]): HttpGet =
     new MemoryHttpClient(responses) with HttpGet {

--- a/sierra_adapter/sierra_reader/src/test/scala/weco/pipeline/sierra_reader/fixtures/WorkerServiceFixture.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/weco/pipeline/sierra_reader/fixtures/WorkerServiceFixture.scala
@@ -17,10 +17,12 @@ import weco.sierra.models.identifiers.SierraRecordTypes
 import scala.concurrent.ExecutionContext.Implicits.global
 
 trait WorkerServiceFixture extends Akka with SQS with S3Fixtures {
-  override val s3Port: Int = 4566
-
   val sierraUri = "http://sierra:1234"
 
+  // TODO: We're overriding these values while scala-libs is still tied to scality/s3server,
+  // but when we update it to use localstack, we can remove these.
+  // See https://github.com/wellcomecollection/platform/issues/5547
+  override val s3Port: Int = 4566
   override implicit val s3Client: AmazonS3 =
     createS3ClientWithEndpoint(s"http://localhost:$s3Port")
 

--- a/sierra_adapter/sierra_reader/src/test/scala/weco/pipeline/sierra_reader/services/WindowManagerTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/weco/pipeline/sierra_reader/services/WindowManagerTest.scala
@@ -1,5 +1,6 @@
 package weco.pipeline.sierra_reader.services
 
+import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.AmazonS3Exception
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.funspec.AnyFunSpec
@@ -21,6 +22,13 @@ class WindowManagerTest
     with ScalaFutures
     with IntegrationPatience
     with SierraRecordGenerators {
+
+  // TODO: We're overriding these values while scala-libs is still tied to scality/s3server,
+  // but when we update it to use localstack, we can remove these.
+  // See https://github.com/wellcomecollection/platform/issues/5547
+  override val s3Port: Int = 4566
+  override implicit val s3Client: AmazonS3 =
+    createS3ClientWithEndpoint(s"http://localhost:$s3Port")
 
   private def withWindowManager[R](bucket: Bucket)(
     testWith: TestWith[WindowManager, R]) = {

--- a/sierra_adapter/sierra_reader/src/test/scala/weco/pipeline/sierra_reader/sink/SequentialS3SinkTest.scala
+++ b/sierra_adapter/sierra_reader/src/test/scala/weco/pipeline/sierra_reader/sink/SequentialS3SinkTest.scala
@@ -2,6 +2,7 @@ package weco.pipeline.sierra_reader.sink
 
 import akka.Done
 import akka.stream.scaladsl.{Sink, Source}
+import com.amazonaws.services.s3.AmazonS3
 import io.circe.Json
 import io.circe.parser._
 import org.scalatest.BeforeAndAfterAll
@@ -26,6 +27,13 @@ class SequentialS3SinkTest
     with BeforeAndAfterAll
     with ScalaFutures
     with IntegrationPatience {
+
+  // TODO: We're overriding these values while scala-libs is still tied to scality/s3server,
+  // but when we update it to use localstack, we can remove these.
+  // See https://github.com/wellcomecollection/platform/issues/5547
+  override val s3Port: Int = 4566
+  override implicit val s3Client: AmazonS3 =
+    createS3ClientWithEndpoint(s"http://localhost:$s3Port")
 
   private def withSink(bucket: Bucket, keyPrefix: String, offset: Int = 0)(
     testWith: TestWith[Sink[(Json, Long), Future[Done]], Assertion]) = {


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5547

Note: I don't plan to merge this as-is; I'm using it to prove these tests can pass with localstack. Our localstack container runs on port 4566; our existing S3 container uses port 33333. I'd like to collapse it all into 4566, but that's defined in the S3Fixtures trait – I'll have to patch scala-libs to use the new port, then use the new version of the library here, then remove the overrides.