### PR TITLE
MeSH, not MESH

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/IdentifierType.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/IdentifierType.scala
@@ -68,7 +68,7 @@ object IdentifierType extends Enum[IdentifierType] {
 
   case object MESH extends IdentifierType {
     val id = "nlm-mesh"
-    val label = "Medical Subject Headings (MESH) identifier"
+    val label = "Medical Subject Headings (MeSH) identifier"
   }
 
   case object CalmRefNo extends IdentifierType {

--- a/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.0.json
+++ b/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-09-30T08:11:42.234160Z",
+  "createdAt" : "2022-10-01T19:21:01.779185Z",
   "id" : "tayys6jp",
   "document" : {
     "debug" : {
@@ -161,7 +161,7 @@
             {
               "identifierType" : {
                 "id" : "nlm-mesh",
-                "label" : "Medical Subject Headings (MESH) identifier",
+                "label" : "Medical Subject Headings (MeSH) identifier",
                 "type" : "IdentifierType"
               },
               "value" : "mesh-sanitation",


### PR DESCRIPTION
If you look at the NLM website, it's a lowercase 'e': https://www.nlm.nih.gov/mesh/meshhome.html