### PR TITLE
Remove records from a bib if they were modified at the same time as the existing record

### DIFF
--- a/sierra_adapter/sierra_merger/src/main/scala/weco/pipeline/sierra_merger/models/TransformableOps.scala
+++ b/sierra_adapter/sierra_merger/src/main/scala/weco/pipeline/sierra_merger/models/TransformableOps.scala
@@ -123,7 +123,8 @@ object TransformableOps {
     // In these cases, we want to process the deletion, so we use
     // "latest to the merger wins".  If this is wrong, somebody can
     // update the record in Sierra again to increment the updatedDate.
-    private def shouldReplaceExisting(existing: Record, newRecord: Record): Boolean =
+    private def shouldReplaceExisting(existing: Record,
+                                      newRecord: Record): Boolean =
       newRecord.modifiedDate.isAfter(existing.modifiedDate) ||
         newRecord.modifiedDate == existing.modifiedDate
 

--- a/sierra_adapter/sierra_merger/src/main/scala/weco/pipeline/sierra_merger/models/TransformableOps.scala
+++ b/sierra_adapter/sierra_merger/src/main/scala/weco/pipeline/sierra_merger/models/TransformableOps.scala
@@ -113,6 +113,20 @@ object TransformableOps {
       setRecords(t, newRecords)
     }
 
+    // Note: we do care about strict equality here, not just "after".
+    //
+    // In particular, there have been cases where we saw:
+    //
+    //    - a record be modified and get an "updatedDate: $t"
+    //    - the same record be deleted with "updatedDate: $t"
+    //
+    // In these cases, we want to process the deletion, so we use
+    // "latest to the merger wins".  If this is wrong, somebody can
+    // update the record in Sierra again to increment the updatedDate.
+    private def shouldReplaceExisting(existing: Record, newRecord: Record): Boolean =
+      newRecord.modifiedDate.isAfter(existing.modifiedDate) ||
+        newRecord.modifiedDate == existing.modifiedDate
+
     override def add(t: SierraTransformable,
                      record: Record): Option[SierraTransformable] = {
       if (!recordOps.getBibIds(record).contains(t.sierraId)) {
@@ -130,10 +144,8 @@ object TransformableOps {
       //
       val isNewerData = {
         getRecords(t).get(record.id) match {
-          case Some(existing) =>
-            record.modifiedDate.isAfter(existing.modifiedDate) ||
-              record.modifiedDate == existing.modifiedDate
-          case None => true
+          case Some(existing) => shouldReplaceExisting(existing, record)
+          case None           => true
         }
       }
 
@@ -155,14 +167,10 @@ object TransformableOps {
       val newRecords =
         getRecords(t)
           .filterNot {
-            case (id, currentRecord) =>
-              val matchesCurrentRecord = id == record.id
+            case (id, existing) =>
+              val hasMatchingId = id == record.id
 
-              val modifiedAfter = record.modifiedDate.isAfter(
-                currentRecord.modifiedDate
-              )
-
-              matchesCurrentRecord && modifiedAfter
+              hasMatchingId && shouldReplaceExisting(existing, record)
           }
 
       if (getRecords(t) != newRecords) {

--- a/sierra_adapter/sierra_merger/src/test/scala/weco/pipeline/sierra_merger/models/TransformableOpsTest.scala
+++ b/sierra_adapter/sierra_merger/src/test/scala/weco/pipeline/sierra_merger/models/TransformableOpsTest.scala
@@ -455,6 +455,36 @@ class TransformableOpsTest
           .get shouldBe expectedSierraTransformable
       }
 
+      it("removes the holdings if the modified date matches the existing record") {
+        val bibId = createSierraBibNumber
+
+        val record = createSierraHoldingsRecordWith(
+          bibIds = List(bibId),
+          unlinkedBibIds = List()
+        )
+
+        val unlinkedRecord = createSierraHoldingsRecordWith(
+          id = record.id,
+          bibIds = List(),
+          modifiedDate = record.modifiedDate,
+          unlinkedBibIds = List(bibId)
+        )
+
+        val sierraTransformable = createSierraTransformableStubWith(
+          bibId = bibId,
+          holdingsRecords = List(record)
+        )
+
+        val expectedSierraTransformable = sierraTransformable.copy(
+          holdingsRecords = Map.empty,
+          modifiedTime = unlinkedRecord.modifiedDate
+        )
+
+        sierraTransformable
+          .remove(unlinkedRecord)
+          .get shouldBe expectedSierraTransformable
+      }
+
       it("returns None when merging an unlinked record which is already absent") {
         val bibId = createSierraBibNumber
 

--- a/sierra_adapter/sierra_merger/src/test/scala/weco/pipeline/sierra_merger/models/TransformableOpsTest.scala
+++ b/sierra_adapter/sierra_merger/src/test/scala/weco/pipeline/sierra_merger/models/TransformableOpsTest.scala
@@ -455,7 +455,8 @@ class TransformableOpsTest
           .get shouldBe expectedSierraTransformable
       }
 
-      it("removes the holdings if the modified date matches the existing record") {
+      it(
+        "removes the holdings if the modified date matches the existing record") {
         val bibId = createSierraBibNumber
 
         val record = createSierraHoldingsRecordWith(

--- a/sierra_adapter/terraform/stack/s3_sierra_adapter.tf
+++ b/sierra_adapter/terraform/stack/s3_sierra_adapter.tf
@@ -24,4 +24,24 @@ resource "aws_s3_bucket" "sierra_adapter" {
       days = 7
     }
   }
+
+  lifecycle_rule {
+    id      = "expire_old_holdings"
+    prefix  = "records_holdings/"
+    enabled = true
+
+    expiration {
+      days = 7
+    }
+  }
+
+  lifecycle_rule {
+    id      = "expire_old_orders"
+    prefix  = "records_orders/"
+    enabled = true
+
+    expiration {
+      days = 7
+    }
+  }
 }


### PR DESCRIPTION
When we add records to a SierraTransformable, we add anything that was modified *after or at the same time as* the existing record.

When we remove records to a SierraTransformable, we were removing anything that was modified *after* the existing record.  This meant we were losing some real updates where the `modifiedDate` of the deleted record was somehow identical to a prior version.

This makes the behaviour consistent and hopefully will avoid future bugs where records aren't removed properly.