### PR TITLE
Remove ids when aggregating by subject

### DIFF
--- a/pipeline/ingestor/ingestor_common/src/main/scala/weco/pipeline/ingestor/common/models/AggregatableValues.scala
+++ b/pipeline/ingestor/ingestor_common/src/main/scala/weco/pipeline/ingestor/common/models/AggregatableValues.scala
@@ -28,10 +28,17 @@ trait AggregatableValues {
         .map(DisplayGenre(_, includesIdentifiers = false))
         .asJson(_.update("concepts", Json.fromValues(List())))
 
-    def subjectAggregatableValues: List[String] =
+    // We use this aggregation for subject *labels*, not ids.
+    //
+    // It's possible for the same subject label to appear with different identifiers.
+    // e.g. we have "Horses" as an LCSH-identified, MeSH-identified, and unidentified subject.
+    //
+    // For aggregating by label, we don't care about this distinction, so we
+    // remove the ID from subjects before aggregating.
+    def subjectLabelAggregatableValues: List[String] =
       workData.subjects
         .map(DisplaySubject(_, includesIdentifiers = false))
-        .asJson(_.update("concepts", Json.fromValues(List())))
+        .asJson(_.update("concepts", Json.fromValues(List())).remove("id"))
 
     def contributorAggregatableValues: List[String] =
       workData.contributors
@@ -123,5 +130,18 @@ trait AggregatableValues {
             )
             .asObject
             .get)
+
+    // Remove a key pair from a JSON object.
+    //
+    // e.g.
+    //
+    //    json =
+    //    { "color": "red", "sides": 5 }
+    //
+    //    json.remove("sides")
+    //    { "color": "red" }
+    //
+    def remove(key: String): Json =
+      json.mapObject(jsonObj => jsonObj.remove(key))
   }
 }

--- a/pipeline/ingestor/ingestor_images/src/main/scala/weco/pipeline/ingestor/images/models/ImageAggregatableValues.scala
+++ b/pipeline/ingestor/ingestor_images/src/main/scala/weco/pipeline/ingestor/images/models/ImageAggregatableValues.scala
@@ -25,6 +25,6 @@ case object ImageAggregatableValues extends AggregatableValues {
       licenses = workData.licenseAggregatableValues,
       contributors = workData.contributorAggregatableValues,
       genres = workData.genreAggregatableValues,
-      subjects = workData.subjectAggregatableValues
+      subjects = workData.subjectLabelAggregatableValues
     )
 }

--- a/pipeline/ingestor/ingestor_images/src/test/scala/weco/pipeline/ingestor/images/models/ImageAggregatableValuesTest.scala
+++ b/pipeline/ingestor/ingestor_images/src/test/scala/weco/pipeline/ingestor/images/models/ImageAggregatableValuesTest.scala
@@ -112,9 +112,49 @@ class ImageAggregatableValuesTest
       subjects = List(
         """{"label":"Sharp scissors","concepts":[],"type":"Subject"}""",
         """{"label":"Split sandwiches","concepts":[],"type":"Subject"}""",
-        """{"id":"subject1","label":"Soft spinners","concepts":[],"type":"Subject"}""",
-        """{"id":"subject2","label":"Straight strings","concepts":[],"type":"Subject"}"""
+        """{"label":"Soft spinners","concepts":[],"type":"Subject"}""",
+        """{"label":"Straight strings","concepts":[],"type":"Subject"}"""
       )
+    )
+  }
+
+  it("removes identifiers from subjects") {
+    val data = WorkData[DataState.Identified](
+      title = Some("a work used in the ImageAggregatableValues tests"),
+      subjects = List(
+        Subject(
+          id = IdState.Identified(
+            canonicalId = createCanonicalId,
+            sourceIdentifier = createSourceIdentifier
+          ),
+          label = "impish indicators"
+        ),
+        Subject(
+          id = IdState.Identified(
+            canonicalId = createCanonicalId,
+            sourceIdentifier = createSourceIdentifier
+          ),
+          label = "ill-fated ideas"
+        ),
+        Subject(label = "illicit implications", concepts = List()),
+      )
+    )
+
+    val w = ParentWork(
+      id = IdState.Identified(
+        canonicalId = createCanonicalId,
+        sourceIdentifier = createSourceIdentifier
+      ),
+      data = data,
+      version = 1
+    )
+
+    val aggregatableValues = ImageAggregatableValues(w)
+
+    aggregatableValues.subjects shouldBe List(
+      """{"label":"impish indicators","concepts":[],"type":"Subject"}""",
+      """{"label":"ill-fated ideas","concepts":[],"type":"Subject"}""",
+      """{"label":"illicit implications","concepts":[],"type":"Subject"}"""
     )
   }
 }

--- a/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/WorkAggregatableValues.scala
+++ b/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/WorkAggregatableValues.scala
@@ -23,7 +23,7 @@ case object WorkAggregatableValues extends AggregatableValues {
       workTypes = workData.workTypeAggregatableValues,
       genres = workData.genreAggregatableValues,
       productionDates = workData.productionDateAggregatableValues,
-      subjects = workData.subjectAggregatableValues,
+      subjects = workData.subjectLabelAggregatableValues,
       languages = workData.languageAggregatableValues,
       contributors = workData.contributorAggregatableValues,
       itemLicenses = workData.licenseAggregatableValues,

--- a/pipeline/ingestor/ingestor_works/src/test/scala/weco/pipeline/ingestor/works/models/WorkAggregatableValuesTest.scala
+++ b/pipeline/ingestor/ingestor_works/src/test/scala/weco/pipeline/ingestor/works/models/WorkAggregatableValuesTest.scala
@@ -150,7 +150,8 @@ class WorkAggregatableValuesTest
       )
     )
 
-    val aggregatableValues = WorkAggregatableValues(data, availabilities = Set())
+    val aggregatableValues =
+      WorkAggregatableValues(data, availabilities = Set())
 
     aggregatableValues.subjects shouldBe List(
       """{"label":"impish indicators","concepts":[],"type":"Subject"}""",

--- a/pipeline/ingestor/ingestor_works/src/test/scala/weco/pipeline/ingestor/works/models/WorkAggregatableValuesTest.scala
+++ b/pipeline/ingestor/ingestor_works/src/test/scala/weco/pipeline/ingestor/works/models/WorkAggregatableValuesTest.scala
@@ -20,7 +20,7 @@ class WorkAggregatableValuesTest
     with PeriodGenerators {
   it("creates aggregatable values") {
     val data = WorkData[DataState.Identified](
-      title = Some("a work used in the ImageAggregatableValues tests"),
+      title = Some("a work used in the WorkAggregatableValues tests"),
       format = Some(Format.CDRoms),
       genres = List(
         Genre(label = "grabby gerbils", concepts = List(Concept("rodents"))),
@@ -125,6 +125,37 @@ class WorkAggregatableValuesTest
         """{"id":"closed-stores","label":"Closed stores","type":"Availability"}""",
         """{"id":"online","label":"Online","type":"Availability"}"""
       ),
+    )
+  }
+
+  it("removes identifiers from subjects") {
+    val data = WorkData[DataState.Identified](
+      title = Some("a work used in the WorkAggregatableValues tests"),
+      subjects = List(
+        Subject(
+          id = IdState.Identified(
+            canonicalId = createCanonicalId,
+            sourceIdentifier = createSourceIdentifier
+          ),
+          label = "impish indicators"
+        ),
+        Subject(
+          id = IdState.Identified(
+            canonicalId = createCanonicalId,
+            sourceIdentifier = createSourceIdentifier
+          ),
+          label = "ill-fated ideas"
+        ),
+        Subject(label = "illicit implications", concepts = List()),
+      )
+    )
+
+    val aggregatableValues = WorkAggregatableValues(data, availabilities = Set())
+
+    aggregatableValues.subjects shouldBe List(
+      """{"label":"impish indicators","concepts":[],"type":"Subject"}""",
+      """{"label":"ill-fated ideas","concepts":[],"type":"Subject"}""",
+      """{"label":"illicit implications","concepts":[],"type":"Subject"}"""
     )
   }
 

--- a/pipeline/ingestor/test_documents/images.subjects.screwdrivers-1.json
+++ b/pipeline/ingestor/test_documents/images.subjects.screwdrivers-1.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different subjects",
-  "createdAt" : "2022-06-17T14:17:37.580230Z",
+  "createdAt" : "2022-06-27T08:19:26.712408Z",
   "id" : "e4perwdd",
   "document" : {
     "version" : 1,
@@ -4437,7 +4437,7 @@
       "source.genres.label" : [
       ],
       "source.subjects.label" : [
-        "{\"id\":\"subject1\",\"label\":\"Simple screwdrivers\",\"concepts\":[],\"type\":\"Subject\"}"
+        "{\"label\":\"Simple screwdrivers\",\"concepts\":[],\"type\":\"Subject\"}"
       ]
     }
   }

--- a/pipeline/ingestor/test_documents/images.subjects.screwdrivers-2.json
+++ b/pipeline/ingestor/test_documents/images.subjects.screwdrivers-2.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different subjects",
-  "createdAt" : "2022-06-17T14:17:37.593619Z",
+  "createdAt" : "2022-06-27T08:19:26.844237Z",
   "id" : "xlfyrof0",
   "document" : {
     "version" : 1,
@@ -4439,7 +4439,7 @@
       "source.genres.label" : [
       ],
       "source.subjects.label" : [
-        "{\"id\":\"subject1\",\"label\":\"Simple screwdrivers\",\"concepts\":[],\"type\":\"Subject\"}"
+        "{\"label\":\"Simple screwdrivers\",\"concepts\":[],\"type\":\"Subject\"}"
       ]
     }
   }

--- a/pipeline/ingestor/test_documents/images.subjects.squirrel,sample.json
+++ b/pipeline/ingestor/test_documents/images.subjects.squirrel,sample.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different subjects",
-  "createdAt" : "2022-06-17T14:17:37.606745Z",
+  "createdAt" : "2022-06-27T08:19:26.876411Z",
   "id" : "hszkjtb7",
   "document" : {
     "version" : 1,
@@ -4451,7 +4451,7 @@
       ],
       "source.subjects.label" : [
         "{\"label\":\"Squashed squirrels\",\"concepts\":[],\"type\":\"Subject\"}",
-        "{\"id\":\"subject2\",\"label\":\"Struck samples\",\"concepts\":[],\"type\":\"Subject\"}"
+        "{\"label\":\"Struck samples\",\"concepts\":[],\"type\":\"Subject\"}"
       ]
     }
   }

--- a/pipeline/ingestor/test_documents/images.subjects.squirrel,screwdriver.json
+++ b/pipeline/ingestor/test_documents/images.subjects.squirrel,screwdriver.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different subjects",
-  "createdAt" : "2022-06-17T14:17:37.620662Z",
+  "createdAt" : "2022-06-27T08:19:26.911013Z",
   "id" : "yuy15ulc",
   "document" : {
     "version" : 1,
@@ -4455,7 +4455,7 @@
       ],
       "source.subjects.label" : [
         "{\"label\":\"Squashed squirrels\",\"concepts\":[],\"type\":\"Subject\"}",
-        "{\"id\":\"subject1\",\"label\":\"Simple screwdrivers\",\"concepts\":[],\"type\":\"Subject\"}"
+        "{\"label\":\"Simple screwdrivers\",\"concepts\":[],\"type\":\"Subject\"}"
       ]
     }
   }

--- a/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.0.json
+++ b/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-06-20T10:13:38.428548Z",
+  "createdAt" : "2022-06-27T08:16:13.992329Z",
   "id" : "tayys6jp",
   "document" : {
     "debug" : {
@@ -260,7 +260,7 @@
       "production.dates" : [
       ],
       "subjects.label" : [
-        "{\"id\":\"sanitati\",\"label\":\"Sanitation.\",\"concepts\":[],\"type\":\"Subject\"}"
+        "{\"label\":\"Sanitation.\",\"concepts\":[],\"type\":\"Subject\"}"
       ],
       "languages" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.3.json
+++ b/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-06-20T10:13:38.437129Z",
+  "createdAt" : "2022-06-27T08:16:13.995678Z",
   "id" : "b1r485o0",
   "document" : {
     "debug" : {
@@ -244,7 +244,7 @@
       "production.dates" : [
       ],
       "subjects.label" : [
-        "{\"id\":\"darwin01\",\"label\":\"Darwin \\\"Jones\\\", Charles\",\"concepts\":[],\"type\":\"Subject\"}"
+        "{\"label\":\"Darwin \\\"Jones\\\", Charles\",\"concepts\":[],\"type\":\"Subject\"}"
       ],
       "languages" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.4.json
+++ b/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-06-20T10:13:38.440295Z",
+  "createdAt" : "2022-06-27T08:16:13.997693Z",
   "id" : "gmzc1icz",
   "document" : {
     "debug" : {
@@ -346,7 +346,7 @@
       "subjects.label" : [
         "{\"label\":\"London (England)\",\"concepts\":[],\"type\":\"Subject\"}",
         "{\"label\":\"Psychology, Pathological\",\"concepts\":[],\"type\":\"Subject\"}",
-        "{\"id\":\"darwin01\",\"label\":\"Darwin \\\"Jones\\\", Charles\",\"concepts\":[],\"type\":\"Subject\"}"
+        "{\"label\":\"Darwin \\\"Jones\\\", Charles\",\"concepts\":[],\"type\":\"Subject\"}"
       ],
       "languages" : [
       ],


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5563

This is a bug I introduced with the index restructuring; previously the API would aggregate over `data.subjects.label.keyword` and synthesise the Subject type. Now we store the whole Subject value in `aggregatableValues.subjects`, that means extra fields were coming along for the ride (in particular, "id"). We had separate aggregation values for:

```
{
  "data": {
    "id": "zssqcytq",
    "label": "Horses",
    "concepts": [],
    "type": "Subject"
  },
  "count": 364,
  "type": "AggregationBucket"
},
{
  "data": {
    "label": "Horses",
    "concepts": [],
    "type": "Subject"
  },
  "count": 150,
  "type": "AggregationBucket"
},
...
{
  "data": {
    "id": "jrnfsbrf",
    "label": "Horses",
    "concepts": [],
    "type": "Subject"
  },
  "count": 12,
  "type": "AggregationBucket"
},
```

Binning the ID should collapse these three back into a single, unidentified subject aggregation.