### PR TITLE
Bump the timeout in a flaky matcher test

### DIFF
--- a/pipeline/matcher/src/test/scala/weco/pipeline/matcher/matcher/WorkMatcherTest.scala
+++ b/pipeline/matcher/src/test/scala/weco/pipeline/matcher/matcher/WorkMatcherTest.scala
@@ -386,7 +386,7 @@ class WorkMatcherTest
         // First store work B in the graph.
         //
         // This will put two nodes in the graph: a node for B, and a stub for A.
-        Await.result(workMatcher.matchWork(workB), atMost = 3 seconds)
+        Await.result(workMatcher.matchWork(workB), atMost = 5 seconds)
 
         // Now try to store works A and C simultaneously.
         //
@@ -401,10 +401,10 @@ class WorkMatcherTest
         val futureC = workMatcher.matchWork(workC)
 
         val resultA = Try {
-          Await.result(futureA, atMost = 3 seconds)
+          Await.result(futureA, atMost = 5 seconds)
         }
         val resultC = Try {
-          Await.result(futureC, atMost = 3 seconds)
+          Await.result(futureC, atMost = 5 seconds)
         }
 
         // The update to A should have succeeded; the update to B should have failed


### PR DESCRIPTION
This test keeps failing with

    [info]   Failure(java.util.concurrent.TimeoutException: Futures
    timed out after [3 seconds]) was not an instance of scala.util.Success,
    but an instance of scala.util.Failure (WorkMatcherTest.scala:412)

This timeout wasn't chosen for a particular reason, so let's bump the
timeout and see if that makes the test stop being flaky.