### PR TITLE
Remove a comment to the now-deleted WorkState.Indexed

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Work.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Work.scala
@@ -141,10 +141,6 @@ case class WorkData[State <: DataState](
   *      | (relation embedder)
   *      ▼
   * Denormalised
-  *      |
-  *      | (ingestor)
-  *      ▼
-  *   Indexed
   */
 sealed trait WorkState {
 


### PR DESCRIPTION
Spotted while writing up https://github.com/wellcomecollection/catalogue-pipeline/issues/2261 – WorkState.Indexed doesn't exist any more, so we shouldn't be referring to it in comments!