### PR TITLE
Tweak the way we use due dates on Sierra items

### DIFF
--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -303,23 +303,25 @@ object SierraItemAccess extends SierraQueryOps with Logging {
       // we prefer defaulting to unavailable and forcing the user to ask then sending
       // them looking on the shelves for a book which isn't there.
       case (
-        _,
-        _,
-        _,
-        NotRequestable.InUseByAnotherReader(_),
-        Some(LocationType.OpenShelves)) =>
-
+          _,
+          _,
+          _,
+          NotRequestable.InUseByAnotherReader(_),
+          Some(LocationType.OpenShelves)) =>
         AccessCondition(
           method = AccessMethod.OpenShelves,
           status = Some(AccessStatus.TemporarilyUnavailable),
-          note = Some("Item is in use by another reader. Please ask at Library Enquiry Desk.")
+          note = Some(
+            "Item is in use by another reader. Please ask at Library Enquiry Desk.")
         )
 
-      case (_, _, _, _, Some(LocationType.OpenShelves)) if itemData.hasDueDate =>
+      case (_, _, _, _, Some(LocationType.OpenShelves))
+          if itemData.hasDueDate =>
         AccessCondition(
           method = AccessMethod.OpenShelves,
           status = Some(AccessStatus.TemporarilyUnavailable),
-          note = Some("Item is in use by another reader. Please ask at Library Enquiry Desk.")
+          note = Some(
+            "Item is in use by another reader. Please ask at Library Enquiry Desk.")
         )
 
       case (_, _, _, _, _) if itemData.hasDueDate =>

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -629,7 +629,7 @@ class SierraItemAccessTest
       )
     }
 
-    it("is not available if it has a due date") {
+    it("is not available if it has a loan rule 14 and a due date") {
       val itemData = createSierraItemDataWith(
         fixedFields = Map(
           "65" -> createFixedFieldWith("DUE DATE")("2020-09-01T03:00:00Z"),
@@ -649,11 +649,36 @@ class SierraItemAccessTest
         method(AccessMethod.OpenShelves),
         status(AccessStatus.TemporarilyUnavailable),
         note(
-          "This item is temporarily unavailable. It is due for return on 1 September 2020."),
+          "Item is in use by another reader. Please ask at Library Enquiry Desk."),
+        noTerms()
+      )
+    }
+
+    it("is not available if it has a due date") {
+      val itemData = createSierraItemDataWith(
+        fixedFields = Map(
+          "65" -> createFixedFieldWith("DUE DATE")("2020-09-01T03:00:00Z"),
+          "79" -> createLocationWith("wgpvm", "History of Medicine"),
+          "88" -> createStatusWith("-", "Available"),
+          "108" -> createOpacMsgWith("o", "Open shelves")
+        )
+      )
+
+      val (ac, _) = SierraItemAccess(
+        location = Some(LocationType.OpenShelves),
+        itemData = itemData
+      )
+
+      ac should have(
+        method(AccessMethod.OpenShelves),
+        status(AccessStatus.TemporarilyUnavailable),
+        note(
+          "Item is in use by another reader. Please ask at Library Enquiry Desk."),
         noTerms()
       )
     }
   }
+
   describe("an item on exhibition") {
     it("has a note based on its Reserves Note") {
       val displayreservation =


### PR DESCRIPTION
1.  We don't display the due date on the public catalogue record, because often they'll just cause awkward questions for LE&E.  These dates don't seem to be accurate or enforced.

    e.g. "The catalogue says this was due for return 2019. Why can't I find it?"

    A generic message that takes somebody to the desk avoids extra hassle.

3.  If an item has a due date, assume it's checked out to somebody and mark it as unavailable in the catalogue.  I don't totally understand how to detect if items are checked out, but this seems like a good starting heuristic.

    As noted in the comment, if this is drastically wrong we'll hear about it from LE&E; sending people to the desk is the more conservative approach and should reduce confusion.

For https://github.com/wellcomecollection/platform/issues/5632