### PR TITLE
[WIP] Refactor the SierraItemAccess tests to use the more verbose style

### DIFF
--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -18,7 +18,8 @@ class SierraItemAccessTest
     with Matchers
     with SierraDataGenerators {
 
-  def createFixedFieldWith(label: String)(value: String, display: String): FixedField = {
+  def createFixedFieldWith(label: String)(value: String,
+                                          display: String): FixedField = {
     And(s"$label = '$value' / '$display''")
     FixedField(
       label = label,
@@ -27,9 +28,12 @@ class SierraItemAccessTest
     )
   }
 
-  def createLocationWith: (String, String) => FixedField = createFixedFieldWith(label = "LOCATION")
-  def createOpacMsgWith: (String, String) => FixedField = createFixedFieldWith(label = "OPACMSG")
-  def createStatusWith: (String, String) => FixedField = createFixedFieldWith(label = "STATUS")
+  def createLocationWith: (String, String) => FixedField =
+    createFixedFieldWith(label = "LOCATION")
+  def createOpacMsgWith: (String, String) => FixedField =
+    createFixedFieldWith(label = "OPACMSG")
+  def createStatusWith: (String, String) => FixedField =
+    createFixedFieldWith(label = "STATUS")
 
   it("an open item in the closed stores") {
     Given("an item in the closed stores with no holds")

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -35,20 +35,16 @@ class SierraItemAccessTest
     Given("an item in the closed stores with no holds")
     val holdCount = Some(0)
 
-    val location = createLocationWith("scmac", "Closed stores Arch. & MSS")
-    val status = createStatusWith("-", "Available")
-    val opacMsg = createOpacMsgWith("f", "Online request")
-
-    When("we create an access condition")
     val itemData = createSierraItemDataWith(
       fixedFields = Map(
-        "79" -> location,
-        "88" -> status,
-        "108" -> opacMsg,
+        "79" -> createLocationWith("scmac", "Closed stores Arch. & MSS"),
+        "88" -> createStatusWith("-", "Available"),
+        "108" -> createOpacMsgWith("f", "Online request"),
       ),
       holdCount = holdCount
     )
 
+    When("we create an access condition")
     val (ac, _) = SierraItemAccess(
       location = Some(LocationType.ClosedStores),
       itemData = itemData
@@ -69,20 +65,16 @@ class SierraItemAccessTest
     Given("an item in the closed stores with no holds")
     val holdCount = Some(0)
 
-    val location = createLocationWith("scmac", "Closed stores Arch. & MSS")
-    val status = createStatusWith("-", "Available")
-    val opacMsg = createOpacMsgWith("c", "Restricted")
-
-    When("we create an access condition")
     val itemData = createSierraItemDataWith(
       fixedFields = Map(
-        "79" -> location,
-        "88" -> status,
-        "108" -> opacMsg,
+        "79" -> createLocationWith("scmac", "Closed stores Arch. & MSS"),
+        "88" -> createStatusWith("-", "Available"),
+        "108" -> createOpacMsgWith("c", "Restricted"),
       ),
       holdCount = holdCount
     )
 
+    When("we create an access condition")
     val (ac, _) = SierraItemAccess(
       location = Some(LocationType.ClosedStores),
       itemData = itemData


### PR DESCRIPTION
For https://github.com/wellcomecollection/catalogue-pipeline/issues/2145

This is an experiment into what these tests might look like if we took the more verbose GivenWhenThen style that Paul showed off in Tuesday's review. These tests are definitely a bit unwieldy, and I think maybe this is nicer?

Example output:

```
Given an item in the closed stores with no holds
  And LOCATION = 'scmac' / 'Closed stores Arch. & MSS''
  And STATUS = '-' / 'Available''
  And OPACMSG = 'f' / 'Online request''
  When we create an access condition
  Then the access method is 'online request'
  And the access status is 'open'
  And there's no free-text terms or note

Given an item in the closed stores with no holds
  And LOCATION = 'scmac' / 'Closed stores Arch. & MSS''
  And STATUS = '-' / 'Available''
  And OPACMSG = 'c' / 'Restricted''
  When we create an access condition
  Then the access method is 'online request'
  And the access status is 'restricted'
  And there's no free-text terms or note
```

I'm using `it` instead of `Scenario` for now, but when I swap out AnyFunSpec I should be able to change that.