### PR TITLE
strip trailing punctuation from both titles

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Relations.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Relations.scala
@@ -67,7 +67,7 @@ object RelationSet {
 
     // duplicated if it shares a title, but not if it already has an identifier.
     def isRelationDuplicated(relation: Relation): Boolean =
-      relation.id.isEmpty && newTitles.contains(relation.title.getOrElse(""))
+      relation.id.isEmpty && newTitles.contains(removeTerminalPunctuation(relation.title))
 
     val relationsToKeep =
       existingRelations.filter(r => !isRelationDuplicated(r))

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Relations.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Relations.scala
@@ -67,7 +67,8 @@ object RelationSet {
 
     // duplicated if it shares a title, but not if it already has an identifier.
     def isRelationDuplicated(relation: Relation): Boolean =
-      relation.id.isEmpty && newTitles.contains(removeTerminalPunctuation(relation.title))
+      relation.id.isEmpty && newTitles.contains(
+        removeTerminalPunctuation(relation.title))
 
     val relationsToKeep =
       existingRelations.filter(r => !isRelationDuplicated(r))

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/StateTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/StateTest.scala
@@ -213,13 +213,16 @@ class StateTest
           // Unnecessary trailing punctuation is expected to have
           // been removed in the creation of a SeriesRelation.
           relations = Relations(
-            ancestors = List(SeriesRelation("Basil Hood. Photograph Album"))
+            ancestors = List(
+              SeriesRelation("Basil Hood. Photograph Album"),
+              SeriesRelation("Studio Portraits of Women.")
+            )
           )
         ),
         data = WorkData(title = Some("My Title"))
       )
 
-      val newAlbum = new Relation(
+      val album = new Relation(
         id = Some(CanonicalId("deadbeef")),
         // The title is the same as the one already there, but with a trailing '.'
         title = Some("Basil Hood. Photograph Album."),
@@ -230,12 +233,23 @@ class StateTest
         numDescendents = 1
       )
 
+      val portraits = new Relation(
+        id = Some(CanonicalId("cafefeed")),
+        // The title is the same as the one already there, retaining the trailing '.'
+        title = Some("Studio Portraits of Women."),
+        collectionPath = Some(CollectionPath("abadcafe/cafefeed")),
+        workType = WorkType.Standard,
+        depth = 0,
+        numChildren = 1,
+        numDescendents = 1
+      )
+
       val denormalised = merged.transition[Denormalised](
         Relations(
-          ancestors = List(newAlbum)
+          ancestors = List(album, portraits)
         )
       )
-      denormalised.state.relations.ancestors shouldBe List(newAlbum)
+      denormalised.state.relations.ancestors shouldBe List(album, portraits)
     }
 
     it("preserves existing state members") {


### PR DESCRIPTION
https://github.com/wellcomecollection/platform/issues/5554

Code to ignore trailing punctuation when comparing series titles failed to take into account that both titles might have it.