### PR TITLE
Move more fields into the `query` object

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# See https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github
+pipeline/ingestor/test_documents/*.json linguist-generated=true

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/IndexConfigFields.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/IndexConfigFields.scala
@@ -54,7 +54,10 @@ trait IndexConfigFields extends ElasticFieldOps {
       )
       .analyzer(asciifoldingAnalyzer.name)
 
-  val label = asciifoldingTextFieldWithKeyword("label")
+  def labelField(name: String): TextField =
+    asciifoldingTextFieldWithKeyword(name)
+
+  val label = labelField(name = "label")
 
   val canonicalId = lowercaseKeyword("canonicalId")
 

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksIndexConfig.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksIndexConfig.scala
@@ -235,6 +235,9 @@ object WorksIndexConfig extends IndexConfigFields {
           // items
           canonicalIdField("items.id"),
           sourceIdentifierField("items.identifiers.value"),
+          keywordField("items.locations.accessConditions.status.id"),
+          keywordField("items.locations.license.id"),
+          keywordField("items.locations.locationType.id"),
           // subjects
           canonicalIdField("subjects.id"),
           sourceIdentifierField("subjects.identifiers.value"),

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksIndexConfig.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksIndexConfig.scala
@@ -242,9 +242,9 @@ object WorksIndexConfig extends IndexConfigFields {
           canonicalIdField("subjects.id"),
           sourceIdentifierField("subjects.identifiers.value"),
           keywordField("subjects.label"),
-          asciifoldingTextFieldWithKeyword("subjects.concepts.label"),
+          labelField("subjects.concepts.label"),
           // genres
-          asciifoldingTextFieldWithKeyword("genres.concepts.label"),
+          labelField("genres.concepts.label"),
           // languages
           keywordField("languages.id"),
           // relations

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksIndexConfig.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksIndexConfig.scala
@@ -245,6 +245,8 @@ object WorksIndexConfig extends IndexConfigFields {
           asciifoldingTextFieldWithKeyword("subjects.concepts.label"),
           // genres
           asciifoldingTextFieldWithKeyword("genres.concepts.label"),
+          // languages
+          keywordField("languages.id"),
           // relations
           canonicalIdField("partOf.id"),
           multilingualFieldWithKeyword("partOf.title"),

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksIndexConfig.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksIndexConfig.scala
@@ -247,6 +247,8 @@ object WorksIndexConfig extends IndexConfigFields {
           labelField("genres.concepts.label"),
           // languages
           keywordField("languages.id"),
+          // contributors
+          labelField("contributors.agent.label"),
           // relations
           canonicalIdField("partOf.id"),
           multilingualFieldWithKeyword("partOf.title"),

--- a/common/internal_model/src/test/resources/WorksIndexConfig.json
+++ b/common/internal_model/src/test/resources/WorksIndexConfig.json
@@ -1022,6 +1022,9 @@
               }
             }
           },
+          "languages.id" : {
+            "type" : "keyword"
+          },
           "partOf.id" : {
             "type" : "keyword",
             "normalizer" : "lowercase_normalizer"

--- a/common/internal_model/src/test/resources/WorksIndexConfig.json
+++ b/common/internal_model/src/test/resources/WorksIndexConfig.json
@@ -976,6 +976,15 @@
             "type" : "keyword",
             "normalizer" : "lowercase_normalizer"
           },
+          "items.locations.accessConditions.status.id" : {
+            "type" : "keyword"
+          },
+          "items.locations.license.id" : {
+            "type" : "keyword"
+          },
+          "items.locations.locationType.id" : {
+            "type" : "keyword"
+          },
           "subjects.id" : {
             "type" : "keyword",
             "normalizer" : "lowercase_normalizer"

--- a/common/internal_model/src/test/resources/WorksIndexConfig.json
+++ b/common/internal_model/src/test/resources/WorksIndexConfig.json
@@ -1025,6 +1025,19 @@
           "languages.id" : {
             "type" : "keyword"
           },
+          "contributors.agent.label" : {
+            "type" : "text",
+            "analyzer" : "asciifolding_analyzer",
+            "fields" : {
+              "keyword" : {
+                "type" : "keyword"
+              },
+              "lowercaseKeyword" : {
+                "type" : "keyword",
+                "normalizer" : "lowercase_normalizer"
+              }
+            }
+          },
           "partOf.id" : {
             "type" : "keyword",
             "normalizer" : "lowercase_normalizer"

--- a/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/WorkQueryableValues.scala
+++ b/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/WorkQueryableValues.scala
@@ -16,6 +16,9 @@ case class WorkQueryableValues(
   @JsonKey("images.identifiers.value") imageIdentifiers: List[String],
   @JsonKey("items.id") itemIds: List[String],
   @JsonKey("items.identifiers.value") itemIdentifiers: List[String],
+  @JsonKey("items.locations.accessConditions.status.id") itemAccessStatusIds: List[String],
+  @JsonKey("items.locations.license.id") itemLicenseIds: List[String],
+  @JsonKey("items.locations.locationType.id") itemLocationTypeIds: List[String],
   @JsonKey("subjects.id") subjectIds: List[String],
   @JsonKey("subjects.identifiers.value") subjectIdentifiers: List[String],
   @JsonKey("subjects.label") subjectLabels: List[String],
@@ -31,7 +34,9 @@ case object WorkQueryableValues {
             sourceIdentifier: SourceIdentifier,
             workData: WorkData[DataState.Identified],
             relations: Relations,
-            availabilities: Set[Availability]): WorkQueryableValues =
+            availabilities: Set[Availability]): WorkQueryableValues = {
+    val locations = workData.items.flatMap(_.locations)
+
     WorkQueryableValues(
       id = id.underlying,
       workIdentifiers =
@@ -41,6 +46,9 @@ case object WorkQueryableValues {
       itemIds = workData.items.flatMap(_.id.maybeCanonicalId).map(_.underlying),
       itemIdentifiers =
         workData.items.flatMap(_.id.allSourceIdentifiers).map(_.value),
+      itemAccessStatusIds = locations.flatMap(_.accessConditions).flatMap(_.status).map(_.id),
+      itemLicenseIds = locations.flatMap(_.license).map(_.id),
+      itemLocationTypeIds = locations.map(_.locationType.id),
       subjectIds = workData.subjects.map(_.id).canonicalIds,
       subjectIdentifiers = workData.subjects.map(_.id).sourceIdentifiers,
       subjectLabels = workData.subjects.map(_.label),
@@ -50,6 +58,7 @@ case object WorkQueryableValues {
       partOfTitles = relations.ancestors.flatMap(_.title),
       availabilityIds = availabilities.map(_.id).toList
     )
+  }
 
   implicit class IdStateOps(ids: Seq[IdState.Minted]) {
     def canonicalIds: List[String] =

--- a/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/WorkQueryableValues.scala
+++ b/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/WorkQueryableValues.scala
@@ -16,7 +16,8 @@ case class WorkQueryableValues(
   @JsonKey("images.identifiers.value") imageIdentifiers: List[String],
   @JsonKey("items.id") itemIds: List[String],
   @JsonKey("items.identifiers.value") itemIdentifiers: List[String],
-  @JsonKey("items.locations.accessConditions.status.id") itemAccessStatusIds: List[String],
+  @JsonKey("items.locations.accessConditions.status.id") itemAccessStatusIds: List[
+    String],
   @JsonKey("items.locations.license.id") itemLicenseIds: List[String],
   @JsonKey("items.locations.locationType.id") itemLocationTypeIds: List[String],
   @JsonKey("subjects.id") subjectIds: List[String],
@@ -48,7 +49,8 @@ case object WorkQueryableValues {
       itemIds = workData.items.flatMap(_.id.maybeCanonicalId).map(_.underlying),
       itemIdentifiers =
         workData.items.flatMap(_.id.allSourceIdentifiers).map(_.value),
-      itemAccessStatusIds = locations.flatMap(_.accessConditions).flatMap(_.status).map(_.id),
+      itemAccessStatusIds =
+        locations.flatMap(_.accessConditions).flatMap(_.status).map(_.id),
       itemLicenseIds = locations.flatMap(_.license).map(_.id),
       itemLocationTypeIds = locations.map(_.locationType.id),
       subjectIds = workData.subjects.map(_.id).canonicalIds,

--- a/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/WorkQueryableValues.scala
+++ b/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/WorkQueryableValues.scala
@@ -24,6 +24,7 @@ case class WorkQueryableValues(
   @JsonKey("subjects.label") subjectLabels: List[String],
   @JsonKey("subjects.concepts.label") subjectConceptLabels: List[String],
   @JsonKey("genres.concepts.label") genreConceptLabels: List[String],
+  @JsonKey("languages.id") languageIds: List[String],
   @JsonKey("partOf.id") partOfIds: List[String],
   @JsonKey("partOf.title") partOfTitles: List[String],
   @JsonKey("availabilities.id") availabilityIds: List[String],
@@ -54,6 +55,7 @@ case object WorkQueryableValues {
       subjectLabels = workData.subjects.map(_.label),
       subjectConceptLabels = workData.subjects.flatMap(_.concepts).map(_.label),
       genreConceptLabels = workData.genres.flatMap(_.concepts).map(_.label),
+      languageIds = workData.languages.map(_.id),
       partOfIds = relations.ancestors.flatMap(_.id).map(_.underlying),
       partOfTitles = relations.ancestors.flatMap(_.title),
       availabilityIds = availabilities.map(_.id).toList

--- a/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/WorkQueryableValues.scala
+++ b/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/WorkQueryableValues.scala
@@ -25,6 +25,7 @@ case class WorkQueryableValues(
   @JsonKey("subjects.concepts.label") subjectConceptLabels: List[String],
   @JsonKey("genres.concepts.label") genreConceptLabels: List[String],
   @JsonKey("languages.id") languageIds: List[String],
+  @JsonKey("contributors.agent.label") contributorAgentLabels: List[String],
   @JsonKey("partOf.id") partOfIds: List[String],
   @JsonKey("partOf.title") partOfTitles: List[String],
   @JsonKey("availabilities.id") availabilityIds: List[String],
@@ -56,6 +57,7 @@ case object WorkQueryableValues {
       subjectConceptLabels = workData.subjects.flatMap(_.concepts).map(_.label),
       genreConceptLabels = workData.genres.flatMap(_.concepts).map(_.label),
       languageIds = workData.languages.map(_.id),
+      contributorAgentLabels = workData.contributors.map(_.agent.label),
       partOfIds = relations.ancestors.flatMap(_.id).map(_.underlying),
       partOfTitles = relations.ancestors.flatMap(_.title),
       availabilityIds = availabilities.map(_.id).toList

--- a/pipeline/ingestor/ingestor_works/src/test/scala/weco/pipeline/ingestor/works/models/WorkQueryableValuesTest.scala
+++ b/pipeline/ingestor/ingestor_works/src/test/scala/weco/pipeline/ingestor/works/models/WorkQueryableValuesTest.scala
@@ -182,7 +182,10 @@ class WorkQueryableValuesTest
       availabilities = Set()
     )
 
-    q.contributorAgentLabels shouldBe List("Crafty Carol", "Cruel Cinderella", "Careful Carlos")
+    q.contributorAgentLabels shouldBe List(
+      "Crafty Carol",
+      "Cruel Cinderella",
+      "Careful Carlos")
   }
 
   it("adds items") {
@@ -259,11 +262,17 @@ class WorkQueryableValuesTest
     q.itemIds shouldBe List("item1111", "item2222")
     q.itemIdentifiers shouldBe List("sourceItem1", "sourceItem2", "otherItem2")
     q.itemAccessStatusIds shouldBe List(
-      "open", "open-with-advisory", "closed", "open-with-advisory"
+      "open",
+      "open-with-advisory",
+      "closed",
+      "open-with-advisory"
     )
     q.itemLicenseIds shouldBe List("cc-by", "cc-by-nc")
     q.itemLocationTypeIds shouldBe List(
-      "open-shelves", "closed-stores", "iiif-image", "iiif-presentation"
+      "open-shelves",
+      "closed-stores",
+      "iiif-image",
+      "iiif-presentation"
     )
   }
 

--- a/pipeline/ingestor/ingestor_works/src/test/scala/weco/pipeline/ingestor/works/models/WorkQueryableValuesTest.scala
+++ b/pipeline/ingestor/ingestor_works/src/test/scala/weco/pipeline/ingestor/works/models/WorkQueryableValuesTest.scala
@@ -4,9 +4,17 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.catalogue.internal_model.generators.ImageGenerators
 import weco.catalogue.internal_model.identifiers._
-import weco.catalogue.internal_model.locations.{AccessCondition, AccessMethod, AccessStatus, License, LocationType}
+import weco.catalogue.internal_model.languages.Language
+import weco.catalogue.internal_model.locations.{
+  AccessCondition,
+  AccessMethod,
+  AccessStatus,
+  License,
+  LocationType
+}
 import weco.catalogue.internal_model.work._
 import weco.catalogue.internal_model.work.generators.{
+  ContributorGenerators,
   ItemsGenerators,
   WorkGenerators
 }
@@ -14,6 +22,7 @@ import weco.catalogue.internal_model.work.generators.{
 class WorkQueryableValuesTest
     extends AnyFunSpec
     with Matchers
+    with ContributorGenerators
     with ItemsGenerators
     with ImageGenerators
     with WorkGenerators {
@@ -132,6 +141,48 @@ class WorkQueryableValuesTest
     )
 
     q.genreConceptLabels shouldBe List("generosity", "greebles", "greatness")
+  }
+
+  it("adds languages") {
+    val workData = WorkData[DataState.Identified](
+      title = Some(s"title-${randomAlphanumeric(length = 10)}"),
+      languages = List(
+        Language(id = "eng", label = "English"),
+        Language(id = "ger", label = "German"),
+        Language(id = "fre", label = "French"),
+      )
+    )
+
+    val q = WorkQueryableValues(
+      id = createCanonicalId,
+      sourceIdentifier = createSourceIdentifier,
+      workData = workData,
+      relations = Relations(),
+      availabilities = Set()
+    )
+
+    q.languageIds shouldBe List("eng", "ger", "fre")
+  }
+
+  it("adds contributors") {
+    val workData = WorkData[DataState.Identified](
+      title = Some(s"title-${randomAlphanumeric(length = 10)}"),
+      contributors = List(
+        createPersonContributorWith(label = "Crafty Carol"),
+        createPersonContributorWith(label = "Cruel Cinderella"),
+        createPersonContributorWith(label = "Careful Carlos"),
+      )
+    )
+
+    val q = WorkQueryableValues(
+      id = createCanonicalId,
+      sourceIdentifier = createSourceIdentifier,
+      workData = workData,
+      relations = Relations(),
+      availabilities = Set()
+    )
+
+    q.contributorAgentLabels shouldBe List("Crafty Carol", "Cruel Cinderella", "Careful Carlos")
   }
 
   it("adds items") {

--- a/pipeline/ingestor/ingestor_works/src/test/scala/weco/pipeline/ingestor/works/models/WorkQueryableValuesTest.scala
+++ b/pipeline/ingestor/ingestor_works/src/test/scala/weco/pipeline/ingestor/works/models/WorkQueryableValuesTest.scala
@@ -4,6 +4,7 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.catalogue.internal_model.generators.ImageGenerators
 import weco.catalogue.internal_model.identifiers._
+import weco.catalogue.internal_model.locations.{AccessCondition, AccessMethod, AccessStatus, License, LocationType}
 import weco.catalogue.internal_model.work._
 import weco.catalogue.internal_model.work.generators.{
   ItemsGenerators,
@@ -137,11 +138,37 @@ class WorkQueryableValuesTest
     val data = WorkData[DataState.Identified](
       title = Some(s"title-${randomAlphanumeric(length = 10)}"),
       items = List(
-        createUnidentifiableItem,
+        createUnidentifiableItemWith(locations = List()),
         createIdentifiedItemWith(
           canonicalId = CanonicalId("item1111"),
           sourceIdentifier = createSourceIdentifierWith(value = "sourceItem1"),
           otherIdentifiers = List(),
+          locations = List(
+            createPhysicalLocationWith(
+              locationType = LocationType.OpenShelves,
+              accessConditions = List(
+                AccessCondition(
+                  method = AccessMethod.OpenShelves,
+                  status = AccessStatus.Open
+                ),
+                AccessCondition(
+                  method = AccessMethod.OpenShelves,
+                  status = AccessStatus.OpenWithAdvisory
+                )
+              ),
+              license = None
+            ),
+            createPhysicalLocationWith(
+              locationType = LocationType.ClosedStores,
+              accessConditions = List(
+                AccessCondition(
+                  method = AccessMethod.NotRequestable,
+                  status = AccessStatus.Closed
+                )
+              ),
+              license = None
+            )
+          )
         ),
         createIdentifiedItemWith(
           canonicalId = CanonicalId("item2222"),
@@ -149,6 +176,23 @@ class WorkQueryableValuesTest
           otherIdentifiers = List(
             createSourceIdentifierWith(value = "otherItem2")
           ),
+          locations = List(
+            createDigitalLocationWith(
+              locationType = LocationType.IIIFImageAPI,
+              license = Some(License.CCBY),
+              accessConditions = List(
+                AccessCondition(
+                  method = AccessMethod.ViewOnline,
+                  status = AccessStatus.OpenWithAdvisory
+                )
+              )
+            ),
+            createDigitalLocationWith(
+              locationType = LocationType.IIIFPresentationAPI,
+              license = Some(License.CCBYNC),
+              accessConditions = List()
+            )
+          )
         )
       )
     )
@@ -163,6 +207,13 @@ class WorkQueryableValuesTest
 
     q.itemIds shouldBe List("item1111", "item2222")
     q.itemIdentifiers shouldBe List("sourceItem1", "sourceItem2", "otherItem2")
+    q.itemAccessStatusIds shouldBe List(
+      "open", "open-with-advisory", "closed", "open-with-advisory"
+    )
+    q.itemLicenseIds shouldBe List("cc-by", "cc-by-nc")
+    q.itemLocationTypeIds shouldBe List(
+      "open-shelves", "closed-stores", "iiif-image", "iiif-presentation"
+    )
   }
 
   it("adds images") {

--- a/pipeline/ingestor/test_documents/work-production.1098.json
+++ b/pipeline/ingestor/test_documents/work-production.1098.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 1098",
-  "createdAt" : "2022-06-06T11:16:20.610345Z",
+  "createdAt" : "2022-06-13T13:06:48.360331Z",
   "id" : "guav7chy",
   "document" : {
     "debug" : {
@@ -175,6 +175,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -184,6 +190,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/work-production.1900.json
+++ b/pipeline/ingestor/test_documents/work-production.1900.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 1900",
-  "createdAt" : "2022-06-06T11:16:20.581054Z",
+  "createdAt" : "2022-06-13T13:06:48.331858Z",
   "id" : "rbnro6wx",
   "document" : {
     "debug" : {
@@ -175,6 +175,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -184,6 +190,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/work-production.1904.json
+++ b/pipeline/ingestor/test_documents/work-production.1904.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 1904",
-  "createdAt" : "2022-06-06T11:16:20.594913Z",
+  "createdAt" : "2022-06-13T13:06:48.347219Z",
   "id" : "aiv95swj",
   "document" : {
     "debug" : {
@@ -175,6 +175,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -184,6 +190,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/work-production.1976.json
+++ b/pipeline/ingestor/test_documents/work-production.1976.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 1976",
-  "createdAt" : "2022-06-06T11:16:20.588375Z",
+  "createdAt" : "2022-06-13T13:06:48.340575Z",
   "id" : "5vjghupy",
   "document" : {
     "debug" : {
@@ -175,6 +175,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -184,6 +190,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/work-production.2020.json
+++ b/pipeline/ingestor/test_documents/work-production.2020.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 2020",
-  "createdAt" : "2022-06-06T11:16:20.602970Z",
+  "createdAt" : "2022-06-13T13:06:48.353748Z",
   "id" : "0fucriyr",
   "document" : {
     "debug" : {
@@ -175,6 +175,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -184,6 +190,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/work-thumbnail.json
+++ b/pipeline/ingestor/test_documents/work-thumbnail.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a thumbnail",
-  "createdAt" : "2022-06-06T11:16:20.493854Z",
+  "createdAt" : "2022-06-13T13:06:48.260653Z",
   "id" : "sahqcluh",
   "document" : {
     "debug" : {
@@ -169,6 +169,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -178,6 +184,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/work-title-dodo.json
+++ b/pipeline/ingestor/test_documents/work-title-dodo.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with 'dodo' in the title",
-  "createdAt" : "2022-06-06T11:16:20.501887Z",
+  "createdAt" : "2022-06-13T13:06:48.269722Z",
   "id" : "ezagik4b",
   "document" : {
     "debug" : {
@@ -141,6 +141,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -150,6 +156,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/work-title-mouse.json
+++ b/pipeline/ingestor/test_documents/work-title-mouse.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with 'mouse' in the title",
-  "createdAt" : "2022-06-06T11:16:20.507953Z",
+  "createdAt" : "2022-06-13T13:06:48.275864Z",
   "id" : "lnn17cwk",
   "document" : {
     "debug" : {
@@ -141,6 +141,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -150,6 +156,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/work-with-edition-and-duration.json
+++ b/pipeline/ingestor/test_documents/work-with-edition-and-duration.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with optional top-level fields",
-  "createdAt" : "2022-06-06T11:16:20.403453Z",
+  "createdAt" : "2022-06-13T13:06:48.189082Z",
   "id" : "gsruvqwf",
   "document" : {
     "debug" : {
@@ -142,6 +142,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -151,6 +157,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/work.items-with-location-types.0.json
+++ b/pipeline/ingestor/test_documents/work.items-with-location-types.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "items with different location types",
-  "createdAt" : "2022-06-09T10:25:50.648903Z",
+  "createdAt" : "2022-06-13T13:06:49.153690Z",
   "id" : "kdwct2lf",
   "document" : {
     "debug" : {
@@ -209,6 +209,14 @@
       "items.identifiers.value" : [
         "LIHkQjFHQR"
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+        "cc-by"
+      ],
+      "items.locations.locationType.id" : [
+        "iiif-image"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -218,6 +226,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/work.items-with-location-types.1.json
+++ b/pipeline/ingestor/test_documents/work.items-with-location-types.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "items with different location types",
-  "createdAt" : "2022-06-09T10:25:50.649871Z",
+  "createdAt" : "2022-06-13T13:06:49.154417Z",
   "id" : "sgatphra",
   "document" : {
     "debug" : {
@@ -241,6 +241,16 @@
       "items.identifiers.value" : [
         "lPj6a56tuj"
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+        "cc-by",
+        "cc-by"
+      ],
+      "items.locations.locationType.id" : [
+        "iiif-image",
+        "iiif-presentation"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -250,6 +260,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/work.items-with-location-types.2.json
+++ b/pipeline/ingestor/test_documents/work.items-with-location-types.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "items with different location types",
-  "createdAt" : "2022-06-09T10:25:50.650563Z",
+  "createdAt" : "2022-06-13T13:06:49.155017Z",
   "id" : "wt6pclbs",
   "document" : {
     "debug" : {
@@ -217,6 +217,14 @@
       "items.identifiers.value" : [
         "G3f7j0ub0t"
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+        "pdm"
+      ],
+      "items.locations.locationType.id" : [
+        "closed-stores"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -226,6 +234,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/work.visible.everything.0.json
+++ b/pipeline/ingestor/test_documents/work.visible.everything.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "a list of work with all the include-able fields",
-  "createdAt" : "2022-06-09T10:25:50.116487Z",
+  "createdAt" : "2022-06-13T13:06:48.591451Z",
   "id" : "tmdfbk5k",
   "document" : {
     "debug" : {
@@ -1011,6 +1011,18 @@
         "hKyStbKjx1",
         "XLNdBtGWWF"
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+        "cc-by",
+        "cc-by",
+        "cc-by"
+      ],
+      "items.locations.locationType.id" : [
+        "iiif-presentation",
+        "iiif-presentation",
+        "iiif-presentation"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -1034,6 +1046,15 @@
         "DgAW3Gj5M4V6Fk1",
         "Uu2KL5QXsRV8G10",
         "ObxxWE1MLX8biK5"
+      ],
+      "languages.id" : [
+        "qbV",
+        "2DH",
+        "yMV"
+      ],
+      "contributors.agent.label" : [
+        "person-W9SVIX0fEg",
+        "person-IWtB2H6"
       ],
       "partOf.id" : [
         "0cs6cerb",

--- a/pipeline/ingestor/test_documents/work.visible.everything.1.json
+++ b/pipeline/ingestor/test_documents/work.visible.everything.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "a list of work with all the include-able fields",
-  "createdAt" : "2022-06-09T10:25:50.165238Z",
+  "createdAt" : "2022-06-13T13:06:48.643535Z",
   "id" : "nlqnlwch",
   "document" : {
     "debug" : {
@@ -1080,6 +1080,18 @@
         "CnNOdtzVPO",
         "ezIlsnnb0Z"
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+        "cc-by",
+        "cc-by",
+        "cc-by"
+      ],
+      "items.locations.locationType.id" : [
+        "iiif-presentation",
+        "iiif-presentation",
+        "iiif-presentation"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -1103,6 +1115,15 @@
         "e6G99aHcLRRBkyn",
         "24xZvMlY5yFST4h",
         "zY1cKoWGXrGHlOd"
+      ],
+      "languages.id" : [
+        "yc6",
+        "hi6",
+        "GkI"
+      ],
+      "contributors.agent.label" : [
+        "person-kGPDWLL",
+        "person-2Xsatm0"
       ],
       "partOf.id" : [
         "jlsj0le6",

--- a/pipeline/ingestor/test_documents/work.visible.everything.2.json
+++ b/pipeline/ingestor/test_documents/work.visible.everything.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "a list of work with all the include-able fields",
-  "createdAt" : "2022-06-09T10:25:50.170626Z",
+  "createdAt" : "2022-06-13T13:06:48.649256Z",
   "id" : "jfzz4ou9",
   "document" : {
     "debug" : {
@@ -1089,6 +1089,18 @@
         "haLIuxnEwk",
         "KFWEKKm2rQ"
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+        "cc-by",
+        "cc-by",
+        "cc-by"
+      ],
+      "items.locations.locationType.id" : [
+        "iiif-presentation",
+        "iiif-presentation",
+        "iiif-presentation"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -1112,6 +1124,15 @@
         "ZGNVldxfQFhVctB",
         "FwsNPAX3Wg9bz6n",
         "2QtjPUbfZXARrSC"
+      ],
+      "languages.id" : [
+        "6hh",
+        "EHn",
+        "7Jx"
+      ],
+      "contributors.agent.label" : [
+        "person-UFES8H2",
+        "person-LQeClX"
       ],
       "partOf.id" : [
         "k4gltrjv",

--- a/pipeline/ingestor/test_documents/works.collection-path.NUFFINK.json
+++ b/pipeline/ingestor/test_documents/works.collection-path.NUFFINK.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a collection path",
-  "createdAt" : "2022-06-09T10:25:50.494497Z",
+  "createdAt" : "2022-06-13T13:06:48.984287Z",
   "id" : "dtqmc0yn",
   "document" : {
     "debug" : {
@@ -143,6 +143,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -152,6 +158,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.collection-path.PPCRI.json
+++ b/pipeline/ingestor/test_documents/works.collection-path.PPCRI.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a collection path",
-  "createdAt" : "2022-06-09T10:25:50.487153Z",
+  "createdAt" : "2022-06-13T13:06:48.979099Z",
   "id" : "mlqs2qbd",
   "document" : {
     "debug" : {
@@ -143,6 +143,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -152,6 +158,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.contributor.0.json
+++ b/pipeline/ingestor/test_documents/works.contributor.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different contributor",
-  "createdAt" : "2022-06-09T10:25:50.427772Z",
+  "createdAt" : "2022-06-13T13:06:48.915173Z",
   "id" : "gvkz3vff",
   "document" : {
     "debug" : {
@@ -163,6 +163,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -172,6 +178,11 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
+        "47"
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.contributor.1.json
+++ b/pipeline/ingestor/test_documents/works.contributor.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different contributor",
-  "createdAt" : "2022-06-09T10:25:50.428801Z",
+  "createdAt" : "2022-06-13T13:06:48.916079Z",
   "id" : "bj9evx0c",
   "document" : {
     "debug" : {
@@ -163,6 +163,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -172,6 +178,11 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
+        "47"
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.contributor.2.json
+++ b/pipeline/ingestor/test_documents/works.contributor.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different contributor",
-  "createdAt" : "2022-06-09T10:25:50.432822Z",
+  "createdAt" : "2022-06-13T13:06:48.925093Z",
   "id" : "z08k6cnn",
   "document" : {
     "debug" : {
@@ -186,6 +186,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -195,6 +201,12 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
+        "007",
+        "MI5"
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.contributor.3.json
+++ b/pipeline/ingestor/test_documents/works.contributor.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different contributor",
-  "createdAt" : "2022-06-09T10:25:50.433693Z",
+  "createdAt" : "2022-06-13T13:06:48.925962Z",
   "id" : "gtfjchvo",
   "document" : {
     "debug" : {
@@ -186,6 +186,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -195,6 +201,12 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
+        "MI5",
+        "GCHQ"
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.every-format.0.json
+++ b/pipeline/ingestor/test_documents/works.every-format.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-06-09T10:25:50.506758Z",
+  "createdAt" : "2022-06-13T13:06:48.992574Z",
   "id" : "4njkixz6",
   "document" : {
     "debug" : {
@@ -148,6 +148,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -157,6 +163,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.every-format.1.json
+++ b/pipeline/ingestor/test_documents/works.every-format.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-06-09T10:25:50.507207Z",
+  "createdAt" : "2022-06-13T13:06:48.993235Z",
   "id" : "jugcpduf",
   "document" : {
     "debug" : {
@@ -148,6 +148,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -157,6 +163,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.every-format.10.json
+++ b/pipeline/ingestor/test_documents/works.every-format.10.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-06-09T10:25:50.510756Z",
+  "createdAt" : "2022-06-13T13:06:48.998175Z",
   "id" : "4wwgkp4h",
   "document" : {
     "debug" : {
@@ -148,6 +148,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -157,6 +163,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.every-format.11.json
+++ b/pipeline/ingestor/test_documents/works.every-format.11.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-06-09T10:25:50.511202Z",
+  "createdAt" : "2022-06-13T13:06:48.998771Z",
   "id" : "kkcl3dhq",
   "document" : {
     "debug" : {
@@ -148,6 +148,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -157,6 +163,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.every-format.12.json
+++ b/pipeline/ingestor/test_documents/works.every-format.12.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-06-09T10:25:50.511590Z",
+  "createdAt" : "2022-06-13T13:06:48.999228Z",
   "id" : "ilrp0gol",
   "document" : {
     "debug" : {
@@ -148,6 +148,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -157,6 +163,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.every-format.13.json
+++ b/pipeline/ingestor/test_documents/works.every-format.13.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-06-09T10:25:50.512024Z",
+  "createdAt" : "2022-06-13T13:06:48.999746Z",
   "id" : "rdqs25hn",
   "document" : {
     "debug" : {
@@ -148,6 +148,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -157,6 +163,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.every-format.14.json
+++ b/pipeline/ingestor/test_documents/works.every-format.14.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-06-09T10:25:50.512450Z",
+  "createdAt" : "2022-06-13T13:06:49.000158Z",
   "id" : "124qx5km",
   "document" : {
     "debug" : {
@@ -148,6 +148,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -157,6 +163,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.every-format.15.json
+++ b/pipeline/ingestor/test_documents/works.every-format.15.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-06-09T10:25:50.512838Z",
+  "createdAt" : "2022-06-13T13:06:49.000602Z",
   "id" : "tlc5rq9a",
   "document" : {
     "debug" : {
@@ -148,6 +148,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -157,6 +163,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.every-format.16.json
+++ b/pipeline/ingestor/test_documents/works.every-format.16.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-06-09T10:25:50.513254Z",
+  "createdAt" : "2022-06-13T13:06:49.001029Z",
   "id" : "sdb22mdv",
   "document" : {
     "debug" : {
@@ -148,6 +148,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -157,6 +163,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.every-format.17.json
+++ b/pipeline/ingestor/test_documents/works.every-format.17.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-06-09T10:25:50.513630Z",
+  "createdAt" : "2022-06-13T13:06:49.001470Z",
   "id" : "9tar4kg6",
   "document" : {
     "debug" : {
@@ -148,6 +148,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -157,6 +163,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.every-format.18.json
+++ b/pipeline/ingestor/test_documents/works.every-format.18.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-06-09T10:25:50.514001Z",
+  "createdAt" : "2022-06-13T13:06:49.002019Z",
   "id" : "au6tjof0",
   "document" : {
     "debug" : {
@@ -148,6 +148,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -157,6 +163,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.every-format.19.json
+++ b/pipeline/ingestor/test_documents/works.every-format.19.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-06-09T10:25:50.514503Z",
+  "createdAt" : "2022-06-13T13:06:49.002488Z",
   "id" : "ogdq417u",
   "document" : {
     "debug" : {
@@ -148,6 +148,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -157,6 +163,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.every-format.2.json
+++ b/pipeline/ingestor/test_documents/works.every-format.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-06-09T10:25:50.507591Z",
+  "createdAt" : "2022-06-13T13:06:48.993804Z",
   "id" : "fuwvinln",
   "document" : {
     "debug" : {
@@ -148,6 +148,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -157,6 +163,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.every-format.20.json
+++ b/pipeline/ingestor/test_documents/works.every-format.20.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-06-09T10:25:50.514867Z",
+  "createdAt" : "2022-06-13T13:06:49.002903Z",
   "id" : "jyum0yf1",
   "document" : {
     "debug" : {
@@ -148,6 +148,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -157,6 +163,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.every-format.21.json
+++ b/pipeline/ingestor/test_documents/works.every-format.21.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-06-09T10:25:50.515274Z",
+  "createdAt" : "2022-06-13T13:06:49.003311Z",
   "id" : "cwippax3",
   "document" : {
     "debug" : {
@@ -148,6 +148,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -157,6 +163,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.every-format.22.json
+++ b/pipeline/ingestor/test_documents/works.every-format.22.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-06-09T10:25:50.515696Z",
+  "createdAt" : "2022-06-13T13:06:49.003742Z",
   "id" : "9rgmu63i",
   "document" : {
     "debug" : {
@@ -148,6 +148,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -157,6 +163,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.every-format.3.json
+++ b/pipeline/ingestor/test_documents/works.every-format.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-06-09T10:25:50.507961Z",
+  "createdAt" : "2022-06-13T13:06:48.994366Z",
   "id" : "i77xk8vj",
   "document" : {
     "debug" : {
@@ -148,6 +148,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -157,6 +163,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.every-format.4.json
+++ b/pipeline/ingestor/test_documents/works.every-format.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-06-09T10:25:50.508382Z",
+  "createdAt" : "2022-06-13T13:06:48.994879Z",
   "id" : "xgsosrhr",
   "document" : {
     "debug" : {
@@ -148,6 +148,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -157,6 +163,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.every-format.5.json
+++ b/pipeline/ingestor/test_documents/works.every-format.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-06-09T10:25:50.508765Z",
+  "createdAt" : "2022-06-13T13:06:48.995591Z",
   "id" : "cvdyxyqr",
   "document" : {
     "debug" : {
@@ -148,6 +148,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -157,6 +163,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.every-format.6.json
+++ b/pipeline/ingestor/test_documents/works.every-format.6.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-06-09T10:25:50.509138Z",
+  "createdAt" : "2022-06-13T13:06:48.996109Z",
   "id" : "aftvp1wz",
   "document" : {
     "debug" : {
@@ -148,6 +148,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -157,6 +163,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.every-format.7.json
+++ b/pipeline/ingestor/test_documents/works.every-format.7.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-06-09T10:25:50.509544Z",
+  "createdAt" : "2022-06-13T13:06:48.996663Z",
   "id" : "y8glbwdh",
   "document" : {
     "debug" : {
@@ -148,6 +148,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -157,6 +163,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.every-format.8.json
+++ b/pipeline/ingestor/test_documents/works.every-format.8.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-06-09T10:25:50.509951Z",
+  "createdAt" : "2022-06-13T13:06:48.997124Z",
   "id" : "4fkr6m6l",
   "document" : {
     "debug" : {
@@ -148,6 +148,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -157,6 +163,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.every-format.9.json
+++ b/pipeline/ingestor/test_documents/works.every-format.9.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-06-09T10:25:50.510384Z",
+  "createdAt" : "2022-06-13T13:06:48.997667Z",
   "id" : "e2zva5mj",
   "document" : {
     "debug" : {
@@ -148,6 +148,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -157,6 +163,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.0.json
+++ b/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2022-06-09T10:25:51.030520Z",
+  "createdAt" : "2022-06-13T13:06:49.668873Z",
   "id" : "stsp385v",
   "document" : {
     "debug" : {
@@ -234,6 +234,15 @@
       "items.identifiers.value" : [
         "VBNn8SqD7q"
       ],
+      "items.locations.accessConditions.status.id" : [
+        "restricted"
+      ],
+      "items.locations.license.id" : [
+        "cc-by"
+      ],
+      "items.locations.locationType.id" : [
+        "iiif-presentation"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -243,6 +252,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.1.json
+++ b/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2022-06-09T10:25:51.031349Z",
+  "createdAt" : "2022-06-13T13:06:49.669879Z",
   "id" : "jwvfegzn",
   "document" : {
     "debug" : {
@@ -232,6 +232,15 @@
       "items.identifiers.value" : [
         "2AKxyW0lR7"
       ],
+      "items.locations.accessConditions.status.id" : [
+        "restricted"
+      ],
+      "items.locations.license.id" : [
+        "cc-by"
+      ],
+      "items.locations.locationType.id" : [
+        "iiif-presentation"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -241,6 +250,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.2.json
+++ b/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2022-06-09T10:25:51.032227Z",
+  "createdAt" : "2022-06-13T13:06:49.670477Z",
   "id" : "glagakd2",
   "document" : {
     "debug" : {
@@ -232,6 +232,15 @@
       "items.identifiers.value" : [
         "Cba0kh0iB2"
       ],
+      "items.locations.accessConditions.status.id" : [
+        "closed"
+      ],
+      "items.locations.license.id" : [
+        "cc-by"
+      ],
+      "items.locations.locationType.id" : [
+        "iiif-presentation"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -241,6 +250,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.3.json
+++ b/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2022-06-09T10:25:51.032867Z",
+  "createdAt" : "2022-06-13T13:06:49.671030Z",
   "id" : "wys5lz5r",
   "document" : {
     "debug" : {
@@ -241,6 +241,15 @@
       "items.identifiers.value" : [
         "zf5rF0XzQw"
       ],
+      "items.locations.accessConditions.status.id" : [
+        "open"
+      ],
+      "items.locations.license.id" : [
+        "cc-by"
+      ],
+      "items.locations.locationType.id" : [
+        "iiif-presentation"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -250,6 +259,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.4.json
+++ b/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2022-06-09T10:25:51.033401Z",
+  "createdAt" : "2022-06-13T13:06:49.671531Z",
   "id" : "iqani2su",
   "document" : {
     "debug" : {
@@ -240,6 +240,15 @@
       "items.identifiers.value" : [
         "clr9E9aLfx"
       ],
+      "items.locations.accessConditions.status.id" : [
+        "open-with-advisory"
+      ],
+      "items.locations.license.id" : [
+        "cc-by"
+      ],
+      "items.locations.locationType.id" : [
+        "iiif-presentation"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -249,6 +258,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.5.json
+++ b/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2022-06-09T10:25:51.053433Z",
+  "createdAt" : "2022-06-13T13:06:49.703919Z",
   "id" : "yh6sk7pv",
   "document" : {
     "debug" : {
@@ -244,6 +244,15 @@
       "items.identifiers.value" : [
         "M7iXmYa3Fc"
       ],
+      "items.locations.accessConditions.status.id" : [
+        "licensed-resources"
+      ],
+      "items.locations.license.id" : [
+        "cc-by"
+      ],
+      "items.locations.locationType.id" : [
+        "iiif-presentation"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -253,6 +262,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.6.json
+++ b/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.6.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2022-06-09T10:25:51.054165Z",
+  "createdAt" : "2022-06-13T13:06:49.704869Z",
   "id" : "uqhxoxvf",
   "document" : {
     "debug" : {
@@ -236,6 +236,15 @@
       "items.identifiers.value" : [
         "y8mU1pknKH"
       ],
+      "items.locations.accessConditions.status.id" : [
+        "licensed-resources"
+      ],
+      "items.locations.license.id" : [
+        "cc-by"
+      ],
+      "items.locations.locationType.id" : [
+        "iiif-presentation"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -245,6 +254,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.0.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-06-09T10:25:50.667701Z",
+  "createdAt" : "2022-06-13T13:06:49.176278Z",
   "id" : "vqys4hio",
   "document" : {
     "debug" : {
@@ -195,6 +195,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -208,6 +214,10 @@
         "pzyMJLtI2pjU6xn"
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.1.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-06-09T10:25:50.668492Z",
+  "createdAt" : "2022-06-13T13:06:49.177493Z",
   "id" : "scernate",
   "document" : {
     "debug" : {
@@ -195,6 +195,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -208,6 +214,10 @@
         "pzyMJLtI2pjU6xn"
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.10.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.10.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-06-09T10:25:50.675084Z",
+  "createdAt" : "2022-06-13T13:06:49.184735Z",
   "id" : "sw2fzgit",
   "document" : {
     "debug" : {
@@ -195,6 +195,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -208,6 +214,10 @@
         "IvUnhx12Z5Ks7r7"
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.11.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.11.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-06-09T10:25:50.675814Z",
+  "createdAt" : "2022-06-13T13:06:49.185418Z",
   "id" : "4elqjncu",
   "document" : {
     "debug" : {
@@ -195,6 +195,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -208,6 +214,10 @@
         "IvUnhx12Z5Ks7r7"
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.12.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.12.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-06-09T10:25:50.676671Z",
+  "createdAt" : "2022-06-13T13:06:49.186185Z",
   "id" : "8yitytyw",
   "document" : {
     "debug" : {
@@ -195,6 +195,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -208,6 +214,10 @@
         "acffLiQzk2sxFZY"
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.13.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.13.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-06-09T10:25:50.677381Z",
+  "createdAt" : "2022-06-13T13:06:49.186933Z",
   "id" : "66bwuadw",
   "document" : {
     "debug" : {
@@ -195,6 +195,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -208,6 +214,10 @@
         "acffLiQzk2sxFZY"
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.14.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.14.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-06-09T10:25:50.678037Z",
+  "createdAt" : "2022-06-13T13:06:49.187730Z",
   "id" : "dborzqld",
   "document" : {
     "debug" : {
@@ -195,6 +195,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -208,6 +214,10 @@
         "acffLiQzk2sxFZY"
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.15.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.15.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-06-09T10:25:50.678672Z",
+  "createdAt" : "2022-06-13T13:06:49.188409Z",
   "id" : "fu0kybma",
   "document" : {
     "debug" : {
@@ -195,6 +195,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -208,6 +214,10 @@
         "acffLiQzk2sxFZY"
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.16.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.16.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-06-09T10:25:50.679373Z",
+  "createdAt" : "2022-06-13T13:06:49.189277Z",
   "id" : "pyub9jxo",
   "document" : {
     "debug" : {
@@ -195,6 +195,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -208,6 +214,10 @@
         "acffLiQzk2sxFZY"
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.17.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.17.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-06-09T10:25:50.680036Z",
+  "createdAt" : "2022-06-13T13:06:49.190072Z",
   "id" : "izlcv3sm",
   "document" : {
     "debug" : {
@@ -195,6 +195,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -208,6 +214,10 @@
         "acffLiQzk2sxFZY"
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.18.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.18.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-06-09T10:25:50.680722Z",
+  "createdAt" : "2022-06-13T13:06:49.190925Z",
   "id" : "s4ry14qu",
   "document" : {
     "debug" : {
@@ -195,6 +195,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -208,6 +214,10 @@
         "uD4zaFerI8P7W1W"
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.19.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.19.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-06-09T10:25:50.681399Z",
+  "createdAt" : "2022-06-13T13:06:49.191666Z",
   "id" : "svr3x3ca",
   "document" : {
     "debug" : {
@@ -195,6 +195,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -208,6 +214,10 @@
         "uD4zaFerI8P7W1W"
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.2.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-06-09T10:25:50.669319Z",
+  "createdAt" : "2022-06-13T13:06:49.178598Z",
   "id" : "vpkqafpg",
   "document" : {
     "debug" : {
@@ -195,6 +195,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -208,6 +214,10 @@
         "pzyMJLtI2pjU6xn"
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.20.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.20.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-06-09T10:25:50.682092Z",
+  "createdAt" : "2022-06-13T13:06:49.192341Z",
   "id" : "w4lfjuza",
   "document" : {
     "debug" : {
@@ -195,6 +195,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -208,6 +214,10 @@
         "uD4zaFerI8P7W1W"
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.21.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.21.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-06-09T10:25:50.682711Z",
+  "createdAt" : "2022-06-13T13:06:49.192993Z",
   "id" : "5hlmpzzh",
   "document" : {
     "debug" : {
@@ -195,6 +195,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -208,6 +214,10 @@
         "uD4zaFerI8P7W1W"
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.22.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.22.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-06-09T10:25:50.683318Z",
+  "createdAt" : "2022-06-13T13:06:49.193638Z",
   "id" : "b5lylqvq",
   "document" : {
     "debug" : {
@@ -195,6 +195,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -208,6 +214,10 @@
         "uD4zaFerI8P7W1W"
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.3.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-06-09T10:25:50.670177Z",
+  "createdAt" : "2022-06-13T13:06:49.179505Z",
   "id" : "ivw1mq40",
   "document" : {
     "debug" : {
@@ -195,6 +195,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -208,6 +214,10 @@
         "pzyMJLtI2pjU6xn"
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.4.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-06-09T10:25:50.670901Z",
+  "createdAt" : "2022-06-13T13:06:49.180339Z",
   "id" : "mxssba8u",
   "document" : {
     "debug" : {
@@ -195,6 +195,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -208,6 +214,10 @@
         "pzyMJLtI2pjU6xn"
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.5.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-06-09T10:25:50.671598Z",
+  "createdAt" : "2022-06-13T13:06:49.181097Z",
   "id" : "pi8hxmce",
   "document" : {
     "debug" : {
@@ -195,6 +195,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -208,6 +214,10 @@
         "pzyMJLtI2pjU6xn"
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.6.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.6.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-06-09T10:25:50.672341Z",
+  "createdAt" : "2022-06-13T13:06:49.181843Z",
   "id" : "lwt2ohte",
   "document" : {
     "debug" : {
@@ -195,6 +195,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -208,6 +214,10 @@
         "IvUnhx12Z5Ks7r7"
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.7.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.7.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-06-09T10:25:50.673036Z",
+  "createdAt" : "2022-06-13T13:06:49.182648Z",
   "id" : "a62ffqxh",
   "document" : {
     "debug" : {
@@ -195,6 +195,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -208,6 +214,10 @@
         "IvUnhx12Z5Ks7r7"
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.8.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.8.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-06-09T10:25:50.673681Z",
+  "createdAt" : "2022-06-13T13:06:49.183311Z",
   "id" : "atgvzcvy",
   "document" : {
     "debug" : {
@@ -195,6 +195,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -208,6 +214,10 @@
         "IvUnhx12Z5Ks7r7"
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.9.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.9.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-06-09T10:25:50.674431Z",
+  "createdAt" : "2022-06-13T13:06:49.184033Z",
   "id" : "mopzrqzu",
   "document" : {
     "debug" : {
@@ -195,6 +195,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -208,6 +214,10 @@
         "IvUnhx12Z5Ks7r7"
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.0.json
+++ b/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-06-09T10:25:50.833929Z",
+  "createdAt" : "2022-06-13T13:06:49.394437Z",
   "id" : "h5zn9bqm",
   "document" : {
     "debug" : {
@@ -165,6 +165,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -174,6 +180,11 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
+        "Bath, Patricia"
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.1.json
+++ b/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-06-09T10:25:50.834476Z",
+  "createdAt" : "2022-06-13T13:06:49.394958Z",
   "id" : "gnuj1it3",
   "document" : {
     "debug" : {
@@ -165,6 +165,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -174,6 +180,11 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
+        "Karl Marx"
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.2.json
+++ b/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-06-09T10:25:50.834917Z",
+  "createdAt" : "2022-06-13T13:06:49.395552Z",
   "id" : "e1k1l8xu",
   "document" : {
     "debug" : {
@@ -165,6 +165,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -174,6 +180,11 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
+        "Jake Paul"
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.3.json
+++ b/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-06-09T10:25:50.835470Z",
+  "createdAt" : "2022-06-13T13:06:49.396003Z",
   "id" : "6q7wkowr",
   "document" : {
     "debug" : {
@@ -165,6 +165,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -174,6 +180,11 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
+        "Darwin \"Jones\", Charles"
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.4.json
+++ b/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-06-09T10:25:50.836056Z",
+  "createdAt" : "2022-06-13T13:06:49.396702Z",
   "id" : "cpwnrkdo",
   "document" : {
     "debug" : {
@@ -190,6 +190,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -199,6 +205,12 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
+        "Bath, Patricia",
+        "Darwin \"Jones\", Charles"
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.5.json
+++ b/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-06-09T10:25:50.836369Z",
+  "createdAt" : "2022-06-13T13:06:49.397097Z",
   "id" : "bexh6kx6",
   "document" : {
     "debug" : {
@@ -140,6 +140,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -149,6 +155,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.different-work-types.Collection.json
+++ b/pipeline/ingestor/test_documents/works.examples.different-work-types.Collection.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples of works with different types",
-  "createdAt" : "2022-06-09T10:25:50.767287Z",
+  "createdAt" : "2022-06-13T13:06:49.310415Z",
   "id" : "2tqcclh1",
   "document" : {
     "debug" : {
@@ -140,6 +140,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -149,6 +155,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.different-work-types.Section.json
+++ b/pipeline/ingestor/test_documents/works.examples.different-work-types.Section.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples of works with different types",
-  "createdAt" : "2022-06-09T10:25:50.763176Z",
+  "createdAt" : "2022-06-13T13:06:49.304713Z",
   "id" : "iw5fnuyy",
   "document" : {
     "debug" : {
@@ -140,6 +140,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -149,6 +155,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.different-work-types.Series.json
+++ b/pipeline/ingestor/test_documents/works.examples.different-work-types.Series.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples of works with different types",
-  "createdAt" : "2022-06-09T10:25:50.771103Z",
+  "createdAt" : "2022-06-13T13:06:49.315389Z",
   "id" : "fndkxmxs",
   "document" : {
     "debug" : {
@@ -140,6 +140,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -149,6 +155,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.0.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-06-09T10:25:51.077632Z",
+  "createdAt" : "2022-06-13T13:06:49.739514Z",
   "id" : "phodmv5g",
   "document" : {
     "debug" : {
@@ -157,6 +157,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -166,6 +172,11 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+        "bak"
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.1.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-06-09T10:25:51.078082Z",
+  "createdAt" : "2022-06-13T13:06:49.739960Z",
   "id" : "580nnpfa",
   "document" : {
     "debug" : {
@@ -157,6 +157,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -166,6 +172,11 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+        "mar"
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.2.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-06-09T10:25:51.078507Z",
+  "createdAt" : "2022-06-13T13:06:49.740330Z",
   "id" : "jfnymrg2",
   "document" : {
     "debug" : {
@@ -157,6 +157,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -166,6 +172,11 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+        "que"
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.3.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-06-09T10:25:51.078860Z",
+  "createdAt" : "2022-06-13T13:06:49.740786Z",
   "id" : "lpoz1fy9",
   "document" : {
     "debug" : {
@@ -157,6 +157,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -166,6 +172,11 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+        "bak"
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.4.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-06-09T10:25:51.079290Z",
+  "createdAt" : "2022-06-13T13:06:49.741209Z",
   "id" : "in2u7aru",
   "document" : {
     "debug" : {
@@ -157,6 +157,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -166,6 +172,11 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+        "bak"
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.5.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-06-09T10:25:51.079697Z",
+  "createdAt" : "2022-06-13T13:06:49.741599Z",
   "id" : "wkzjlx5a",
   "document" : {
     "debug" : {
@@ -157,6 +157,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -166,6 +172,11 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+        "bak"
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.6.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.6.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-06-09T10:25:51.080271Z",
+  "createdAt" : "2022-06-13T13:06:49.741938Z",
   "id" : "iykrudzs",
   "document" : {
     "debug" : {
@@ -157,6 +157,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -166,6 +172,11 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+        "que"
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.7.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.7.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-06-09T10:25:51.080682Z",
+  "createdAt" : "2022-06-13T13:06:49.742338Z",
   "id" : "pskvh87t",
   "document" : {
     "debug" : {
@@ -157,6 +157,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -166,6 +172,11 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+        "mar"
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.8.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.8.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-06-09T10:25:51.080994Z",
+  "createdAt" : "2022-06-13T13:06:49.742758Z",
   "id" : "k57syong",
   "document" : {
     "debug" : {
@@ -157,6 +157,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -166,6 +172,11 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+        "que"
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.9.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.9.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-06-09T10:25:51.081357Z",
+  "createdAt" : "2022-06-13T13:06:49.743206Z",
   "id" : "lkq8nygj",
   "document" : {
     "debug" : {
@@ -157,6 +157,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -166,6 +172,11 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+        "che"
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.0.json
+++ b/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2022-06-09T10:25:50.777848Z",
+  "createdAt" : "2022-06-13T13:06:49.322349Z",
   "id" : "jywtq4xg",
   "document" : {
     "debug" : {
@@ -184,6 +184,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -196,6 +202,10 @@
         "qp5RA4f5gWVIptl",
         "xE0qlBbPiSihnTe",
         "JBs3eSemcGNQXd8"
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.1.json
+++ b/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2022-06-09T10:25:50.778698Z",
+  "createdAt" : "2022-06-13T13:06:49.323040Z",
   "id" : "ahr8n4ei",
   "document" : {
     "debug" : {
@@ -184,6 +184,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -196,6 +202,10 @@
         "7ZYKrzxgMS4HDJM",
         "nToBweq2UFKJPlz",
         "YfNgtG1SKw3klDA"
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.2.json
+++ b/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2022-06-09T10:25:50.779371Z",
+  "createdAt" : "2022-06-13T13:06:49.323652Z",
   "id" : "yhjhxcof",
   "document" : {
     "debug" : {
@@ -184,6 +184,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -196,6 +202,10 @@
         "uK4GKNsXvX3NJfI",
         "XCFVccBcFLmxtr1",
         "wn4mlLNPr0YHU0g"
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.3.json
+++ b/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2022-06-09T10:25:50.779872Z",
+  "createdAt" : "2022-06-13T13:06:49.324218Z",
   "id" : "1mqutqzm",
   "document" : {
     "debug" : {
@@ -184,6 +184,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -196,6 +202,10 @@
         "7V2pOSQnJOeXjVu",
         "ylz3BDWIViYo3qv",
         "sJ0y4QwQTlrFnQP"
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.4.json
+++ b/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2022-06-09T10:25:50.780669Z",
+  "createdAt" : "2022-06-13T13:06:49.325142Z",
   "id" : "4btprmwn",
   "document" : {
     "debug" : {
@@ -272,6 +272,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -290,6 +296,10 @@
         "7V2pOSQnJOeXjVu",
         "ylz3BDWIViYo3qv",
         "sJ0y4QwQTlrFnQP"
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.5.json
+++ b/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2022-06-09T10:25:50.781058Z",
+  "createdAt" : "2022-06-13T13:06:49.325516Z",
   "id" : "oo0o5odf",
   "document" : {
     "debug" : {
@@ -140,6 +140,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -149,6 +155,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.0.json
+++ b/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-06-09T10:25:50.803353Z",
+  "createdAt" : "2022-06-13T13:06:49.358212Z",
   "id" : "tayys6jp",
   "document" : {
     "debug" : {
@@ -225,6 +225,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
         "sanitati"
       ],
@@ -241,6 +247,10 @@
         "lsqnu7hZZtHlWPI"
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.1.json
+++ b/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-06-09T10:25:50.804018Z",
+  "createdAt" : "2022-06-13T13:06:49.358905Z",
   "id" : "zwggainv",
   "document" : {
     "debug" : {
@@ -187,6 +187,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -200,6 +206,10 @@
         "G177tcCDpKgb0Wd"
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.2.json
+++ b/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-06-09T10:25:50.804666Z",
+  "createdAt" : "2022-06-13T13:06:49.359812Z",
   "id" : "mazaizfa",
   "document" : {
     "debug" : {
@@ -187,6 +187,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -200,6 +206,10 @@
         "8DrDsk2kCAGURhx"
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.3.json
+++ b/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-06-09T10:25:50.805340Z",
+  "createdAt" : "2022-06-13T13:06:49.360678Z",
   "id" : "b1r485o0",
   "document" : {
     "debug" : {
@@ -209,6 +209,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
         "darwin01"
       ],
@@ -224,6 +230,10 @@
         "KOlZmZXOWd5kJ1F"
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.4.json
+++ b/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-06-09T10:25:50.806326Z",
+  "createdAt" : "2022-06-13T13:06:49.362025Z",
   "id" : "gmzc1icz",
   "document" : {
     "debug" : {
@@ -303,6 +303,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
         "darwin01"
       ],
@@ -326,6 +332,10 @@
         "KOlZmZXOWd5kJ1F"
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.5.json
+++ b/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-06-09T10:25:50.806753Z",
+  "createdAt" : "2022-06-13T13:06:49.362954Z",
   "id" : "rbao66qq",
   "document" : {
     "debug" : {
@@ -140,6 +140,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -149,6 +155,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.formats.0.Books.json
+++ b/pipeline/ingestor/test_documents/works.formats.0.Books.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-06-09T10:25:50.219004Z",
+  "createdAt" : "2022-06-13T13:06:48.682458Z",
   "id" : "gfw8fs9l",
   "document" : {
     "debug" : {
@@ -148,6 +148,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -157,6 +163,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.formats.1.Books.json
+++ b/pipeline/ingestor/test_documents/works.formats.1.Books.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-06-09T10:25:50.224583Z",
+  "createdAt" : "2022-06-13T13:06:48.688594Z",
   "id" : "ciweswu5",
   "document" : {
     "debug" : {
@@ -148,6 +148,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -157,6 +163,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.formats.2.Books.json
+++ b/pipeline/ingestor/test_documents/works.formats.2.Books.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-06-09T10:25:50.229909Z",
+  "createdAt" : "2022-06-13T13:06:48.694637Z",
   "id" : "j27g6hhl",
   "document" : {
     "debug" : {
@@ -148,6 +148,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -157,6 +163,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.formats.3.Books.json
+++ b/pipeline/ingestor/test_documents/works.formats.3.Books.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-06-09T10:25:50.236082Z",
+  "createdAt" : "2022-06-13T13:06:48.700304Z",
   "id" : "bujceq4p",
   "document" : {
     "debug" : {
@@ -148,6 +148,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -157,6 +163,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.formats.4.Journals.json
+++ b/pipeline/ingestor/test_documents/works.formats.4.Journals.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-06-09T10:25:50.241067Z",
+  "createdAt" : "2022-06-13T13:06:48.705835Z",
   "id" : "wqcumcet",
   "document" : {
     "debug" : {
@@ -148,6 +148,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -157,6 +163,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.formats.5.Journals.json
+++ b/pipeline/ingestor/test_documents/works.formats.5.Journals.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-06-09T10:25:50.246489Z",
+  "createdAt" : "2022-06-13T13:06:48.711544Z",
   "id" : "plmmmkup",
   "document" : {
     "debug" : {
@@ -148,6 +148,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -157,6 +163,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.formats.6.Journals.json
+++ b/pipeline/ingestor/test_documents/works.formats.6.Journals.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-06-09T10:25:50.251449Z",
+  "createdAt" : "2022-06-13T13:06:48.717979Z",
   "id" : "xc5d7pc4",
   "document" : {
     "debug" : {
@@ -148,6 +148,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -157,6 +163,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.formats.7.Audio.json
+++ b/pipeline/ingestor/test_documents/works.formats.7.Audio.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-06-09T10:25:50.256292Z",
+  "createdAt" : "2022-06-13T13:06:48.723703Z",
   "id" : "t3q2ufnz",
   "document" : {
     "debug" : {
@@ -148,6 +148,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -157,6 +163,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.formats.8.Audio.json
+++ b/pipeline/ingestor/test_documents/works.formats.8.Audio.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-06-09T10:25:50.261055Z",
+  "createdAt" : "2022-06-13T13:06:48.729073Z",
   "id" : "elrgwjtd",
   "document" : {
     "debug" : {
@@ -148,6 +148,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -157,6 +163,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.formats.9.Pictures.json
+++ b/pipeline/ingestor/test_documents/works.formats.9.Pictures.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-06-09T10:25:50.265937Z",
+  "createdAt" : "2022-06-13T13:06:48.735198Z",
   "id" : "sym6ne7x",
   "document" : {
     "debug" : {
@@ -148,6 +148,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -157,6 +163,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.genres.json
+++ b/pipeline/ingestor/test_documents/works.genres.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with different concepts in the genre",
-  "createdAt" : "2022-06-09T10:25:50.365481Z",
+  "createdAt" : "2022-06-13T13:06:48.847325Z",
   "id" : "2zo588up",
   "document" : {
     "debug" : {
@@ -207,6 +207,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -219,6 +225,10 @@
         "Conceptual Conversations",
         "Pleasant Paris",
         "Past Prehistory"
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.items-with-licenses.0.json
+++ b/pipeline/ingestor/test_documents/works.items-with-licenses.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with licensed digital items",
-  "createdAt" : "2022-06-09T10:25:50.321114Z",
+  "createdAt" : "2022-06-13T13:06:48.797998Z",
   "id" : "yodfctxx",
   "document" : {
     "debug" : {
@@ -187,6 +187,14 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+        "cc-by"
+      ],
+      "items.locations.locationType.id" : [
+        "iiif-presentation"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -196,6 +204,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.items-with-licenses.1.json
+++ b/pipeline/ingestor/test_documents/works.items-with-licenses.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with licensed digital items",
-  "createdAt" : "2022-06-09T10:25:50.321886Z",
+  "createdAt" : "2022-06-13T13:06:48.798729Z",
   "id" : "runiusy8",
   "document" : {
     "debug" : {
@@ -189,6 +189,14 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+        "cc-by"
+      ],
+      "items.locations.locationType.id" : [
+        "iiif-presentation"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -198,6 +206,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.items-with-licenses.2.json
+++ b/pipeline/ingestor/test_documents/works.items-with-licenses.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with licensed digital items",
-  "createdAt" : "2022-06-09T10:25:50.322795Z",
+  "createdAt" : "2022-06-13T13:06:48.799322Z",
   "id" : "ougtipki",
   "document" : {
     "debug" : {
@@ -187,6 +187,14 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+        "cc-by-nc"
+      ],
+      "items.locations.locationType.id" : [
+        "iiif-presentation"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -196,6 +204,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.items-with-licenses.3.json
+++ b/pipeline/ingestor/test_documents/works.items-with-licenses.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with licensed digital items",
-  "createdAt" : "2022-06-09T10:25:50.323997Z",
+  "createdAt" : "2022-06-13T13:06:48.800280Z",
   "id" : "rstrzip9",
   "document" : {
     "debug" : {
@@ -238,6 +238,16 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+        "cc-by",
+        "cc-by-nc"
+      ],
+      "items.locations.locationType.id" : [
+        "iiif-presentation",
+        "iiif-presentation"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -247,6 +257,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.items-with-licenses.4.json
+++ b/pipeline/ingestor/test_documents/works.items-with-licenses.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with licensed digital items",
-  "createdAt" : "2022-06-09T10:25:50.324823Z",
+  "createdAt" : "2022-06-13T13:06:48.800858Z",
   "id" : "vwg1cj2y",
   "document" : {
     "debug" : {
@@ -140,6 +140,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -149,6 +155,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.items-with-other-identifiers.0.json
+++ b/pipeline/ingestor/test_documents/works.items-with-other-identifiers.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2022-06-09T10:25:50.451711Z",
+  "createdAt" : "2022-06-13T13:06:48.947058Z",
   "id" : "qjnwiqbs",
   "document" : {
     "debug" : {
@@ -226,6 +226,14 @@
         "nDSV5vB01p",
         "xJJHLpGvU7"
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+        "cc-by"
+      ],
+      "items.locations.locationType.id" : [
+        "iiif-presentation"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -235,6 +243,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.items-with-other-identifiers.1.json
+++ b/pipeline/ingestor/test_documents/works.items-with-other-identifiers.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2022-06-09T10:25:50.452543Z",
+  "createdAt" : "2022-06-13T13:06:48.947815Z",
   "id" : "upm4bal7",
   "document" : {
     "debug" : {
@@ -227,6 +227,14 @@
         "yxr73XcQDx",
         "YGFYXAaEL2"
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+        "cc-by"
+      ],
+      "items.locations.locationType.id" : [
+        "iiif-presentation"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -236,6 +244,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.items-with-other-identifiers.2.json
+++ b/pipeline/ingestor/test_documents/works.items-with-other-identifiers.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2022-06-09T10:25:50.453249Z",
+  "createdAt" : "2022-06-13T13:06:48.948503Z",
   "id" : "zbejhda8",
   "document" : {
     "debug" : {
@@ -227,6 +227,14 @@
         "Px23iBj3EH",
         "QCHJJ4MhQv"
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+        "cc-by"
+      ],
+      "items.locations.locationType.id" : [
+        "iiif-presentation"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -236,6 +244,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.items-with-other-identifiers.3.json
+++ b/pipeline/ingestor/test_documents/works.items-with-other-identifiers.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2022-06-09T10:25:50.453922Z",
+  "createdAt" : "2022-06-13T13:06:48.949145Z",
   "id" : "pex9vogp",
   "document" : {
     "debug" : {
@@ -228,6 +228,14 @@
         "J5itRSq6vD",
         "6G93zt70MS"
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+        "cc-by"
+      ],
+      "items.locations.locationType.id" : [
+        "iiif-presentation"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -237,6 +245,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.items-with-other-identifiers.4.json
+++ b/pipeline/ingestor/test_documents/works.items-with-other-identifiers.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2022-06-09T10:25:50.454838Z",
+  "createdAt" : "2022-06-13T13:06:48.949803Z",
   "id" : "c5xw2xfj",
   "document" : {
     "debug" : {
@@ -228,6 +228,14 @@
         "mhIMFLtNyg",
         "T07LdJrNoV"
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+        "cc-by"
+      ],
+      "items.locations.locationType.id" : [
+        "iiif-presentation"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -237,6 +245,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.languages.0.eng.json
+++ b/pipeline/ingestor/test_documents/works.languages.0.eng.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2022-06-09T10:25:50.281429Z",
+  "createdAt" : "2022-06-13T13:06:48.754672Z",
   "id" : "i8zcsj78",
   "document" : {
     "debug" : {
@@ -149,6 +149,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -158,6 +164,11 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+        "eng"
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.languages.1.eng.json
+++ b/pipeline/ingestor/test_documents/works.languages.1.eng.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2022-06-09T10:25:50.286510Z",
+  "createdAt" : "2022-06-13T13:06:48.760970Z",
   "id" : "qn97gvxq",
   "document" : {
     "debug" : {
@@ -149,6 +149,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -158,6 +164,11 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+        "eng"
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.languages.2.eng.json
+++ b/pipeline/ingestor/test_documents/works.languages.2.eng.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2022-06-09T10:25:50.291554Z",
+  "createdAt" : "2022-06-13T13:06:48.766381Z",
   "id" : "yhrq0rmr",
   "document" : {
     "debug" : {
@@ -149,6 +149,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -158,6 +164,11 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+        "eng"
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.languages.3.eng+swe.json
+++ b/pipeline/ingestor/test_documents/works.languages.3.eng+swe.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2022-06-09T10:25:50.297092Z",
+  "createdAt" : "2022-06-13T13:06:48.771962Z",
   "id" : "ioqwetut",
   "document" : {
     "debug" : {
@@ -158,6 +158,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -167,6 +173,12 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+        "eng",
+        "swe"
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.languages.4.eng+swe+tur.json
+++ b/pipeline/ingestor/test_documents/works.languages.4.eng+swe+tur.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2022-06-09T10:25:50.302633Z",
+  "createdAt" : "2022-06-13T13:06:48.777767Z",
   "id" : "edfiesed",
   "document" : {
     "debug" : {
@@ -167,6 +167,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -176,6 +182,13 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+        "eng",
+        "swe",
+        "tur"
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.languages.5.swe.json
+++ b/pipeline/ingestor/test_documents/works.languages.5.swe.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2022-06-09T10:25:50.308055Z",
+  "createdAt" : "2022-06-13T13:06:48.783815Z",
   "id" : "qfscz1rj",
   "document" : {
     "debug" : {
@@ -149,6 +149,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -158,6 +164,11 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+        "swe"
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.languages.6.tur.json
+++ b/pipeline/ingestor/test_documents/works.languages.6.tur.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2022-06-09T10:25:50.313367Z",
+  "createdAt" : "2022-06-13T13:06:48.789331Z",
   "id" : "yblbdpjf",
   "document" : {
     "debug" : {
@@ -149,6 +149,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -158,6 +164,11 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+        "tur"
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.production.multi-year.0.json
+++ b/pipeline/ingestor/test_documents/works.production.multi-year.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2022-06-09T10:25:50.596450Z",
+  "createdAt" : "2022-06-13T13:06:49.112726Z",
   "id" : "31spt9st",
   "document" : {
     "debug" : {
@@ -198,6 +198,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -207,6 +213,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.production.multi-year.1.json
+++ b/pipeline/ingestor/test_documents/works.production.multi-year.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2022-06-09T10:25:50.597276Z",
+  "createdAt" : "2022-06-13T13:06:49.113330Z",
   "id" : "v9is9e3t",
   "document" : {
     "debug" : {
@@ -198,6 +198,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -207,6 +213,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.production.multi-year.2.json
+++ b/pipeline/ingestor/test_documents/works.production.multi-year.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2022-06-09T10:25:50.597979Z",
+  "createdAt" : "2022-06-13T13:06:49.113943Z",
   "id" : "wg3kq4ux",
   "document" : {
     "debug" : {
@@ -198,6 +198,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -207,6 +213,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.production.multi-year.3.json
+++ b/pipeline/ingestor/test_documents/works.production.multi-year.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2022-06-09T10:25:50.599768Z",
+  "createdAt" : "2022-06-13T13:06:49.114575Z",
   "id" : "q4abgj9v",
   "document" : {
     "debug" : {
@@ -198,6 +198,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -207,6 +213,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.production.multi-year.4.json
+++ b/pipeline/ingestor/test_documents/works.production.multi-year.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2022-06-09T10:25:50.602478Z",
+  "createdAt" : "2022-06-13T13:06:49.115330Z",
   "id" : "cuh8ak2g",
   "document" : {
     "debug" : {
@@ -198,6 +198,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -207,6 +213,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.production.multi-year.5.json
+++ b/pipeline/ingestor/test_documents/works.production.multi-year.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2022-06-09T10:25:50.603303Z",
+  "createdAt" : "2022-06-13T13:06:49.116250Z",
   "id" : "wmzcsqaf",
   "document" : {
     "debug" : {
@@ -198,6 +198,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -207,6 +213,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.subjects.0.json
+++ b/pipeline/ingestor/test_documents/works.subjects.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different subjects",
-  "createdAt" : "2022-06-09T10:25:50.372606Z",
+  "createdAt" : "2022-06-13T13:06:48.854862Z",
   "id" : "6uwysojy",
   "document" : {
     "debug" : {
@@ -187,6 +187,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -200,6 +206,10 @@
         "2pMEZn8L2YCE8E9"
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.subjects.1.json
+++ b/pipeline/ingestor/test_documents/works.subjects.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different subjects",
-  "createdAt" : "2022-06-09T10:25:50.373522Z",
+  "createdAt" : "2022-06-13T13:06:48.855697Z",
   "id" : "mihwfxry",
   "document" : {
     "debug" : {
@@ -187,6 +187,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -200,6 +206,10 @@
         "H8GnKqkwP9ugIes"
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.subjects.2.json
+++ b/pipeline/ingestor/test_documents/works.subjects.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different subjects",
-  "createdAt" : "2022-06-09T10:25:50.374409Z",
+  "createdAt" : "2022-06-13T13:06:48.856648Z",
   "id" : "evraub2i",
   "document" : {
     "debug" : {
@@ -187,6 +187,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -200,6 +206,10 @@
         "H8GnKqkwP9ugIes"
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.subjects.3.json
+++ b/pipeline/ingestor/test_documents/works.subjects.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different subjects",
-  "createdAt" : "2022-06-09T10:25:50.375477Z",
+  "createdAt" : "2022-06-13T13:06:48.857916Z",
   "id" : "xcssabt1",
   "document" : {
     "debug" : {
@@ -234,6 +234,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -251,6 +257,10 @@
         "H8GnKqkwP9ugIes"
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.subjects.4.json
+++ b/pipeline/ingestor/test_documents/works.subjects.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different subjects",
-  "createdAt" : "2022-06-09T10:25:50.375962Z",
+  "createdAt" : "2022-06-13T13:06:48.858338Z",
   "id" : "t9nj8zse",
   "document" : {
     "debug" : {
@@ -140,6 +140,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -149,6 +155,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.title-query-parens.json
+++ b/pipeline/ingestor/test_documents/works.title-query-parens.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work whose title has parens meant to trip up ES",
-  "createdAt" : "2022-06-09T10:25:50.275495Z",
+  "createdAt" : "2022-06-13T13:06:48.747442Z",
   "id" : "omok5a37",
   "document" : {
     "debug" : {
@@ -140,6 +140,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -149,6 +155,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.title-query-syntax.json
+++ b/pipeline/ingestor/test_documents/works.title-query-syntax.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work whose title has lots of ES query syntax operators",
-  "createdAt" : "2022-06-09T10:25:50.270721Z",
+  "createdAt" : "2022-06-13T13:06:48.740218Z",
   "id" : "hjjs3mu3",
   "document" : {
     "debug" : {
@@ -140,6 +140,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -149,6 +155,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.visible.0.json
+++ b/pipeline/ingestor/test_documents/works.visible.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of visible works",
-  "createdAt" : "2022-06-06T11:16:19.695387Z",
+  "createdAt" : "2022-06-13T13:06:47.535585Z",
   "id" : "2twopft1",
   "document" : {
     "debug" : {
@@ -140,6 +140,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -149,6 +155,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.visible.1.json
+++ b/pipeline/ingestor/test_documents/works.visible.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of visible works",
-  "createdAt" : "2022-06-06T11:16:19.702679Z",
+  "createdAt" : "2022-06-13T13:06:47.544677Z",
   "id" : "dph7sjip",
   "document" : {
     "debug" : {
@@ -140,6 +140,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -149,6 +155,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.visible.2.json
+++ b/pipeline/ingestor/test_documents/works.visible.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of visible works",
-  "createdAt" : "2022-06-06T11:16:19.705513Z",
+  "createdAt" : "2022-06-13T13:06:47.548650Z",
   "id" : "fyqts0co",
   "document" : {
     "debug" : {
@@ -140,6 +140,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -149,6 +155,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.visible.3.json
+++ b/pipeline/ingestor/test_documents/works.visible.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of visible works",
-  "createdAt" : "2022-06-06T11:16:19.707214Z",
+  "createdAt" : "2022-06-13T13:06:47.553708Z",
   "id" : "raob2ruv",
   "document" : {
     "debug" : {
@@ -140,6 +140,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -149,6 +155,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.visible.4.json
+++ b/pipeline/ingestor/test_documents/works.visible.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of visible works",
-  "createdAt" : "2022-06-06T11:16:19.708608Z",
+  "createdAt" : "2022-06-13T13:06:47.558663Z",
   "id" : "vbi1ii19",
   "document" : {
     "debug" : {
@@ -140,6 +140,12 @@
       ],
       "items.identifiers.value" : [
       ],
+      "items.locations.accessConditions.status.id" : [
+      ],
+      "items.locations.license.id" : [
+      ],
+      "items.locations.locationType.id" : [
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -149,6 +155,10 @@
       "subjects.concepts.label" : [
       ],
       "genres.concepts.label" : [
+      ],
+      "languages.id" : [
+      ],
+      "contributors.agent.label" : [
       ],
       "partOf.id" : [
       ],


### PR DESCRIPTION
This pulls across item, language, and contributor data into the `query` object. For https://github.com/wellcomecollection/platform/issues/5550

I'll add this as part of the reindex to add subject filtering for images.