### PR TITLE
If a matcher graph node is suppressed, say so explicitly

### DIFF
--- a/pipeline/matcher/scripts/graphAttributes.ts
+++ b/pipeline/matcher/scripts/graphAttributes.ts
@@ -116,7 +116,12 @@ function getLabelAttributes(
 export async function getAttributes(
   w: SourceWork
 ): Promise<Record<string, string>> {
-  const labelAttributes = await getLabelAttributes(w);
+  const { label } = await getLabelAttributes(w);
+
+  const labelAttributes = w.suppressed
+    ? { label: `${label}\n(suppressed)` }
+    : { label };
+
 
   const styleAttributes = w.suppressed ? { style: 'dashed' } : {};
 


### PR DESCRIPTION
A while back I introduced a convention that dashed line = suppressed in the matcher graphs. I promptly forgot I'd done that, and when I ran the matcher graph tool this morning I couldn't remember what it meant.

This patch adds the word "suppressed" to the graph:

<img width="1081" alt="Screenshot 2022-10-26 at 09 06 34" src="https://user-images.githubusercontent.com/301220/197970108-ccfda744-7a5a-4651-a6ff-bebe4c00269a.png">
