### PR TITLE
Bump test ES clusters to 8.3.3

### DIFF
--- a/calm_adapter/calm_indexer/docker-compose.yml
+++ b/calm_adapter/calm_indexer/docker-compose.yml
@@ -5,7 +5,7 @@ localstack:
   ports:
     - "4566:4566"
 elasticsearch:
-  image: "docker.elastic.co/elasticsearch/elasticsearch:7.17.5"
+  image: "docker.elastic.co/elasticsearch/elasticsearch:8.3.3"
   ports:
     - "9200:9200"
     - "9300:9300"

--- a/common/internal_model/docker-compose.yml
+++ b/common/internal_model/docker-compose.yml
@@ -1,5 +1,5 @@
 elasticsearch:
-  image: "docker.elastic.co/elasticsearch/elasticsearch:7.17.5"
+  image: "docker.elastic.co/elasticsearch/elasticsearch:8.3.3"
   ports:
     - "9200:9200"
     - "9300:9300"

--- a/common/pipeline_storage/docker-compose.yml
+++ b/common/pipeline_storage/docker-compose.yml
@@ -5,7 +5,7 @@ localstack:
   ports:
     - "4566:4566"
 elasticsearch:
-  image: "docker.elastic.co/elasticsearch/elasticsearch:7.17.5"
+  image: "docker.elastic.co/elasticsearch/elasticsearch:8.3.3"
   ports:
     - "9200:9200"
     - "9300:9300"

--- a/pipeline/ingestor/ingestor_images/docker-compose.yml
+++ b/pipeline/ingestor/ingestor_images/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - "4566:4566"
   elasticsearch:
-    image: "docker.elastic.co/elasticsearch/elasticsearch:7.17.5"
+    image: "docker.elastic.co/elasticsearch/elasticsearch:8.3.3"
     ports:
       - "9200:9200"
       - "9300:9300"

--- a/pipeline/ingestor/ingestor_works/docker-compose.yml
+++ b/pipeline/ingestor/ingestor_works/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - "4566:4566"
   elasticsearch:
-    image: "docker.elastic.co/elasticsearch/elasticsearch:7.17.5"
+    image: "docker.elastic.co/elasticsearch/elasticsearch:8.3.3"
     ports:
       - "9200:9200"
       - "9300:9300"

--- a/pipeline/matcher/docker-compose.yml
+++ b/pipeline/matcher/docker-compose.yml
@@ -9,7 +9,7 @@ dynamodb:
   ports:
     - "45678:8000"
 elasticsearch:
-  image: "docker.elastic.co/elasticsearch/elasticsearch:7.17.5"
+  image: "docker.elastic.co/elasticsearch/elasticsearch:8.3.3"
   ports:
     - "9200:9200"
     - "9300:9300"

--- a/pipeline/relation_embedder/path_concatenator/docker-compose.yml
+++ b/pipeline/relation_embedder/path_concatenator/docker-compose.yml
@@ -5,7 +5,7 @@ localstack:
   ports:
     - "4566:4566"
 elasticsearch:
-  image: "docker.elastic.co/elasticsearch/elasticsearch:7.17.5"
+  image: "docker.elastic.co/elasticsearch/elasticsearch:8.3.3"
   ports:
     - "9200:9200"
     - "9300:9300"

--- a/pipeline/relation_embedder/relation_embedder/docker-compose.yml
+++ b/pipeline/relation_embedder/relation_embedder/docker-compose.yml
@@ -5,7 +5,7 @@ localstack:
   ports:
     - "4566:4566"
 elasticsearch:
-  image: "docker.elastic.co/elasticsearch/elasticsearch:7.17.5"
+  image: "docker.elastic.co/elasticsearch/elasticsearch:8.3.3"
   ports:
     - "9200:9200"
     - "9300:9300"

--- a/sierra_adapter/sierra_indexer/docker-compose.yml
+++ b/sierra_adapter/sierra_indexer/docker-compose.yml
@@ -5,7 +5,7 @@ localstack:
   ports:
     - "4566:4566"
 elasticsearch:
-  image: "docker.elastic.co/elasticsearch/elasticsearch:7.17.5"
+  image: "docker.elastic.co/elasticsearch/elasticsearch:8.3.3"
   ports:
     - "9200:9200"
     - "9300:9300"


### PR DESCRIPTION
Following the workflow in https://www.elastic.co/guide/en/elasticsearch/reference/current/rest-api-compatibility.html#_rest_api_compatibility_workflow