### PR TITLE
Truncate label-derived IDs to 256 characters

### DIFF
--- a/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/identifiers/LabelDerivedIdentifiers.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/identifiers/LabelDerivedIdentifiers.scala
@@ -32,10 +32,22 @@ trait LabelDerivedIdentifiers {
       .replaceAll("[^\\p{ASCII}]", "")
       .trim
 
+    // We have a handful of works that need label-derived identifiers which are
+    // longer than the 'SourceId' column in the ID minter database.
+    //
+    // (Here "a handful" is approximately two dozen as of September 2022, and within
+    // that set it looks like there are some duplicate labels.)
+    //
+    // These labels aren't meant to be human-readable, and truncating is easier than
+    // making the ID minter handle extreme edge cases.
+    val truncatedLabel = normalizedLabel
+      .slice(0, 256)
+      .trim
+
     IdState.Identifiable(
       sourceIdentifier = SourceIdentifier(
         identifierType = IdentifierType.LabelDerived,
-        value = normalizedLabel,
+        value = truncatedLabel,
         ontologyType = ontologyType
       )
     )

--- a/pipeline/transformer/transformer_common/src/test/scala/weco/pipeline/transformer/identifiers/LabelDerivedIdentifiersTest.scala
+++ b/pipeline/transformer/transformer_common/src/test/scala/weco/pipeline/transformer/identifiers/LabelDerivedIdentifiersTest.scala
@@ -16,9 +16,12 @@ class LabelDerivedIdentifiersTest extends AnyFunSpec with Matchers {
 
   it("truncates label-derived identifiers to 256 characters") {
     // This comes from b28117293
-    val label = "National Insurance Act, 1911 : explained, annotated and indexed, with appendices consisting of the Insurance Commissioners' official explanatory leaflets, Treasury regulations for the joint committee, tables of reserve values and voluntary contributions, regulations for procedure by the umpire, etc."
+    val label =
+      "National Insurance Act, 1911 : explained, annotated and indexed, with appendices consisting of the Insurance Commissioners' official explanatory leaflets, Treasury regulations for the joint committee, tables of reserve values and voluntary contributions, regulations for procedure by the umpire, etc."
     val identifier =
-      identifiers.identifierFromText(label = label, ontologyType = "Organisation")
+      identifiers.identifierFromText(
+        label = label,
+        ontologyType = "Organisation")
 
     // truncated at 256 chars
     identifier.sourceIdentifier.value shouldBe "national insurance act, 1911 : explained, annotated and indexed, with appendices consisting of the insurance commissioners' official explanatory leaflets, treasury regulations for the joint committee, tables of reserve values and voluntary contributions, r"

--- a/pipeline/transformer/transformer_common/src/test/scala/weco/pipeline/transformer/identifiers/LabelDerivedIdentifiersTest.scala
+++ b/pipeline/transformer/transformer_common/src/test/scala/weco/pipeline/transformer/identifiers/LabelDerivedIdentifiersTest.scala
@@ -13,4 +13,14 @@ class LabelDerivedIdentifiersTest extends AnyFunSpec with Matchers {
       identifiers.identifierFromText(label = label, ontologyType = "Person")
     identifier.sourceIdentifier.value shouldBe "mikic, zelimir"
   }
+
+  it("truncates label-derived identifiers to 256 characters") {
+    // This comes from b28117293
+    val label = "National Insurance Act, 1911 : explained, annotated and indexed, with appendices consisting of the Insurance Commissioners' official explanatory leaflets, Treasury regulations for the joint committee, tables of reserve values and voluntary contributions, regulations for procedure by the umpire, etc."
+    val identifier =
+      identifiers.identifierFromText(label = label, ontologyType = "Organisation")
+
+    // truncated at 256 chars
+    identifier.sourceIdentifier.value shouldBe "national insurance act, 1911 : explained, annotated and indexed, with appendices consisting of the insurance commissioners' official explanatory leaflets, treasury regulations for the joint committee, tables of reserve values and voluntary contributions, r"
+  }
 }


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/catalogue-pipeline/issues/2208