### PR TITLE
add debug indexedTime to the Elasticsearch mapping

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksIndexConfig.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksIndexConfig.scala
@@ -73,7 +73,9 @@ object WorksIndexConfig extends IndexConfigFields {
 
       // This field contains debugging information which we don't want to index, which
       // is just used by developers debugging the pipeline.
-      val debug = objectField("debug").withEnabled(false)
+      // See dynamic-field-mapping in elasticsearch reference site: Setting the dynamic parameter to false ignores new fields
+      // This means we will only index the indexedTime field within debug object for the snapshot reporter
+      val debug = objectField("debug").withDynamic("false").fields(dateField("indexedTime"))
 
       // This field contains the display document used by the API, but we don't want
       // to index it -- it's just an arbitrary blob of JSON.
@@ -87,7 +89,6 @@ object WorksIndexConfig extends IndexConfigFields {
           keywordField("type"),
           keywordField("format.id"),
           keywordField("workType"),
-          dateField("debug.indexedTime"),
           multilingualFieldWithKeyword("title").copy(
             copyTo = titlesAndContributorsPath),
           multilingualFieldWithKeyword("alternativeTitles").copy(

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksIndexConfig.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksIndexConfig.scala
@@ -75,7 +75,9 @@ object WorksIndexConfig extends IndexConfigFields {
       // is just used by developers debugging the pipeline.
       // See dynamic-field-mapping in elasticsearch reference site: Setting the dynamic parameter to false ignores new fields
       // This means we will only index the indexedTime field within debug object for the snapshot reporter
-      val debug = objectField("debug").withDynamic("false").fields(dateField("indexedTime"))
+      val debug = objectField("debug")
+        .withDynamic("false")
+        .fields(dateField("indexedTime"))
 
       // This field contains the display document used by the API, but we don't want
       // to index it -- it's just an arbitrary blob of JSON.

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksIndexConfig.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksIndexConfig.scala
@@ -87,6 +87,7 @@ object WorksIndexConfig extends IndexConfigFields {
           keywordField("type"),
           keywordField("format.id"),
           keywordField("workType"),
+          dateField("debug.indexedTime"),
           multilingualFieldWithKeyword("title").copy(
             copyTo = titlesAndContributorsPath),
           multilingualFieldWithKeyword("alternativeTitles").copy(

--- a/common/internal_model/src/test/resources/WorksIndexConfig.json
+++ b/common/internal_model/src/test/resources/WorksIndexConfig.json
@@ -62,8 +62,12 @@
         }
       },
       "debug": {
-        "type": "object",
-        "enabled": false
+        "dynamic": "false",
+        "properties": {
+          "indexedTime": {
+            "type": "date"
+          }
+        }
       },
       "display": {
         "type": "object",


### PR DESCRIPTION
Not convinced I have this right, but what i'm trying to do is add `debug.indexedTime` to the elasticsearch index.
As part of https://github.com/wellcomecollection/platform/issues/5621

Now using `withDynamic` to only index the `debug.indexedTime` field. 
https://www.elastic.co/guide/en/elasticsearch/reference/current/dynamic-field-mapping.html