### PR TITLE
Reduce the flush time on the ingestor

### DIFF
--- a/pipeline/terraform/stack/service_ingestor_works.tf
+++ b/pipeline/terraform/stack/service_ingestor_works.tf
@@ -10,6 +10,7 @@ locals {
   # very low, this can be prevented.
   ingestor_works_flush_interval_seconds = 10
 }
+
 module "ingestor_works_output_topic" {
   source = "../modules/topic"
 

--- a/pipeline/terraform/stack/service_ingestor_works.tf
+++ b/pipeline/terraform/stack/service_ingestor_works.tf
@@ -1,7 +1,15 @@
 locals {
-  ingestor_works_flush_interval_seconds = 60
+  # The flush interval must be significantly lower than the cooldown period
+  # for the scaling down alarm (1 minute).
+  # Fargate services take 60-90s to start up.
+  # Assuming the worst - that scaling up on detecting a message in the queue took
+  # 90s, that gives the ingestor a maximum of 30 seconds to finish working or
+  # it will be terminated prematurely.
+  # It is still a possibility that messages will fail, if they are received after the first flush
+  # and less than the flush period before the scale down happens, but by keeping this number
+  # very low, this can be prevented.
+  ingestor_works_flush_interval_seconds = 10
 }
-
 module "ingestor_works_output_topic" {
   source = "../modules/topic"
 


### PR DESCRIPTION
See slack thread: https://wellcome.slack.com/archives/C3TQSF63C/p1665579555151989

In a low-volume scenario, records are not being ingested because (I surmise) the tasks were being scaled down between pulling from the queue and hitting the flush interval.  This was previously masked by the fact that messages would be retried, but I switched off retries: https://github.com/wellcomecollection/catalogue-pipeline/issues/2224 revealing that we seem to be relying on them to make the ingestor work under normal circumstances, rather than in an exceptional situation such as when the database is having a bit of a sulk.