### PR TITLE
Add a way to turn down unused ES clusters

### DIFF
--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -4,12 +4,12 @@ module "catalogue_pipeline_2022-08-24" {
   pipeline_date = "2022-08-24"
   release_label = "2022-08-24"
 
-  # The cluster in the 2022-08-24 pipeline is having issues, so we've
-  # turned off all the services to avoid making the problem worse.
-  #
-  # Additionally, the changes to add label-derived IDs to contributors
-  # may cause a flood of updates in the overnight harvest on the weekend.
-  max_capacity = 0
+  # This pipeline is running Elasticsearch 8.4.2, which seems to be
+  # broken with the queries we use.  I don't want to delete it without
+  # double checking (in case it's useful for further investigation),
+  # but we don't need to be running anything through it.
+  max_capacity    = 0
+  es_cluster_size = "2x2"
 
   reindexing_state = {
     listen_to_reindexer      = false
@@ -37,6 +37,13 @@ module "catalogue_pipeline_2022-09-22" {
 
   pipeline_date = "2022-09-22"
   release_label = "2022-09-22"
+
+  # This pipeline is running Elasticsearch 8.4.2, which seems to be
+  # broken with the queries we use.  I don't want to delete it without
+  # double checking (in case it's useful for further investigation),
+  # but we don't need to be running anything through it.
+  max_capacity    = 0
+  es_cluster_size = "2x2"
 
   reindexing_state = {
     listen_to_reindexer      = false

--- a/pipeline/terraform/stack/elastic_pipeline.tf
+++ b/pipeline/terraform/stack/elastic_pipeline.tf
@@ -1,14 +1,3 @@
-locals {
-  es_memory = var.reindexing_state.scale_up_elastic_cluster ? "58g" : "8g"
-
-  # When we're reindexing, this cluster isn't depended on for anything.
-  # It's ephemeral data (and at 58GB of memory, expensive).
-  #
-  # Once we stop reindexing and make the pipeline live, we want it to be
-  # highly available, because it's serving API traffic.
-  es_node_count = var.reindexing_state.scale_up_elastic_cluster ? 2 : 3
-}
-
 data "ec_stack" "latest_patch" {
   # We're deliberately pinning to 8.3.x because there's an issue in 8.4.2
   # affecting the cross_fields query we use in the API.

--- a/pipeline/terraform/stack/variables.tf
+++ b/pipeline/terraform/stack/variables.tf
@@ -63,15 +63,15 @@ variable "es_cluster_size" {
 
 locals {
   es_memory_lookup = {
-    "58x2": "58g"
-    "8x3": "8g"
-    "2x2": "2g"
+    "58x2" : "58g"
+    "8x3" : "8g"
+    "2x2" : "2g"
   }
 
   es_node_lookup = {
-    "58x2": 2
-    "8x3": 3
-    "2x2": 2
+    "58x2" : 2
+    "8x3" : 3
+    "2x2" : 2
   }
 
   es_memory = var.reindexing_state.scale_up_elastic_cluster ? "58g" : local.es_memory_lookup[var.es_cluster_size]


### PR DESCRIPTION
Our Elastic Cloud bill has been climbing a little, and one reason is that running an API-ready cluster costs ~$30/day.  This gives us a way to turn it down in a non-destructive way.

This weekend alone will save ~$100 from not running the broken clusters hot.  They can *probably* be safely deleted… but this means we can turn them down if the other devs aren't around to check.