### PR TITLE
drive pipeline deployment from latest pipeline in terraform

### DIFF
--- a/.buildkite/scripts/deploy_latest_pipeline.py
+++ b/.buildkite/scripts/deploy_latest_pipeline.py
@@ -16,27 +16,7 @@ def get_current_index_name():
     return resp.json()["worksIndex"]
 
 
-if __name__ == "__main__":
-    index_name = get_current_index_name()
-    print(f"The current index name is {index_name}")
-
-    print()
-
-    # The works index name is a string that looks something like
-    #
-    #     works-indexed-2021-08-19
-    #
-    index_regex = re.compile(r"^works-indexed-(?P<date>\d{4}-\d{2}-\d{2})[a-f]*$")
-    pipeline_date = index_regex.match(index_name).group("date")
-    print(f"The current prod pipeline is {pipeline_date}")
-
-    print()
-
-    root = (
-        subprocess.check_output(["git", "rev-parse", "--show-toplevel"])
-        .decode("utf8")
-        .strip()
-    )
+def deploy_to(root, pipeline_date):
 
     os.environ.update({"PIPELINE_DATE": pipeline_date})
 
@@ -47,3 +27,58 @@ if __name__ == "__main__":
             "tag_images_and_deploy_services",
         ]
     )
+
+def get_pipeline_names_from_terraform_file(root):
+    with open(f"{root}/pipeline/terraform/main.tf", 'r') as maintf:
+        return get_pipeline_names_from_terraform_data(maintf.read())
+
+def get_pipeline_names_from_terraform_data(tf_data):
+    """
+    returns any pipeline date definitions found in a terraform file
+    >>> get_pipeline_names_from_terraform_data('\tpipeline_date = "1999-12-25"')
+    ['1999-12-25']
+
+    ignores other lines
+    >>> get_pipeline_names_from_terraform_data('''
+    ... module "catalogue_pipeline_1999-12-25" {
+    ... pipeline_date = "1999-12-25"
+    ... }
+    ...
+    ... module "catalogue_pipeline_2022-12-25" {
+    ... pipeline_date = "2022-12-25"
+    ... }
+    ... ''')
+    ['1999-12-25', '2022-12-25']
+    """
+    pipeline_date_regex = re.compile(r'^\s*pipeline_date\s*=\s*"(?P<date>[^"]*)', re.MULTILINE)
+    return pipeline_date_regex.findall(tf_data)
+
+
+if __name__ == "__main__":
+    index_name = get_current_index_name()
+    print(f"The current index name is {index_name}")
+
+    print()
+    # The works index name is a string that looks something like
+    #
+    #     works-indexed-2021-08-19
+    #
+    index_regex = re.compile(r"^works-indexed-(?P<date>\d{4}-\d{2}-\d{2})[a-f]*$")
+    prod_pipeline = index_regex.match(index_name).group("date")
+    print(f"The current prod pipeline is {prod_pipeline}")
+    print()
+
+    root = (
+        subprocess.check_output(["git", "rev-parse", "--show-toplevel"])
+        .decode("utf8")
+        .strip()
+    )
+    candidate_pipelines = get_pipeline_names_from_terraform_file(root)
+    print(f"possible existing pipeline are: {', '.join(candidate_pipelines)}")
+    latest_pipeline = sorted(candidate_pipelines, reverse=True)[0]
+    print(f"most recent pipeline is: {latest_pipeline}")
+    if latest_pipeline != prod_pipeline:
+        print("WARNING: The most up to date pipeline is not the current production pipeline ")
+        print(f"production:{prod_pipeline} latest:{latest_pipeline}")
+    deploy_to(root, latest_pipeline)
+

--- a/.buildkite/scripts/deploy_latest_pipeline.py
+++ b/.buildkite/scripts/deploy_latest_pipeline.py
@@ -28,9 +28,11 @@ def deploy_to(root, pipeline_date):
         ]
     )
 
+
 def get_pipeline_names_from_terraform_file(root):
-    with open(f"{root}/pipeline/terraform/main.tf", 'r') as maintf:
+    with open(f"{root}/pipeline/terraform/main.tf", "r") as maintf:
         return get_pipeline_names_from_terraform_data(maintf.read())
+
 
 def get_pipeline_names_from_terraform_data(tf_data):
     """
@@ -50,7 +52,9 @@ def get_pipeline_names_from_terraform_data(tf_data):
     ... ''')
     ['1999-12-25', '2022-12-25']
     """
-    pipeline_date_regex = re.compile(r'^\s*pipeline_date\s*=\s*"(?P<date>[^"]*)', re.MULTILINE)
+    pipeline_date_regex = re.compile(
+        r'^\s*pipeline_date\s*=\s*"(?P<date>[^"]*)', re.MULTILINE
+    )
     return pipeline_date_regex.findall(tf_data)
 
 
@@ -78,7 +82,8 @@ if __name__ == "__main__":
     latest_pipeline = sorted(candidate_pipelines, reverse=True)[0]
     print(f"most recent pipeline is: {latest_pipeline}")
     if latest_pipeline != prod_pipeline:
-        print("WARNING: The most up to date pipeline is not the current production pipeline ")
+        print(
+            "WARNING: The most up to date pipeline is not the current production pipeline "
+        )
         print(f"production:{prod_pipeline} latest:{latest_pipeline}")
     deploy_to(root, latest_pipeline)
-

--- a/.buildkite/scripts/deploy_latest_pipeline.py
+++ b/.buildkite/scripts/deploy_latest_pipeline.py
@@ -85,5 +85,5 @@ if __name__ == "__main__":
         print(
             "WARNING: The most up to date pipeline is not the current production pipeline "
         )
-        print(f"production:{prod_pipeline} latest:{latest_pipeline}")
+        print(f"production:\t{prod_pipeline}\nlatest:\t\t{latest_pipeline}")
     deploy_to(root, latest_pipeline)

--- a/pipeline/terraform/main.tf
+++ b/pipeline/terraform/main.tf
@@ -1,8 +1,8 @@
-module "catalogue_pipeline_2022-10-03" {
+module "catalogue_pipeline_2022-11-03" {
   source = "./stack"
 
-  pipeline_date = "2022-10-03"
-  release_label = "2022-10-03"
+  pipeline_date = "2022-11-03"
+  release_label = "2022-11-03"
 
   reindexing_state = {
     listen_to_reindexer      = false
@@ -25,18 +25,18 @@ module "catalogue_pipeline_2022-10-03" {
   }
 }
 
-module "catalogue_pipeline_2022-11-03" {
+module "catalogue_pipeline_2022-11-17" {
   source = "./stack"
 
-  pipeline_date = "2022-11-03"
-  release_label = "2022-11-03"
+  pipeline_date = "2022-11-17"
+  release_label = "2022-11-17"
 
   reindexing_state = {
-    listen_to_reindexer      = false
-    scale_up_tasks           = false
-    scale_up_elastic_cluster = false
-    scale_up_id_minter_db    = false
-    scale_up_matcher_db      = false
+    listen_to_reindexer      = true
+    scale_up_tasks           = true
+    scale_up_elastic_cluster = true
+    scale_up_id_minter_db    = true
+    scale_up_matcher_db      = true
   }
 
   # Boilerplate that shouldn't change between pipelines.


### PR DESCRIPTION
There is a little trap in the way we deploy, which this PR is intended to fix:

*  To deploy, it must be on main (to put all the correct latest images on ECR)
*  Once on main, it gets automatically deployed to production

This means that we can't easily create a new pipeline with new code, whilst leaving the existing production pipeline unmodified.  

Leaving the old code running on the existing production pipeline is desirable when there are significantly widespread changes, and we wish to run a reindex on a new pipeline in preparation for that new pipeline becoming the production pipeline. (e.g. for the change I recently made, to avoid an overload during the overnight harvest)

Previously, the choice of pipeline to deploy to was driven by asking the API which pipeline it points to.

With this change, the choice of pipeline is the most recently dated pipeline in main.tf.

It still identifies the production pipeline so that it can print a warning that production is not necessarily up to date, but its target will always be the latest pipeline in terraform.

Scenarios:

1. latest pipeline is production, no change to existing behaviour
2. latest pipeline is not production, deploys to latest, production starts to lag behind main
    * Normally, the latest pipeline is expected to replace production soon, so scenario 1 will resume
    * If a change needs to be pushed to production, without promoting the latest pipeline, we can remove the later pipeline from the tf file on main.