### PR TITLE
Add label-derived IDs for subjects on non-Sierra works

### DIFF
--- a/pipeline/transformer/transformer_common/src/test/scala/weco/pipeline/transformer/generators/LabelDerivedIdentifiersGenerators.scala
+++ b/pipeline/transformer/transformer_common/src/test/scala/weco/pipeline/transformer/generators/LabelDerivedIdentifiersGenerators.scala
@@ -25,4 +25,13 @@ trait LabelDerivedIdentifiersGenerators {
         ontologyType = "Person"
       )
     )
+
+  def labelDerivedSubjectIdentifier(value: String): Identifiable =
+    IdState.Identifiable(
+      sourceIdentifier = SourceIdentifier(
+        identifierType = IdentifierType.LabelDerived,
+        value = value,
+        ontologyType = "Subject"
+      )
+    )
 }

--- a/pipeline/transformer/transformer_miro/src/main/scala/weco/pipeline/transformer/miro/transformers/MiroSubjects.scala
+++ b/pipeline/transformer/transformer_miro/src/main/scala/weco/pipeline/transformer/miro/transformers/MiroSubjects.scala
@@ -2,10 +2,11 @@ package weco.pipeline.transformer.miro.transformers
 
 import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.work.{Concept, Subject}
+import weco.pipeline.transformer.identifiers.LabelDerivedIdentifiers
 import weco.pipeline.transformer.miro.source.MiroRecord
 import weco.pipeline.transformer.text.TextNormalisation._
 
-trait MiroSubjects {
+trait MiroSubjects extends LabelDerivedIdentifiers {
 
   /* Populate the subjects field.  This is based on two fields in the XML,
    *  <image_keywords> and <image_keywords_unauth>.  Both of these were
@@ -29,6 +30,7 @@ trait MiroSubjects {
     (keywords ++ keywordsUnauth).map { keyword =>
       val normalisedLabel = keyword.sentenceCase
       Subject(
+        id = identifierFromText(normalisedLabel, ontologyType = "Subject"),
         label = normalisedLabel,
         concepts = List(Concept(normalisedLabel))
       )

--- a/pipeline/transformer/transformer_miro/src/test/scala/weco/pipeline/transformer/miro/transformers/MiroSubjectsTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/weco/pipeline/transformer/miro/transformers/MiroSubjectsTest.scala
@@ -3,7 +3,11 @@ package weco.pipeline.transformer.miro.transformers
 import org.scalatest.Assertion
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import weco.catalogue.internal_model.identifiers.{IdState, IdentifierType, SourceIdentifier}
+import weco.catalogue.internal_model.identifiers.{
+  IdState,
+  IdentifierType,
+  SourceIdentifier
+}
 import weco.catalogue.internal_model.work.{Concept, Subject}
 import weco.pipeline.transformer.miro.generators.MiroRecordGenerators
 import weco.pipeline.transformer.miro.source.MiroRecord
@@ -32,7 +36,10 @@ class MiroSubjectsTest
       miroRecord = createMiroRecordWith(
         keywords = Some(List("Animals", "Arachnids", "Fruit"))
       ),
-      expectedSubjectLabels = List(("animals", "Animals"), ("arachnids", "Arachnids"), ("fruit", "Fruit"))
+      expectedSubjectLabels = List(
+        ("animals", "Animals"),
+        ("arachnids", "Arachnids"),
+        ("fruit", "Fruit"))
     )
   }
 
@@ -41,7 +48,8 @@ class MiroSubjectsTest
       miroRecord = createMiroRecordWith(
         keywordsUnauth = Some(List(Some("Altruism"), Some("Mammals")))
       ),
-      expectedSubjectLabels = List(("altruism", "Altruism"), ("mammals", "Mammals"))
+      expectedSubjectLabels =
+        List(("altruism", "Altruism"), ("mammals", "Mammals"))
     )
   }
 
@@ -51,7 +59,8 @@ class MiroSubjectsTest
         keywords = Some(List("Humour")),
         keywordsUnauth = Some(List(Some("Marine creatures")))
       ),
-      expectedSubjectLabels = List(("humour", "Humour"), ("marine creatures", "Marine creatures"))
+      expectedSubjectLabels =
+        List(("humour", "Humour"), ("marine creatures", "Marine creatures"))
     )
   }
 
@@ -61,8 +70,10 @@ class MiroSubjectsTest
         keywords = Some(List("humour", "comedic aspect")),
         keywordsUnauth = Some(List(Some("marine creatures")))
       ),
-      expectedSubjectLabels =
-        List(("humour", "Humour"), ("comedic aspect", "Comedic aspect"), ("marine creatures", "Marine creatures"))
+      expectedSubjectLabels = List(
+        ("humour", "Humour"),
+        ("comedic aspect", "Comedic aspect"),
+        ("marine creatures", "Marine creatures"))
     )
   }
 
@@ -71,18 +82,19 @@ class MiroSubjectsTest
     expectedSubjectLabels: List[(String, String)]
   ): Assertion = {
     val transformedWork = transformWork(miroRecord)
-    val expectedSubjects = expectedSubjectLabels.map { case (idLabel, label) =>
-      Subject(
-        id = IdState.Identifiable(
-          sourceIdentifier = SourceIdentifier(
-            identifierType = IdentifierType.LabelDerived,
-            ontologyType = "Subject",
-            value = idLabel
-          )
-        ),
-        label = label,
-        concepts = List(Concept(label))
-      )
+    val expectedSubjects = expectedSubjectLabels.map {
+      case (idLabel, label) =>
+        Subject(
+          id = IdState.Identifiable(
+            sourceIdentifier = SourceIdentifier(
+              identifierType = IdentifierType.LabelDerived,
+              ontologyType = "Subject",
+              value = idLabel
+            )
+          ),
+          label = label,
+          concepts = List(Concept(label))
+        )
     }
     transformedWork.data.subjects shouldBe expectedSubjects
   }

--- a/pipeline/transformer/transformer_miro/src/test/scala/weco/pipeline/transformer/miro/transformers/MiroSubjectsTest.scala
+++ b/pipeline/transformer/transformer_miro/src/test/scala/weco/pipeline/transformer/miro/transformers/MiroSubjectsTest.scala
@@ -3,6 +3,7 @@ package weco.pipeline.transformer.miro.transformers
 import org.scalatest.Assertion
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+import weco.catalogue.internal_model.identifiers.{IdState, IdentifierType, SourceIdentifier}
 import weco.catalogue.internal_model.work.{Concept, Subject}
 import weco.pipeline.transformer.miro.generators.MiroRecordGenerators
 import weco.pipeline.transformer.miro.source.MiroRecord
@@ -31,7 +32,7 @@ class MiroSubjectsTest
       miroRecord = createMiroRecordWith(
         keywords = Some(List("Animals", "Arachnids", "Fruit"))
       ),
-      expectedSubjectLabels = List("Animals", "Arachnids", "Fruit")
+      expectedSubjectLabels = List(("animals", "Animals"), ("arachnids", "Arachnids"), ("fruit", "Fruit"))
     )
   }
 
@@ -40,7 +41,7 @@ class MiroSubjectsTest
       miroRecord = createMiroRecordWith(
         keywordsUnauth = Some(List(Some("Altruism"), Some("Mammals")))
       ),
-      expectedSubjectLabels = List("Altruism", "Mammals")
+      expectedSubjectLabels = List(("altruism", "Altruism"), ("mammals", "Mammals"))
     )
   }
 
@@ -50,7 +51,7 @@ class MiroSubjectsTest
         keywords = Some(List("Humour")),
         keywordsUnauth = Some(List(Some("Marine creatures")))
       ),
-      expectedSubjectLabels = List("Humour", "Marine creatures")
+      expectedSubjectLabels = List(("humour", "Humour"), ("marine creatures", "Marine creatures"))
     )
   }
 
@@ -61,17 +62,24 @@ class MiroSubjectsTest
         keywordsUnauth = Some(List(Some("marine creatures")))
       ),
       expectedSubjectLabels =
-        List("Humour", "Comedic aspect", "Marine creatures")
+        List(("humour", "Humour"), ("comedic aspect", "Comedic aspect"), ("marine creatures", "Marine creatures"))
     )
   }
 
   private def transformRecordAndCheckSubjects(
     miroRecord: MiroRecord,
-    expectedSubjectLabels: List[String]
+    expectedSubjectLabels: List[(String, String)]
   ): Assertion = {
     val transformedWork = transformWork(miroRecord)
-    val expectedSubjects = expectedSubjectLabels.map { label =>
+    val expectedSubjects = expectedSubjectLabels.map { case (idLabel, label) =>
       Subject(
+        id = IdState.Identifiable(
+          sourceIdentifier = SourceIdentifier(
+            identifierType = IdentifierType.LabelDerived,
+            ontologyType = "Subject",
+            value = idLabel
+          )
+        ),
         label = label,
         concepts = List(Concept(label))
       )

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiSubjects.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiSubjects.scala
@@ -1,6 +1,10 @@
 package weco.pipeline.transformer.tei.transformers
 
-import weco.catalogue.internal_model.identifiers.{IdState, IdentifierType, SourceIdentifier}
+import weco.catalogue.internal_model.identifiers.{
+  IdState,
+  IdentifierType,
+  SourceIdentifier
+}
 import weco.catalogue.internal_model.work.{Concept, Subject}
 import weco.pipeline.transformer.identifiers.LabelDerivedIdentifiers
 import weco.pipeline.transformer.tei.NormaliseText
@@ -42,7 +46,9 @@ object TeiSubjects extends LabelDerivedIdentifiers {
       }
     }.toList
 
-  private def createIdentifier(keywords: Node, reference: Option[String], label: String): IdState.Unminted = {
+  private def createIdentifier(keywords: Node,
+                               reference: Option[String],
+                               label: String): IdState.Unminted = {
     val identifierType = (keywords \@ "scheme").toLowerCase.trim match {
       case s if s == "#lcsh" => Some(IdentifierType.LCSubjects)
       case s if s == "#mesh" => Some(IdentifierType.MESH)

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiSubjects.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiSubjects.scala
@@ -1,9 +1,5 @@
 package weco.pipeline.transformer.tei.transformers
 
-import weco.catalogue.internal_model.identifiers.IdState.{
-  Identifiable,
-  Unidentifiable
-}
 import weco.catalogue.internal_model.identifiers.{
   IdState,
   IdentifierType,
@@ -39,15 +35,28 @@ object TeiSubjects {
         case _                 => None
       }
       (keywords \\ "term").flatMap { term =>
-        val label = NormaliseText(term.text)
+        val maybeLabel = NormaliseText(term.text)
         val reference = parseReference(term)
+
         val id = (reference, identifierType) match {
-          case (Some(r), Some(identifierType)) =>
-            Identifiable(SourceIdentifier(identifierType, "Subject", r))
-          case _ => Unidentifiable
+          case (Some(value), Some(identifierType)) =>
+            IdState.Identifiable(
+              sourceIdentifier = SourceIdentifier(
+                identifierType = identifierType,
+                ontologyType = "Subject",
+                value = value
+              )
+            )
+          case _ => IdState.Unidentifiable
         }
-        label.map(l =>
-          Subject(id = id, label = l, concepts = List(Concept(label = l))))
+
+        maybeLabel.map(label =>
+          Subject(
+            id = id,
+            label = label,
+            concepts = List(Concept(label))
+          )
+        )
       }
     }.toList
 

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiSubjects.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiSubjects.scala
@@ -1,16 +1,13 @@
 package weco.pipeline.transformer.tei.transformers
 
-import weco.catalogue.internal_model.identifiers.{
-  IdState,
-  IdentifierType,
-  SourceIdentifier
-}
+import weco.catalogue.internal_model.identifiers.{IdState, IdentifierType, SourceIdentifier}
 import weco.catalogue.internal_model.work.{Concept, Subject}
+import weco.pipeline.transformer.identifiers.LabelDerivedIdentifiers
 import weco.pipeline.transformer.tei.NormaliseText
 
 import scala.xml.{Elem, Node}
 
-object TeiSubjects {
+object TeiSubjects extends LabelDerivedIdentifiers {
 
   /**
     * Subjects live in the profileDesc block of the tei which looks like this:
@@ -61,7 +58,8 @@ object TeiSubjects {
             value = value
           )
         )
-      case _ => IdState.Unidentifiable
+      case _ =>
+        identifierFromText(label, ontologyType = "Subject")
     }
   }
 

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiXmlTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiXmlTest.scala
@@ -197,7 +197,9 @@ class TeiXmlTest
         id,
         profileDesc = Some(profileDesc(keywords = List(keywords(subjects = List(subject("Botany"))))))      )).parse
 
-    result.value.subjects shouldBe List(Subject(label = "Botany", concepts = List(Concept(label ="Botany"))))
+    result.value.subjects shouldBe List(Subject(
+      id = labelDerivedSubjectIdentifier("Botany"),
+      label = "Botany", concepts = List(Concept(label ="Botany"))))
   }
 
   it("adds hand notes"){

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiXmlTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiXmlTest.scala
@@ -198,7 +198,7 @@ class TeiXmlTest
         profileDesc = Some(profileDesc(keywords = List(keywords(subjects = List(subject("Botany"))))))      )).parse
 
     result.value.subjects shouldBe List(Subject(
-      id = labelDerivedSubjectIdentifier("Botany"),
+      id = labelDerivedSubjectIdentifier("botany"),
       label = "Botany", concepts = List(Concept(label ="Botany"))))
   }
 

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/transformers/TeiSubjectsTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/transformers/TeiSubjectsTest.scala
@@ -5,9 +5,10 @@ import org.scalatest.matchers.should.Matchers
 import weco.catalogue.internal_model.identifiers.IdState.Identifiable
 import weco.catalogue.internal_model.identifiers.{IdentifierType, SourceIdentifier}
 import weco.catalogue.internal_model.work.{Concept, Subject}
+import weco.pipeline.transformer.generators.LabelDerivedIdentifiersGenerators
 import weco.pipeline.transformer.tei.generators.TeiGenerators
 
-class TeiSubjectsTest extends AnyFunSpec with TeiGenerators with Matchers{
+class TeiSubjectsTest extends AnyFunSpec with TeiGenerators with Matchers with LabelDerivedIdentifiersGenerators {
   val id = "MS123"
   it("extracts a subject"){
     val result = TeiSubjects(teiXml(
@@ -15,17 +16,25 @@ class TeiSubjectsTest extends AnyFunSpec with TeiGenerators with Matchers{
       profileDesc = Some(profileDesc(keywords = List(keywords(subjects = List(subject("Botany"))))))
     ))
 
-    result shouldBe List(Subject(label = "Botany", concepts = List(Concept("Botany"))))
+    result shouldBe List(
+      Subject(
+        id = labelDerivedSubjectIdentifier("botany"),
+        label = "Botany",
+        concepts = List(Concept("Botany"))
+      )
+    )
   }
+
   it("extracts a list of subjects"){
     val result = TeiSubjects(teiXml(
       id = id,
       profileDesc = Some(profileDesc(keywords = List(keywords(subjects = List(subject("Botany"),subject("Computers"),subject("Aliens"))))))
     ))
 
-    result shouldBe List(Subject(label = "Botany", concepts = List(Concept("Botany"))),
-      Subject(label = "Computers", concepts = List(Concept("Computers"))),
-      Subject(label = "Aliens", concepts = List(Concept("Aliens"))))
+    result shouldBe List(
+      Subject(id = labelDerivedSubjectIdentifier("botany"),label = "Botany", concepts = List(Concept("Botany"))),
+      Subject(id = labelDerivedSubjectIdentifier("computers"),label = "Computers", concepts = List(Concept("Computers"))),
+      Subject(id = labelDerivedSubjectIdentifier("aliens"),label = "Aliens", concepts = List(Concept("Aliens"))))
   }
   it("doesn't extract subjects with an empty label"){
     val result = TeiSubjects(teiXml(
@@ -45,7 +54,9 @@ class TeiSubjectsTest extends AnyFunSpec with TeiGenerators with Matchers{
           |   cars  """.stripMargin))))))
     ))
 
-    result shouldBe List(Subject(label = "Very fast cars", concepts = List(Concept("Very fast cars"))))
+    result shouldBe List(Subject(
+      id = labelDerivedSubjectIdentifier("very fast cars"),
+      label = "Very fast cars", concepts = List(Concept("Very fast cars"))))
   }
 
   it("extracts a subject with an lcsh id"){
@@ -100,7 +111,7 @@ class TeiSubjectsTest extends AnyFunSpec with TeiGenerators with Matchers{
       profileDesc = Some(profileDesc(keywords = List(keywords(keywordsScheme = Some("#somethingsomething"), subjects = List(subject("Botany", reference = Some("subject_D001901")))))))
     ))
 
-    result shouldBe List(Subject(label = "Botany", concepts = List(Concept(label ="Botany"))))
+    result shouldBe List(Subject(id = labelDerivedSubjectIdentifier("botany"),label = "Botany", concepts = List(Concept(label ="Botany"))))
   }
 
   it("extracts a subject with authority no reference"){
@@ -109,7 +120,7 @@ class TeiSubjectsTest extends AnyFunSpec with TeiGenerators with Matchers{
       profileDesc = Some(profileDesc(keywords = List(keywords(keywordsScheme = Some("#MeSH"), subjects = List(subject("Botany"))))))
     ))
 
-    result shouldBe List(Subject(label = "Botany", concepts = List(Concept(label ="Botany"))))
+    result shouldBe List(Subject(id = labelDerivedSubjectIdentifier("botany"),label = "Botany", concepts = List(Concept(label ="Botany"))))
   }
   it("extracts subjects from 2 lists with different authorities"){
     val result = TeiSubjects(teiXml(
@@ -117,8 +128,8 @@ class TeiSubjectsTest extends AnyFunSpec with TeiGenerators with Matchers{
       profileDesc = Some(profileDesc(keywords = List(keywords(subjects = List(subject("Botany"),subject("Computers"),subject("Aliens"))))))
     ))
 
-    result shouldBe List(Subject(label = "Botany", concepts = List(Concept("Botany"))),
-      Subject(label = "Computers", concepts = List(Concept("Computers"))),
-      Subject(label = "Aliens", concepts = List(Concept("Aliens"))))
+    result shouldBe List(Subject(id = labelDerivedSubjectIdentifier("botany"),label = "Botany", concepts = List(Concept("Botany"))),
+      Subject(id = labelDerivedSubjectIdentifier("computers"),label = "Computers", concepts = List(Concept("Computers"))),
+      Subject(id = labelDerivedSubjectIdentifier("aliens"),label = "Aliens", concepts = List(Concept("Aliens"))))
   }
 }


### PR DESCRIPTION
For https://github.com/wellcomecollection/catalogue-pipeline/issues/2210

* CALM: We don't create subjects
* METS: We don't create subjects
* Miro: added in this PR
* TEI: added in this PR