### PR TITLE
Non unique sourceidentifiers

### DIFF
--- a/pipeline/id_minter/src/main/scala/weco/pipeline/id_minter/steps/IdentifierGenerator.scala
+++ b/pipeline/id_minter/src/main/scala/weco/pipeline/id_minter/steps/IdentifierGenerator.scala
@@ -35,7 +35,7 @@ class IdentifierGenerator(identifiersDao: IdentifiersDao) extends Logging {
     retrieveOrGenerateCanonicalIdsOnce(sourceIdentifiers) match {
       case Failure(_: InsertError) =>
         retrieveOrGenerateCanonicalIdsOnce(sourceIdentifiers)
-      case x => x
+      case success => success
     }
 
   /*

--- a/pipeline/id_minter/src/main/scala/weco/pipeline/id_minter/steps/IdentifierGenerator.scala
+++ b/pipeline/id_minter/src/main/scala/weco/pipeline/id_minter/steps/IdentifierGenerator.scala
@@ -6,10 +6,38 @@ import weco.pipeline.id_minter.database.IdentifiersDao
 import weco.pipeline.id_minter.models.Identifier
 import weco.pipeline.id_minter.utils.Identifiable
 
-import scala.util.{Success, Try}
+import scala.util.{Failure, Success, Try}
 
 class IdentifierGenerator(identifiersDao: IdentifiersDao) extends Logging {
   import IdentifiersDao._
+
+  /*
+   * Fetch canonicalIds for any existing sourceIdentifiers, generate
+   * canonicalIds for any new ones and save them.  Retrying if
+   * the save fails.
+   *
+   * In any kind of parallel execution, a race condition may occur here,
+   * whereby two executors try to create new identifiers for the same
+   * SourceIdentifier simultaneously.  In that situation, the "second"
+   * executor will fail with an InsertError due to the uniqueness constraint.
+   *
+   * When that happens, this function will make one retry attempt, refreshing
+   * its list of pre-existing identifiers.  This *should* be sufficient, as it
+   * would be terribly bad luck if this document has new identifiers in it
+   * and those new identifiers are also spread across multiple other documents
+   * that are being processed at the same time, and in between the first and
+   * the second calls to lookupIds, the second "other" document finishes writing
+   * its ids.
+   *
+   */
+  def retrieveOrGenerateCanonicalIds(sourceIdentifiers: Seq[SourceIdentifier])
+    : Try[Map[SourceIdentifier, Identifier]] =
+    retrieveOrGenerateCanonicalIdsOnce(sourceIdentifiers) match {
+    case Failure(_: InsertError) =>
+      retrieveOrGenerateCanonicalIdsOnce(sourceIdentifiers)
+    case x => x
+    }
+
   /*
    * This function fetches canonicalIds for sourceIdentifiers, and generates
    * and saves canonicalIds where it can't find existing ones.
@@ -19,8 +47,8 @@ class IdentifierGenerator(identifiersDao: IdentifiersDao) extends Logging {
    * the updates will fail due to duplicate key errors, when an identifier
    * is saved by another thread after `lookupIds` has been called.
    */
-  def retrieveOrGenerateCanonicalIds(sourceIdentifiers: Seq[SourceIdentifier])
-    : Try[Map[SourceIdentifier, Identifier]] =
+  private def retrieveOrGenerateCanonicalIdsOnce(sourceIdentifiers: Seq[SourceIdentifier])
+  : Try[Map[SourceIdentifier, Identifier]] =
     identifiersDao
       .lookupIds(sourceIdentifiers)
       .flatMap {

--- a/pipeline/id_minter/src/main/scala/weco/pipeline/id_minter/steps/IdentifierGenerator.scala
+++ b/pipeline/id_minter/src/main/scala/weco/pipeline/id_minter/steps/IdentifierGenerator.scala
@@ -33,9 +33,9 @@ class IdentifierGenerator(identifiersDao: IdentifiersDao) extends Logging {
   def retrieveOrGenerateCanonicalIds(sourceIdentifiers: Seq[SourceIdentifier])
     : Try[Map[SourceIdentifier, Identifier]] =
     retrieveOrGenerateCanonicalIdsOnce(sourceIdentifiers) match {
-    case Failure(_: InsertError) =>
-      retrieveOrGenerateCanonicalIdsOnce(sourceIdentifiers)
-    case x => x
+      case Failure(_: InsertError) =>
+        retrieveOrGenerateCanonicalIdsOnce(sourceIdentifiers)
+      case x => x
     }
 
   /*
@@ -47,8 +47,9 @@ class IdentifierGenerator(identifiersDao: IdentifiersDao) extends Logging {
    * the updates will fail due to duplicate key errors, when an identifier
    * is saved by another thread after `lookupIds` has been called.
    */
-  private def retrieveOrGenerateCanonicalIdsOnce(sourceIdentifiers: Seq[SourceIdentifier])
-  : Try[Map[SourceIdentifier, Identifier]] =
+  private def retrieveOrGenerateCanonicalIdsOnce(
+    sourceIdentifiers: Seq[SourceIdentifier])
+    : Try[Map[SourceIdentifier, Identifier]] =
     identifiersDao
       .lookupIds(sourceIdentifiers)
       .flatMap {

--- a/pipeline/id_minter/src/test/scala/weco/pipeline/id_minter/steps/IdentifierGeneratorTest.scala
+++ b/pipeline/id_minter/src/test/scala/weco/pipeline/id_minter/steps/IdentifierGeneratorTest.scala
@@ -197,7 +197,9 @@ class IdentifierGeneratorTest
         )
 
         triedIds shouldBe a[Success[_]]
+        // LookupIds runs once at the start, then once again when saveIdentifiers fails.
         verify(daoStub, times(2)).lookupIds(sourceIdentifiers)
+        // saveIdentifiers is only called first time, the second run through it has nothing to save.
         verify(daoStub, times(1)).saveIdentifiers(any[List[Identifier]])
     }
   }

--- a/pipeline/id_minter/src/test/scala/weco/pipeline/id_minter/steps/IdentifierGeneratorTest.scala
+++ b/pipeline/id_minter/src/test/scala/weco/pipeline/id_minter/steps/IdentifierGeneratorTest.scala
@@ -197,6 +197,9 @@ class IdentifierGeneratorTest
         )
 
         triedIds shouldBe a[Success[_]]
+        val ids = triedIds.get
+        ids shouldBe existingEntries
+
         // LookupIds runs once at the start, then once again when saveIdentifiers fails.
         verify(daoStub, times(2)).lookupIds(sourceIdentifiers)
         // saveIdentifiers is only called first time, the second run through it has nothing to save.

--- a/pipeline/id_minter/src/test/scala/weco/pipeline/id_minter/steps/IdentifierGeneratorTest.scala
+++ b/pipeline/id_minter/src/test/scala/weco/pipeline/id_minter/steps/IdentifierGeneratorTest.scala
@@ -136,9 +136,9 @@ class IdentifierGeneratorTest
   }
 
   it("tries looking up identifiers again if it fails to insert 'new' ids") {
-    // Simulation of a race condition.  This test the behaviour of the
-    // "second" participant in the race, with mocks representing the result
-    // of the "first" participant.
+    // Simulation of a race condition.  This test represents the behaviour of the
+    // "second" participant in the race, with mocks representing the  "first"
+    // participant.
     // When running in parallel (multiple threads, multiple hosts, whatever),
     // it is possible for a clash to occur, where two processes create a new
     // id for the same sourceIdentifier almost simultaneously.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -105,6 +105,9 @@ object ExternalDependencies {
     val enumeratumScalacheck = "1.6.1"
     val jsoup = "1.13.1"
     val logback = "1.1.8"
+ //   val mockito = "1.10.19"
+    val scalatestPlus = "3.2.12.0"
+    val scalatestPlusMockitoArtifactId = "mockito-4-5"
   }
 
   val enumeratumDependencies = Seq(
@@ -139,9 +142,14 @@ object ExternalDependencies {
     "org.scala-graph" %% "graph-core" % versions.scalaGraph
   )
 
+  val mockitoDependencies = Seq(
+    "org.scalatestplus" %% versions.scalatestPlusMockitoArtifactId % versions.scalatestPlus % Test,
+//    "org.mockito" % "mockito-core" % versions.mockito % Test
+  )
+
   val scalatestDependencies = Seq(
     "org.scalatest" %% "scalatest" % versions.scalatest % "test"
-  )
+  ) ++ mockitoDependencies
 
   val parseDependencies = Seq(
     "com.lihaoyi" %% "fastparse" % versions.fastparse
@@ -203,7 +211,8 @@ object CatalogueDependencies {
 
   val idminterDependencies: Seq[ModuleID] =
     ExternalDependencies.mySqlDependencies ++
-      ExternalDependencies.circeOpticsDependencies
+      ExternalDependencies.circeOpticsDependencies ++
+      ExternalDependencies.scalatestDependencies
 
   val matcherDependencies: Seq[ModuleID] =
     ExternalDependencies.scalaGraphDependencies ++

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -105,7 +105,6 @@ object ExternalDependencies {
     val enumeratumScalacheck = "1.6.1"
     val jsoup = "1.13.1"
     val logback = "1.1.8"
- //   val mockito = "1.10.19"
     val scalatestPlus = "3.2.12.0"
     val scalatestPlusMockitoArtifactId = "mockito-4-5"
   }
@@ -144,7 +143,6 @@ object ExternalDependencies {
 
   val mockitoDependencies = Seq(
     "org.scalatestplus" %% versions.scalatestPlusMockitoArtifactId % versions.scalatestPlus % Test,
-//    "org.mockito" % "mockito-core" % versions.mockito % Test
   )
 
   val scalatestDependencies = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -141,13 +141,10 @@ object ExternalDependencies {
     "org.scala-graph" %% "graph-core" % versions.scalaGraph
   )
 
-  val mockitoDependencies = Seq(
-    "org.scalatestplus" %% versions.scalatestPlusMockitoArtifactId % versions.scalatestPlus % Test,
-  )
-
   val scalatestDependencies = Seq(
+    "org.scalatestplus" %% versions.scalatestPlusMockitoArtifactId % versions.scalatestPlus % Test,
     "org.scalatest" %% "scalatest" % versions.scalatest % "test"
-  ) ++ mockitoDependencies
+  )
 
   val parseDependencies = Seq(
     "com.lihaoyi" %% "fastparse" % versions.fastparse


### PR DESCRIPTION
A race condition occurs when documents containing the same SourceIdentifiers are processed simultaneously.

Until now, this race has been vanishingly unlikely, because
- new ids are not encountered very often
- ids have tended to refer to something quite specific, so less likely to clash in this way e.g. compound subjects like Dentistry+Orthodontics+History

However, this has become a problem with the introduction of individual, label-derived concept identifiers.  
- many new ids will be encountered as they are now being generated from labels in the absence of a proper id
- very broad concepts are being identified, e.g. "History", so it is more likely that multiple simultaneous documents will contain the same id.

This change fixes the problem by retrying if the document in question has been beaten in a race.  I have set it to retry only once, as I think that should be sufficient.

The situations in which this comes into play are: 
* https://github.com/wellcomecollection/platform/issues/5475#issuecomment-1203914337 the race is almost guaranteed to occur exactly once for a given document.  This change fixes that.
* During the first full reindex, it will probably occur.  This should catch and fix most of those instances, but it is possible that some documents might need to be redriven if the "terribly bad luck" situation occurs.


