### PR TITLE
Don't merge Sierra physical bibs with the digitised AV items

### DIFF
--- a/pipeline/merger/src/main/scala/weco/pipeline/merger/rules/TargetPrecedence.scala
+++ b/pipeline/merger/src/main/scala/weco/pipeline/merger/rules/TargetPrecedence.scala
@@ -10,7 +10,7 @@ object TargetPrecedence {
   private val targetPrecedence = Seq(
     teiWork,
     singlePhysicalItemCalmWork,
-    sierraElectronicVideo,
+    sierraDigitisedAv,
     physicalSierra,
     sierraWork
   )

--- a/pipeline/merger/src/main/scala/weco/pipeline/merger/rules/WorkPredicates.scala
+++ b/pipeline/merger/src/main/scala/weco/pipeline/merger/rules/WorkPredicates.scala
@@ -105,10 +105,10 @@ object WorkPredicates {
   val sierraDigitisedMiro: WorkPredicate =
     satisfiesAll(sierraWork, digaids or digmiro)
 
-  val sierraElectronicVideo: WorkPredicate =
+  val sierraDigitisedAv: WorkPredicate =
     satisfiesAll(
       sierraWork,
-      format(Format.Videos),
+      isAudiovisual,
       // We may get unidentified items on Sierra bibs, drawn from
       // resources in field 856 -- we don't care about those here.
       zeroIdentifiedItems


### PR DESCRIPTION
This is extending a rule for video to cover audio and other AV also. I've added a regression test – I suspect the merger tests could do with a bit of a spring clean, as they overlap/repeat in a bunch of places, but that's a bigger piece of work than I want to do right now.