### PR TITLE
Finish migrating all the `data` fields on a Work to the new index structure

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksIndexConfig.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksIndexConfig.scala
@@ -76,6 +76,9 @@ object WorksIndexConfig extends IndexConfigFields {
       val identifiersPath = List("search.identifiers")
       val titlesAndContributorsPath = List("search.titlesAndContributors")
 
+      val newIdentifiersPath = List("query.allIentifiers")
+      val newTitlesAndContributorsPath = List("query.titlesAndContributors")
+
       // Indexing lots of individual fields on Elasticsearch can be very CPU
       // intensive, so here only include fields that are needed for querying in the
       // API.
@@ -222,24 +225,26 @@ object WorksIndexConfig extends IndexConfigFields {
       val query = objectField("query")
         .fields(
           // top-level work
-          canonicalIdField("id"),
+          canonicalIdField("id").copy(copyTo = newIdentifiersPath),
           keywordField("type"),
           keywordField("format.id"),
           keywordField("workType"),
-          multilingualFieldWithKeyword("title"),
+          multilingualFieldWithKeyword("title").copy(copyTo = newTitlesAndContributorsPath),
+          multilingualFieldWithKeyword("alternativeTitles").copy(copyTo = newTitlesAndContributorsPath),
           englishTextField("description"),
           englishTextKeywordField("physicalDescription"),
           textField("edition"),
           englishTextField("notes.contents"),
           multilingualField("lettering"),
           // identifiers
-          sourceIdentifierField("identifiers.value"),
+          sourceIdentifierField("identifiers.value")
+            .copy(copyTo = newIdentifiersPath),
           // images
-          canonicalIdField("images.id"),
-          sourceIdentifierField("images.identifiers.value"),
+          canonicalIdField("images.id").copy(copyTo = newIdentifiersPath),
+          sourceIdentifierField("images.identifiers.value").copy(copyTo = newIdentifiersPath),
           // items
-          canonicalIdField("items.id"),
-          sourceIdentifierField("items.identifiers.value"),
+          canonicalIdField("items.id").copy(copyTo = newIdentifiersPath),
+          sourceIdentifierField("items.identifiers.value").copy(copyTo = newIdentifiersPath),
           keywordField("items.locations.accessConditions.status.id"),
           keywordField("items.locations.license.id"),
           keywordField("items.locations.locationType.id"),
@@ -255,7 +260,7 @@ object WorksIndexConfig extends IndexConfigFields {
           labelField("languages.label"),
           // contributors
           canonicalIdField("contributors.agent.id"),
-          labelField("contributors.agent.label"),
+          labelField("contributors.agent.label").copy(copyTo = newTitlesAndContributorsPath),
           // production events
           labelField("production.label"),
           // relations
@@ -279,7 +284,10 @@ object WorksIndexConfig extends IndexConfigFields {
               textField("path").analyzer(exactPathAnalyzer.name)
             ),
           // reference number
-          keywordField("referenceNumber")
+          keywordField("referenceNumber").copy(copyTo = newIdentifiersPath),
+          // fields populated by copyTo
+          lowercaseKeyword("allIdentifiers"),
+          multilingualField("titlesAndContributors")
         )
 
       // This field contains the display documents used by aggregations.

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksIndexConfig.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksIndexConfig.scala
@@ -76,7 +76,7 @@ object WorksIndexConfig extends IndexConfigFields {
       val identifiersPath = List("search.identifiers")
       val titlesAndContributorsPath = List("search.titlesAndContributors")
 
-      val newIdentifiersPath = List("query.allIentifiers")
+      val newIdentifiersPath = List("query.allIdentifiers")
       val newTitlesAndContributorsPath = List("query.titlesAndContributors")
 
       // Indexing lots of individual fields on Elasticsearch can be very CPU

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksIndexConfig.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksIndexConfig.scala
@@ -229,8 +229,10 @@ object WorksIndexConfig extends IndexConfigFields {
           keywordField("type"),
           keywordField("format.id"),
           keywordField("workType"),
-          multilingualFieldWithKeyword("title").copy(copyTo = newTitlesAndContributorsPath),
-          multilingualFieldWithKeyword("alternativeTitles").copy(copyTo = newTitlesAndContributorsPath),
+          multilingualFieldWithKeyword("title").copy(
+            copyTo = newTitlesAndContributorsPath),
+          multilingualFieldWithKeyword("alternativeTitles").copy(
+            copyTo = newTitlesAndContributorsPath),
           englishTextField("description"),
           englishTextKeywordField("physicalDescription"),
           textField("edition"),
@@ -241,10 +243,12 @@ object WorksIndexConfig extends IndexConfigFields {
             .copy(copyTo = newIdentifiersPath),
           // images
           canonicalIdField("images.id").copy(copyTo = newIdentifiersPath),
-          sourceIdentifierField("images.identifiers.value").copy(copyTo = newIdentifiersPath),
+          sourceIdentifierField("images.identifiers.value").copy(
+            copyTo = newIdentifiersPath),
           // items
           canonicalIdField("items.id").copy(copyTo = newIdentifiersPath),
-          sourceIdentifierField("items.identifiers.value").copy(copyTo = newIdentifiersPath),
+          sourceIdentifierField("items.identifiers.value").copy(
+            copyTo = newIdentifiersPath),
           keywordField("items.locations.accessConditions.status.id"),
           keywordField("items.locations.license.id"),
           keywordField("items.locations.locationType.id"),
@@ -260,7 +264,8 @@ object WorksIndexConfig extends IndexConfigFields {
           labelField("languages.label"),
           // contributors
           canonicalIdField("contributors.agent.id"),
-          labelField("contributors.agent.label").copy(copyTo = newTitlesAndContributorsPath),
+          labelField("contributors.agent.label").copy(
+            copyTo = newTitlesAndContributorsPath),
           // production events
           labelField("production.label"),
           // relations

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksIndexConfig.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksIndexConfig.scala
@@ -256,11 +256,30 @@ object WorksIndexConfig extends IndexConfigFields {
           // contributors
           canonicalIdField("contributors.agent.id"),
           labelField("contributors.agent.label"),
+          // production events
+          labelField("production.label"),
           // relations
           canonicalIdField("partOf.id"),
           multilingualFieldWithKeyword("partOf.title"),
           // availabilities
-          keywordField("availabilities.id")
+          keywordField("availabilities.id"),
+          // collection path
+          textField("collectionPath.path")
+            .analyzer(exactPathAnalyzer.name)
+            .fields(
+              keywordField("keyword"),
+              textField("clean").analyzer(cleanPathAnalyzer.name)
+            ),
+          textField("collectionPath.label")
+            .analyzer(asciifoldingAnalyzer.name)
+            .fields(
+              keywordField("keyword"),
+              lowercaseKeyword("lowercaseKeyword"),
+              textField("cleanPath").analyzer(cleanPathAnalyzer.name),
+              textField("path").analyzer(exactPathAnalyzer.name)
+            ),
+          // reference number
+          keywordField("referenceNumber")
         )
 
       // This field contains the display documents used by aggregations.

--- a/common/internal_model/src/test/resources/WorksIndexConfig.json
+++ b/common/internal_model/src/test/resources/WorksIndexConfig.json
@@ -1036,7 +1036,7 @@
           "referenceNumber": {
             "type": "keyword",
             "copy_to": [
-              "query.identifiers"
+              "query.allIdentifiers"
             ]
           },
           "subjects": {

--- a/common/internal_model/src/test/resources/WorksIndexConfig.json
+++ b/common/internal_model/src/test/resources/WorksIndexConfig.json
@@ -1152,10 +1152,6 @@
                 "type": "text",
                 "analyzer": "italian_analyzer"
               },
-              "keyword": {
-                "type": "keyword",
-                "normalizer": "lowercase_normalizer"
-              },
               "shingles": {
                 "type": "text",
                 "analyzer": "shingle_asciifolding_analyzer"

--- a/common/internal_model/src/test/resources/WorksIndexConfig.json
+++ b/common/internal_model/src/test/resources/WorksIndexConfig.json
@@ -614,6 +614,54 @@
       },
       "query": {
         "properties": {
+          "allIdentifiers": {
+            "type": "keyword",
+            "normalizer": "lowercase_normalizer"
+          },
+          "alternativeTitles": {
+            "type": "text",
+            "fields": {
+              "arabic": {
+                "type": "text",
+                "analyzer": "arabic_analyzer"
+              },
+              "bengali": {
+                "type": "text",
+                "analyzer": "bengali_analyzer"
+              },
+              "english": {
+                "type": "text",
+                "analyzer": "english_analyzer"
+              },
+              "french": {
+                "type": "text",
+                "analyzer": "french_analyzer"
+              },
+              "german": {
+                "type": "text",
+                "analyzer": "german_analyzer"
+              },
+              "hindi": {
+                "type": "text",
+                "analyzer": "hindi_analyzer"
+              },
+              "italian": {
+                "type": "text",
+                "analyzer": "italian_analyzer"
+              },
+              "keyword": {
+                "type": "keyword",
+                "normalizer": "lowercase_normalizer"
+              },
+              "shingles": {
+                "type": "text",
+                "analyzer": "shingle_asciifolding_analyzer"
+              }
+            },
+            "copy_to": [
+              "query.titlesAndContributors"
+            ]
+          },
           "availabilities": {
             "properties": {
               "id": {
@@ -674,7 +722,10 @@
                         "normalizer": "lowercase_normalizer"
                       }
                     },
-                    "analyzer": "asciifolding_analyzer"
+                    "analyzer": "asciifolding_analyzer",
+                    "copy_to": [
+                      "query.titlesAndContributors"
+                    ]
                   },
                   "id": {
                     "type": "keyword",
@@ -732,7 +783,10 @@
           },
           "id": {
             "type": "keyword",
-            "normalizer": "lowercase_normalizer"
+            "normalizer": "lowercase_normalizer",
+            "copy_to": [
+              "query.allIdentifiers"
+            ]
           },
           "type": {
             "type": "keyword"
@@ -751,7 +805,10 @@
             "properties": {
               "value": {
                 "type": "keyword",
-                "normalizer": "lowercase_normalizer"
+                "normalizer": "lowercase_normalizer",
+                "copy_to": [
+                  "query.allIdentifiers"
+                ]
               }
             }
           },
@@ -759,13 +816,19 @@
             "properties": {
               "id": {
                 "type": "keyword",
-                "normalizer": "lowercase_normalizer"
+                "normalizer": "lowercase_normalizer",
+                "copy_to": [
+                  "query.allIdentifiers"
+                ]
               },
               "identifiers": {
                 "properties": {
                   "value": {
                     "type": "keyword",
-                    "normalizer": "lowercase_normalizer"
+                    "normalizer": "lowercase_normalizer",
+                    "copy_to": [
+                      "query.allIdentifiers"
+                    ]
                   }
                 }
               }
@@ -775,13 +838,19 @@
             "properties": {
               "id": {
                 "type": "keyword",
-                "normalizer": "lowercase_normalizer"
+                "normalizer": "lowercase_normalizer",
+                "copy_to": [
+                  "query.allIdentifiers"
+                ]
               },
               "identifiers": {
                 "properties": {
                   "value": {
                     "type": "keyword",
-                    "normalizer": "lowercase_normalizer"
+                    "normalizer": "lowercase_normalizer",
+                    "copy_to": [
+                      "query.allIdentifiers"
+                    ]
                   }
                 }
               },
@@ -965,7 +1034,10 @@
             }
           },
           "referenceNumber": {
-            "type": "keyword"
+            "type": "keyword",
+            "copy_to": [
+              "query.identifiers"
+            ]
           },
           "subjects": {
             "properties": {
@@ -1006,6 +1078,50 @@
             }
           },
           "title": {
+            "type": "text",
+            "fields": {
+              "arabic": {
+                "type": "text",
+                "analyzer": "arabic_analyzer"
+              },
+              "bengali": {
+                "type": "text",
+                "analyzer": "bengali_analyzer"
+              },
+              "english": {
+                "type": "text",
+                "analyzer": "english_analyzer"
+              },
+              "french": {
+                "type": "text",
+                "analyzer": "french_analyzer"
+              },
+              "german": {
+                "type": "text",
+                "analyzer": "german_analyzer"
+              },
+              "hindi": {
+                "type": "text",
+                "analyzer": "hindi_analyzer"
+              },
+              "italian": {
+                "type": "text",
+                "analyzer": "italian_analyzer"
+              },
+              "keyword": {
+                "type": "keyword",
+                "normalizer": "lowercase_normalizer"
+              },
+              "shingles": {
+                "type": "text",
+                "analyzer": "shingle_asciifolding_analyzer"
+              }
+            },
+            "copy_to": [
+              "query.titlesAndContributors"
+            ]
+          },
+          "titlesAndContributors": {
             "type": "text",
             "fields": {
               "arabic": {

--- a/common/internal_model/src/test/resources/WorksIndexConfig.json
+++ b/common/internal_model/src/test/resources/WorksIndexConfig.json
@@ -621,6 +621,44 @@
               }
             }
           },
+          "collectionPath": {
+            "properties": {
+              "label": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword"
+                  },
+                  "lowercaseKeyword": {
+                    "type": "keyword",
+                    "normalizer": "lowercase_normalizer"
+                  },
+                  "cleanPath": {
+                    "type": "text",
+                    "analyzer": "clean_path_analyzer"
+                  },
+                  "path": {
+                    "type": "text",
+                    "analyzer": "exact_path_analyzer"
+                  }
+                },
+                "analyzer": "asciifolding_analyzer"
+              },
+              "path": {
+                "type": "text",
+                "fields": {
+                  "clean": {
+                    "type": "text",
+                    "analyzer": "clean_path_analyzer"
+                  },
+                  "keyword": {
+                    "type": "keyword"
+                  }
+                },
+                "analyzer": "exact_path_analyzer"
+              }
+            }
+          },
           "contributors": {
             "properties": {
               "agent": {
@@ -908,6 +946,26 @@
                 "type": "keyword"
               }
             }
+          },
+          "production": {
+            "properties": {
+              "label": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword"
+                  },
+                  "lowercaseKeyword": {
+                    "type": "keyword",
+                    "normalizer": "lowercase_normalizer"
+                  }
+                },
+                "analyzer": "asciifolding_analyzer"
+              }
+            }
+          },
+          "referenceNumber": {
+            "type": "keyword"
           },
           "subjects": {
             "properties": {

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/index/SearchIndexConfigJsonTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/index/SearchIndexConfigJsonTest.scala
@@ -1,6 +1,10 @@
 package weco.catalogue.internal_model.index
 
 import com.sksamuel.elastic4s.ElasticDsl._
+import diffson._
+import diffson.lcs._
+import diffson.circe._
+import diffson.jsonpatch.lcsdiff._
 import io.circe.{ACursor, Json}
 import io.circe.parser._
 import org.scalatest.{Assertion, EitherValues, OptionValues}
@@ -67,6 +71,14 @@ class SearchIndexConfigJsonTest
           .value,
         indexName = index.name
       )
+
+      implicit val lcs: Patience[Json] = new Patience[Json]
+
+      println("Mapping diff:")
+      println(diff(fileMapping, indexMapping))
+
+      println("Settings diff:")
+      println(diff(fileMapping, indexMapping))
 
       fileMapping shouldBe indexMapping
       fileSettings shouldBe indexSettings

--- a/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/WorkQueryableValues.scala
+++ b/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/WorkQueryableValues.scala
@@ -37,9 +37,13 @@ case class WorkQueryableValues(
   @JsonKey("languages.label") languageLabels: List[String],
   @JsonKey("contributors.agent.id") contributorAgentIds: List[String],
   @JsonKey("contributors.agent.label") contributorAgentLabels: List[String],
+  @JsonKey("production.label") productionLabels: List[String],
   @JsonKey("partOf.id") partOfIds: List[String],
   @JsonKey("partOf.title") partOfTitles: List[String],
   @JsonKey("availabilities.id") availabilityIds: List[String],
+  @JsonKey("collectionPath.label") collectionPathLabel: Option[String],
+  @JsonKey("collectionPath.path") collectionPathPath: Option[String],
+  @JsonKey("referenceNumber") referenceNumber: Option[String],
 )
 
 case object WorkQueryableValues {
@@ -80,9 +84,15 @@ case object WorkQueryableValues {
       languageLabels = workData.languages.map(_.label),
       contributorAgentIds = workData.contributors.map(_.agent.id).canonicalIds,
       contributorAgentLabels = workData.contributors.map(_.agent.label),
+      productionLabels = workData.production.flatMap(p =>
+        p.places.map(_.label) ++ p.agents.map(_.label) ++ p.dates.map(_.label)
+      ),
       partOfIds = relations.ancestors.flatMap(_.id).map(_.underlying),
       partOfTitles = relations.ancestors.flatMap(_.title),
-      availabilityIds = availabilities.map(_.id).toList
+      availabilityIds = availabilities.map(_.id).toList,
+      collectionPathLabel = workData.collectionPath.flatMap(_.label),
+      collectionPathPath = workData.collectionPath.map(_.path),
+      referenceNumber = workData.referenceNumber.map(_.underlying)
     )
   }
 

--- a/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/WorkQueryableValues.scala
+++ b/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/WorkQueryableValues.scala
@@ -87,8 +87,7 @@ case object WorkQueryableValues {
       contributorAgentIds = workData.contributors.map(_.agent.id).canonicalIds,
       contributorAgentLabels = workData.contributors.map(_.agent.label),
       productionLabels = workData.production.flatMap(p =>
-        p.places.map(_.label) ++ p.agents.map(_.label) ++ p.dates.map(_.label)
-      ),
+        p.places.map(_.label) ++ p.agents.map(_.label) ++ p.dates.map(_.label)),
       partOfIds = relations.ancestors.flatMap(_.id).map(_.underlying),
       partOfTitles = relations.ancestors.flatMap(_.title),
       availabilityIds = availabilities.map(_.id).toList,

--- a/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/WorkQueryableValues.scala
+++ b/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/WorkQueryableValues.scala
@@ -15,6 +15,7 @@ case class WorkQueryableValues(
   @JsonKey("workType") workType: String,
   @JsonKey("identifiers.value") workIdentifiers: List[String],
   @JsonKey("title") title: Option[String],
+  @JsonKey("alternativeTitles") alternativeTitles: List[String],
   @JsonKey("description") description: Option[String],
   @JsonKey("physicalDescription") physicalDescription: Option[String],
   @JsonKey("edition") edition: Option[String],
@@ -61,6 +62,7 @@ case object WorkQueryableValues {
       workIdentifiers =
         (sourceIdentifier +: workData.otherIdentifiers).map(_.value),
       title = workData.title,
+      alternativeTitles = workData.alternativeTitles,
       description = workData.description,
       physicalDescription = workData.physicalDescription,
       edition = workData.edition,

--- a/pipeline/ingestor/ingestor_works/src/test/scala/weco/pipeline/ingestor/works/models/WorkQueryableValuesTest.scala
+++ b/pipeline/ingestor/ingestor_works/src/test/scala/weco/pipeline/ingestor/works/models/WorkQueryableValuesTest.scala
@@ -397,6 +397,59 @@ class WorkQueryableValuesTest
     q.availabilityIds shouldBe List("online", "open-shelves")
   }
 
+  it("adds production labels") {
+    val workData = WorkData[DataState.Identified](
+      title = Some(s"title-${randomAlphanumeric(length = 10)}"),
+      production = List(
+        ProductionEvent(
+          label = "Percy publisher (top-level label => not included)",
+          places = List(
+            Place("Paris the place"),
+            Place("Perth the port")
+          ),
+          agents = List(
+            Person("Penny the press officer"),
+          ),
+          dates = List(
+            Period(id = IdState.Unidentifiable, label = "The past")
+          )
+        ),
+        ProductionEvent(
+          label = "Patrick the pharmacist (top-level label => not included)",
+          places = List(
+            Place("Porto the Portuguese"),
+          ),
+          agents = List(
+            Organisation("Purple People"),
+            Meeting("Proactive Publicists"),
+          ),
+          dates = List(
+            Period(id = IdState.Unidentifiable, label = "The rose-tinted past")
+          )
+        )
+      )
+    )
+
+    val q = WorkQueryableValues(
+      id = createCanonicalId,
+      sourceIdentifier = createSourceIdentifier,
+      workData = workData,
+      relations = Relations(),
+      availabilities = Set()
+    )
+
+    q.productionLabels shouldBe List(
+      "Paris the place",
+      "Perth the port",
+      "Penny the press officer",
+      "The past",
+      "Porto the Portuguese",
+      "Purple People",
+      "Proactive Publicists",
+      "The rose-tinted past"
+    )
+  }
+
   private def relation(id: Option[String], title: Option[String]): Relation =
     Relation(
       id = id.map(CanonicalId(_)),

--- a/pipeline/ingestor/test_documents/work-production.1098.json
+++ b/pipeline/ingestor/test_documents/work-production.1098.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 1098",
-  "createdAt" : "2022-09-26T11:29:27.282394Z",
+  "createdAt" : "2022-09-28T15:53:38.397736Z",
   "id" : "guav7chy",
   "document" : {
     "debug" : {
@@ -170,6 +170,8 @@
         "W9fptfa5Xn"
       ],
       "title" : "Production event in 1098",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -208,12 +210,18 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+        "1098"
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/work-production.1900.json
+++ b/pipeline/ingestor/test_documents/work-production.1900.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 1900",
-  "createdAt" : "2022-09-26T11:29:27.244442Z",
+  "createdAt" : "2022-09-28T15:53:38.318683Z",
   "id" : "rbnro6wx",
   "document" : {
     "debug" : {
@@ -170,6 +170,8 @@
         "akaUmx5H3i"
       ],
       "title" : "Production event in 1900",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -208,12 +210,18 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+        "1900"
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/work-production.1904.json
+++ b/pipeline/ingestor/test_documents/work-production.1904.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 1904",
-  "createdAt" : "2022-09-26T11:29:27.266410Z",
+  "createdAt" : "2022-09-28T15:53:38.360189Z",
   "id" : "aiv95swj",
   "document" : {
     "debug" : {
@@ -170,6 +170,8 @@
         "h0QyLvGt20"
       ],
       "title" : "Production event in 1904",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -208,12 +210,18 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+        "1904"
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/work-production.1976.json
+++ b/pipeline/ingestor/test_documents/work-production.1976.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 1976",
-  "createdAt" : "2022-09-26T11:29:27.257410Z",
+  "createdAt" : "2022-09-28T15:53:38.340357Z",
   "id" : "5vjghupy",
   "document" : {
     "debug" : {
@@ -170,6 +170,8 @@
         "xrdlOL8J49"
       ],
       "title" : "Production event in 1976",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -208,12 +210,18 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+        "1976"
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/work-production.2020.json
+++ b/pipeline/ingestor/test_documents/work-production.2020.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 2020",
-  "createdAt" : "2022-09-26T11:29:27.274530Z",
+  "createdAt" : "2022-09-28T15:53:38.374898Z",
   "id" : "0fucriyr",
   "document" : {
     "debug" : {
@@ -170,6 +170,8 @@
         "KgSH5dUX0Z"
       ],
       "title" : "Production event in 2020",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -208,12 +210,18 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+        "2020"
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/work-thumbnail.json
+++ b/pipeline/ingestor/test_documents/work-thumbnail.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a thumbnail",
-  "createdAt" : "2022-09-26T11:29:27.167985Z",
+  "createdAt" : "2022-09-28T15:53:38.124862Z",
   "id" : "sahqcluh",
   "document" : {
     "debug" : {
@@ -164,6 +164,8 @@
         "rRRYGQYiF7"
       ],
       "title" : "title-LSfnjHB2TS",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -202,12 +204,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/work-title-dodo.json
+++ b/pipeline/ingestor/test_documents/work-title-dodo.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with 'dodo' in the title",
-  "createdAt" : "2022-09-26T11:29:27.180235Z",
+  "createdAt" : "2022-09-28T15:53:38.167109Z",
   "id" : "ezagik4b",
   "document" : {
     "debug" : {
@@ -136,6 +136,8 @@
         "xg9OuzGali"
       ],
       "title" : "A drawing of a dodo",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -174,12 +176,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/work-title-mouse.json
+++ b/pipeline/ingestor/test_documents/work-title-mouse.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with 'mouse' in the title",
-  "createdAt" : "2022-09-26T11:29:27.187468Z",
+  "createdAt" : "2022-09-28T15:53:38.190717Z",
   "id" : "lnn17cwk",
   "document" : {
     "debug" : {
@@ -136,6 +136,8 @@
         "EhPpSB8mq7"
       ],
       "title" : "A mezzotint of a mouse",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -174,12 +176,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/work-with-edition-and-duration.json
+++ b/pipeline/ingestor/test_documents/work-with-edition-and-duration.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with optional top-level fields",
-  "createdAt" : "2022-09-26T11:29:27.107456Z",
+  "createdAt" : "2022-09-28T15:53:37.928867Z",
   "id" : "gsruvqwf",
   "document" : {
     "debug" : {
@@ -137,6 +137,8 @@
         "7YNi35xO0f"
       ],
       "title" : "title-4pIj0kgXrt",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : "Special edition",
@@ -175,12 +177,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/work.items-with-location-types.0.json
+++ b/pipeline/ingestor/test_documents/work.items-with-location-types.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "items with different location types",
-  "createdAt" : "2022-09-26T11:29:28.189533Z",
+  "createdAt" : "2022-09-28T15:53:40.901800Z",
   "id" : "kdwct2lf",
   "document" : {
     "debug" : {
@@ -202,6 +202,8 @@
         "vUprsjrX3O"
       ],
       "title" : "title-sLaubb73X6",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -244,12 +246,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/work.items-with-location-types.1.json
+++ b/pipeline/ingestor/test_documents/work.items-with-location-types.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "items with different location types",
-  "createdAt" : "2022-09-26T11:29:28.190576Z",
+  "createdAt" : "2022-09-28T15:53:40.907824Z",
   "id" : "sgatphra",
   "document" : {
     "debug" : {
@@ -234,6 +234,8 @@
         "GsIdzZyGYB"
       ],
       "title" : "title-GkJTZWwn4A",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -278,12 +280,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/work.items-with-location-types.2.json
+++ b/pipeline/ingestor/test_documents/work.items-with-location-types.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "items with different location types",
-  "createdAt" : "2022-09-26T11:29:28.191463Z",
+  "createdAt" : "2022-09-28T15:53:40.909295Z",
   "id" : "wt6pclbs",
   "document" : {
     "debug" : {
@@ -210,6 +210,8 @@
         "D31AdK5EfQ"
       ],
       "title" : "title-e4jqB3DBkI",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -252,13 +254,18 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
         "closed-stores"
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/work.visible.everything.0.json
+++ b/pipeline/ingestor/test_documents/work.visible.everything.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "a list of work with all the include-able fields",
-  "createdAt" : "2022-09-26T11:29:27.526306Z",
+  "createdAt" : "2022-09-28T15:53:39.109041Z",
   "id" : "tmdfbk5k",
   "document" : {
     "debug" : {
@@ -1002,6 +1002,8 @@
         "UfcQYSxE7g"
       ],
       "title" : "A work with all the include-able fields",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -1082,6 +1084,14 @@
         "person-W9SVIX0fEg",
         "person-IWtB2H6"
       ],
+      "production.label" : [
+        "Nr11C9xxYE",
+        "dUXSLHjmev",
+        "8ssuR",
+        "zvroF4g2k9",
+        "frr0xAeKZI",
+        "7aEhJ"
+      ],
       "partOf.id" : [
         "0cs6cerb",
         "nrvdy0jg"
@@ -1091,7 +1101,10 @@
         "title-MS5Hy6x38N"
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/work.visible.everything.1.json
+++ b/pipeline/ingestor/test_documents/work.visible.everything.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "a list of work with all the include-able fields",
-  "createdAt" : "2022-09-26T11:29:27.571095Z",
+  "createdAt" : "2022-09-28T15:53:39.245671Z",
   "id" : "nlqnlwch",
   "document" : {
     "debug" : {
@@ -1071,6 +1071,8 @@
         "aGKxAEeG0H"
       ],
       "title" : "A work with all the include-able fields",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -1151,6 +1153,14 @@
         "person-kGPDWLL",
         "person-2Xsatm0"
       ],
+      "production.label" : [
+        "RL51HaiqMv",
+        "Pe7X4srn7y",
+        "dL6XA",
+        "iRibBOUDMp",
+        "ITHk4Fal6y",
+        "LEuJL"
+      ],
       "partOf.id" : [
         "jlsj0le6",
         "qfoju3if"
@@ -1161,7 +1171,10 @@
       ],
       "availabilities.id" : [
         "closed-stores"
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/work.visible.everything.2.json
+++ b/pipeline/ingestor/test_documents/work.visible.everything.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "a list of work with all the include-able fields",
-  "createdAt" : "2022-09-26T11:29:27.577852Z",
+  "createdAt" : "2022-09-28T15:53:39.330982Z",
   "id" : "jfzz4ou9",
   "document" : {
     "debug" : {
@@ -1080,6 +1080,8 @@
         "FhqVjVef8B"
       ],
       "title" : "A work with all the include-able fields",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -1160,6 +1162,14 @@
         "person-UFES8H2",
         "person-LQeClX"
       ],
+      "production.label" : [
+        "Vibco3T5a2",
+        "CtekEl0aPD",
+        "tepg6",
+        "ba2c8ykXyK",
+        "H9vtTXh5eC",
+        "S91lO"
+      ],
       "partOf.id" : [
         "k4gltrjv",
         "0le4q0ih"
@@ -1171,7 +1181,10 @@
       "availabilities.id" : [
         "open-shelves",
         "closed-stores"
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.collection-path.NUFFINK.json
+++ b/pipeline/ingestor/test_documents/works.collection-path.NUFFINK.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a collection path",
-  "createdAt" : "2022-09-26T11:29:27.997100Z",
+  "createdAt" : "2022-09-28T15:53:40.461661Z",
   "id" : "dtqmc0yn",
   "document" : {
     "debug" : {
@@ -138,6 +138,8 @@
         "Lq95TrUx7A"
       ],
       "title" : "title-boqbXNAi3a",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -176,12 +178,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : "NUF/FINK",
+      "collectionPath.path" : "NUFFINK",
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.collection-path.PPCRI.json
+++ b/pipeline/ingestor/test_documents/works.collection-path.PPCRI.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a collection path",
-  "createdAt" : "2022-09-26T11:29:27.985572Z",
+  "createdAt" : "2022-09-28T15:53:40.443537Z",
   "id" : "mlqs2qbd",
   "document" : {
     "debug" : {
@@ -138,6 +138,8 @@
         "yQb1GgWKF4"
       ],
       "title" : "title-X1EiWSsi1c",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -176,12 +178,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : "PP/CRI",
+      "collectionPath.path" : "PPCRI",
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.contributor.0.json
+++ b/pipeline/ingestor/test_documents/works.contributor.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different contributor",
-  "createdAt" : "2022-09-26T11:29:27.909515Z",
+  "createdAt" : "2022-09-28T15:53:40.217422Z",
   "id" : "gvkz3vff",
   "document" : {
     "debug" : {
@@ -160,6 +160,8 @@
         "5CJlp05MGl"
       ],
       "title" : "title-Wh4OVfDtEV",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -199,12 +201,17 @@
       "contributors.agent.label" : [
         "47"
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.contributor.1.json
+++ b/pipeline/ingestor/test_documents/works.contributor.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different contributor",
-  "createdAt" : "2022-09-26T11:29:27.910624Z",
+  "createdAt" : "2022-09-28T15:53:40.220593Z",
   "id" : "bj9evx0c",
   "document" : {
     "debug" : {
@@ -160,6 +160,8 @@
         "TjLML0MOH1"
       ],
       "title" : "title-h70mKj49k3",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -199,12 +201,17 @@
       "contributors.agent.label" : [
         "47"
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.contributor.2.json
+++ b/pipeline/ingestor/test_documents/works.contributor.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different contributor",
-  "createdAt" : "2022-09-26T11:29:27.916077Z",
+  "createdAt" : "2022-09-28T15:53:40.236628Z",
   "id" : "z08k6cnn",
   "document" : {
     "debug" : {
@@ -185,6 +185,8 @@
         "juTufKU2Ye"
       ],
       "title" : "title-UVMdWdPx74",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -225,12 +227,17 @@
         "007",
         "MI5"
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.contributor.3.json
+++ b/pipeline/ingestor/test_documents/works.contributor.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different contributor",
-  "createdAt" : "2022-09-26T11:29:27.917335Z",
+  "createdAt" : "2022-09-28T15:53:40.242525Z",
   "id" : "gtfjchvo",
   "document" : {
     "debug" : {
@@ -185,6 +185,8 @@
         "xKXAvquihJ"
       ],
       "title" : "title-AJeGRUgE73",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -225,12 +227,17 @@
         "MI5",
         "GCHQ"
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.every-format.0.json
+++ b/pipeline/ingestor/test_documents/works.every-format.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.013931Z",
+  "createdAt" : "2022-09-28T15:53:40.489516Z",
   "id" : "4njkixz6",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "BApNW5yJ4Q"
       ],
       "title" : "title-6YygLZHy7Z",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.every-format.1.json
+++ b/pipeline/ingestor/test_documents/works.every-format.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.014484Z",
+  "createdAt" : "2022-09-28T15:53:40.492107Z",
   "id" : "jugcpduf",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "YysYTJPbhB"
       ],
       "title" : "title-DhzFoUvfxn",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.every-format.10.json
+++ b/pipeline/ingestor/test_documents/works.every-format.10.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.019907Z",
+  "createdAt" : "2022-09-28T15:53:40.531034Z",
   "id" : "4wwgkp4h",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "miNkeZ17CI"
       ],
       "title" : "title-uALANM5eCQ",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.every-format.11.json
+++ b/pipeline/ingestor/test_documents/works.every-format.11.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.023792Z",
+  "createdAt" : "2022-09-28T15:53:40.533332Z",
   "id" : "kkcl3dhq",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "INEpZD4veL"
       ],
       "title" : "title-ooZVNybADY",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.every-format.12.json
+++ b/pipeline/ingestor/test_documents/works.every-format.12.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.024679Z",
+  "createdAt" : "2022-09-28T15:53:40.539395Z",
   "id" : "ilrp0gol",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "TRLxjc4Dv7"
       ],
       "title" : "title-5MZkkqME2t",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.every-format.13.json
+++ b/pipeline/ingestor/test_documents/works.every-format.13.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.025349Z",
+  "createdAt" : "2022-09-28T15:53:40.544320Z",
   "id" : "rdqs25hn",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "fZ9zaDFnzp"
       ],
       "title" : "title-uQBSkLFL8C",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.every-format.14.json
+++ b/pipeline/ingestor/test_documents/works.every-format.14.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.026102Z",
+  "createdAt" : "2022-09-28T15:53:40.548040Z",
   "id" : "124qx5km",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "LCpWDX84If"
       ],
       "title" : "title-WpmMJGY9dh",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.every-format.15.json
+++ b/pipeline/ingestor/test_documents/works.every-format.15.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.026845Z",
+  "createdAt" : "2022-09-28T15:53:40.549521Z",
   "id" : "tlc5rq9a",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "mz25207khU"
       ],
       "title" : "title-jNr737MdPw",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.every-format.16.json
+++ b/pipeline/ingestor/test_documents/works.every-format.16.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.027416Z",
+  "createdAt" : "2022-09-28T15:53:40.550645Z",
   "id" : "sdb22mdv",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "qjgnqBCXUR"
       ],
       "title" : "title-8D1YQhdjF0",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.every-format.17.json
+++ b/pipeline/ingestor/test_documents/works.every-format.17.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.028074Z",
+  "createdAt" : "2022-09-28T15:53:40.552036Z",
   "id" : "9tar4kg6",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "WpfpIxjlf3"
       ],
       "title" : "title-zifN5hzpvx",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.every-format.18.json
+++ b/pipeline/ingestor/test_documents/works.every-format.18.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.028774Z",
+  "createdAt" : "2022-09-28T15:53:40.553084Z",
   "id" : "au6tjof0",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "vISRu7MtEo"
       ],
       "title" : "title-GajAY87vuu",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.every-format.19.json
+++ b/pipeline/ingestor/test_documents/works.every-format.19.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.029343Z",
+  "createdAt" : "2022-09-28T15:53:40.554206Z",
   "id" : "ogdq417u",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "lq8kfIsxyr"
       ],
       "title" : "title-7J1fupAzsf",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.every-format.2.json
+++ b/pipeline/ingestor/test_documents/works.every-format.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.015175Z",
+  "createdAt" : "2022-09-28T15:53:40.494494Z",
   "id" : "fuwvinln",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "40wEIb4rPR"
       ],
       "title" : "title-8ljlZQFqGf",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.every-format.20.json
+++ b/pipeline/ingestor/test_documents/works.every-format.20.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.030073Z",
+  "createdAt" : "2022-09-28T15:53:40.555668Z",
   "id" : "jyum0yf1",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "KzDNfalpwO"
       ],
       "title" : "title-ImZeIhkjzt",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.every-format.21.json
+++ b/pipeline/ingestor/test_documents/works.every-format.21.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.030680Z",
+  "createdAt" : "2022-09-28T15:53:40.557545Z",
   "id" : "cwippax3",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "2PauY4Py8G"
       ],
       "title" : "title-5qt38YgNxO",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.every-format.22.json
+++ b/pipeline/ingestor/test_documents/works.every-format.22.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.031194Z",
+  "createdAt" : "2022-09-28T15:53:40.559505Z",
   "id" : "9rgmu63i",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "3tyy1ghzsQ"
       ],
       "title" : "title-sDHZ5kGsC2",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.every-format.3.json
+++ b/pipeline/ingestor/test_documents/works.every-format.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.015808Z",
+  "createdAt" : "2022-09-28T15:53:40.500311Z",
   "id" : "i77xk8vj",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "SZKltFZVRN"
       ],
       "title" : "title-3TPxT5oi8C",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.every-format.4.json
+++ b/pipeline/ingestor/test_documents/works.every-format.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.016379Z",
+  "createdAt" : "2022-09-28T15:53:40.506343Z",
   "id" : "xgsosrhr",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "L5s2axrzcV"
       ],
       "title" : "title-K7J5071Cwm",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.every-format.5.json
+++ b/pipeline/ingestor/test_documents/works.every-format.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.017149Z",
+  "createdAt" : "2022-09-28T15:53:40.516509Z",
   "id" : "cvdyxyqr",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "LIOVK6f1ni"
       ],
       "title" : "title-eWPnruNlWw",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.every-format.6.json
+++ b/pipeline/ingestor/test_documents/works.every-format.6.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.017781Z",
+  "createdAt" : "2022-09-28T15:53:40.520648Z",
   "id" : "aftvp1wz",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "rMq0Chsgjm"
       ],
       "title" : "title-K883LiigJ4",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.every-format.7.json
+++ b/pipeline/ingestor/test_documents/works.every-format.7.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.018332Z",
+  "createdAt" : "2022-09-28T15:53:40.524495Z",
   "id" : "y8glbwdh",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "NrhJtvfJrH"
       ],
       "title" : "title-PcZctCb44q",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.every-format.8.json
+++ b/pipeline/ingestor/test_documents/works.every-format.8.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.018867Z",
+  "createdAt" : "2022-09-28T15:53:40.526074Z",
   "id" : "4fkr6m6l",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "Ngls6zS4b2"
       ],
       "title" : "title-uUZlr85jkf",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.every-format.9.json
+++ b/pipeline/ingestor/test_documents/works.every-format.9.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.019371Z",
+  "createdAt" : "2022-09-28T15:53:40.527494Z",
   "id" : "e2zva5mj",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "2Ap82csHfk"
       ],
       "title" : "title-AcxE29kiXI",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.0.json
+++ b/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2022-09-26T11:29:28.642707Z",
+  "createdAt" : "2022-09-28T15:53:42.194247Z",
   "id" : "stsp385v",
   "document" : {
     "debug" : {
@@ -227,6 +227,8 @@
         "PD8H80xrR5"
       ],
       "title" : "title-GLuYXYlnwW",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -270,12 +272,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.1.json
+++ b/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2022-09-26T11:29:28.643552Z",
+  "createdAt" : "2022-09-28T15:53:42.195931Z",
   "id" : "jwvfegzn",
   "document" : {
     "debug" : {
@@ -225,6 +225,8 @@
         "FvAY3kDPeO"
       ],
       "title" : "title-8X1iQV3o0G",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -268,12 +270,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.2.json
+++ b/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2022-09-26T11:29:28.644286Z",
+  "createdAt" : "2022-09-28T15:53:42.197834Z",
   "id" : "glagakd2",
   "document" : {
     "debug" : {
@@ -225,6 +225,8 @@
         "aCHuXzrv8P"
       ],
       "title" : "title-zPZAnMiJNW",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -268,12 +270,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.3.json
+++ b/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2022-09-26T11:29:28.644983Z",
+  "createdAt" : "2022-09-28T15:53:42.200053Z",
   "id" : "wys5lz5r",
   "document" : {
     "debug" : {
@@ -234,6 +234,8 @@
         "GWT6gTiZ6K"
       ],
       "title" : "title-MofTOW5bCv",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -277,13 +279,18 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
         "online"
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.4.json
+++ b/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2022-09-26T11:29:28.645621Z",
+  "createdAt" : "2022-09-28T15:53:42.201474Z",
   "id" : "iqani2su",
   "document" : {
     "debug" : {
@@ -233,6 +233,8 @@
         "jYpuBxuni2"
       ],
       "title" : "title-7p7NJFW4Dx",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -276,13 +278,18 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
         "online"
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.5.json
+++ b/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2022-09-26T11:29:28.660671Z",
+  "createdAt" : "2022-09-28T15:53:42.221076Z",
   "id" : "yh6sk7pv",
   "document" : {
     "debug" : {
@@ -237,6 +237,8 @@
         "5tbPGXaLqw"
       ],
       "title" : "title-r7VLiwfab6",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -280,13 +282,18 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
         "online"
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.6.json
+++ b/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.6.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2022-09-26T11:29:28.661843Z",
+  "createdAt" : "2022-09-28T15:53:42.222910Z",
   "id" : "uqhxoxvf",
   "document" : {
     "debug" : {
@@ -229,6 +229,8 @@
         "Ey1hoMJJvc"
       ],
       "title" : "title-tU496lvqxD",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -272,12 +274,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.0.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.215713Z",
+  "createdAt" : "2022-09-28T15:53:40.999773Z",
   "id" : "vqys4hio",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "ESZHkohLBq"
       ],
       "title" : "title-vwQleJkqVb",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.1.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.216895Z",
+  "createdAt" : "2022-09-28T15:53:41.001772Z",
   "id" : "scernate",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "mxTT1Dnad9"
       ],
       "title" : "title-ZtfG4qEc4M",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.10.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.10.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.226315Z",
+  "createdAt" : "2022-09-28T15:53:41.056386Z",
   "id" : "sw2fzgit",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "6gzFFn0MzM"
       ],
       "title" : "title-5K9RmsgKYJ",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.11.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.11.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.227296Z",
+  "createdAt" : "2022-09-28T15:53:41.067660Z",
   "id" : "4elqjncu",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "WyiVFCEDYI"
       ],
       "title" : "title-pZH75AXbZo",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.12.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.12.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.228148Z",
+  "createdAt" : "2022-09-28T15:53:41.069398Z",
   "id" : "8yitytyw",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "a33KTr4gSW"
       ],
       "title" : "title-3z92KVUKZD",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.13.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.13.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.228924Z",
+  "createdAt" : "2022-09-28T15:53:41.086516Z",
   "id" : "66bwuadw",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "t9Z95L7cLo"
       ],
       "title" : "title-2M9CVkukQI",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.14.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.14.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.229866Z",
+  "createdAt" : "2022-09-28T15:53:41.115665Z",
   "id" : "dborzqld",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "xZlpWaXi4Y"
       ],
       "title" : "title-LN4dq7YPgQ",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.15.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.15.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.230867Z",
+  "createdAt" : "2022-09-28T15:53:41.125965Z",
   "id" : "fu0kybma",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "SlRRldG9e4"
       ],
       "title" : "title-54cIcDQPXI",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.16.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.16.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.231835Z",
+  "createdAt" : "2022-09-28T15:53:41.135003Z",
   "id" : "pyub9jxo",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "qajt54m4dW"
       ],
       "title" : "title-bp7ZbfAOv6",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.17.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.17.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.232808Z",
+  "createdAt" : "2022-09-28T15:53:41.144258Z",
   "id" : "izlcv3sm",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "x0zgHgbzqM"
       ],
       "title" : "title-aNuUq84cRg",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.18.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.18.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.234053Z",
+  "createdAt" : "2022-09-28T15:53:41.149321Z",
   "id" : "s4ry14qu",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "Ue8m3HVuer"
       ],
       "title" : "title-XX1muoI8Tp",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.19.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.19.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.235237Z",
+  "createdAt" : "2022-09-28T15:53:41.154931Z",
   "id" : "svr3x3ca",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "FRfKD3vr5o"
       ],
       "title" : "title-lluSXGQIID",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.2.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.218197Z",
+  "createdAt" : "2022-09-28T15:53:41.010613Z",
   "id" : "vpkqafpg",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "dPAcgpfIbf"
       ],
       "title" : "title-z7am59I9Cw",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.20.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.20.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.236280Z",
+  "createdAt" : "2022-09-28T15:53:41.157898Z",
   "id" : "w4lfjuza",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "P7HD59gW9t"
       ],
       "title" : "title-quWoTqEmJ6",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.21.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.21.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.237197Z",
+  "createdAt" : "2022-09-28T15:53:41.159403Z",
   "id" : "5hlmpzzh",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "PyW5z3uVBA"
       ],
       "title" : "title-JtbkBsxzfE",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.22.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.22.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.238070Z",
+  "createdAt" : "2022-09-28T15:53:41.161071Z",
   "id" : "b5lylqvq",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "DIlUXQf0x4"
       ],
       "title" : "title-SQr2rDSofx",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.3.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.219698Z",
+  "createdAt" : "2022-09-28T15:53:41.015786Z",
   "id" : "ivw1mq40",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "zoIhNdLDgG"
       ],
       "title" : "title-gbiIgGzgYB",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.4.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.220962Z",
+  "createdAt" : "2022-09-28T15:53:41.025428Z",
   "id" : "mxssba8u",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "QnFei9OwDH"
       ],
       "title" : "title-TG3GuW07LA",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.5.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.221884Z",
+  "createdAt" : "2022-09-28T15:53:41.032442Z",
   "id" : "pi8hxmce",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "tXxMtg7dko"
       ],
       "title" : "title-jABF1suXYC",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.6.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.6.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.222760Z",
+  "createdAt" : "2022-09-28T15:53:41.034188Z",
   "id" : "lwt2ohte",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "zOTvHYjPJX"
       ],
       "title" : "title-5AXQEaJ1be",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.7.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.7.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.223627Z",
+  "createdAt" : "2022-09-28T15:53:41.036170Z",
   "id" : "a62ffqxh",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "dUrbgrWtto"
       ],
       "title" : "title-ojQsszds7w",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.8.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.8.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.224443Z",
+  "createdAt" : "2022-09-28T15:53:41.047350Z",
   "id" : "atgvzcvy",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "za69e7zAIP"
       ],
       "title" : "title-WMl0kbMOTy",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.9.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.9.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.225321Z",
+  "createdAt" : "2022-09-28T15:53:41.053322Z",
   "id" : "mopzrqzu",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "DIXUuyd8hW"
       ],
       "title" : "title-pVU0ULWN0n",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.0.json
+++ b/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-09-26T11:29:28.474688Z",
+  "createdAt" : "2022-09-28T15:53:41.907335Z",
   "id" : "h5zn9bqm",
   "document" : {
     "debug" : {
@@ -162,6 +162,8 @@
         "OQ6G6Rkv6Q"
       ],
       "title" : "title-6Obq6lxZzG",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -201,12 +203,17 @@
       "contributors.agent.label" : [
         "Bath, Patricia"
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.1.json
+++ b/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-09-26T11:29:28.475482Z",
+  "createdAt" : "2022-09-28T15:53:41.908904Z",
   "id" : "gnuj1it3",
   "document" : {
     "debug" : {
@@ -162,6 +162,8 @@
         "Og3KGy7Mz5"
       ],
       "title" : "title-c4OR9LzJV7",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -201,12 +203,17 @@
       "contributors.agent.label" : [
         "Karl Marx"
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.2.json
+++ b/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-09-26T11:29:28.476364Z",
+  "createdAt" : "2022-09-28T15:53:41.910214Z",
   "id" : "e1k1l8xu",
   "document" : {
     "debug" : {
@@ -162,6 +162,8 @@
         "Kvqw9fGol7"
       ],
       "title" : "title-cLZhc35m9C",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -201,12 +203,17 @@
       "contributors.agent.label" : [
         "Jake Paul"
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.3.json
+++ b/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-09-26T11:29:28.477016Z",
+  "createdAt" : "2022-09-28T15:53:41.911232Z",
   "id" : "6q7wkowr",
   "document" : {
     "debug" : {
@@ -162,6 +162,8 @@
         "AgxJAjEybh"
       ],
       "title" : "title-NOoLbpS5jR",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -201,12 +203,17 @@
       "contributors.agent.label" : [
         "Darwin \"Jones\", Charles"
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.4.json
+++ b/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-09-26T11:29:28.477659Z",
+  "createdAt" : "2022-09-28T15:53:41.912074Z",
   "id" : "cpwnrkdo",
   "document" : {
     "debug" : {
@@ -189,6 +189,8 @@
         "FqozNGJ9Pf"
       ],
       "title" : "title-Vp3bULWghZ",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -229,12 +231,17 @@
         "Bath, Patricia",
         "Darwin \"Jones\", Charles"
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.5.json
+++ b/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-09-26T11:29:28.478039Z",
+  "createdAt" : "2022-09-28T15:53:41.913091Z",
   "id" : "bexh6kx6",
   "document" : {
     "debug" : {
@@ -135,6 +135,8 @@
         "5q2ktKEnxz"
       ],
       "title" : "title-ERuJHArEMd",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -173,12 +175,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.different-work-types.Collection.json
+++ b/pipeline/ingestor/test_documents/works.examples.different-work-types.Collection.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples of works with different types",
-  "createdAt" : "2022-09-26T11:29:28.376725Z",
+  "createdAt" : "2022-09-28T15:53:41.700435Z",
   "id" : "2tqcclh1",
   "document" : {
     "debug" : {
@@ -135,6 +135,8 @@
         "ZiS5MlN0hQ"
       ],
       "title" : "rats",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -173,12 +175,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.different-work-types.Section.json
+++ b/pipeline/ingestor/test_documents/works.examples.different-work-types.Section.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples of works with different types",
-  "createdAt" : "2022-09-26T11:29:28.370171Z",
+  "createdAt" : "2022-09-28T15:53:41.680150Z",
   "id" : "iw5fnuyy",
   "document" : {
     "debug" : {
@@ -135,6 +135,8 @@
         "Xo35aec2Io"
       ],
       "title" : "rats",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -173,12 +175,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.different-work-types.Series.json
+++ b/pipeline/ingestor/test_documents/works.examples.different-work-types.Series.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples of works with different types",
-  "createdAt" : "2022-09-26T11:29:28.382399Z",
+  "createdAt" : "2022-09-28T15:53:41.718547Z",
   "id" : "fndkxmxs",
   "document" : {
     "debug" : {
@@ -135,6 +135,8 @@
         "yW6CgVzwIJ"
       ],
       "title" : "rats",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -173,12 +175,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.0.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-09-26T11:29:28.697765Z",
+  "createdAt" : "2022-09-28T15:53:42.313786Z",
   "id" : "phodmv5g",
   "document" : {
     "debug" : {
@@ -152,6 +152,8 @@
         "kSl7z2IaIy"
       ],
       "title" : "rats",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -192,12 +194,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.1.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-09-26T11:29:28.698291Z",
+  "createdAt" : "2022-09-28T15:53:42.315824Z",
   "id" : "580nnpfa",
   "document" : {
     "debug" : {
@@ -152,6 +152,8 @@
         "wz2OkOJHcs"
       ],
       "title" : "capybara",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -192,12 +194,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.2.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-09-26T11:29:28.698779Z",
+  "createdAt" : "2022-09-28T15:53:42.318028Z",
   "id" : "jfnymrg2",
   "document" : {
     "debug" : {
@@ -152,6 +152,8 @@
         "zrSaF1p8IU"
       ],
       "title" : "tapirs",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -192,12 +194,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.3.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-09-26T11:29:28.699339Z",
+  "createdAt" : "2022-09-28T15:53:42.319583Z",
   "id" : "lpoz1fy9",
   "document" : {
     "debug" : {
@@ -152,6 +152,8 @@
         "FGpPdnmb6i"
       ],
       "title" : "rats",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -192,12 +194,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.4.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-09-26T11:29:28.699870Z",
+  "createdAt" : "2022-09-28T15:53:42.320922Z",
   "id" : "in2u7aru",
   "document" : {
     "debug" : {
@@ -152,6 +152,8 @@
         "OHrklHuS07"
       ],
       "title" : "capybara",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -192,12 +194,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.5.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-09-26T11:29:28.700313Z",
+  "createdAt" : "2022-09-28T15:53:42.322068Z",
   "id" : "wkzjlx5a",
   "document" : {
     "debug" : {
@@ -152,6 +152,8 @@
         "SKphDnojLC"
       ],
       "title" : "tapirs",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -192,12 +194,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.6.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.6.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-09-26T11:29:28.700810Z",
+  "createdAt" : "2022-09-28T15:53:42.328301Z",
   "id" : "iykrudzs",
   "document" : {
     "debug" : {
@@ -152,6 +152,8 @@
         "QnjXRANbEF"
       ],
       "title" : "rats",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -192,12 +194,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.7.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.7.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-09-26T11:29:28.701369Z",
+  "createdAt" : "2022-09-28T15:53:42.333284Z",
   "id" : "pskvh87t",
   "document" : {
     "debug" : {
@@ -152,6 +152,8 @@
         "lBGTOMLJUB"
       ],
       "title" : "capybara",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -192,12 +194,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.8.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.8.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-09-26T11:29:28.701927Z",
+  "createdAt" : "2022-09-28T15:53:42.334770Z",
   "id" : "k57syong",
   "document" : {
     "debug" : {
@@ -152,6 +152,8 @@
         "czKSHpT0IR"
       ],
       "title" : "tapirs",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -192,12 +194,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.9.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.9.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-09-26T11:29:28.702525Z",
+  "createdAt" : "2022-09-28T15:53:42.337374Z",
   "id" : "lkq8nygj",
   "document" : {
     "debug" : {
@@ -152,6 +152,8 @@
         "UBhh45MMdu"
       ],
       "title" : "rats",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -192,12 +194,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.0.json
+++ b/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2022-09-26T11:29:28.390646Z",
+  "createdAt" : "2022-09-28T15:53:41.740845Z",
   "id" : "jywtq4xg",
   "document" : {
     "debug" : {
@@ -179,6 +179,8 @@
         "LgGFRAV0Zs"
       ],
       "title" : "title-ZEnp6i2y6i",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -221,12 +223,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.1.json
+++ b/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2022-09-26T11:29:28.391574Z",
+  "createdAt" : "2022-09-28T15:53:41.749659Z",
   "id" : "ahr8n4ei",
   "document" : {
     "debug" : {
@@ -179,6 +179,8 @@
         "g4JnCRDZnk"
       ],
       "title" : "title-Rew3RmJ48v",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -221,12 +223,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.2.json
+++ b/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2022-09-26T11:29:28.392276Z",
+  "createdAt" : "2022-09-28T15:53:41.753164Z",
   "id" : "yhjhxcof",
   "document" : {
     "debug" : {
@@ -179,6 +179,8 @@
         "lydjDVoexx"
       ],
       "title" : "title-wsvmZKLOsI",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -221,12 +223,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.3.json
+++ b/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2022-09-26T11:29:28.393018Z",
+  "createdAt" : "2022-09-28T15:53:41.763522Z",
   "id" : "1mqutqzm",
   "document" : {
     "debug" : {
@@ -179,6 +179,8 @@
         "EmqhmRoJyr"
       ],
       "title" : "title-bPJWDqmpbe",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -221,12 +223,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.4.json
+++ b/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2022-09-26T11:29:28.394343Z",
+  "createdAt" : "2022-09-28T15:53:41.769527Z",
   "id" : "4btprmwn",
   "document" : {
     "debug" : {
@@ -267,6 +267,8 @@
         "C7XCeymDdf"
       ],
       "title" : "title-iLGpm85YYF",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -317,12 +319,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.5.json
+++ b/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2022-09-26T11:29:28.394959Z",
+  "createdAt" : "2022-09-28T15:53:41.772396Z",
   "id" : "oo0o5odf",
   "document" : {
     "debug" : {
@@ -135,6 +135,8 @@
         "T9fhswtSuP"
       ],
       "title" : "title-odercwIWKJ",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -173,12 +175,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.0.json
+++ b/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-09-26T11:29:28.430885Z",
+  "createdAt" : "2022-09-28T15:53:41.837932Z",
   "id" : "tayys6jp",
   "document" : {
     "debug" : {
@@ -220,6 +220,8 @@
         "3OfWNE6m5y"
       ],
       "title" : "title-JiYzJ9DWDL",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -263,12 +265,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.1.json
+++ b/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-09-26T11:29:28.431846Z",
+  "createdAt" : "2022-09-28T15:53:41.840248Z",
   "id" : "zwggainv",
   "document" : {
     "debug" : {
@@ -182,6 +182,8 @@
         "RdbNpFC2P5"
       ],
       "title" : "title-k5aVuGQD3S",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -224,12 +226,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.2.json
+++ b/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-09-26T11:29:28.432760Z",
+  "createdAt" : "2022-09-28T15:53:41.842446Z",
   "id" : "mazaizfa",
   "document" : {
     "debug" : {
@@ -182,6 +182,8 @@
         "QFJOR9VqAE"
       ],
       "title" : "title-vTVR490Vab",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -224,12 +226,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.3.json
+++ b/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-09-26T11:29:28.433704Z",
+  "createdAt" : "2022-09-28T15:53:41.845504Z",
   "id" : "b1r485o0",
   "document" : {
     "debug" : {
@@ -204,6 +204,8 @@
         "4zh18D0cbF"
       ],
       "title" : "title-DxPLXKke6N",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -247,12 +249,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.4.json
+++ b/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-09-26T11:29:28.435096Z",
+  "createdAt" : "2022-09-28T15:53:41.849256Z",
   "id" : "gmzc1icz",
   "document" : {
     "debug" : {
@@ -298,6 +298,8 @@
         "Q8QOPJdAXF"
       ],
       "title" : "title-vNWbRfsAZ5",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -349,12 +351,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.5.json
+++ b/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-09-26T11:29:28.436784Z",
+  "createdAt" : "2022-09-28T15:53:41.851230Z",
   "id" : "rbao66qq",
   "document" : {
     "debug" : {
@@ -135,6 +135,8 @@
         "5hoUH5ZhFq"
       ],
       "title" : "title-bcmHn7act9",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -173,12 +175,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.formats.0.Books.json
+++ b/pipeline/ingestor/test_documents/works.formats.0.Books.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-09-26T11:29:27.616384Z",
+  "createdAt" : "2022-09-28T15:53:39.524543Z",
   "id" : "gfw8fs9l",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "wayOhJ3Mha"
       ],
       "title" : "A work with format Books",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.formats.1.Books.json
+++ b/pipeline/ingestor/test_documents/works.formats.1.Books.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-09-26T11:29:27.623345Z",
+  "createdAt" : "2022-09-28T15:53:39.553432Z",
   "id" : "ciweswu5",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "ESu6j0cajz"
       ],
       "title" : "A work with format Books",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.formats.2.Books.json
+++ b/pipeline/ingestor/test_documents/works.formats.2.Books.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-09-26T11:29:27.630005Z",
+  "createdAt" : "2022-09-28T15:53:39.571734Z",
   "id" : "j27g6hhl",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "vyeItSna2X"
       ],
       "title" : "A work with format Books",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.formats.3.Books.json
+++ b/pipeline/ingestor/test_documents/works.formats.3.Books.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-09-26T11:29:27.635967Z",
+  "createdAt" : "2022-09-28T15:53:39.594817Z",
   "id" : "bujceq4p",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "HuLHN83UU0"
       ],
       "title" : "A work with format Books",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.formats.4.Journals.json
+++ b/pipeline/ingestor/test_documents/works.formats.4.Journals.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-09-26T11:29:27.641905Z",
+  "createdAt" : "2022-09-28T15:53:39.623686Z",
   "id" : "wqcumcet",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "vc628Sgu9f"
       ],
       "title" : "A work with format Journals",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.formats.5.Journals.json
+++ b/pipeline/ingestor/test_documents/works.formats.5.Journals.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-09-26T11:29:27.648234Z",
+  "createdAt" : "2022-09-28T15:53:39.643198Z",
   "id" : "plmmmkup",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "X7kBc19InD"
       ],
       "title" : "A work with format Journals",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.formats.6.Journals.json
+++ b/pipeline/ingestor/test_documents/works.formats.6.Journals.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-09-26T11:29:27.655877Z",
+  "createdAt" : "2022-09-28T15:53:39.665389Z",
   "id" : "xc5d7pc4",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "HXsUYY6dN4"
       ],
       "title" : "A work with format Journals",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.formats.7.Audio.json
+++ b/pipeline/ingestor/test_documents/works.formats.7.Audio.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-09-26T11:29:27.665058Z",
+  "createdAt" : "2022-09-28T15:53:39.681956Z",
   "id" : "t3q2ufnz",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "nNHPpdWbrm"
       ],
       "title" : "A work with format Audio",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.formats.8.Audio.json
+++ b/pipeline/ingestor/test_documents/works.formats.8.Audio.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-09-26T11:29:27.675735Z",
+  "createdAt" : "2022-09-28T15:53:39.701423Z",
   "id" : "elrgwjtd",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "RMKkkMWH2B"
       ],
       "title" : "A work with format Audio",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.formats.9.Pictures.json
+++ b/pipeline/ingestor/test_documents/works.formats.9.Pictures.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-09-26T11:29:27.686618Z",
+  "createdAt" : "2022-09-28T15:53:39.718631Z",
   "id" : "sym6ne7x",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "FRzpe3bQyh"
       ],
       "title" : "A work with format Pictures",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.genres.json
+++ b/pipeline/ingestor/test_documents/works.genres.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with different concepts in the genre",
-  "createdAt" : "2022-09-26T11:29:27.832681Z",
+  "createdAt" : "2022-09-28T15:53:40.005116Z",
   "id" : "2zo588up",
   "document" : {
     "debug" : {
@@ -202,6 +202,8 @@
         "rVoekomuzt"
       ],
       "title" : "A work with different concepts in the genre",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -244,12 +246,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.items-with-licenses.0.json
+++ b/pipeline/ingestor/test_documents/works.items-with-licenses.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with licensed digital items",
-  "createdAt" : "2022-09-26T11:29:27.784973Z",
+  "createdAt" : "2022-09-28T15:53:39.880995Z",
   "id" : "yodfctxx",
   "document" : {
     "debug" : {
@@ -182,6 +182,8 @@
         "HfU454vgiI"
       ],
       "title" : "title-AIpgBtHAhx",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -222,12 +224,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.items-with-licenses.1.json
+++ b/pipeline/ingestor/test_documents/works.items-with-licenses.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with licensed digital items",
-  "createdAt" : "2022-09-26T11:29:27.785908Z",
+  "createdAt" : "2022-09-28T15:53:39.884477Z",
   "id" : "runiusy8",
   "document" : {
     "debug" : {
@@ -184,6 +184,8 @@
         "ZGWEGMyTaq"
       ],
       "title" : "title-wjvsf3c3yc",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -224,12 +226,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.items-with-licenses.2.json
+++ b/pipeline/ingestor/test_documents/works.items-with-licenses.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with licensed digital items",
-  "createdAt" : "2022-09-26T11:29:27.786906Z",
+  "createdAt" : "2022-09-28T15:53:39.888761Z",
   "id" : "ougtipki",
   "document" : {
     "debug" : {
@@ -182,6 +182,8 @@
         "fbITZO5oAg"
       ],
       "title" : "title-pEBp6sf3WU",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -222,12 +224,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.items-with-licenses.3.json
+++ b/pipeline/ingestor/test_documents/works.items-with-licenses.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with licensed digital items",
-  "createdAt" : "2022-09-26T11:29:27.788234Z",
+  "createdAt" : "2022-09-28T15:53:39.894047Z",
   "id" : "rstrzip9",
   "document" : {
     "debug" : {
@@ -233,6 +233,8 @@
         "AbkJTEEoLH"
       ],
       "title" : "title-7h7G222BsR",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -275,12 +277,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.items-with-licenses.4.json
+++ b/pipeline/ingestor/test_documents/works.items-with-licenses.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with licensed digital items",
-  "createdAt" : "2022-09-26T11:29:27.788862Z",
+  "createdAt" : "2022-09-28T15:53:39.895662Z",
   "id" : "vwg1cj2y",
   "document" : {
     "debug" : {
@@ -135,6 +135,8 @@
         "FIC2DNd6NA"
       ],
       "title" : "title-YmmH4BoIsw",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -173,12 +175,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.items-with-other-identifiers.0.json
+++ b/pipeline/ingestor/test_documents/works.items-with-other-identifiers.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2022-09-26T11:29:27.941844Z",
+  "createdAt" : "2022-09-28T15:53:40.323642Z",
   "id" : "qjnwiqbs",
   "document" : {
     "debug" : {
@@ -218,6 +218,8 @@
         "Jj1GugWgka"
       ],
       "title" : "title-m47LFZN2Zg",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -261,12 +263,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.items-with-other-identifiers.1.json
+++ b/pipeline/ingestor/test_documents/works.items-with-other-identifiers.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2022-09-26T11:29:27.942701Z",
+  "createdAt" : "2022-09-28T15:53:40.333398Z",
   "id" : "upm4bal7",
   "document" : {
     "debug" : {
@@ -219,6 +219,8 @@
         "wkKE1s2opA"
       ],
       "title" : "title-lcjNV5vdX9",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -262,12 +264,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.items-with-other-identifiers.2.json
+++ b/pipeline/ingestor/test_documents/works.items-with-other-identifiers.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2022-09-26T11:29:27.943533Z",
+  "createdAt" : "2022-09-28T15:53:40.339453Z",
   "id" : "zbejhda8",
   "document" : {
     "debug" : {
@@ -219,6 +219,8 @@
         "l7ykrmHfSg"
       ],
       "title" : "title-yvIxyfRHMd",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -262,12 +264,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.items-with-other-identifiers.3.json
+++ b/pipeline/ingestor/test_documents/works.items-with-other-identifiers.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2022-09-26T11:29:27.944456Z",
+  "createdAt" : "2022-09-28T15:53:40.346511Z",
   "id" : "pex9vogp",
   "document" : {
     "debug" : {
@@ -220,6 +220,8 @@
         "MEUfT3H8Xn"
       ],
       "title" : "title-YI3LUHDJYY",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -263,12 +265,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.items-with-other-identifiers.4.json
+++ b/pipeline/ingestor/test_documents/works.items-with-other-identifiers.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2022-09-26T11:29:27.945397Z",
+  "createdAt" : "2022-09-28T15:53:40.349899Z",
   "id" : "c5xw2xfj",
   "document" : {
     "debug" : {
@@ -220,6 +220,8 @@
         "fREqoThymw"
       ],
       "title" : "title-jI6EjEMJ47",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -263,12 +265,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.languages.0.eng.json
+++ b/pipeline/ingestor/test_documents/works.languages.0.eng.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2022-09-26T11:29:27.721067Z",
+  "createdAt" : "2022-09-28T15:53:39.764288Z",
   "id" : "i8zcsj78",
   "document" : {
     "debug" : {
@@ -144,6 +144,8 @@
         "ZquhBnzQPW"
       ],
       "title" : "A work with languages English",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -184,12 +186,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.languages.1.eng.json
+++ b/pipeline/ingestor/test_documents/works.languages.1.eng.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2022-09-26T11:29:27.735690Z",
+  "createdAt" : "2022-09-28T15:53:39.779191Z",
   "id" : "qn97gvxq",
   "document" : {
     "debug" : {
@@ -144,6 +144,8 @@
         "BbZQhYTTwR"
       ],
       "title" : "A work with languages English",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -184,12 +186,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.languages.2.eng.json
+++ b/pipeline/ingestor/test_documents/works.languages.2.eng.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2022-09-26T11:29:27.743710Z",
+  "createdAt" : "2022-09-28T15:53:39.795282Z",
   "id" : "yhrq0rmr",
   "document" : {
     "debug" : {
@@ -144,6 +144,8 @@
         "tXlgR2VtcJ"
       ],
       "title" : "A work with languages English",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -184,12 +186,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.languages.3.eng+swe.json
+++ b/pipeline/ingestor/test_documents/works.languages.3.eng+swe.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2022-09-26T11:29:27.754654Z",
+  "createdAt" : "2022-09-28T15:53:39.809811Z",
   "id" : "ioqwetut",
   "document" : {
     "debug" : {
@@ -153,6 +153,8 @@
         "5WuJppwWsm"
       ],
       "title" : "A work with languages English, Swedish",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -195,12 +197,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.languages.4.eng+swe+tur.json
+++ b/pipeline/ingestor/test_documents/works.languages.4.eng+swe+tur.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2022-09-26T11:29:27.761351Z",
+  "createdAt" : "2022-09-28T15:53:39.824813Z",
   "id" : "edfiesed",
   "document" : {
     "debug" : {
@@ -162,6 +162,8 @@
         "tQZYPmQieO"
       ],
       "title" : "A work with languages English, Swedish, Turkish",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -206,12 +208,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.languages.5.swe.json
+++ b/pipeline/ingestor/test_documents/works.languages.5.swe.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2022-09-26T11:29:27.768678Z",
+  "createdAt" : "2022-09-28T15:53:39.844267Z",
   "id" : "qfscz1rj",
   "document" : {
     "debug" : {
@@ -144,6 +144,8 @@
         "Gk6juMbOeK"
       ],
       "title" : "A work with languages Swedish",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -184,12 +186,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.languages.6.tur.json
+++ b/pipeline/ingestor/test_documents/works.languages.6.tur.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2022-09-26T11:29:27.775151Z",
+  "createdAt" : "2022-09-28T15:53:39.859517Z",
   "id" : "yblbdpjf",
   "document" : {
     "debug" : {
@@ -144,6 +144,8 @@
         "vcw0LP9LzQ"
       ],
       "title" : "A work with languages Turkish",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -184,12 +186,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.production.multi-year.0.json
+++ b/pipeline/ingestor/test_documents/works.production.multi-year.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2022-09-26T11:29:28.147985Z",
+  "createdAt" : "2022-09-28T15:53:40.806288Z",
   "id" : "31spt9st",
   "document" : {
     "debug" : {
@@ -193,6 +193,8 @@
         "WzsZA7OUAa"
       ],
       "title" : "title-QoeggPvgjR",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -231,12 +233,20 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+        "54blSY3iyd",
+        "rQHICakdbo",
+        "1850"
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.production.multi-year.1.json
+++ b/pipeline/ingestor/test_documents/works.production.multi-year.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2022-09-26T11:29:28.148897Z",
+  "createdAt" : "2022-09-28T15:53:40.809016Z",
   "id" : "v9is9e3t",
   "document" : {
     "debug" : {
@@ -193,6 +193,8 @@
         "fZVe3xG7r6"
       ],
       "title" : "title-JGYTcwsJbl",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -231,12 +233,20 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+        "Qjq4EFefGh",
+        "SS8PUjTA45",
+        "1850-2000"
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.production.multi-year.2.json
+++ b/pipeline/ingestor/test_documents/works.production.multi-year.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2022-09-26T11:29:28.149815Z",
+  "createdAt" : "2022-09-28T15:53:40.811628Z",
   "id" : "wg3kq4ux",
   "document" : {
     "debug" : {
@@ -193,6 +193,8 @@
         "lfq9upMxJZ"
       ],
       "title" : "title-oirzqph7Io",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -231,12 +233,20 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+        "YdIXqL6hBi",
+        "4EVx0a62zj",
+        "1860-1960"
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.production.multi-year.3.json
+++ b/pipeline/ingestor/test_documents/works.production.multi-year.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2022-09-26T11:29:28.150549Z",
+  "createdAt" : "2022-09-28T15:53:40.813629Z",
   "id" : "q4abgj9v",
   "document" : {
     "debug" : {
@@ -193,6 +193,8 @@
         "09dkccFCHG"
       ],
       "title" : "title-PDvN43mh0p",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -231,12 +233,20 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+        "aIg4BPWRHb",
+        "uSqTDzUOjO",
+        "1960"
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.production.multi-year.4.json
+++ b/pipeline/ingestor/test_documents/works.production.multi-year.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2022-09-26T11:29:28.151489Z",
+  "createdAt" : "2022-09-28T15:53:40.815999Z",
   "id" : "cuh8ak2g",
   "document" : {
     "debug" : {
@@ -193,6 +193,8 @@
         "KabHlF2fhJ"
       ],
       "title" : "title-PdAnZy8IL7",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -231,12 +233,20 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+        "QHgcJPyjdm",
+        "hcczXNV4U4",
+        "1960-1964"
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.production.multi-year.5.json
+++ b/pipeline/ingestor/test_documents/works.production.multi-year.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2022-09-26T11:29:28.152645Z",
+  "createdAt" : "2022-09-28T15:53:40.817464Z",
   "id" : "wmzcsqaf",
   "document" : {
     "debug" : {
@@ -193,6 +193,8 @@
         "Kwytcvu6mF"
       ],
       "title" : "title-tBeNhpR5aF",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -231,12 +233,20 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+        "QMh6zvv2Jj",
+        "5pKO9kAlfI",
+        "1962"
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.subjects.0.json
+++ b/pipeline/ingestor/test_documents/works.subjects.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different subjects",
-  "createdAt" : "2022-09-26T11:29:27.840975Z",
+  "createdAt" : "2022-09-28T15:53:40.041971Z",
   "id" : "6uwysojy",
   "document" : {
     "debug" : {
@@ -182,6 +182,8 @@
         "pzLgxSR5EK"
       ],
       "title" : "title-Dtaaw5YmCW",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -224,12 +226,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.subjects.1.json
+++ b/pipeline/ingestor/test_documents/works.subjects.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different subjects",
-  "createdAt" : "2022-09-26T11:29:27.841965Z",
+  "createdAt" : "2022-09-28T15:53:40.046136Z",
   "id" : "mihwfxry",
   "document" : {
     "debug" : {
@@ -182,6 +182,8 @@
         "HypKD9r1zH"
       ],
       "title" : "title-miZHgL6jXR",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -224,12 +226,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.subjects.2.json
+++ b/pipeline/ingestor/test_documents/works.subjects.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different subjects",
-  "createdAt" : "2022-09-26T11:29:27.842957Z",
+  "createdAt" : "2022-09-28T15:53:40.054330Z",
   "id" : "evraub2i",
   "document" : {
     "debug" : {
@@ -182,6 +182,8 @@
         "E3Fqby26w1"
       ],
       "title" : "title-sNTcYSKPkF",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -224,12 +226,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.subjects.3.json
+++ b/pipeline/ingestor/test_documents/works.subjects.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different subjects",
-  "createdAt" : "2022-09-26T11:29:27.844207Z",
+  "createdAt" : "2022-09-28T15:53:40.063807Z",
   "id" : "xcssabt1",
   "document" : {
     "debug" : {
@@ -229,6 +229,8 @@
         "7XE0Jxv45o"
       ],
       "title" : "title-p2sZlO6WXi",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -275,12 +277,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.subjects.4.json
+++ b/pipeline/ingestor/test_documents/works.subjects.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different subjects",
-  "createdAt" : "2022-09-26T11:29:27.844897Z",
+  "createdAt" : "2022-09-28T15:53:40.066015Z",
   "id" : "t9nj8zse",
   "document" : {
     "debug" : {
@@ -135,6 +135,8 @@
         "8imBUVPHmu"
       ],
       "title" : "title-9al0iIjgaH",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -173,12 +175,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.title-query-parens.json
+++ b/pipeline/ingestor/test_documents/works.title-query-parens.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work whose title has parens meant to trip up ES",
-  "createdAt" : "2022-09-26T11:29:27.707048Z",
+  "createdAt" : "2022-09-28T15:53:39.746995Z",
   "id" : "omok5a37",
   "document" : {
     "debug" : {
@@ -135,6 +135,8 @@
         "y59nY1Nuok"
       ],
       "title" : "(a b c d e) h",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -173,12 +175,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.title-query-syntax.json
+++ b/pipeline/ingestor/test_documents/works.title-query-syntax.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work whose title has lots of ES query syntax operators",
-  "createdAt" : "2022-09-26T11:29:27.696488Z",
+  "createdAt" : "2022-09-28T15:53:39.732141Z",
   "id" : "hjjs3mu3",
   "document" : {
     "debug" : {
@@ -135,6 +135,8 @@
         "Z3LIdvnOPk"
       ],
       "title" : "+a -title | with (all the simple) query~4 syntax operators in it*",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -173,12 +175,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.visible.0.json
+++ b/pipeline/ingestor/test_documents/works.visible.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of visible works",
-  "createdAt" : "2022-09-26T11:29:26.462829Z",
+  "createdAt" : "2022-09-28T15:53:36.426844Z",
   "id" : "2twopft1",
   "document" : {
     "debug" : {
@@ -135,6 +135,8 @@
         "Uaequ81tpB"
       ],
       "title" : "title-vaMzxd8prf",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -173,12 +175,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.visible.1.json
+++ b/pipeline/ingestor/test_documents/works.visible.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of visible works",
-  "createdAt" : "2022-09-26T11:29:26.469706Z",
+  "createdAt" : "2022-09-28T15:53:36.443941Z",
   "id" : "dph7sjip",
   "document" : {
     "debug" : {
@@ -135,6 +135,8 @@
         "WpBejTwv1N"
       ],
       "title" : "title-3hvGdgZfc8",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -173,12 +175,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.visible.2.json
+++ b/pipeline/ingestor/test_documents/works.visible.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of visible works",
-  "createdAt" : "2022-09-26T11:29:26.471498Z",
+  "createdAt" : "2022-09-28T15:53:36.447259Z",
   "id" : "fyqts0co",
   "document" : {
     "debug" : {
@@ -135,6 +135,8 @@
         "ZvWebpA5WH"
       ],
       "title" : "title-XQqPyuxbr5",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -173,12 +175,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.visible.3.json
+++ b/pipeline/ingestor/test_documents/works.visible.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of visible works",
-  "createdAt" : "2022-09-26T11:29:26.473381Z",
+  "createdAt" : "2022-09-28T15:53:36.450910Z",
   "id" : "raob2ruv",
   "document" : {
     "debug" : {
@@ -135,6 +135,8 @@
         "wyJzS2SuiH"
       ],
       "title" : "title-bFbQPNB7Zu",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -173,12 +175,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/pipeline/ingestor/test_documents/works.visible.4.json
+++ b/pipeline/ingestor/test_documents/works.visible.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of visible works",
-  "createdAt" : "2022-09-26T11:29:26.475309Z",
+  "createdAt" : "2022-09-28T15:53:36.453821Z",
   "id" : "vbi1ii19",
   "document" : {
     "debug" : {
@@ -135,6 +135,8 @@
         "CzLNHBFHuR"
       ],
       "title" : "title-jGGR8UNWut",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -173,12 +175,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -95,6 +95,7 @@ object ExternalDependencies {
   lazy val versions = new {
     val apacheCommons = "1.9"
     val circe = "0.13.0"
+    val diffJson = "4.1.1"
     val fastparse = "2.3.0"
     val scalatest = "3.2.3"
     val scalatestplus = "3.1.2.0"
@@ -163,6 +164,10 @@ object ExternalDependencies {
     "ch.qos.logback" % "logback-core" % versions.logback,
     "ch.qos.logback" % "logback-access" % versions.logback
   )
+
+  val diffJsonDependencies = Seq(
+    "org.gnieh" %% f"diffson-circe" % versions.diffJson % "test"
+  )
 }
 
 object CatalogueDependencies {
@@ -174,7 +179,8 @@ object CatalogueDependencies {
       ExternalDependencies.scalacheckDependencies ++
       ExternalDependencies.enumeratumDependencies ++
       ExternalDependencies.scalaXmlDependencies ++
-      WellcomeDependencies.storageLibrary
+      WellcomeDependencies.storageLibrary ++
+      ExternalDependencies.diffJsonDependencies
 
   val displayModelDependencies: Seq[ModuleID] =
     WellcomeDependencies.httpLibrary


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5550

After this I think we'll be able to delete the `data` and `state` fields from an IndexedWork, but that's a sufficiently disruptive change I think we should do that in a new pipeline.