### PR TITLE
prefer key over ref for subject id extraction

### DIFF
--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiSubjects.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiSubjects.scala
@@ -70,18 +70,18 @@ object TeiSubjects extends LabelDerivedIdentifiers {
   }
 
   /**
-   * Extract the identifier from a term.
-   * *
-   * The relevant attributes are those in the att.canonical group
-   * https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-att.canonical.html
-   *
-   * `key` should contain a "coded value of some kind" and
-   * `ref` should contain one or more URIs to locate the full definition.
-   *
-   *  However, in practice, these have been mostly used interchangeably.
-   *  As such, we prefer to return the key, which is expected to contain an
-   *  "externally-defined string identifying the referent"
-   */
+    * Extract the identifier from a term.
+    * *
+    * The relevant attributes are those in the att.canonical group
+    * https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-att.canonical.html
+    *
+    * `key` should contain a "coded value of some kind" and
+    * `ref` should contain one or more URIs to locate the full definition.
+    *
+    *  However, in practice, these have been mostly used interchangeably.
+    *  As such, we prefer to return the key, which is expected to contain an
+    *  "externally-defined string identifying the referent"
+    */
   private def parseReference(term: Node) = {
     val referenceString = term \@ "ref"
     // arabic manuscripts seem to have the subject id in the

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiSubjects.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiSubjects.scala
@@ -73,8 +73,9 @@ object TeiSubjects extends LabelDerivedIdentifiers {
     val referenceString = term \@ "ref"
     // arabic manuscripts seem to have the subject id in the
     // attribute "key" instead of "ref" ¯\_(ツ)_/¯
+    val keyString = term \@ "key"
     val idValue =
-      if (referenceString.isEmpty) term \@ "key" else referenceString
+      if (keyString.isEmpty) referenceString else keyString
     // some of the subject ids are prepended with "subject_sh" for lcsh or " subject_" for mesh.
     // So here we remove the prepended "subject_".
     // We also remove any spaces because sometimes some ids look like "sh 1234567"

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiSubjects.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiSubjects.scala
@@ -69,6 +69,19 @@ object TeiSubjects extends LabelDerivedIdentifiers {
     }
   }
 
+  /**
+   * Extract the identifier from a term.
+   * *
+   * The relevant attributes are those in the att.canonical group
+   * https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-att.canonical.html
+   *
+   * `key` should contain a "coded value of some kind" and
+   * `ref` should contain one or more URIs to locate the full definition.
+   *
+   *  However, in practice, these have been mostly used interchangeably.
+   *  As such, we prefer to return the key, which is expected to contain an
+   *  "externally-defined string identifying the referent"
+   */
   private def parseReference(term: Node) = {
     val referenceString = term \@ "ref"
     // arabic manuscripts seem to have the subject id in the

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/transformers/TeiSubjectsTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/transformers/TeiSubjectsTest.scala
@@ -68,14 +68,28 @@ class TeiSubjectsTest extends AnyFunSpec with TeiGenerators with Matchers with L
     result shouldBe List(Subject(id = Identifiable(SourceIdentifier(IdentifierType.LCSubjects, "Subject","sh12345" )),label = "Botany", concepts = List(Concept(label ="Botany"))))
   }
 
-  it("extracts a subject id from attribute key"){
+  it("extracts a subject id from attribute key") {
     val result = TeiSubjects(teiXml(
       id = id,
       profileDesc = Some(profileDesc(keywords = List(keywords(keywordsScheme = Some("#LCSH"), subjects =
-        List(<item><term key="sh12345">Botany</term></item>)))))
+        List(<item>
+          <term key="sh12345">Botany</term>
+        </item>)))))
     ))
 
-    result shouldBe List(Subject(id = Identifiable(SourceIdentifier(IdentifierType.LCSubjects, "Subject","sh12345" )),label = "Botany", concepts = List(Concept(label ="Botany"))))
+    result shouldBe List(Subject(id = Identifiable(SourceIdentifier(IdentifierType.LCSubjects, "Subject", "sh12345")), label = "Botany", concepts = List(Concept(label = "Botany"))))
+  }
+
+  it("prefers to extract from key over ref") {
+    val result = TeiSubjects(teiXml(
+      id = id,
+      profileDesc = Some(profileDesc(keywords = List(keywords(keywordsScheme = Some("#LCSH"), subjects =
+        List(<item>
+          <term key="sh12345" ref="#WMS_Arabic_592-item1">Botany</term>
+        </item>)))))
+    ))
+
+    result shouldBe List(Subject(id = Identifiable(SourceIdentifier(IdentifierType.LCSubjects, "Subject", "sh12345")), label = "Botany", concepts = List(Concept(label = "Botany"))))
   }
 
   it("normalises the subject id"){


### PR DESCRIPTION
I will suggest to the TEI team that this could be more consistent.  However, I have looked at the data, and in every situation with both `@key` and `@ref`, it is the `key` that holds the id value.

```
{'key': 'subject_sh85072959', 'ref': '#WMS_Arabic_592-item2 #WMS_Arabic_592-item3'}
{'key': 'subject_sh85072967', 'ref': '#WMS_Arabic_592-item1'}
{'key': 'subject_sh85006337', 'ref': '#WMS_Arabic_592-item4 #WMS_Arabic_592-item5 #WMS_Arabic_592-item6'}
{'key': 'subject_sh2007100984', 'ref': '#WMS_Arabic_697-item3'}
{'key': 'subject_sh85007164', 'ref': '#WMS_Arabic_697-item1'}
{'key': 'subject_sh85008996', 'ref': '#WMS_Arabic_697-item8'}
{'key': 'subject_sh85008893', 'ref': '#WMS_Arabic_697-item6'}
{'key': 'subject_sh85038589', 'ref': '#WMS_Arabic_716-item1'}
{'key': 'subject_sh85129660', 'ref': '#WMS_Arabic_716-item2'}
{'key': 'subject_sh85006333', 'ref': '#WMS_Arabic_716-item3 #WMS_Arabic_716-item4'}
{'key': 'subject_sh85093823', 'ref': ' #WMS_Arabic_716-item1 #WMS_Arabic_716-item5 #WMS_Arabic_716-item6'}
{'key': 'subject_sh85006297', 'ref': '#WMS_Arabic_716-item5 #WMS_Arabic_716-item6'}
```