### PR TITLE
We always get inferredData, so it need not be optional

### DIFF
--- a/common/display_model/src/main/scala/weco/catalogue/display_model/image/DisplayImage.scala
+++ b/common/display_model/src/main/scala/weco/catalogue/display_model/image/DisplayImage.scala
@@ -31,11 +31,8 @@ object DisplayImage {
       id = image.id,
       thumbnail = DisplayDigitalLocation(thumbnail(image)),
       locations = image.locations.map(DisplayDigitalLocation(_)),
-      aspectRatio =
-        image.state.inferredData.flatMap(_.aspectRatio).getOrElse(1.0f),
-      averageColor = image.state.inferredData
-        .flatMap(_.averageColorHex)
-        .getOrElse("#ffffff"),
+      aspectRatio = image.state.inferredData.aspectRatio.getOrElse(1.0F),
+      averageColor = image.state.inferredData.averageColorHex.getOrElse("#ffffff"),
       source = DisplayImageSource(image.source)
     )
 }

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/image/Image.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/image/Image.scala
@@ -75,15 +75,15 @@ object ImageState {
   case class Augmented(
     sourceIdentifier: SourceIdentifier,
     canonicalId: CanonicalId,
-    inferredData: Option[InferredData] = None
+    inferredData: InferredData
   ) extends ImageState {
-    type TransitionArgs = Option[InferredData]
+    type TransitionArgs = InferredData
   }
 
   case class Indexed(
     sourceIdentifier: SourceIdentifier,
     canonicalId: CanonicalId,
-    inferredData: Option[InferredData] = None
+    inferredData: InferredData
   ) extends ImageState {
     type TransitionArgs = Unit
   }
@@ -100,7 +100,7 @@ object ImageFsm {
   implicit val initialToAugmented = new Transition[Initial, Augmented] {
     def state(
       self: Image[Initial],
-      inferredData: Option[InferredData]
+      inferredData: InferredData
     ): Augmented =
       Augmented(
         sourceIdentifier = self.state.sourceIdentifier,

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/generators/ImageGenerators.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/generators/ImageGenerators.scala
@@ -71,7 +71,7 @@ trait ImageGenerators
   ) {
 
     def toAugmentedImageWith(
-      inferredData: Option[InferredData] = createInferredData,
+      inferredData: InferredData = createInferredData,
       parentWork: Work[WorkState.Identified] = sierraIdentifiedWork(),
       redirectedWork: Option[Work[WorkState.Identified]] = Some(
         sierraIdentifiedWork()
@@ -88,7 +88,7 @@ trait ImageGenerators
       canonicalId: CanonicalId = createCanonicalId,
       parentWork: Work[WorkState.Identified] = identifiedWork(),
       redirectedWork: Option[Work[WorkState.Identified]] = None,
-      inferredData: Option[InferredData] = createInferredData
+      inferredData: InferredData = createInferredData
     ): Image[ImageState.Indexed] =
       imageData
         .toIdentifiedWith(canonicalId = canonicalId)
@@ -151,7 +151,7 @@ trait ImageGenerators
     )
 
     def toAugmentedImageWith(
-      inferredData: Option[InferredData] = createInferredData,
+      inferredData: InferredData = createInferredData,
       parentWork: Work[WorkState.Identified] = sierraIdentifiedWork(),
       redirectedWork: Option[Work[WorkState.Identified]] = Some(
         sierraIdentifiedWork()
@@ -164,7 +164,7 @@ trait ImageGenerators
     def toIndexedImageWith(
       parentWork: Work[WorkState.Identified] = identifiedWork(),
       redirectedWork: Option[Work[WorkState.Identified]] = None,
-      inferredData: Option[InferredData] = createInferredData
+      inferredData: InferredData = createInferredData
     ): Image[ImageState.Indexed] =
       imageData
         .toAugmentedImageWith(
@@ -189,13 +189,13 @@ trait ImageGenerators
   def randomHexString: String =
     s"#${randomBytes(3).map(b => f"$b%02X").mkString}"
 
-  def createInferredData = {
+  def createInferredData: InferredData = {
     val features = randomVector(4096)
     val (features1, features2) = features.splitAt(features.size / 2)
     val lshEncodedFeatures = randomHash(32)
     val palette = randomColorVector()
-    Some(
-      InferredData(
+
+    InferredData(
         features1 = features1.toList,
         features2 = features2.toList,
         lshEncodedFeatures = lshEncodedFeatures.toList,
@@ -204,7 +204,6 @@ trait ImageGenerators
         binSizes = inferredDataBinSizes,
         binMinima = inferredDataBinMinima,
         aspectRatio = inferredDataAspectRatio
-      )
     )
   }
 
@@ -249,7 +248,7 @@ trait ImageGenerators
     (features, lshFeatures, palettes).zipped.map {
       case (f, l, p) =>
         createImageData.toAugmentedImageWith(
-          inferredData = Some(
+          inferredData =
             InferredData(
               features1 = f.slice(0, 2048).toList,
               features2 = f.slice(2048, 4096).toList,
@@ -260,7 +259,6 @@ trait ImageGenerators
               binMinima = inferredDataBinMinima,
               aspectRatio = inferredDataAspectRatio
             )
-          )
         )
     }
   }

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/index/ImagesIndexConfigTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/index/ImagesIndexConfigTest.scala
@@ -28,7 +28,7 @@ class ImagesIndexConfigTest
   it("indexes an image without feature vectors") {
     withLocalImagesIndex { implicit index =>
       assertImageCanBeIndexed(
-        image = createImageData.toAugmentedImageWith(inferredData = None)
+        image = createImageData.toAugmentedImageWith(inferredData = InferredData.empty)
       )
     }
   }
@@ -38,7 +38,7 @@ class ImagesIndexConfigTest
       val features1 = (0 until 3000).map(_ => Random.nextFloat() * 100).toList
       val features2 = (0 until 3000).map(_ => Random.nextFloat() * 100).toList
       val image = createImageData.toAugmentedImageWith(
-        inferredData = Some(
+        inferredData =
           InferredData(
             features1,
             features2,
@@ -49,7 +49,6 @@ class ImagesIndexConfigTest
             List(0f, 10f / 256, 10f / 256),
             Some(Random.nextFloat())
           )
-        )
       )
 
       val response = indexImage(id = image.id, image = image)
@@ -61,7 +60,7 @@ class ImagesIndexConfigTest
   it("cannot index an image with image vectors that are shorter than 2048") {
     withLocalImagesIndex { implicit index =>
       val image = createImageData.toAugmentedImageWith(
-        inferredData = Some(
+        inferredData =
           InferredData(
             List(2.0f),
             List(2.0f),
@@ -72,7 +71,6 @@ class ImagesIndexConfigTest
             List(0f, 10f / 256, 10f / 256),
             Some(Random.nextFloat())
           )
-        )
       )
 
       val response = indexImage(id = image.id, image = image)

--- a/pipeline/inferrer/inference_manager/src/main/scala/weco/pipeline/inference_manager/services/InferenceManagerWorkerService.scala
+++ b/pipeline/inferrer/inference_manager/src/main/scala/weco/pipeline/inference_manager/services/InferenceManagerWorkerService.scala
@@ -157,7 +157,7 @@ class InferenceManagerWorkerService[Destination](
                   AdapterResponseBundle(DownloadedImage(image, _), _, _),
                   ctx) =>
                 (
-                  image.transition[ImageState.Augmented](Some(inferredData)),
+                  image.transition[ImageState.Augmented](inferredData),
                   ctx)
             }
           }


### PR DESCRIPTION
An improvement spotted while working on a different PR; in practice, `inferredData` should never be empty.