### PR TITLE
Fix the way we strip whitespace on identifiers

### DIFF
--- a/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/identifiers/LabelDerivedIdentifiers.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/identifiers/LabelDerivedIdentifiers.scala
@@ -30,6 +30,7 @@ trait LabelDerivedIdentifiers {
         Normalizer.Form.NFKD
       )
       .replaceAll("[^\\p{ASCII}]", "")
+      .trim
 
     IdState.Identifiable(
       sourceIdentifier = SourceIdentifier(

--- a/pipeline/transformer/transformer_common/src/test/scala/weco/pipeline/transformer/identifiers/LabelDerivedIdentifiersTest.scala
+++ b/pipeline/transformer/transformer_common/src/test/scala/weco/pipeline/transformer/identifiers/LabelDerivedIdentifiersTest.scala
@@ -1,0 +1,15 @@
+package weco.pipeline.transformer.identifiers
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class LabelDerivedIdentifiersTest extends AnyFunSpec with Matchers {
+  val identifiers = new LabelDerivedIdentifiers {}
+
+  it("removes whitespace that's added after we filter out non-ASCII characters") {
+    // This comes from b16631614
+    val label = "Miki\u0107, \u017delimir \u0110."
+    val identifier = identifiers.identifierFromText(label = label, ontologyType = "Person")
+    identifier.sourceIdentifier.value shouldBe "mikic, zelimir"
+  }
+}

--- a/pipeline/transformer/transformer_common/src/test/scala/weco/pipeline/transformer/identifiers/LabelDerivedIdentifiersTest.scala
+++ b/pipeline/transformer/transformer_common/src/test/scala/weco/pipeline/transformer/identifiers/LabelDerivedIdentifiersTest.scala
@@ -9,7 +9,8 @@ class LabelDerivedIdentifiersTest extends AnyFunSpec with Matchers {
   it("removes whitespace that's added after we filter out non-ASCII characters") {
     // This comes from b16631614
     val label = "Miki\u0107, \u017delimir \u0110."
-    val identifier = identifiers.identifierFromText(label = label, ontologyType = "Person")
+    val identifier =
+      identifiers.identifierFromText(label = label, ontologyType = "Person")
     identifier.sourceIdentifier.value shouldBe "mikic, zelimir"
   }
 }


### PR DESCRIPTION
If we remove non-ASCII characters on L32, we can have whitespace left over, which means we can't create the SourceIdentifier.

I suspect we can remove the `.trim` on L29, but I'm not 100% sure and leaving it doesn't seem like a big issue.

This is affecting two Sierra records: b16631614 and b25186085.