### PR TITLE
Refactor a few things around contributors and label-derived identifiers

### DIFF
--- a/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/CalmTransformer.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/CalmTransformer.scala
@@ -155,7 +155,7 @@ object CalmTransformer
         subjects = subjects(record),
         languages = languages,
         items = CalmItems(record),
-        contributors = contributors(record),
+        contributors = CalmContributors(record),
         description = description(record),
         physicalDescription = physicalDescription(record),
         production = production(record),
@@ -268,9 +268,4 @@ object CalmTransformer
           concepts = List(Concept(normalisedLabel))
         )
       }
-
-  def contributors(record: CalmRecord): List[Contributor[IdState.Unminted]] =
-    record.getList("CreatorName").map { name =>
-      Contributor(Agent(name), Nil)
-    }
 }

--- a/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/transformers/CalmContributors.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/transformers/CalmContributors.scala
@@ -1,0 +1,13 @@
+package weco.pipeline.transformer.calm.transformers
+
+import weco.catalogue.internal_model.identifiers.IdState
+import weco.catalogue.internal_model.work.{Agent, Contributor}
+import weco.catalogue.source_model.calm.CalmRecord
+import weco.pipeline.transformer.calm.models.CalmRecordOps
+
+object CalmContributors extends CalmRecordOps {
+  def apply(record: CalmRecord): List[Contributor[IdState.Unminted]] =
+    record.getList("CreatorName").map { name =>
+      Contributor(Agent(name), Nil)
+    }
+}

--- a/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/transformers/CalmContributorsTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/transformers/CalmContributorsTest.scala
@@ -6,7 +6,10 @@ import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.work.{Agent, Contributor}
 import weco.catalogue.source_model.generators.CalmRecordGenerators
 
-class CalmContributorsTest extends AnyFunSpec with Matchers with CalmRecordGenerators {
+class CalmContributorsTest
+    extends AnyFunSpec
+    with Matchers
+    with CalmRecordGenerators {
   it("returns an empty list if there's nothing in 'CreatorName'") {
     val record = createCalmRecord
 

--- a/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/transformers/CalmContributorsTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/transformers/CalmContributorsTest.scala
@@ -1,0 +1,39 @@
+package weco.pipeline.transformer.calm.transformers
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import weco.catalogue.internal_model.identifiers.IdState
+import weco.catalogue.internal_model.work.{Agent, Contributor}
+import weco.catalogue.source_model.generators.CalmRecordGenerators
+
+class CalmContributorsTest extends AnyFunSpec with Matchers with CalmRecordGenerators {
+  it("returns an empty list if there's nothing in 'CreatorName'") {
+    val record = createCalmRecord
+
+    CalmContributors(record) shouldBe empty
+  }
+
+  it("creates an Agent for every entry in 'CreatorName'") {
+    val record = createCalmRecordWith(
+      "CreatorName" -> "Gabrielle Enthoven",
+      "CreatorName" -> "Simone Berbain"
+    )
+
+    CalmContributors(record) shouldBe List(
+      Contributor(
+        id = IdState.Unidentifiable,
+        agent = Agent(
+          id = IdState.Unidentifiable,
+          label = "Gabrielle Enthoven"
+        )
+      ),
+      Contributor(
+        id = IdState.Unidentifiable,
+        agent = Agent(
+          id = IdState.Unidentifiable,
+          label = "Simone Berbain"
+        )
+      ),
+    )
+  }
+}

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/identifiers/LabelDerivedIdentifiers.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/identifiers/LabelDerivedIdentifiers.scala
@@ -1,0 +1,37 @@
+package weco.pipeline.transformer.identifiers
+
+import weco.catalogue.internal_model.identifiers.{IdState, IdentifierType, SourceIdentifier}
+import weco.pipeline.transformer.text.TextNormalisation._
+
+import java.text.Normalizer
+
+trait LabelDerivedIdentifiers {
+
+  /** Create a label-derived identifier for a label.
+   *
+   * Normalisation is required here for both case and ascii folding.
+   * With label-derived ids, case is (probably rightly) inconsistent, as the subfields
+   * are intended to be concatenated, e.g. "History, bananas" and "Bananas, history"
+   * In some cases, we see the names being shown in different forms in different fields.
+   * e.g. in b24313270, (Memoirs of the Cardinal de Retz,)
+   * The Cardinal in question (Author: Retz, Jean François Paul de Gondi de, 1613-1679.) wrote about himself
+   * (Subject: Retz, Jean Francois Paul de Gondi de, 1613-1679.)
+   *
+   */
+  def identifierFromText(label: String, ontologyType: String): IdState.Identifiable = {
+    val normalizedLabel = Normalizer
+      .normalize(
+        label.trimTrailingPeriod.trim.toLowerCase,
+        Normalizer.Form.NFKD
+      )
+      .replaceAll("[^\\p{ASCII}]", "")
+
+    IdState.Identifiable(
+      sourceIdentifier = SourceIdentifier(
+        identifierType = IdentifierType.LabelDerived,
+        value = normalizedLabel,
+        ontologyType = ontologyType
+      )
+    )
+  }
+}

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/identifiers/LabelDerivedIdentifiers.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/identifiers/LabelDerivedIdentifiers.scala
@@ -1,6 +1,10 @@
 package weco.pipeline.transformer.identifiers
 
-import weco.catalogue.internal_model.identifiers.{IdState, IdentifierType, SourceIdentifier}
+import weco.catalogue.internal_model.identifiers.{
+  IdState,
+  IdentifierType,
+  SourceIdentifier
+}
 import weco.pipeline.transformer.text.TextNormalisation._
 
 import java.text.Normalizer
@@ -8,17 +12,18 @@ import java.text.Normalizer
 trait LabelDerivedIdentifiers {
 
   /** Create a label-derived identifier for a label.
-   *
-   * Normalisation is required here for both case and ascii folding.
-   * With label-derived ids, case is (probably rightly) inconsistent, as the subfields
-   * are intended to be concatenated, e.g. "History, bananas" and "Bananas, history"
-   * In some cases, we see the names being shown in different forms in different fields.
-   * e.g. in b24313270, (Memoirs of the Cardinal de Retz,)
-   * The Cardinal in question (Author: Retz, Jean François Paul de Gondi de, 1613-1679.) wrote about himself
-   * (Subject: Retz, Jean Francois Paul de Gondi de, 1613-1679.)
-   *
-   */
-  def identifierFromText(label: String, ontologyType: String): IdState.Identifiable = {
+    *
+    * Normalisation is required here for both case and ascii folding.
+    * With label-derived ids, case is (probably rightly) inconsistent, as the subfields
+    * are intended to be concatenated, e.g. "History, bananas" and "Bananas, history"
+    * In some cases, we see the names being shown in different forms in different fields.
+    * e.g. in b24313270, (Memoirs of the Cardinal de Retz,)
+    * The Cardinal in question (Author: Retz, Jean François Paul de Gondi de, 1613-1679.) wrote about himself
+    * (Subject: Retz, Jean Francois Paul de Gondi de, 1613-1679.)
+    *
+    */
+  def identifierFromText(label: String,
+                         ontologyType: String): IdState.Identifiable = {
     val normalizedLabel = Normalizer
       .normalize(
         label.trimTrailingPeriod.trim.toLowerCase,

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/transformers/ConceptsTransformer.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/transformers/ConceptsTransformer.scala
@@ -16,7 +16,7 @@ trait ConceptsTransformer extends LabelDerivedIdentifiers {
   ): IdState.Identifiable =
     currentState match {
       case currentAsIdentifiable: IdState.Identifiable => currentAsIdentifiable
-      case _                                           =>
+      case _ =>
         replacementState.getOrElse(
           identifierFromText(label = label, ontologyType = ontologyType)
         )

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraAbstractConcepts.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraAbstractConcepts.scala
@@ -46,7 +46,8 @@ trait SierraAbstractConcepts extends Logging with LabelDerivedIdentifiers {
     ontologyType: String,
     varField: VarField): IdState.Unminted =
     getLabel(varField) match {
-      case Some(label) => identifierFromText(label = label, ontologyType = ontologyType)
-      case None        => IdState.Unidentifiable
+      case Some(label) =>
+        identifierFromText(label = label, ontologyType = ontologyType)
+      case None => IdState.Unidentifiable
     }
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraAbstractConcepts.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraAbstractConcepts.scala
@@ -1,16 +1,12 @@
 package weco.pipeline.transformer.sierra.transformers
+
 import grizzled.slf4j.Logging
 import weco.pipeline.transformer.text.TextNormalisation._
-import weco.catalogue.internal_model.identifiers.{
-  IdState,
-  IdentifierType,
-  SourceIdentifier
-}
+import weco.catalogue.internal_model.identifiers.IdState
+import weco.pipeline.transformer.identifiers.LabelDerivedIdentifiers
 import weco.sierra.models.marc.VarField
 
-import java.text.Normalizer
-
-trait SierraAbstractConcepts extends Logging {
+trait SierraAbstractConcepts extends Logging with LabelDerivedIdentifiers {
   protected def getLabel(varField: VarField): Option[String]
   protected def getIdentifierSubfieldContents(varField: VarField): List[String]
   protected def maybeAddIdentifier(
@@ -50,29 +46,7 @@ trait SierraAbstractConcepts extends Logging {
     ontologyType: String,
     varField: VarField): IdState.Unminted =
     getLabel(varField) match {
-      case Some(label) =>
-        addIdentifierFromText(
-          ontologyType = ontologyType,
-          label = label.trimTrailingPeriod.trim)
-      case None => IdState.Unidentifiable
+      case Some(label) => identifierFromText(label = label, ontologyType = ontologyType)
+      case None        => IdState.Unidentifiable
     }
-
-  def addIdentifierFromText(ontologyType: String,
-                            label: String): IdState.Unminted = {
-    val normalizedLabel = Normalizer
-      .normalize(
-        label.toLowerCase,
-        Normalizer.Form.NFKD
-      )
-      .replaceAll("[^\\p{ASCII}]", "")
-
-    IdState.Identifiable(
-      sourceIdentifier = SourceIdentifier(
-        identifierType = IdentifierType.LabelDerived,
-        value = normalizedLabel,
-        ontologyType = ontologyType
-      )
-    )
-  }
-
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraAbstractConcepts.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraAbstractConcepts.scala
@@ -1,7 +1,6 @@
 package weco.pipeline.transformer.sierra.transformers
 
 import grizzled.slf4j.Logging
-import weco.pipeline.transformer.text.TextNormalisation._
 import weco.catalogue.internal_model.identifiers.IdState
 import weco.pipeline.transformer.identifiers.LabelDerivedIdentifiers
 import weco.sierra.models.marc.VarField

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraContributors.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraContributors.scala
@@ -6,6 +6,7 @@ import weco.catalogue.internal_model.identifiers.{
   SourceIdentifier
 }
 import weco.catalogue.internal_model.work._
+import weco.pipeline.transformer.identifiers.LabelDerivedIdentifiers
 import weco.sierra.models.SierraQueryOps
 import weco.sierra.models.data.SierraBibData
 import weco.sierra.models.marc.Subfield
@@ -35,7 +36,8 @@ import weco.sierra.models.marc.Subfield
 object SierraContributors
     extends SierraDataTransformer
     with SierraQueryOps
-    with SierraAgents {
+    with SierraAgents
+    with LabelDerivedIdentifiers {
 
   type Output = List[Contributor[IdState.Unminted]]
 
@@ -206,7 +208,7 @@ object SierraContributors
             ontologyType = ontologyType
           )
         )
-      case _ => addIdentifierFromText(ontologyType, label)
+      case _ => identifierFromText(label = label, ontologyType = ontologyType)
     }
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraGenres.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraGenres.scala
@@ -74,7 +74,7 @@ object SierraGenres
     )
     wholeFieldConceptId match {
       case identifiable: IdState.Identifiable
-          if (identifiable.sourceIdentifier.identifierType == IdentifierType.LabelDerived) =>
+          if identifiable.sourceIdentifier.identifierType == IdentifierType.LabelDerived =>
         IdState.Unidentifiable
 
       case other => other

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/subjects/SierraConceptSubjectsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/subjects/SierraConceptSubjectsTest.scala
@@ -592,7 +592,7 @@ class SierraConceptSubjectsTest
 
     concept should have(
       sourceIdentifier(
-        value = "united states.",
+        value = "united states",
         ontologyType = "Place",
         identifierType = IdentifierType.LabelDerived)
     )


### PR DESCRIPTION
I imagine we'll want to add label-derived identifiers to contributors from other sources; this does some refactoring to get some of the normalisation code into a common location, so all the transformers can use it.

It changes the behaviour of the Sierra transformer slightly; it looks like some of the normalisation was being applied inconsistently.

I'll change the Miro/CALM/TEI transformers in separate patches.