### PR TITLE
Move Image queryable fields into the `query` object

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/image/Image.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/image/Image.scala
@@ -75,15 +75,15 @@ object ImageState {
   case class Augmented(
     sourceIdentifier: SourceIdentifier,
     canonicalId: CanonicalId,
-    inferredData: Option[InferredData] = None
+    inferredData: InferredData
   ) extends ImageState {
-    type TransitionArgs = Option[InferredData]
+    type TransitionArgs = InferredData
   }
 
   case class Indexed(
     sourceIdentifier: SourceIdentifier,
     canonicalId: CanonicalId,
-    inferredData: Option[InferredData] = None
+    inferredData: InferredData
   ) extends ImageState {
     type TransitionArgs = Unit
   }
@@ -100,7 +100,7 @@ object ImageFsm {
   implicit val initialToAugmented = new Transition[Initial, Augmented] {
     def state(
       self: Image[Initial],
-      inferredData: Option[InferredData]
+      inferredData: InferredData
     ): Augmented =
       Augmented(
         sourceIdentifier = self.state.sourceIdentifier,

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/ImagesIndexConfig.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/ImagesIndexConfig.scala
@@ -4,6 +4,7 @@ import buildinfo.BuildInfo
 import com.sksamuel.elastic4s.ElasticDsl.{keywordField, _}
 import com.sksamuel.elastic4s.fields.{DenseVectorField, ObjectField}
 import com.sksamuel.elastic4s.requests.mappings.dynamictemplate.DynamicMapping
+import weco.catalogue.internal_model.index.WorksAnalysis.{asciifoldingAnalyzer, cleanPathAnalyzer, exactPathAnalyzer}
 import weco.elasticsearch.IndexConfig
 
 object ImagesIndexConfig extends IndexConfigFields {
@@ -78,10 +79,74 @@ object ImagesIndexConfig extends IndexConfigFields {
       val display = objectField("display").withEnabled(false)
 
       // This field contains the values we're actually going to query in search.
+      val sourceWork = objectField("source")
+        .fields(
+          // top-level work
+          canonicalIdField("id"),
+          keywordField("type"),
+          keywordField("format.id"),
+          keywordField("workType"),
+          multilingualFieldWithKeyword("title"),
+          multilingualFieldWithKeyword("alternativeTitles"),
+          englishTextField("description"),
+          englishTextKeywordField("physicalDescription"),
+          textField("edition"),
+          englishTextField("notes.contents"),
+          multilingualField("lettering"),
+          // identifiers
+          sourceIdentifierField("identifiers.value"),
+          // images
+          canonicalIdField("images.id"),
+          sourceIdentifierField("images.identifiers.value"),
+          // items
+          canonicalIdField("items.id"),
+          sourceIdentifierField("items.identifiers.value"),
+          keywordField("items.locations.accessConditions.status.id"),
+          keywordField("items.locations.license.id"),
+          keywordField("items.locations.locationType.id"),
+          // subjects
+          canonicalIdField("subjects.id"),
+          labelField("subjects.label"),
+          labelField("subjects.concepts.label"),
+          // genres
+          labelField("genres.label"),
+          labelField("genres.concepts.label"),
+          // languages
+          keywordField("languages.id"),
+          labelField("languages.label"),
+          // contributors
+          canonicalIdField("contributors.agent.id"),
+          labelField("contributors.agent.label"),
+          // production events
+          labelField("production.label"),
+          dateField("production.dates.range.from"),
+          // relations
+          canonicalIdField("partOf.id"),
+          multilingualFieldWithKeyword("partOf.title"),
+          // availabilities
+          keywordField("availabilities.id"),
+          // collection path
+          textField("collectionPath.path")
+            .analyzer(exactPathAnalyzer.name)
+            .fields(
+              keywordField("keyword"),
+              textField("clean").analyzer(cleanPathAnalyzer.name)
+            ),
+          textField("collectionPath.label")
+            .analyzer(asciifoldingAnalyzer.name)
+            .fields(
+              keywordField("keyword"),
+              lowercaseKeyword("lowercaseKeyword"),
+              textField("cleanPath").analyzer(cleanPathAnalyzer.name),
+              textField("path").analyzer(exactPathAnalyzer.name)
+            ),
+          // reference number
+          keywordField("referenceNumber"),
+        )
+
       val query = objectField("query")
         .fields(
-          keywordField("source.genres.label"),
-          keywordField("source.subjects.label")
+          sourceWork
         )
 
       // This field contains the display documents used by aggregations.

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/ImagesIndexConfig.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/ImagesIndexConfig.scala
@@ -4,7 +4,11 @@ import buildinfo.BuildInfo
 import com.sksamuel.elastic4s.ElasticDsl.{keywordField, _}
 import com.sksamuel.elastic4s.fields.{DenseVectorField, ObjectField}
 import com.sksamuel.elastic4s.requests.mappings.dynamictemplate.DynamicMapping
-import weco.catalogue.internal_model.index.WorksAnalysis.{asciifoldingAnalyzer, cleanPathAnalyzer, exactPathAnalyzer}
+import weco.catalogue.internal_model.index.WorksAnalysis.{
+  asciifoldingAnalyzer,
+  cleanPathAnalyzer,
+  exactPathAnalyzer
+}
 import weco.elasticsearch.IndexConfig
 
 object ImagesIndexConfig extends IndexConfigFields {
@@ -146,6 +150,7 @@ object ImagesIndexConfig extends IndexConfigFields {
 
       val query = objectField("query")
         .fields(
+          inferredData,
           sourceWork
         )
 

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/IndexConfigFields.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/IndexConfigFields.scala
@@ -1,12 +1,7 @@
 package weco.catalogue.internal_model.index
 
 import com.sksamuel.elastic4s.ElasticDsl._
-import com.sksamuel.elastic4s.fields.{
-  IntegerField,
-  KeywordField,
-  ObjectField,
-  TextField
-}
+import com.sksamuel.elastic4s.fields.{IntegerField, KeywordField, ObjectField, TextField}
 import weco.catalogue.internal_model.index.WorksAnalysis._
 import weco.elasticsearch.ElasticFieldOps
 
@@ -82,4 +77,10 @@ trait IndexConfigFields extends ElasticFieldOps {
     objectField("sourceIdentifier")
       .fields(lowercaseKeyword("value"))
       .withDynamic("false")
+
+  def canonicalIdField(name: String): KeywordField =
+    lowercaseKeyword(name)
+
+  def sourceIdentifierField(name: String): KeywordField =
+    lowercaseKeyword(name)
 }

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/IndexConfigFields.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/IndexConfigFields.scala
@@ -1,7 +1,12 @@
 package weco.catalogue.internal_model.index
 
 import com.sksamuel.elastic4s.ElasticDsl._
-import com.sksamuel.elastic4s.fields.{IntegerField, KeywordField, ObjectField, TextField}
+import com.sksamuel.elastic4s.fields.{
+  IntegerField,
+  KeywordField,
+  ObjectField,
+  TextField
+}
 import weco.catalogue.internal_model.index.WorksAnalysis._
 import weco.elasticsearch.ElasticFieldOps
 

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksIndexConfig.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksIndexConfig.scala
@@ -4,7 +4,6 @@ import buildinfo.BuildInfo
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.fields.{
   ElasticField,
-  KeywordField,
   ObjectField,
   TokenCountField
 }
@@ -330,9 +329,4 @@ object WorksIndexConfig extends IndexConfigFields {
     DynamicMapping.Strict,
     RefreshInterval.On(30.seconds)
   )
-
-  private def canonicalIdField(name: String): KeywordField =
-    lowercaseKeyword(name)
-  private def sourceIdentifierField(name: String): KeywordField =
-    lowercaseKeyword(name)
 }

--- a/common/internal_model/src/test/resources/ImagesIndexConfig.json
+++ b/common/internal_model/src/test/resources/ImagesIndexConfig.json
@@ -68,17 +68,487 @@
         "properties": {
           "source": {
             "properties": {
-              "genres": {
+              "alternativeTitles": {
+                "type": "text",
+                "fields": {
+                  "arabic": {
+                    "type": "text",
+                    "analyzer": "arabic_analyzer"
+                  },
+                  "bengali": {
+                    "type": "text",
+                    "analyzer": "bengali_analyzer"
+                  },
+                  "english": {
+                    "type": "text",
+                    "analyzer": "english_analyzer"
+                  },
+                  "french": {
+                    "type": "text",
+                    "analyzer": "french_analyzer"
+                  },
+                  "german": {
+                    "type": "text",
+                    "analyzer": "german_analyzer"
+                  },
+                  "hindi": {
+                    "type": "text",
+                    "analyzer": "hindi_analyzer"
+                  },
+                  "italian": {
+                    "type": "text",
+                    "analyzer": "italian_analyzer"
+                  },
+                  "keyword": {
+                    "type": "keyword",
+                    "normalizer": "lowercase_normalizer"
+                  },
+                  "shingles": {
+                    "type": "text",
+                    "analyzer": "shingle_asciifolding_analyzer"
+                  }
+                }
+              },
+              "availabilities": {
                 "properties": {
-                  "label": {
+                  "id": {
                     "type": "keyword"
                   }
                 }
               },
-              "subjects": {
+              "collectionPath": {
                 "properties": {
                   "label": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword"
+                      },
+                      "lowercaseKeyword": {
+                        "type": "keyword",
+                        "normalizer": "lowercase_normalizer"
+                      },
+                      "cleanPath": {
+                        "type": "text",
+                        "analyzer": "clean_path_analyzer"
+                      },
+                      "path": {
+                        "type": "text",
+                        "analyzer": "exact_path_analyzer"
+                      }
+                    },
+                    "analyzer": "asciifolding_analyzer"
+                  },
+                  "path": {
+                    "type": "text",
+                    "fields": {
+                      "clean": {
+                        "type": "text",
+                        "analyzer": "clean_path_analyzer"
+                      },
+                      "keyword": {
+                        "type": "keyword"
+                      }
+                    },
+                    "analyzer": "exact_path_analyzer"
+                  }
+                }
+              },
+              "contributors": {
+                "properties": {
+                  "agent": {
+                    "properties": {
+                      "label": {
+                        "type": "text",
+                        "fields": {
+                          "keyword": {
+                            "type": "keyword"
+                          },
+                          "lowercaseKeyword": {
+                            "type": "keyword",
+                            "normalizer": "lowercase_normalizer"
+                          }
+                        },
+                        "analyzer": "asciifolding_analyzer"
+                      },
+                      "id": {
+                        "type": "keyword",
+                        "normalizer": "lowercase_normalizer"
+                      }
+                    }
+                  }
+                }
+              },
+              "description": {
+                "type": "text",
+                "fields": {
+                  "english": {
+                    "type": "text",
+                    "analyzer": "english_analyzer"
+                  }
+                }
+              },
+              "edition": {
+                "type": "text"
+              },
+              "genres": {
+                "properties": {
+                  "concepts": {
+                    "properties": {
+                      "label": {
+                        "type": "text",
+                        "fields": {
+                          "keyword": {
+                            "type": "keyword"
+                          },
+                          "lowercaseKeyword": {
+                            "type": "keyword",
+                            "normalizer": "lowercase_normalizer"
+                          }
+                        },
+                        "analyzer": "asciifolding_analyzer"
+                      }
+                    }
+                  },
+                  "label": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword"
+                      },
+                      "lowercaseKeyword": {
+                        "type": "keyword",
+                        "normalizer": "lowercase_normalizer"
+                      }
+                    },
+                    "analyzer": "asciifolding_analyzer"
+                  }
+                }
+              },
+              "id": {
+                "type": "keyword",
+                "normalizer": "lowercase_normalizer"
+              },
+              "type": {
+                "type": "keyword"
+              },
+              "format": {
+                "properties": {
+                  "id": {
                     "type": "keyword"
+                  }
+                }
+              },
+              "workType": {
+                "type": "keyword"
+              },
+              "identifiers": {
+                "properties": {
+                  "value": {
+                    "type": "keyword",
+                    "normalizer": "lowercase_normalizer"
+                  }
+                }
+              },
+              "images": {
+                "properties": {
+                  "id": {
+                    "type": "keyword",
+                    "normalizer": "lowercase_normalizer"
+                  },
+                  "identifiers": {
+                    "properties": {
+                      "value": {
+                        "type": "keyword",
+                        "normalizer": "lowercase_normalizer"
+                      }
+                    }
+                  }
+                }
+              },
+              "items": {
+                "properties": {
+                  "id": {
+                    "type": "keyword",
+                    "normalizer": "lowercase_normalizer"
+                  },
+                  "identifiers": {
+                    "properties": {
+                      "value": {
+                        "type": "keyword",
+                        "normalizer": "lowercase_normalizer"
+                      }
+                    }
+                  },
+                  "locations": {
+                    "properties": {
+                      "accessConditions": {
+                        "properties": {
+                          "status": {
+                            "properties": {
+                              "id": {
+                                "type": "keyword"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "license": {
+                        "properties": {
+                          "id": {
+                            "type": "keyword"
+                          }
+                        }
+                      },
+                      "locationType": {
+                        "properties": {
+                          "id": {
+                            "type": "keyword"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "languages": {
+                "properties": {
+                  "id": {
+                    "type": "keyword"
+                  },
+                  "label": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword"
+                      },
+                      "lowercaseKeyword": {
+                        "type": "keyword",
+                        "normalizer": "lowercase_normalizer"
+                      }
+                    },
+                    "analyzer": "asciifolding_analyzer"
+                  }
+                }
+              },
+              "lettering": {
+                "type": "text",
+                "fields": {
+                  "arabic": {
+                    "type": "text",
+                    "analyzer": "arabic_analyzer"
+                  },
+                  "bengali": {
+                    "type": "text",
+                    "analyzer": "bengali_analyzer"
+                  },
+                  "english": {
+                    "type": "text",
+                    "analyzer": "english_analyzer"
+                  },
+                  "french": {
+                    "type": "text",
+                    "analyzer": "french_analyzer"
+                  },
+                  "german": {
+                    "type": "text",
+                    "analyzer": "german_analyzer"
+                  },
+                  "hindi": {
+                    "type": "text",
+                    "analyzer": "hindi_analyzer"
+                  },
+                  "italian": {
+                    "type": "text",
+                    "analyzer": "italian_analyzer"
+                  },
+                  "shingles": {
+                    "type": "text",
+                    "analyzer": "shingle_asciifolding_analyzer"
+                  }
+                }
+              },
+              "notes": {
+                "properties": {
+                  "contents": {
+                    "type": "text",
+                    "fields": {
+                      "english": {
+                        "type": "text",
+                        "analyzer": "english_analyzer"
+                      }
+                    }
+                  }
+                }
+              },
+              "partOf": {
+                "properties": {
+                  "id": {
+                    "type": "keyword",
+                    "normalizer": "lowercase_normalizer"
+                  },
+                  "title": {
+                    "type": "text",
+                    "fields": {
+                      "arabic": {
+                        "type": "text",
+                        "analyzer": "arabic_analyzer"
+                      },
+                      "bengali": {
+                        "type": "text",
+                        "analyzer": "bengali_analyzer"
+                      },
+                      "english": {
+                        "type": "text",
+                        "analyzer": "english_analyzer"
+                      },
+                      "french": {
+                        "type": "text",
+                        "analyzer": "french_analyzer"
+                      },
+                      "german": {
+                        "type": "text",
+                        "analyzer": "german_analyzer"
+                      },
+                      "hindi": {
+                        "type": "text",
+                        "analyzer": "hindi_analyzer"
+                      },
+                      "italian": {
+                        "type": "text",
+                        "analyzer": "italian_analyzer"
+                      },
+                      "keyword": {
+                        "type": "keyword",
+                        "normalizer": "lowercase_normalizer"
+                      },
+                      "shingles": {
+                        "type": "text",
+                        "analyzer": "shingle_asciifolding_analyzer"
+                      }
+                    }
+                  }
+                }
+              },
+              "physicalDescription": {
+                "type": "text",
+                "fields": {
+                  "english": {
+                    "type": "text",
+                    "analyzer": "english_analyzer"
+                  },
+                  "keyword": {
+                    "type": "keyword"
+                  }
+                }
+              },
+              "production": {
+                "properties": {
+                  "label": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword"
+                      },
+                      "lowercaseKeyword": {
+                        "type": "keyword",
+                        "normalizer": "lowercase_normalizer"
+                      }
+                    },
+                    "analyzer": "asciifolding_analyzer"
+                  },
+                  "dates": {
+                    "properties": {
+                      "range": {
+                        "properties": {
+                          "from": {
+                            "type": "date"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "referenceNumber": {
+                "type": "keyword"
+              },
+              "subjects": {
+                "properties": {
+                  "concepts": {
+                    "properties": {
+                      "label": {
+                        "type": "text",
+                        "fields": {
+                          "keyword": {
+                            "type": "keyword"
+                          },
+                          "lowercaseKeyword": {
+                            "type": "keyword",
+                            "normalizer": "lowercase_normalizer"
+                          }
+                        },
+                        "analyzer": "asciifolding_analyzer"
+                      }
+                    }
+                  },
+                  "label": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword"
+                      },
+                      "lowercaseKeyword": {
+                        "type": "keyword",
+                        "normalizer": "lowercase_normalizer"
+                      }
+                    },
+                    "analyzer": "asciifolding_analyzer"
+                  },
+                  "id": {
+                    "type": "keyword",
+                    "normalizer": "lowercase_normalizer"
+                  }
+                }
+              },
+              "title": {
+                "type": "text",
+                "fields": {
+                  "arabic": {
+                    "type": "text",
+                    "analyzer": "arabic_analyzer"
+                  },
+                  "bengali": {
+                    "type": "text",
+                    "analyzer": "bengali_analyzer"
+                  },
+                  "english": {
+                    "type": "text",
+                    "analyzer": "english_analyzer"
+                  },
+                  "french": {
+                    "type": "text",
+                    "analyzer": "french_analyzer"
+                  },
+                  "german": {
+                    "type": "text",
+                    "analyzer": "german_analyzer"
+                  },
+                  "hindi": {
+                    "type": "text",
+                    "analyzer": "hindi_analyzer"
+                  },
+                  "italian": {
+                    "type": "text",
+                    "analyzer": "italian_analyzer"
+                  },
+                  "keyword": {
+                    "type": "keyword",
+                    "normalizer": "lowercase_normalizer"
+                  },
+                  "shingles": {
+                    "type": "text",
+                    "analyzer": "shingle_asciifolding_analyzer"
                   }
                 }
               }

--- a/common/internal_model/src/test/resources/ImagesIndexConfig.json
+++ b/common/internal_model/src/test/resources/ImagesIndexConfig.json
@@ -66,6 +66,38 @@
       },
       "query": {
         "properties": {
+          "inferredData": {
+            "properties": {
+              "aspectRatio": {
+                "type": "float"
+              },
+              "binMinima": {
+                "type": "float",
+                "index": false
+              },
+              "binSizes": {
+                "type": "integer",
+                "index": false
+              },
+              "features1": {
+                "type": "dense_vector",
+                "dims": 2048
+              },
+              "features2": {
+                "type": "dense_vector",
+                "dims": 2048
+              },
+              "lshEncodedFeatures": {
+                "type": "keyword"
+              },
+              "palette": {
+                "type": "keyword"
+              },
+              "averageColorHex": {
+                "type": "keyword"
+              }
+            }
+          },
           "source": {
             "properties": {
               "alternativeTitles": {

--- a/pipeline/inferrer/inference_manager/src/main/scala/weco/pipeline/inference_manager/services/InferenceManagerWorkerService.scala
+++ b/pipeline/inferrer/inference_manager/src/main/scala/weco/pipeline/inference_manager/services/InferenceManagerWorkerService.scala
@@ -157,7 +157,7 @@ class InferenceManagerWorkerService[Destination](
                   AdapterResponseBundle(DownloadedImage(image, _), _, _),
                   ctx) =>
                 (
-                  image.transition[ImageState.Augmented](Some(inferredData)),
+                  image.transition[ImageState.Augmented](inferredData),
                   ctx)
             }
           }

--- a/pipeline/inferrer/inference_manager/src/main/scala/weco/pipeline/inference_manager/services/InferenceManagerWorkerService.scala
+++ b/pipeline/inferrer/inference_manager/src/main/scala/weco/pipeline/inference_manager/services/InferenceManagerWorkerService.scala
@@ -156,9 +156,7 @@ class InferenceManagerWorkerService[Destination](
               case (
                   AdapterResponseBundle(DownloadedImage(image, _), _, _),
                   ctx) =>
-                (
-                  image.transition[ImageState.Augmented](inferredData),
-                  ctx)
+                (image.transition[ImageState.Augmented](inferredData), ctx)
             }
           }
           .mergeSubstreamsWithParallelism(

--- a/pipeline/ingestor/ingestor_common/src/main/scala/weco/pipeline/ingestor/common/models/WorkQueryableValues.scala
+++ b/pipeline/ingestor/ingestor_common/src/main/scala/weco/pipeline/ingestor/common/models/WorkQueryableValues.scala
@@ -1,4 +1,4 @@
-package weco.pipeline.ingestor.works.models
+package weco.pipeline.ingestor.common.models
 
 import io.circe.generic.extras.JsonKey
 import weco.catalogue.internal_model.identifiers.{

--- a/pipeline/ingestor/ingestor_common/src/test/scala/weco/pipeline/ingestor/models/WorkQueryableValuesTest.scala
+++ b/pipeline/ingestor/ingestor_common/src/test/scala/weco/pipeline/ingestor/models/WorkQueryableValuesTest.scala
@@ -1,17 +1,11 @@
-package weco.pipeline.ingestor.works.models
+package weco.pipeline.ingestor.models
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.catalogue.internal_model.generators.ImageGenerators
 import weco.catalogue.internal_model.identifiers._
 import weco.catalogue.internal_model.languages.Language
-import weco.catalogue.internal_model.locations.{
-  AccessCondition,
-  AccessMethod,
-  AccessStatus,
-  License,
-  LocationType
-}
+import weco.catalogue.internal_model.locations._
 import weco.catalogue.internal_model.work._
 import weco.catalogue.internal_model.work.generators.{
   ContributorGenerators,
@@ -19,7 +13,7 @@ import weco.catalogue.internal_model.work.generators.{
   WorkGenerators
 }
 
-import java.time.{LocalDate}
+import java.time.LocalDate
 
 class WorkQueryableValuesTest
     extends AnyFunSpec

--- a/pipeline/ingestor/ingestor_images/src/main/scala/weco/pipeline/ingestor/images/ImageTransformer.scala
+++ b/pipeline/ingestor/ingestor_images/src/main/scala/weco/pipeline/ingestor/images/ImageTransformer.scala
@@ -23,7 +23,10 @@ object ImageTransformer {
         source = indexedImage.source,
         modifiedTime = indexedImage.modifiedTime,
         display = DisplayImage(indexedImage).asJson.deepDropNullValues,
-        query = ImageQueryableValues(indexedImage.source),
+        query = ImageQueryableValues(
+          inferredData = indexedImage.state.inferredData,
+          source = indexedImage.source
+        ),
         aggregatableValues = ImageAggregatableValues(indexedImage.source)
       )
     }

--- a/pipeline/ingestor/ingestor_images/src/main/scala/weco/pipeline/ingestor/images/models/ImageQueryableValues.scala
+++ b/pipeline/ingestor/ingestor_images/src/main/scala/weco/pipeline/ingestor/images/models/ImageQueryableValues.scala
@@ -15,7 +15,8 @@ case class ImageQueryableValues(
 )
 
 case object ImageQueryableValues {
-  def apply(inferredData: InferredData, source: ImageSource): ImageQueryableValues =
+  def apply(inferredData: InferredData,
+            source: ImageSource): ImageQueryableValues =
     source match {
       case ParentWork(id, workData, _) =>
         ImageQueryableValues(

--- a/pipeline/ingestor/ingestor_images/src/main/scala/weco/pipeline/ingestor/images/models/ImageQueryableValues.scala
+++ b/pipeline/ingestor/ingestor_images/src/main/scala/weco/pipeline/ingestor/images/models/ImageQueryableValues.scala
@@ -1,19 +1,25 @@
 package weco.pipeline.ingestor.images.models
 
 import io.circe.generic.extras.JsonKey
-import weco.catalogue.internal_model.image.{ImageSource, ParentWork}
+import weco.catalogue.internal_model.image.{
+  ImageSource,
+  InferredData,
+  ParentWork
+}
 import weco.catalogue.internal_model.work.Relations
 import weco.pipeline.ingestor.common.models.WorkQueryableValues
 
 case class ImageQueryableValues(
+  @JsonKey("inferredData") inferredData: InferredData,
   @JsonKey("source") source: WorkQueryableValues,
 )
 
 case object ImageQueryableValues {
-  def apply(source: ImageSource): ImageQueryableValues =
+  def apply(inferredData: InferredData, source: ImageSource): ImageQueryableValues =
     source match {
       case ParentWork(id, workData, _) =>
         ImageQueryableValues(
+          inferredData = inferredData,
           source = WorkQueryableValues(
             id = id.canonicalId,
             sourceIdentifier = id.sourceIdentifier,

--- a/pipeline/ingestor/ingestor_images/src/main/scala/weco/pipeline/ingestor/images/models/ImageQueryableValues.scala
+++ b/pipeline/ingestor/ingestor_images/src/main/scala/weco/pipeline/ingestor/images/models/ImageQueryableValues.scala
@@ -1,26 +1,26 @@
 package weco.pipeline.ingestor.images.models
 
 import io.circe.generic.extras.JsonKey
-import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.image.{ImageSource, ParentWork}
-import weco.catalogue.internal_model.work.{Genre, Subject}
+import weco.catalogue.internal_model.work.Relations
+import weco.pipeline.ingestor.common.models.WorkQueryableValues
 
 case class ImageQueryableValues(
-  @JsonKey("source.subjects.label") sourceSubjectLabels: Seq[String],
-  @JsonKey("source.genres.label") sourceGenreLabels: Seq[String],
+  @JsonKey("source") source: WorkQueryableValues,
 )
 
 case object ImageQueryableValues {
   def apply(source: ImageSource): ImageQueryableValues =
     source match {
-      case ParentWork(_, workData, _) =>
-        create(workData.subjects, workData.genres)
+      case ParentWork(id, workData, _) =>
+        ImageQueryableValues(
+          source = WorkQueryableValues(
+            id = id.canonicalId,
+            sourceIdentifier = id.sourceIdentifier,
+            workData = workData,
+            relations = Relations.none,
+            availabilities = Set()
+          )
+        )
     }
-
-  private def create(subjects: Seq[Subject[IdState.Minted]],
-                     genres: Seq[Genre[IdState.Minted]]): ImageQueryableValues =
-    ImageQueryableValues(
-      sourceSubjectLabels = subjects.map(_.label),
-      sourceGenreLabels = genres.map(_.label)
-    )
 }

--- a/pipeline/ingestor/ingestor_images/src/test/scala/weco/pipeline/ingestor/images/models/ImageQueryableValuesTest.scala
+++ b/pipeline/ingestor/ingestor_images/src/test/scala/weco/pipeline/ingestor/images/models/ImageQueryableValuesTest.scala
@@ -7,7 +7,7 @@ import weco.catalogue.internal_model.identifiers.{
   DataState,
   IdState
 }
-import weco.catalogue.internal_model.image.ParentWork
+import weco.catalogue.internal_model.image.{InferredData, ParentWork}
 import weco.catalogue.internal_model.work.generators.WorkGenerators
 import weco.catalogue.internal_model.work.{Concept, Genre, Subject, WorkData}
 
@@ -55,9 +55,12 @@ class ImageQueryableValuesTest
       version = 1
     )
 
-    val q = ImageQueryableValues(source = canonicalWork)
+    val q = ImageQueryableValues(
+      inferredData = InferredData.empty,
+      source = canonicalWork
+    )
 
-    q.sourceSubjectLabels shouldBe List(
+    q.source.subjectLabels shouldBe List(
       "Sharp scissors",
       "Split sandwiches",
       "Soft spinners",
@@ -83,9 +86,12 @@ class ImageQueryableValuesTest
       version = 1
     )
 
-    val q = ImageQueryableValues(source = canonicalWork)
+    val q = ImageQueryableValues(
+      inferredData = InferredData.empty,
+      source = canonicalWork
+    )
 
-    q.sourceGenreLabels shouldBe List(
+    q.source.genreLabels shouldBe List(
       "Green goblins",
       "Grand grinches",
     )

--- a/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/WorkTransformer.scala
+++ b/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/WorkTransformer.scala
@@ -8,8 +8,7 @@ import weco.pipeline.ingestor.works.models.{
   DebugInformation,
   IndexedWork,
   SourceWorkDebugInformation,
-  WorkAggregatableValues,
-  WorkQueryableValues
+  WorkAggregatableValues
 }
 import weco.catalogue.display_model.Implicits._
 

--- a/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/IndexedWork.scala
+++ b/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/IndexedWork.scala
@@ -3,6 +3,7 @@ package weco.pipeline.ingestor.works.models
 import io.circe.Json
 import weco.catalogue.internal_model.identifiers.{DataState, IdState}
 import weco.catalogue.internal_model.work.{WorkData, WorkState}
+import weco.pipeline.ingestor.common.models.WorkQueryableValues
 import weco.pipeline_storage.Indexable
 
 sealed trait IndexedWork {

--- a/pipeline/ingestor/ingestor_works/src/test/scala/weco/pipeline/ingestor/works/fixtures/WorksIngestorFixtures.scala
+++ b/pipeline/ingestor/ingestor_works/src/test/scala/weco/pipeline/ingestor/works/fixtures/WorksIngestorFixtures.scala
@@ -16,8 +16,7 @@ import weco.pipeline.ingestor.fixtures.IngestorFixtures
 import weco.pipeline.ingestor.works.WorkTransformer
 import weco.pipeline.ingestor.works.models.{
   IndexedWork,
-  WorkAggregatableValues,
-  WorkQueryableValues
+  WorkAggregatableValues
 }
 import weco.pipeline_storage.elastic.{ElasticIndexer, ElasticSourceRetriever}
 import weco.json.JsonUtil._

--- a/pipeline/ingestor/ingestor_works/src/test/scala/weco/pipeline/ingestor/works/fixtures/WorksIngestorFixtures.scala
+++ b/pipeline/ingestor/ingestor_works/src/test/scala/weco/pipeline/ingestor/works/fixtures/WorksIngestorFixtures.scala
@@ -14,10 +14,7 @@ import weco.fixtures.{TestWith, TimeAssertions}
 import weco.messaging.fixtures.SQS.Queue
 import weco.pipeline.ingestor.fixtures.IngestorFixtures
 import weco.pipeline.ingestor.works.WorkTransformer
-import weco.pipeline.ingestor.works.models.{
-  IndexedWork,
-  WorkAggregatableValues
-}
+import weco.pipeline.ingestor.works.models.{IndexedWork, WorkAggregatableValues}
 import weco.pipeline_storage.elastic.{ElasticIndexer, ElasticSourceRetriever}
 import weco.json.JsonUtil._
 

--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -32,33 +32,6 @@ module "catalogue_pipeline_2022-08-24" {
   }
 }
 
-module "catalogue_pipeline_2022-09-22" {
-  source = "./stack"
-
-  pipeline_date = "2022-09-22"
-  release_label = "2022-09-22"
-
-  reindexing_state = {
-    listen_to_reindexer      = false
-    scale_up_tasks           = false
-    scale_up_elastic_cluster = false
-    scale_up_id_minter_db    = false
-    scale_up_matcher_db      = false
-  }
-
-  # Boilerplate that shouldn't change between pipelines.
-
-  adapter_config    = local.adapter_config
-  inferrer_config   = local.inferrer_config
-  monitoring_config = local.monitoring_config
-  network_config    = local.network_config
-  rds_config        = local.rds_config
-
-  providers = {
-    aws.catalogue = aws.catalogue
-  }
-}
-
 module "catalogue_pipeline_2022-09-23" {
   source = "./stack"
 


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5550

In particular this:

* Creates a complete copy of `WorkQueryableValues` inside `ImageQueryableValues`. We could get away with a smaller index by only indexing the subset of work fields we use inside the image query, but this is simpler and mirrors the existing behaviour.
* Put the `inferredData` inside `ImageQueryableValues`.
* Makes `inferredData` required on `ImageState`, because in practice it's always available.

As with previous patches, this is strictly additive – I’ll come back in a later patch to remove all the bits we aren't using, but we'll do that in a separate reindex.