### PR TITLE
Extract the title from the $s subfield for 773 series links

### DIFF
--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraParents.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraParents.scala
@@ -55,6 +55,7 @@ object SierraParents extends SierraQueryOps with Logging {
         SeriesRelation(_)
       )
   }
+
   /**
     * Return the title of the parent object represented by the given VarField
     * The part of the field that represents the title varies by which MARC tag is in use.

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraParents.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraParents.scala
@@ -55,7 +55,6 @@ object SierraParents extends SierraQueryOps with Logging {
         SeriesRelation(_)
       )
   }
-
   /**
     * Return the title of the parent object represented by the given VarField
     * The part of the field that represents the title varies by which MARC tag is in use.
@@ -63,17 +62,17 @@ object SierraParents extends SierraQueryOps with Logging {
     * 440, 490 and 830 fields normally keep it in the main field content
     */
   private def titleFromVarField(field: VarField): Option[String] = {
-    (field.marcTag.get, field.subfieldsWithTags("t", "a")) match {
+    (field.marcTag.get, field.subfieldsWithTags("t", "a", "s")) match {
       case (marcTag, Nil) =>
         if (!field.content.exists(_.nonEmpty)) {
           warn(
-            s"A $marcTag field is expected to have a title in the field content or one of the title subfields (t or a), there was none: $field")
+            s"A $marcTag field is expected to have a title in the field content or one of the title subfields (t/a/s), there was none: $field")
         }
         field.content
       case (marcTag, subfields) =>
         if (subfields.tail.nonEmpty || field.content.exists(_.nonEmpty)) {
           warn(
-            s"Ambiguous $marcTag Series relationship, only one of t, a or the field content is expected to be populated $field")
+            s"Ambiguous $marcTag Series relationship, only one of t, a, s or the field content is expected to be populated $field")
         }
         Some(subfields.head.content)
     }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraParents.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraParents.scala
@@ -59,21 +59,40 @@ object SierraParents extends SierraQueryOps with Logging {
   /**
     * Return the title of the parent object represented by the given VarField
     * The part of the field that represents the title varies by which MARC tag is in use.
-    * 773 fields have no main field content, the title is in the 'title' subfield
-    * 440, 490 and 830 fields normally keep it in the main field content
+    * 773 fields normally have no main field content, the title is in one of the 'title' subfields
+    * 440, 490 and 830 fields normally keep it in the main field content.
+    * There are three subfields that may represent a title - $a, $s, $t
+    *  - any of these fields may use the $a subfield.
+    *  - 4XX fields only have the $a subfield
+    *  - the $s subfield in an 830 field has a different meaning.
+    *
+    *  In practice, there should be no problem with looking for $t and $a on any field,
+    *  because $a is always possible and $t means the same on both 773 and 830, and simply won't
+    *  be there on 4XX.
+    *  However, 830 $s means Version, so must not be included in the lookup for 830 fields.
     */
+
+  private val subFieldTags = Map[String, List[String]](
+    "440" -> List("a"),
+    "490" -> List("a"),
+    "773" -> List("t", "a", "s"),
+    "830" -> List("t", "a")
+  )
+
   private def titleFromVarField(field: VarField): Option[String] = {
-    (field.marcTag.get, field.subfieldsWithTags("t", "a", "s")) match {
-      case (marcTag, Nil) =>
+    val marcTag = field.marcTag.get
+    val subfieldTagsForField = subFieldTags(marcTag)
+    field.subfieldsWithTags(subfieldTagsForField: _*) match {
+      case Nil =>
         if (!field.content.exists(_.nonEmpty)) {
           warn(
-            s"A $marcTag field is expected to have a title in the field content or one of the title subfields (t/a/s), there was none: $field")
+            s"A $marcTag field is expected to have a title in the field content or one of the title subfields (${subfieldTagsForField.mkString(", ")}), there was none: $field")
         }
         field.content
-      case (marcTag, subfields) =>
+      case subfields =>
         if (subfields.tail.nonEmpty || field.content.exists(_.nonEmpty)) {
           warn(
-            s"Ambiguous $marcTag Series relationship, only one of t, a, s or the field content is expected to be populated $field")
+            s"Ambiguous $marcTag Series relationship, only one of ${subfieldTagsForField.mkString(", ")} or the field content is expected to be populated $field")
         }
         Some(subfields.head.content)
     }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraParents.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraParents.scala
@@ -71,7 +71,6 @@ object SierraParents extends SierraQueryOps with Logging {
     *  be there on 4XX.
     *  However, 830 $s means Version, so must not be included in the lookup for 830 fields.
     */
-
   private val subFieldTags = Map[String, List[String]](
     "440" -> List("a"),
     "490" -> List("a"),
@@ -86,13 +85,15 @@ object SierraParents extends SierraQueryOps with Logging {
       case Nil =>
         if (!field.content.exists(_.nonEmpty)) {
           warn(
-            s"A $marcTag field is expected to have a title in the field content or one of the title subfields (${subfieldTagsForField.mkString(", ")}), there was none: $field")
+            s"A $marcTag field is expected to have a title in the field content or one of the title subfields (${subfieldTagsForField
+              .mkString(", ")}), there was none: $field")
         }
         field.content
       case subfields =>
         if (subfields.tail.nonEmpty || field.content.exists(_.nonEmpty)) {
           warn(
-            s"Ambiguous $marcTag Series relationship, only one of ${subfieldTagsForField.mkString(", ")} or the field content is expected to be populated $field")
+            s"Ambiguous $marcTag Series relationship, only one of ${subfieldTagsForField.mkString(
+              ", ")} or the field content is expected to be populated $field")
         }
         Some(subfields.head.content)
     }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraLinksTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraLinksTest.scala
@@ -77,7 +77,7 @@ class SierraLinksTest
     getLinks(varFields) shouldBe List(SeriesRelation("The Series"))
   }
 
-  it("Extracts the title from the body of a 773 field, if title is absent") {
+  it("extracts the title from the body of a 773 field, if title is absent") {
     // This is not a scenario we expect to encounter, but applying
     // Postel's Law and logging a warning is better than discarding it
     val varFields = List(
@@ -100,7 +100,7 @@ class SierraLinksTest
     getLinks(varFields) shouldBe List(SeriesRelation("A Series"))
   }
 
-  it("Extracts the title from the 'a' subfield") {
+  it("extracts the title from the 'a' subfield") {
     forAll(
       Table(
         "marcTag",
@@ -118,6 +118,39 @@ class SierraLinksTest
       getLinks(varFields) shouldBe List(SeriesRelation("A Series"))
     }
 
+  }
+
+  it("prefers titles from a subfield over field content") {
+    forAll(
+      Table(
+        "marcTag",
+        "440",
+        "490",
+        "773",
+        "830"
+      )) { (marcTag) =>
+      val varFields = List(
+        VarField(
+          marcTag = Some(marcTag),
+          subfields = List(Subfield(tag = "a", content = "A Series")),
+          content = Some("Ignore me, I'm not here")
+        )
+      )
+      getLinks(varFields) shouldBe List(SeriesRelation("A Series"))
+    }
+  }
+
+  it("does not extract the title from the 830 $s subfield") {
+    // $s means Version in an 830 field,
+    // so should not be looked at as a potential "title"
+      val varFields = List(
+        VarField(
+          marcTag = Some("830"),
+          subfields = List(Subfield(tag = "s", content = "A Version")),
+          content = Some("A Series")
+        )
+      )
+      getLinks(varFields) shouldBe List(SeriesRelation("A Series"))
   }
 
   it(
@@ -169,7 +202,7 @@ class SierraLinksTest
         ),
         VarField(
           marcTag = Some(marcTag),
-          subfields = List(Subfield(tag = "t", content = "A Host"))
+          subfields = List(Subfield(tag = "a", content = "A Host"))
         ),
         VarField(
           marcTag = Some(marcTag),

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraLinksTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraLinksTest.scala
@@ -143,14 +143,14 @@ class SierraLinksTest
   it("does not extract the title from the 830 $s subfield") {
     // $s means Version in an 830 field,
     // so should not be looked at as a potential "title"
-      val varFields = List(
-        VarField(
-          marcTag = Some("830"),
-          subfields = List(Subfield(tag = "s", content = "A Version")),
-          content = Some("A Series")
-        )
+    val varFields = List(
+      VarField(
+        marcTag = Some("830"),
+        subfields = List(Subfield(tag = "s", content = "A Version")),
+        content = Some("A Series")
       )
-      getLinks(varFields) shouldBe List(SeriesRelation("A Series"))
+    )
+    getLinks(varFields) shouldBe List(SeriesRelation("A Series"))
   }
 
   it(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraLinksTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraLinksTest.scala
@@ -43,15 +43,15 @@ class SierraLinksTest
     )
     getLinks(varFields) shouldBe List(SeriesRelation("A Series"))
   }
-  it("returns a Series relation for a 773 - Host Item Entry field with the title from a subfield") {
+  it(
+    "returns a Series relation for a 773 - Host Item Entry field with the title from a subfield") {
     forAll(
       Table(
         "tag",
         "t",
         "a",
         "s"
-      )) {
-      (tag) =>
+      )) { (tag) =>
       val varFields = List(
         VarField(
           marcTag = "773",

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraLinksTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraLinksTest.scala
@@ -43,19 +43,38 @@ class SierraLinksTest
     )
     getLinks(varFields) shouldBe List(SeriesRelation("A Series"))
   }
+  it("returns a Series relation for a 773 - Host Item Entry field with the title from a subfield") {
+    forAll(
+      Table(
+        "tag",
+        "t",
+        "a",
+        "s"
+      )) {
+      (tag) =>
+      val varFields = List(
+        VarField(
+          marcTag = "773",
+          subfields = List(Subfield(tag = tag, content = "A Series"))
+        )
+      )
+      getLinks(varFields) shouldBe List(SeriesRelation("A Series"))
+    }
+  }
 
-  it("returns a Series relation for a 773 - Host Item Entry field") {
-    // In phase one, all relations from parent to child are treated as
-    // Series links.
-    // This is subject to change in a later phase.
-    // 773 fields differ from the others in that the title is in a subfield
+  it("returns a Series relation with one title, even if multiple are available") {
+    // It is expected that there is one title subfield in the 773 field.
+    // If there are more than one, the first will be returned as the title
     val varFields = List(
       VarField(
         marcTag = "773",
-        subfields = List(Subfield(tag = "t", content = "A Series"))
+        subfields = List(
+          Subfield(tag = "t", content = "The Series"),
+          Subfield(tag = "a", content = "A Series"),
+          Subfield(tag = "s", content = "Some Series"))
       )
     )
-    getLinks(varFields) shouldBe List(SeriesRelation("A Series"))
+    getLinks(varFields) shouldBe List(SeriesRelation("The Series"))
   }
 
   it("Extracts the title from the body of a 773 field, if title is absent") {


### PR DESCRIPTION
https://github.com/wellcomecollection/platform/issues/5526

Because of the different meanings of $s between 773 and 830, this has forced titleFromVarField to become a bit more specific in what it does for different fields.