### PR TITLE
Fix identifiers on Sierra contributors

### DIFF
--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraAbstractConcepts.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraAbstractConcepts.scala
@@ -57,8 +57,8 @@ trait SierraAbstractConcepts extends Logging {
       case None => IdState.Unidentifiable
     }
 
-  private def addIdentifierFromText(ontologyType: String,
-                                    label: String): IdState.Unminted = {
+  def addIdentifierFromText(ontologyType: String,
+                            label: String): IdState.Unminted = {
     val normalizedLabel = Normalizer
       .normalize(
         label.toLowerCase,

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraAgents.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraAgents.scala
@@ -68,22 +68,7 @@ trait SierraAgents
    * Agents are only identified within the LCNames or LabelDerived schemata.
    *
    */
-  def identify(varfield: VarField, ontologyType: String): IdState.Unminted =
-    varfield.indicator2 match {
-      // 0 indicates LCNames id is in use.
-      // This is a Wellcome-specific convention. MARC 0 for these fields (e.g. https://www.loc.gov/marc/bibliographic/bd610.html)
-      // states that 0 means LCSH.
-      // In this example from b17950235 (fd6nk8fw), n50082847 is the LCNames id for Glaxo Laboratories
-      // 110 2  Glaxo Laboratories.|0n  50082847
-      case Some("0") | Some("") | None =>
-        getIdState(ontologyType, varfield)
-      // Other values of second indicator show that the id is in an unusable scheme.
-      // Do not identify.
-      case _ =>
-        info(
-          s"${varfield.indicator2} is an unusable 2nd indicator value for an Agent in $varfield")
-        IdState.Unidentifiable
-    }
+//
 
   // We take the contents of subfield $0.  They may contain inconsistent
   // spacing and punctuation, such as:

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraContributors.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraContributors.scala
@@ -1,6 +1,10 @@
 package weco.pipeline.transformer.sierra.transformers
 
-import weco.catalogue.internal_model.identifiers.{IdState, IdentifierType, SourceIdentifier}
+import weco.catalogue.internal_model.identifiers.{
+  IdState,
+  IdentifierType,
+  SourceIdentifier
+}
 import weco.catalogue.internal_model.work._
 import weco.sierra.models.SierraQueryOps
 import weco.sierra.models.data.SierraBibData
@@ -106,7 +110,9 @@ object SierraContributors
             val (ontologyType, maybeAgent) = getContributors(varfield.subfields)
             maybeAgent.map { agent =>
               Contributor(
-                agent = withId(agent, identify(varfield.subfields, ontologyType, agent.label)),
+                agent = withId(
+                  agent,
+                  identify(varfield.subfields, ontologyType, agent.label)),
                 roles = getContributionRoles(varfield.subfields, roleTags),
                 primary = isPrimary
               )
@@ -164,11 +170,11 @@ object SierraContributors
     }
 
   /* Given an agent and the associated MARC subfields, look for instances of subfield $0,
- * which are used for identifiers.
- *
- * This methods them (if present) and wraps the agent in Unidentifiable or Identifiable
- * as appropriate.
- */
+   * which are used for identifiers.
+   *
+   * This methods them (if present) and wraps the agent in Unidentifiable or Identifiable
+   * as appropriate.
+   */
   private def identify(subfields: List[Subfield],
                        ontologyType: String,
                        label: String): IdState.Unminted = {

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/subjects/SierraMeetingSubjects.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/subjects/SierraMeetingSubjects.scala
@@ -37,7 +37,7 @@ object SierraMeetingSubjects
       createLabel(varField, subfieldTags = List("a", "c", "d")) match {
         case "" => None
         case label =>
-          val identifier = identify(varField, "Meeting")
+          val identifier = identifyAgentSubject(varField, "Meeting")
 
           Some(
             Subject(

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/subjects/SierraOrganisationSubjects.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/subjects/SierraOrganisationSubjects.scala
@@ -60,6 +60,8 @@ object SierraOrganisationSubjects
 
     Organisation(
       label = label,
-      id = identifyAgentSubject(varfield = varField, ontologyType = "Organisation"))
+      id = identifyAgentSubject(
+        varfield = varField,
+        ontologyType = "Organisation"))
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/subjects/SierraOrganisationSubjects.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/subjects/SierraOrganisationSubjects.scala
@@ -40,7 +40,7 @@ object SierraOrganisationSubjects
       Subject(
         label = label,
         concepts = List(organisation),
-        id = identifyAgentSubject(varField, "Organisation")
+        id = identifyAgentSubject(varField, "Subject")
       )
     }
 

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/subjects/SierraOrganisationSubjects.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/subjects/SierraOrganisationSubjects.scala
@@ -40,7 +40,7 @@ object SierraOrganisationSubjects
       Subject(
         label = label,
         concepts = List(organisation),
-        id = identify(varField, "Subject")
+        id = identifyAgentSubject(varField, "Organisation")
       )
     }
 
@@ -60,6 +60,6 @@ object SierraOrganisationSubjects
 
     Organisation(
       label = label,
-      id = identify(varfield = varField, ontologyType = "Organisation"))
+      id = identifyAgentSubject(varfield = varField, ontologyType = "Organisation"))
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/subjects/SierraPersonSubjects.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/subjects/SierraPersonSubjects.scala
@@ -56,13 +56,13 @@ object SierraPersonSubjects
             generalSubdivisions = generalSubdivisions
           )
           val maybeIdentifiedPerson =
-            person.copy(id = identify(varField, "Person"))
+            person.copy(id = identifyAgentSubject(varField, "Person"))
           Subject(
             label = label,
             concepts = getConcepts(
               maybeIdentifiedPerson.identifiable(),
               generalSubdivisions),
-            id = identify(varField, "Subject")
+            id = identifyAgentSubject(varField, "Subject")
           )
         }
       }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/subjects/SierraSubjectsTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/subjects/SierraSubjectsTransformer.scala
@@ -2,7 +2,10 @@ package weco.pipeline.transformer.sierra.transformers.subjects
 
 import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.work.Subject
-import weco.pipeline.transformer.sierra.transformers.{SierraAbstractConcepts, SierraIdentifiedDataTransformer}
+import weco.pipeline.transformer.sierra.transformers.{
+  SierraAbstractConcepts,
+  SierraIdentifiedDataTransformer
+}
 import weco.pipeline.transformer.text.TextNormalisation._
 import weco.sierra.models.SierraQueryOps
 import weco.sierra.models.data.SierraBibData
@@ -41,13 +44,14 @@ trait SierraSubjectsTransformer
       .trimTrailingPeriod
 
   /** Create an identifier for a subject created from an Agent.
-   *
-   * Note that these rules are different from the rules for Agents created
-   * for contributors, because subjects and contributors are drawn from
-   * different MARC fields with different behaviours.
-   *
-   */
-  def identifyAgentSubject(varfield: VarField, ontologyType: String): IdState.Unminted = {
+    *
+    * Note that these rules are different from the rules for Agents created
+    * for contributors, because subjects and contributors are drawn from
+    * different MARC fields with different behaviours.
+    *
+    */
+  def identifyAgentSubject(varfield: VarField,
+                           ontologyType: String): IdState.Unminted = {
     varfield.indicator2 match {
       // 0 indicates LCNames id is in use.
       // This is a Wellcome-specific convention. MARC 0 for these fields (e.g. https://www.loc.gov/marc/bibliographic/bd610.html)

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/subjects/SierraSubjectsTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/subjects/SierraSubjectsTransformer.scala
@@ -2,7 +2,7 @@ package weco.pipeline.transformer.sierra.transformers.subjects
 
 import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.work.Subject
-import weco.pipeline.transformer.sierra.transformers.SierraIdentifiedDataTransformer
+import weco.pipeline.transformer.sierra.transformers.{SierraAbstractConcepts, SierraIdentifiedDataTransformer}
 import weco.pipeline.transformer.text.TextNormalisation._
 import weco.sierra.models.SierraQueryOps
 import weco.sierra.models.data.SierraBibData
@@ -11,6 +11,7 @@ import weco.sierra.models.marc.VarField
 
 trait SierraSubjectsTransformer
     extends SierraIdentifiedDataTransformer
+    with SierraAbstractConcepts
     with SierraQueryOps {
 
   type Output = List[Subject[IdState.Unminted]]
@@ -38,4 +39,29 @@ trait SierraSubjectsTransformer
       .contents
       .mkString(" ")
       .trimTrailingPeriod
+
+  /** Create an identifier for a subject created from an Agent.
+   *
+   * Note that these rules are different from the rules for Agents created
+   * for contributors, because subjects and contributors are drawn from
+   * different MARC fields with different behaviours.
+   *
+   */
+  def identifyAgentSubject(varfield: VarField, ontologyType: String): IdState.Unminted = {
+    varfield.indicator2 match {
+      // 0 indicates LCNames id is in use.
+      // This is a Wellcome-specific convention. MARC 0 for these fields (e.g. https://www.loc.gov/marc/bibliographic/bd610.html)
+      // states that 0 means LCSH.
+      // In this example from b17950235 (fd6nk8fw), n50082847 is the LCNames id for Glaxo Laboratories
+      // 110 2  Glaxo Laboratories.|0n  50082847
+      case Some("0") | Some("") | None =>
+        getIdState(ontologyType, varfield)
+      // Other values of second indicator show that the id is in an unusable scheme.
+      // Do not identify.
+      case _ =>
+        info(
+          s"${varfield.indicator2} is an unusable 2nd indicator value for an Agent in $varfield")
+        IdState.Unidentifiable
+    }
+  }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraContributorsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraContributorsTest.scala
@@ -355,7 +355,8 @@ class SierraContributorsTest
       contributor.agent shouldBe a[Person[_]]
     }
 
-    it("uses a label-derived identifier if there are multiple distinct identifiers in subfield ǂ0") {
+    it(
+      "uses a label-derived identifier if there are multiple distinct identifiers in subfield ǂ0") {
       val name = "Darren the Dill"
       val varFields = List(
         VarField(
@@ -572,7 +573,8 @@ class SierraContributorsTest
       contributor.agent shouldBe an[Organisation[_]]
     }
 
-    it("uses a label-derived identifier if there are multiple distinct identifiers in subfield ǂ0") {
+    it(
+      "uses a label-derived identifier if there are multiple distinct identifiers in subfield ǂ0") {
       val name = "Luke the lime"
       val varFields = List(
         VarField(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraContributorsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraContributorsTest.scala
@@ -355,8 +355,7 @@ class SierraContributorsTest
       contributor.agent shouldBe a[Person[_]]
     }
 
-    it(
-      "does not identify the contributor if there are multiple distinct identifiers in subfield ǂ0") {
+    it("uses a label-derived identifier if there are multiple distinct identifiers in subfield ǂ0") {
       val name = "Darren the Dill"
       val varFields = List(
         VarField(
@@ -375,7 +374,7 @@ class SierraContributorsTest
       contributor.agent shouldBe a[Person[_]]
       contributor.agent should have(
         'label (name),
-        'id (IdState.Unidentifiable)
+        labelDerivedPersonId(name.toLowerCase)
       )
     }
 
@@ -573,8 +572,7 @@ class SierraContributorsTest
       contributor.agent shouldBe an[Organisation[_]]
     }
 
-    it(
-      "does not identify the contributor if there are multiple distinct identifiers in subfield ǂ0") {
+    it("uses a label-derived identifier if there are multiple distinct identifiers in subfield ǂ0") {
       val name = "Luke the lime"
       val varFields = List(
         VarField(
@@ -592,7 +590,7 @@ class SierraContributorsTest
       contributor.agent shouldBe an[Organisation[_]]
       contributor.agent should have(
         'label (name),
-        'id (IdState.Unidentifiable)
+        labelDerivedOrganisationId(name.toLowerCase)
       )
     }
 

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/matchers/SubjectMatchers.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/matchers/SubjectMatchers.scala
@@ -8,10 +8,11 @@ import weco.catalogue.internal_model.work.{AbstractRootConcept, Subject}
 trait SubjectMatchers {
 
   def labelDerivedSubjectId(
-    value: String): HavePropertyMatcher[Subject[IdState.Unminted], String] =
+    value: String,
+    ontologyType: String = "Subject"): HavePropertyMatcher[Subject[IdState.Unminted], String] =
     new HasIdMatchers.HasIdentifier(
       identifierType = IdentifierType.LabelDerived,
-      ontologyType = "Subject",
+      ontologyType = ontologyType,
       value = value)
 
   implicit class SubjectTestOps[State](subject: Subject[State]) {

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/matchers/SubjectMatchers.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/matchers/SubjectMatchers.scala
@@ -7,9 +7,8 @@ import weco.catalogue.internal_model.work.{AbstractRootConcept, Subject}
 
 trait SubjectMatchers {
 
-  def labelDerivedSubjectId(
-    value: String,
-    ontologyType: String = "Subject"): HavePropertyMatcher[Subject[IdState.Unminted], String] =
+  def labelDerivedSubjectId(value: String, ontologyType: String = "Subject")
+    : HavePropertyMatcher[Subject[IdState.Unminted], String] =
     new HasIdMatchers.HasIdentifier(
       identifierType = IdentifierType.LabelDerived,
       ontologyType = ontologyType,

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/subjects/SierraOrganisationSubjectsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/subjects/SierraOrganisationSubjectsTest.scala
@@ -99,7 +99,7 @@ class SierraOrganisationSubjectsTest
 
       subject.label shouldBe "Hasseröder"
       subject should have(
-        labelDerivedSubjectId("hasseroder", ontologyType = "Organisation")
+        labelDerivedSubjectId("hasseroder")
       )
       subject.onlyConcept.label shouldBe "Hasseröder"
       subject.onlyConcept should have(
@@ -139,7 +139,7 @@ class SierraOrganisationSubjectsTest
       subject.id shouldBe IdState.Identifiable(
         SourceIdentifier(
           identifierType = IdentifierType.LCNames,
-          ontologyType = "Organisation",
+          ontologyType = "Subject",
           value = lcNamesCode
         )
       )
@@ -160,7 +160,7 @@ class SierraOrganisationSubjectsTest
       subject should have(
         sourceIdentifier(
           identifierType = IdentifierType.LCNames,
-          ontologyType = "Organisation",
+          ontologyType = "Subject",
           value = lcNamesCode
         )
       )
@@ -184,7 +184,7 @@ class SierraOrganisationSubjectsTest
       subject.id shouldBe IdState.Identifiable(
         SourceIdentifier(
           identifierType = IdentifierType.LCNames,
-          ontologyType = "Organisation",
+          ontologyType = "Subject",
           value = "n1234"
         )
       )

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/subjects/SierraOrganisationSubjectsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/subjects/SierraOrganisationSubjectsTest.scala
@@ -99,7 +99,7 @@ class SierraOrganisationSubjectsTest
 
       subject.label shouldBe "Hasseröder"
       subject should have(
-        labelDerivedSubjectId("hasseroder")
+        labelDerivedSubjectId("hasseroder", ontologyType = "Organisation")
       )
       subject.onlyConcept.label shouldBe "Hasseröder"
       subject.onlyConcept should have(
@@ -139,7 +139,7 @@ class SierraOrganisationSubjectsTest
       subject.id shouldBe IdState.Identifiable(
         SourceIdentifier(
           identifierType = IdentifierType.LCNames,
-          ontologyType = "Subject",
+          ontologyType = "Organisation",
           value = lcNamesCode
         )
       )
@@ -160,7 +160,7 @@ class SierraOrganisationSubjectsTest
       subject should have(
         sourceIdentifier(
           identifierType = IdentifierType.LCNames,
-          ontologyType = "Subject",
+          ontologyType = "Organisation",
           value = lcNamesCode
         )
       )
@@ -184,7 +184,7 @@ class SierraOrganisationSubjectsTest
       subject.id shouldBe IdState.Identifiable(
         SourceIdentifier(
           identifierType = IdentifierType.LCNames,
-          ontologyType = "Subject",
+          ontologyType = "Organisation",
           value = "n1234"
         )
       )


### PR DESCRIPTION
Previously we were using a single method to mint identifiers for both

* Sierra agents as subjects, and
* Sierra agents as contributors

but these are drawn from different MARC fields and behave in different ways; this PR restores the old approach to getting identifiers for contributors.  This should restore the missing identifiers in the works index.