### PR TITLE
Get duration in seconds, not milliseconds

### DIFF
--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraDuration.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraDuration.scala
@@ -9,7 +9,7 @@ object SierraDuration extends SierraDataTransformer with SierraQueryOps {
 
   type Output = Option[Int]
 
-  def apply(bibData: SierraBibData) =
+  def apply(bibData: SierraBibData): Option[Int] =
     bibData
       .subfieldsWithTag("306" -> "a")
       .firstContent
@@ -21,6 +21,6 @@ object SierraDuration extends SierraDataTransformer with SierraQueryOps {
       }
       .collect {
         case Seq(Some(hours), Some(minutes), Some(seconds)) =>
-          (hours.hours + minutes.minutes + seconds.seconds).toMillis.toInt
+          (hours.hours + minutes.minutes + seconds.seconds).toSeconds.toInt
       }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraDurationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraDurationTest.scala
@@ -10,17 +10,21 @@ class SierraDurationTest
     with Matchers
     with SierraDataGenerators {
 
-  it("should extract duration in milliseconds from 306") {
+  val hours = 60 * 60
+  val minutes = 60
+  val seconds = 1
+
+  it("extracts duration in seconds from 306") {
     val varFields = List(
       VarField(
         marcTag = "306",
         subfields = List(Subfield(tag = "a", content = "011012")))
     )
 
-    getDuration(varFields) shouldBe Some(4212000)
+    getDuration(varFields) shouldBe Some(1 * hours + 10 * minutes + 12 * seconds)
   }
 
-  it("should use first duration when multiple defined") {
+  it("uses the first duration when multiple defined") {
     val varFields = List(
       VarField(
         marcTag = "306",
@@ -30,20 +34,20 @@ class SierraDurationTest
         subfields = List(Subfield(tag = "a", content = "001132")))
     )
 
-    getDuration(varFields) shouldBe Some(600000)
+    getDuration(varFields) shouldBe Some(10 * minutes)
   }
 
-  it("should not extract duration when varfield badly formatted") {
+  it("does not extract duration when varfield badly formatted") {
     val varFields = List(
       VarField(
-        marcTag = "500",
+        marcTag = "306",
         subfields = List(Subfield(tag = "a", content = "01xx1012")))
     )
 
     getDuration(varFields) shouldBe None
   }
 
-  it("should not extract duration when incorrect varfield") {
+  it("does not extract duration when incorrect varfield") {
     val varFields = List(
       VarField(
         marcTag = "500",
@@ -53,7 +57,7 @@ class SierraDurationTest
     getDuration(varFields) shouldBe None
   }
 
-  it("should not extract duration when incorrect subfield") {
+  it("does not extract duration when incorrect subfield") {
     val varFields = List(
       VarField(
         marcTag = "306",

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraDurationTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraDurationTest.scala
@@ -21,7 +21,8 @@ class SierraDurationTest
         subfields = List(Subfield(tag = "a", content = "011012")))
     )
 
-    getDuration(varFields) shouldBe Some(1 * hours + 10 * minutes + 12 * seconds)
+    getDuration(varFields) shouldBe Some(
+      1 * hours + 10 * minutes + 12 * seconds)
   }
 
   it("uses the first duration when multiple defined") {


### PR DESCRIPTION
If you look at the [public API documentation](https://developers.wellcomecollection.org/api/catalogue#operation/getWork), it tells us duration is measured in seconds:

> The playing time for audiovisual works, in seconds.

This is causing issues in the front-end -- we're getting the string `002826` from Sierra, parsing as `28 min 26 sec` and returning 1706000ms.

The front-end treats this as seconds, which becomes ~473 hours.

Spotted by Nic Cook in Slack: https://wellcome.slack.com/archives/C8X9YKM5X/p1664545645244429