### PR TITLE
Sort out the performance of the reingest script

### DIFF
--- a/reindexer/scripts/concurrently.py
+++ b/reindexer/scripts/concurrently.py
@@ -1,0 +1,39 @@
+import concurrent.futures
+import itertools
+
+
+def concurrently(fn, inputs, *, max_concurrency=5):
+    """
+    Calls the function ``fn`` on the values ``inputs``.
+
+    ``fn`` should be a function that takes a single input, which is the
+    individual values in the iterable ``inputs``.
+
+    Generates (input, output) tuples as the calls to ``fn`` complete.
+
+    See https://alexwlchan.net/2019/10/adventures-with-concurrent-futures/ for an explanation
+    of how this function works.
+
+    """
+    # Make sure we get a consistent iterator throughout, rather than
+    # getting the first element repeatedly.
+    fn_inputs = iter(inputs)
+
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        futures = {
+            executor.submit(fn, input): input
+            for input in itertools.islice(fn_inputs, max_concurrency)
+        }
+
+        while futures:
+            done, _ = concurrent.futures.wait(
+                futures, return_when=concurrent.futures.FIRST_COMPLETED
+            )
+
+            for fut in done:
+                original_input = futures.pop(fut)
+                yield original_input, fut.result()
+
+            for input in itertools.islice(fn_inputs, len(done)):
+                fut = executor.submit(fn, input)
+                futures[fut] = input

--- a/reindexer/scripts/reingest_for_display.py
+++ b/reindexer/scripts/reingest_for_display.py
@@ -63,25 +63,16 @@ def main(reindex_date, document_type, test_doc_id):
             ),
             total=reingest_docs_count,
         ),
-        size=100
+        size=100,
     ):
         doc_ids = [hit["_id"] for hit in chunk]
         sns_batches = chunked_iterable(
-            iterable=[
-                {
-                    "Id": id,
-                    "Message": id
-                }
-                for id in doc_ids
-            ],
-            size=10 # Max SNS batch size
+            iterable=[{"Id": id, "Message": id} for id in doc_ids],
+            size=10,  # Max SNS batch size
         )
 
         def publish(batch):
-            sns.publish_batch(
-                TopicArn=dest_topic_arn,
-                PublishBatchRequestEntries=batch
-            )
+            sns.publish_batch(TopicArn=dest_topic_arn, PublishBatchRequestEntries=batch)
             return True
 
         for _ in concurrently(fn=publish, inputs=sns_batches, max_concurrency=10):


### PR DESCRIPTION
This now takes 4 minutes rather than 2 hours thanks to a mix of batching and concurrency - I suspect tweaking some numbers could improve it further, but it's good enough for now.