### PR TITLE
Speed up the script for reindexing the visible Works

### DIFF
--- a/reindexer/scripts/reingest_for_display.py
+++ b/reindexer/scripts/reingest_for_display.py
@@ -71,7 +71,9 @@ def main(reindex_date, document_type, test_doc_id):
         for (batch, _) in concurrently(
             fn=lambda b: sns.publish_batch(
                 TopicArn=dest_topic_arn, PublishBatchRequestEntries=b
-            ), inputs=sns_batches(), max_concurrency=10
+            ),
+            inputs=sns_batches(),
+            max_concurrency=10,
         ):
             pbar.update(len(batch))
 

--- a/reindexer/scripts/reingest_for_display.py
+++ b/reindexer/scripts/reingest_for_display.py
@@ -20,16 +20,10 @@ def chunked_iterable(iterable, size):
 
 def get_work_ids(es, api_index, query, reingest_docs_count):
     for hit in tqdm(
-        scan(
-            es,
-            scroll="15m",
-            index=api_index,
-            query={"query": query},
-            _source=False,
-        ),
+        scan(es, scroll="15m", index=api_index, query={"query": query}, _source=False),
         total=reingest_docs_count,
     ):
-        yield hit['_id']
+        yield hit["_id"]
 
 
 @click.command()

--- a/reindexer/scripts/reingest_for_display.py
+++ b/reindexer/scripts/reingest_for_display.py
@@ -18,6 +18,20 @@ def chunked_iterable(iterable, size):
         yield chunk
 
 
+def get_work_ids(es, api_index, query, reingest_docs_count):
+    for hit in tqdm(
+        scan(
+            es,
+            scroll="15m",
+            index=api_index,
+            query={"query": query},
+            _source=False,
+        ),
+        total=reingest_docs_count,
+    ):
+        yield hit['_id']
+
+
 @click.command()
 @click.argument("reindex_date")
 @click.option(
@@ -52,31 +66,20 @@ def main(reindex_date, document_type, test_doc_id):
         return
 
     print(f"Reingesting {reingest_docs_count} documents...")
-    for chunk in chunked_iterable(
-        iterable=tqdm(
-            scan(
-                es,
-                scroll="15m",
-                index=api_index,
-                query={"query": api_index_query},
-                _source=False,
-            ),
-            total=reingest_docs_count,
-        ),
-        size=100,
-    ):
-        doc_ids = [hit["_id"] for hit in chunk]
-        sns_batches = chunked_iterable(
+
+    def sns_batches():
+        doc_ids = get_work_ids(es, api_index, api_index_query, reingest_docs_count)
+        yield from chunked_iterable(
             iterable=[{"Id": id, "Message": id} for id in doc_ids],
             size=10,  # Max SNS batch size
         )
 
-        def publish(batch):
-            sns.publish_batch(TopicArn=dest_topic_arn, PublishBatchRequestEntries=batch)
-            return True
+    def publish(batch):
+        sns.publish_batch(TopicArn=dest_topic_arn, PublishBatchRequestEntries=batch)
+        return True
 
-        for _ in concurrently(fn=publish, inputs=sns_batches, max_concurrency=10):
-            pass
+    for _ in concurrently(fn=publish, inputs=sns_batches(), max_concurrency=10):
+        pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Previously we were batching in two places:

* We'd get a batch of 100 IDs from Elasticsearch
* We'd split those into 10 batches of 10 to send to SNS in PublishBatch

This created a sawtooth-like set of work: we'd have to publish 10 batches before we could start working on the next batch of 100.  This is the failure mode described here:
https://alexwlchan.net/2019/10/adventures-with-concurrent-futures/#running-a-large-fixed-number-of-tasks

<img width="755" alt="Screenshot 2022-09-20 at 16 29 29" src="https://user-images.githubusercontent.com/301220/191300375-93ae4960-5894-496d-8fc6-31ee50a0afdf.png">

This changes the script to work on a continuous stream of works, which improves the concurrency and takes the script from ~25m to ~2m.