### PR TITLE
Use eclipse-temurin:11-jre-alpine for applications

### DIFF
--- a/calm_adapter/calm_adapter/Dockerfile
+++ b/calm_adapter/calm_adapter/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/calm_adapter/calm_deletion_checker/Dockerfile
+++ b/calm_adapter/calm_deletion_checker/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/calm_adapter/calm_indexer/Dockerfile
+++ b/calm_adapter/calm_indexer/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/mets_adapter/mets_adapter/Dockerfile
+++ b/mets_adapter/mets_adapter/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/pipeline/id_minter/Dockerfile
+++ b/pipeline/id_minter/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/pipeline/inferrer/inference_manager/Dockerfile
+++ b/pipeline/inferrer/inference_manager/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/pipeline/ingestor/ingestor_images/Dockerfile
+++ b/pipeline/ingestor/ingestor_images/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/pipeline/ingestor/ingestor_works/Dockerfile
+++ b/pipeline/ingestor/ingestor_works/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/pipeline/matcher/Dockerfile
+++ b/pipeline/matcher/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/pipeline/merger/Dockerfile
+++ b/pipeline/merger/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/pipeline/relation_embedder/batcher/Dockerfile
+++ b/pipeline/relation_embedder/batcher/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/pipeline/relation_embedder/path_concatenator/Dockerfile
+++ b/pipeline/relation_embedder/path_concatenator/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/pipeline/relation_embedder/relation_embedder/Dockerfile
+++ b/pipeline/relation_embedder/relation_embedder/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/pipeline/relation_embedder/router/Dockerfile
+++ b/pipeline/relation_embedder/router/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/pipeline/transformer/transformer_calm/Dockerfile
+++ b/pipeline/transformer/transformer_calm/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/pipeline/transformer/transformer_mets/Dockerfile
+++ b/pipeline/transformer/transformer_mets/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/pipeline/transformer/transformer_miro/Dockerfile
+++ b/pipeline/transformer/transformer_miro/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/pipeline/transformer/transformer_sierra/Dockerfile
+++ b/pipeline/transformer/transformer_sierra/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/pipeline/transformer/transformer_tei/Dockerfile
+++ b/pipeline/transformer/transformer_tei/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/reindexer/reindex_worker/Dockerfile
+++ b/reindexer/reindex_worker/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/sierra_adapter/sierra_indexer/Dockerfile
+++ b/sierra_adapter/sierra_indexer/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/sierra_adapter/sierra_linker/Dockerfile
+++ b/sierra_adapter/sierra_linker/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/sierra_adapter/sierra_merger/Dockerfile
+++ b/sierra_adapter/sierra_merger/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/sierra_adapter/sierra_reader/Dockerfile
+++ b/sierra_adapter/sierra_reader/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/tei_adapter/tei_adapter/Dockerfile
+++ b/tei_adapter/tei_adapter/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/tei_adapter/tei_id_extractor/Dockerfile
+++ b/tei_adapter/tei_id_extractor/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 


### PR DESCRIPTION
Following on from https://github.com/wellcomecollection/platform-infrastructure/pull/313, using the same (smaller and non-deprecated) image for running our applications as we do for compiling them. This being the JVM I don't expect to see any of the potential oddities of Alpine that occur with compiled code, but will keep an eye on things of course.