### PR TITLE
Be more tolerant of empty <textLang> nodes in TEI

### DIFF
--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiLanguages.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiLanguages.scala
@@ -41,7 +41,8 @@ object TeiLanguages extends Logging {
             case (Right(None), label) if label.trim.nonEmpty =>
               appendNote(languageList, languageNoteList, label)
             case (Right(_), _) =>
-              Left(new Throwable(s"Missing label for language node $n"))
+              warn(s"Missing label for language node $n")
+              Right((languageList, languageNoteList))
             case (Left(err), _) => Left(err)
           }
 

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/transformers/TeiLanguagesTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/transformers/TeiLanguagesTest.scala
@@ -99,11 +99,7 @@ class TeiLanguagesTest
         )
       )
 
-    val result = TeiLanguages(xml)
-
-    result shouldBe a[Left[_, _]]
-    result.left.get.getMessage should startWith(
-      "Missing label for language node")
+    TeiLanguages(xml) shouldBe Right((List(), List()))
   }
 
   it("skips languages without a label and without an id") {
@@ -114,10 +110,6 @@ class TeiLanguagesTest
         )
       )
 
-    val result = TeiLanguages(xml)
-
-    result shouldBe a[Left[_, _]]
-    result.left.get.getMessage should startWith(
-      "Missing label for language node")
+    TeiLanguages(xml) shouldBe Right((List(), List()))
   }
 }


### PR DESCRIPTION
When we wrote the original TEI transformer, we did warnings-as-errors to help flush out issues.  Now it's live, an empty node is a bit annoying but we know what to do with it, and removing it from the TEI may be wrong -- e.g. in Tamil 42, where it's part of a partially completed template:

https://github.com/wellcomecollection/wellcome-collection-tei/blob/0a90dc7843dd76054292c1943e6228c0375b1bc2/Tamil/Tamil_42.xml#L82-L84