### PR TITLE
Unicode sensitivity

### DIFF
--- a/pipeline/id_minter/src/main/scala/weco/pipeline/id_minter/database/IdentifiersDao.scala
+++ b/pipeline/id_minter/src/main/scala/weco/pipeline/id_minter/database/IdentifiersDao.scala
@@ -127,7 +127,8 @@ class IdentifiersDao(identifiers: IdentifiersTable) extends Logging {
                       // Because the METS case is fairly rare, we usually fix this by modifying the row in the
                       // ID minter database to correct the case of the source identifier.  To help somebody
                       // realise what's happened, we include a specific log for this case.
-                      info(msg = s"identifier returned from db not found in request, trying case-insensitive/ascii normalized match: $sourceIdentifier")
+                      info(msg =
+                        s"identifier returned from db not found in request, trying case-insensitive/ascii normalized match: $sourceIdentifier")
                       caseNormalisedIdentifiers.get(
                         NormalizedIdentifier(sourceIdentifier)) match {
                         case Some(sourceId) => (sourceId, Identifier(i)(rs))

--- a/pipeline/id_minter/src/main/scala/weco/pipeline/id_minter/database/IdentifiersDao.scala
+++ b/pipeline/id_minter/src/main/scala/weco/pipeline/id_minter/database/IdentifiersDao.scala
@@ -44,7 +44,7 @@ class IdentifiersDao(identifiers: IdentifiersTable) extends Logging {
       val caseNormalisedIdentifiers = distinctIdentifiers
         .filter(_.identifierType == IdentifierType.LabelDerived)
         .map { sourceIdentifier =>
-          (sourceIdentifier.value.toLowerCase, sourceIdentifier)
+          (sourceIdentifier.copy(value=sourceIdentifier.value.toLowerCase), sourceIdentifier)
         }
         .toMap
 
@@ -106,7 +106,7 @@ class IdentifiersDao(identifiers: IdentifiersTable) extends Logging {
                       info(msg =
                         s"identifier returned from db not found in request, trying case-insensitive match: $sourceIdentifier")
                       caseNormalisedIdentifiers.get(
-                        sourceIdentifier.value.toLowerCase) match {
+                        sourceIdentifier.copy(value=sourceIdentifier.value.toLowerCase)) match {
                         case Some(sourceId) => (sourceId, Identifier(i)(rs))
                         case _ =>
                           throw SurplusIdentifierException(

--- a/pipeline/id_minter/src/main/scala/weco/pipeline/id_minter/database/IdentifiersDao.scala
+++ b/pipeline/id_minter/src/main/scala/weco/pipeline/id_minter/database/IdentifiersDao.scala
@@ -2,13 +2,11 @@ package weco.pipeline.id_minter.database
 
 import grizzled.slf4j.Logging
 import scalikejdbc._
-import weco.catalogue.internal_model.identifiers.{
-  IdentifierType,
-  SourceIdentifier
-}
+import weco.catalogue.internal_model.identifiers.{IdentifierType, SourceIdentifier}
 import weco.pipeline.id_minter.models.{Identifier, IdentifiersTable}
-import java.sql.{BatchUpdateException, Statement}
 
+import java.sql.{BatchUpdateException, Statement}
+import java.text.Normalizer
 import scala.concurrent.blocking
 import scala.concurrent.duration._
 import scala.util.{Failure, Try}
@@ -23,6 +21,25 @@ object IdentifiersDao {
                          e: Throwable,
                          succeeded: List[Identifier])
       extends Exception
+}
+
+object NormalizedIdentifier{
+  /**
+   * Return the given sourceIdentifier, with its value normalized to the
+   * same permissiveness as the database query.
+   * When fetching from the database, an id will match regardless of case
+   * and regardless of diacritics/modifying characters.
+   *
+   * This is specifically intended for use by label-derived ids. Other schemes
+   *  are likely to avoid tricky situations like these, and if encountered,
+   *  it is probably a cataloguing error that needs to be notified.
+   */
+  def apply(sourceIdentifier: SourceIdentifier): SourceIdentifier = {
+    val newValue = Normalizer.normalize(
+      sourceIdentifier.value.toLowerCase, Normalizer.Form.NFKD
+    ).replaceAll("[^\\p{ASCII}]", "")
+    sourceIdentifier.copy(value = newValue)
+  }
 }
 
 class IdentifiersDao(identifiers: IdentifiersTable) extends Logging {
@@ -44,7 +61,7 @@ class IdentifiersDao(identifiers: IdentifiersTable) extends Logging {
       val caseNormalisedIdentifiers = distinctIdentifiers
         .filter(_.identifierType == IdentifierType.LabelDerived)
         .map { sourceIdentifier =>
-          (sourceIdentifier.copy(value=sourceIdentifier.value.toLowerCase), sourceIdentifier)
+          (NormalizedIdentifier(sourceIdentifier), sourceIdentifier)
         }
         .toMap
 
@@ -105,8 +122,7 @@ class IdentifiersDao(identifiers: IdentifiersTable) extends Logging {
                       // realise what's happened, we include a specific log for this case.
                       info(msg =
                         s"identifier returned from db not found in request, trying case-insensitive match: $sourceIdentifier")
-                      caseNormalisedIdentifiers.get(
-                        sourceIdentifier.copy(value=sourceIdentifier.value.toLowerCase)) match {
+                      caseNormalisedIdentifiers.get(NormalizedIdentifier(sourceIdentifier)) match {
                         case Some(sourceId) => (sourceId, Identifier(i)(rs))
                         case _ =>
                           throw SurplusIdentifierException(

--- a/pipeline/id_minter/src/main/scala/weco/pipeline/id_minter/database/IdentifiersDao.scala
+++ b/pipeline/id_minter/src/main/scala/weco/pipeline/id_minter/database/IdentifiersDao.scala
@@ -127,8 +127,7 @@ class IdentifiersDao(identifiers: IdentifiersTable) extends Logging {
                       // Because the METS case is fairly rare, we usually fix this by modifying the row in the
                       // ID minter database to correct the case of the source identifier.  To help somebody
                       // realise what's happened, we include a specific log for this case.
-                      info(msg =
-                        s"identifier returned from db not found in request, trying case-insensitive match: $sourceIdentifier")
+                      info(msg = s"identifier returned from db not found in request, trying case-insensitive/ascii normalized match: $sourceIdentifier")
                       caseNormalisedIdentifiers.get(
                         NormalizedIdentifier(sourceIdentifier)) match {
                         case Some(sourceId) => (sourceId, Identifier(i)(rs))

--- a/pipeline/id_minter/src/main/scala/weco/pipeline/id_minter/database/IdentifiersDao.scala
+++ b/pipeline/id_minter/src/main/scala/weco/pipeline/id_minter/database/IdentifiersDao.scala
@@ -2,7 +2,10 @@ package weco.pipeline.id_minter.database
 
 import grizzled.slf4j.Logging
 import scalikejdbc._
-import weco.catalogue.internal_model.identifiers.{IdentifierType, SourceIdentifier}
+import weco.catalogue.internal_model.identifiers.{
+  IdentifierType,
+  SourceIdentifier
+}
 import weco.pipeline.id_minter.models.{Identifier, IdentifiersTable}
 
 import java.sql.{BatchUpdateException, Statement}
@@ -23,21 +26,25 @@ object IdentifiersDao {
       extends Exception
 }
 
-object NormalizedIdentifier{
+object NormalizedIdentifier {
+
   /**
-   * Return the given sourceIdentifier, with its value normalized to the
-   * same permissiveness as the database query.
-   * When fetching from the database, an id will match regardless of case
-   * and regardless of diacritics/modifying characters.
-   *
-   * This is specifically intended for use by label-derived ids. Other schemes
-   *  are likely to avoid tricky situations like these, and if encountered,
-   *  it is probably a cataloguing error that needs to be notified.
-   */
+    * Return the given sourceIdentifier, with its value normalized to the
+    * same permissiveness as the database query.
+    * When fetching from the database, an id will match regardless of case
+    * and regardless of diacritics/modifying characters.
+    *
+    * This is specifically intended for use by label-derived ids. Other schemes
+    *  are likely to avoid tricky situations like these, and if encountered,
+    *  it is probably a cataloguing error that needs to be notified.
+    */
   def apply(sourceIdentifier: SourceIdentifier): SourceIdentifier = {
-    val newValue = Normalizer.normalize(
-      sourceIdentifier.value.toLowerCase, Normalizer.Form.NFKD
-    ).replaceAll("[^\\p{ASCII}]", "")
+    val newValue = Normalizer
+      .normalize(
+        sourceIdentifier.value.toLowerCase,
+        Normalizer.Form.NFKD
+      )
+      .replaceAll("[^\\p{ASCII}]", "")
     sourceIdentifier.copy(value = newValue)
   }
 }
@@ -122,7 +129,8 @@ class IdentifiersDao(identifiers: IdentifiersTable) extends Logging {
                       // realise what's happened, we include a specific log for this case.
                       info(msg =
                         s"identifier returned from db not found in request, trying case-insensitive match: $sourceIdentifier")
-                      caseNormalisedIdentifiers.get(NormalizedIdentifier(sourceIdentifier)) match {
+                      caseNormalisedIdentifiers.get(
+                        NormalizedIdentifier(sourceIdentifier)) match {
                         case Some(sourceId) => (sourceId, Identifier(i)(rs))
                         case _ =>
                           throw SurplusIdentifierException(

--- a/pipeline/id_minter/src/test/scala/weco/pipeline/id_minter/database/IdentifiersDaoTest.scala
+++ b/pipeline/id_minter/src/test/scala/weco/pipeline/id_minter/database/IdentifiersDaoTest.scala
@@ -158,8 +158,7 @@ class IdentifiersDaoTest
         ("françois", "francois"), // Ascii folded in the document, not in database
         ("francois", "françois") // Ascii folded in the database, not in document
       )
-      forAll(equivalents){
-        (inDatabase, inDocument) =>
+      forAll(equivalents) { (inDatabase, inDocument) =>
         val sourceIdentifier = createSourceIdentifierWith(
           identifierType = IdentifierType.LabelDerived,
           value = inDatabase
@@ -183,17 +182,17 @@ class IdentifiersDaoTest
       }
     }
 
-
-    it("retrieves label derived identifiers case-insensitively from different ontologytypes") {
+    it(
+      "retrieves label derived identifiers case-insensitively from different ontologytypes") {
       val conceptSourceIdentifier = createSourceIdentifierWith(
         identifierType = IdentifierType.LabelDerived,
         value = "bAnAnA",
-        ontologyType="Concept"
+        ontologyType = "Concept"
       )
       val subjectSourceIdentifier = createSourceIdentifierWith(
         identifierType = IdentifierType.LabelDerived,
         value = "bAnAnA",
-        ontologyType="Subject"
+        ontologyType = "Subject"
       )
       val conceptIdentifier = createSQLIdentifierWith(
         sourceIdentifier = conceptSourceIdentifier
@@ -203,12 +202,16 @@ class IdentifiersDaoTest
         sourceIdentifier = subjectSourceIdentifier
       )
 
-      val badCaseConceptIdentifier = conceptSourceIdentifier.copy(value = "BaNaNa")
-      val badCaseSubjectIdentifier = subjectSourceIdentifier.copy(value = "BaNaNa")
+      val badCaseConceptIdentifier =
+        conceptSourceIdentifier.copy(value = "BaNaNa")
+      val badCaseSubjectIdentifier =
+        subjectSourceIdentifier.copy(value = "BaNaNa")
 
-      withIdentifiersDao(existingEntries = Seq(conceptIdentifier, subjectIdentifier)) {
+      withIdentifiersDao(
+        existingEntries = Seq(conceptIdentifier, subjectIdentifier)) {
         case (identifiersDao, _) =>
-          val triedLookup = identifiersDao.lookupIds(List(badCaseConceptIdentifier, badCaseSubjectIdentifier))
+          val triedLookup = identifiersDao.lookupIds(
+            List(badCaseConceptIdentifier, badCaseSubjectIdentifier))
 
           triedLookup shouldBe a[Success[_]]
           // The resulting map maps the _requested_ sourceIdentifiers to

--- a/pipeline/id_minter/src/test/scala/weco/pipeline/id_minter/database/IdentifiersDaoTest.scala
+++ b/pipeline/id_minter/src/test/scala/weco/pipeline/id_minter/database/IdentifiersDaoTest.scala
@@ -181,7 +181,7 @@ class IdentifiersDaoTest
         }
       }
     }
-    
+
     it(
       "retrieves label derived identifiers case-insensitively from different ontologytypes") {
       val conceptSourceIdentifier = createSourceIdentifierWith(

--- a/pipeline/id_minter/src/test/scala/weco/pipeline/id_minter/database/IdentifiersDaoTest.scala
+++ b/pipeline/id_minter/src/test/scala/weco/pipeline/id_minter/database/IdentifiersDaoTest.scala
@@ -181,47 +181,7 @@ class IdentifiersDaoTest
         }
       }
     }
-
-    it(
-      "retrieves label derived identifiers case-insensitively from different ontologytypes") {
-      val conceptSourceIdentifier = createSourceIdentifierWith(
-        identifierType = IdentifierType.LabelDerived,
-        value = "bAnAnA",
-        ontologyType = "Concept"
-      )
-      val subjectSourceIdentifier = createSourceIdentifierWith(
-        identifierType = IdentifierType.LabelDerived,
-        value = "bAnAnA",
-        ontologyType = "Subject"
-      )
-      val conceptIdentifier = createSQLIdentifierWith(
-        sourceIdentifier = conceptSourceIdentifier
-      )
-
-      val subjectIdentifier = createSQLIdentifierWith(
-        sourceIdentifier = subjectSourceIdentifier
-      )
-
-      val badCaseConceptIdentifier =
-        conceptSourceIdentifier.copy(value = "BaNaNa")
-      val badCaseSubjectIdentifier =
-        subjectSourceIdentifier.copy(value = "BaNaNa")
-
-      withIdentifiersDao(
-        existingEntries = Seq(conceptIdentifier, subjectIdentifier)) {
-        case (identifiersDao, _) =>
-          val triedLookup = identifiersDao.lookupIds(
-            List(badCaseConceptIdentifier, badCaseSubjectIdentifier))
-
-          triedLookup shouldBe a[Success[_]]
-          // The resulting map maps the _requested_ sourceIdentifiers to
-          // the returned identifiers.
-          triedLookup.get.unmintedIdentifiers shouldBe empty
-          triedLookup.get.existingIdentifiers shouldBe Map(
-            badCaseIdentifier -> identifier)
-      }
-    }
-
+    
     it(
       "retrieves label derived identifiers case-insensitively from different ontologytypes") {
       val conceptSourceIdentifier = createSourceIdentifierWith(


### PR DESCRIPTION
The identifiersDAO is now insensitive to variations in unicode in label-derived identifiers.

This may not be necessary, given changes to asciifold them in the transformer.