### PR TITLE
Normalise period ids

### DIFF
--- a/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/parse/PeriodParser.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/parse/PeriodParser.scala
@@ -43,7 +43,7 @@ object PeriodParser extends Parser[InstantRange] with DateParserUtils {
     s"(?=[MDCLXVI\\.\\,\\s]{3,})M*$sep(C[MD]|D?C*)$sep(X[CL]|L?X*)$sep(I[XV]|V?I*)".toLowerCase
   }
 
-  private def preprocess(input: String): String =
+  def preprocess(input: String): String =
     ignoreRegex
       .replaceAllIn(input.toLowerCase, "")
       .trim

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/transformers/ConceptsTransformer.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/transformers/ConceptsTransformer.scala
@@ -96,10 +96,10 @@ trait ConceptsTransformer {
   implicit class PeriodOps[State](p: Period[State]) {
     def identifiable(idState: Option[IdState.Identifiable] = None)
       : Period[IdState.Identifiable] =
-    // The label of a period may contain superfluous content that doesn't change the referent of the period
-    // e.g. years duplicated in Roman, punctuation, diverse renditions of the term "floruit".
-    // The id is therefore based on that "preprocessed" label, rather than simply passing through the
-    // label as written.
+      // The label of a period may contain superfluous content that doesn't change the referent of the period
+      // e.g. years duplicated in Roman, punctuation, diverse renditions of the term "floruit".
+      // The id is therefore based on that "preprocessed" label, rather than simply passing through the
+      // label as written.
       p.copy(
         id = newIdIfNeeded(
           p.id,

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/transformers/ConceptsTransformer.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/transformers/ConceptsTransformer.scala
@@ -1,6 +1,10 @@
 package weco.pipeline.transformer.transformers
 
-import weco.catalogue.internal_model.identifiers.{IdState, IdentifierType, SourceIdentifier}
+import weco.catalogue.internal_model.identifiers.{
+  IdState,
+  IdentifierType,
+  SourceIdentifier
+}
 import weco.catalogue.internal_model.work._
 import weco.pipeline.transformer.parse.PeriodParser
 import weco.pipeline.transformer.text.TextNormalisation._
@@ -92,6 +96,11 @@ trait ConceptsTransformer {
   implicit class PeriodOps[State](p: Period[State]) {
     def identifiable(idState: Option[IdState.Identifiable] = None)
       : Period[IdState.Identifiable] =
-      p.copy(id = newIdIfNeeded(p.id, PeriodParser.preprocess(p.label), idState, "Period"))
+      p.copy(
+        id = newIdIfNeeded(
+          p.id,
+          PeriodParser.preprocess(p.label),
+          idState,
+          "Period"))
   }
 }

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/transformers/ConceptsTransformer.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/transformers/ConceptsTransformer.scala
@@ -96,6 +96,10 @@ trait ConceptsTransformer {
   implicit class PeriodOps[State](p: Period[State]) {
     def identifiable(idState: Option[IdState.Identifiable] = None)
       : Period[IdState.Identifiable] =
+    // The label of a period may contain superfluous content that doesn't change the referent of the period
+    // e.g. years duplicated in Roman, punctuation, diverse renditions of the term "floruit".
+    // The id is therefore based on that "preprocessed" label, rather than simply passing through the
+    // label as written.
       p.copy(
         id = newIdIfNeeded(
           p.id,

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/transformers/ConceptsTransformer.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/transformers/ConceptsTransformer.scala
@@ -1,11 +1,8 @@
 package weco.pipeline.transformer.transformers
 
-import weco.catalogue.internal_model.identifiers.{
-  IdState,
-  IdentifierType,
-  SourceIdentifier
-}
+import weco.catalogue.internal_model.identifiers.{IdState, IdentifierType, SourceIdentifier}
 import weco.catalogue.internal_model.work._
+import weco.pipeline.transformer.parse.PeriodParser
 import weco.pipeline.transformer.text.TextNormalisation._
 
 trait ConceptsTransformer {
@@ -95,6 +92,6 @@ trait ConceptsTransformer {
   implicit class PeriodOps[State](p: Period[State]) {
     def identifiable(idState: Option[IdState.Identifiable] = None)
       : Period[IdState.Identifiable] =
-      p.copy(id = newIdIfNeeded(p.id, p.label, idState, "Period"))
+      p.copy(id = newIdIfNeeded(p.id, PeriodParser.preprocess(p.label), idState, "Period"))
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraGenresTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraGenresTest.scala
@@ -196,7 +196,7 @@ class SierraGenresTest
     conceptV shouldBe a[Period[_]]
     conceptV should have(
       'label ("MDCCLXXXVII. [1787]"),
-      labelDerivedPeriodId("mdcclxxxvii. [1787]"),
+      labelDerivedPeriodId("1787"),
       'range (
         Some(
           InstantRange(


### PR DESCRIPTION
Following a discussion with @jtweed, normalise Period ids based on the PeriodParser Preprocessor, to get rid of superfluous text.

This retains the behaviour that the id is based on the label, and not the exact date period, but avoids fragmentation arising from variation in the label convention.