### PR TITLE
Upgrade our RDS instances

### DIFF
--- a/infrastructure/critical/.terraform.lock.hcl
+++ b/infrastructure/critical/.terraform.lock.hcl
@@ -1,27 +1,6 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/elastic/ec" {
-  version     = "0.2.1"
-  constraints = "0.2.1"
-  hashes = [
-    "h1:Njh3l0Del+s0OKnOwuKvPZLcTPSdwx7fnLa8Ex/VJrg=",
-    "zh:145414eaa5015fcad546eb17bd78a14720cadcfcca781a46c9a6493722eb3ba8",
-    "zh:1cb7bacfe088c1145834e0a7d053f7aa7a8897a3554d040becad004774aa45f4",
-    "zh:20e245ae46316853ad18d2eff9107aec3e0ffcaa5407b2aa422669d80a872761",
-    "zh:4c9c52e4ee089d71a9f58f0f53173ded7a65012466dbb857b15e7697f25fdb40",
-    "zh:52877b6e934e932aa27d85868e055a907172df9b0ca6bcc4a2c820cc6890b152",
-    "zh:52cabbd5826ac10b5f4f9be25435f970ae0b9caed3cd3cdf42c71ee773c956ac",
-    "zh:999963c9f6ee6d61f3aea2c76d0e842d963662f71b04b9cf4e003d88bd849d0e",
-    "zh:9bd93ffef87de87b3f04bb8b572098ccb8d363a62a4c7fe43f74447ee4ee023f",
-    "zh:a39bdff8f72d1479a9fa6a2399dab687bf775bcb7a1c4db0e5ef87fbbf66bfa9",
-    "zh:aa3cd16eeae66ccaab372f3a6a819fe117516a4c96bc216663bc244983e11100",
-    "zh:c5d3cc19dcf190bea741e75c4f90e1cda4673bef7a6b86f2b7f2eb1fd926dce0",
-    "zh:fcdb180ef082876458ede8d1cdb2e703330120552c5d80268388d8437c9716fb",
-    "zh:fd595f502fcd0ca8ada078114fbf5341880ac8e53493105c42309560654f3729",
-  ]
-}
-
 provider "registry.terraform.io/hashicorp/aws" {
   version = "3.48.0"
   hashes = [

--- a/infrastructure/critical/modules/rds/main.tf
+++ b/infrastructure/critical/modules/rds/main.tf
@@ -1,6 +1,7 @@
 resource "aws_rds_cluster_instance" "cluster_instances" {
   count = var.instance_count
 
+  engine                  = var.engine
   identifier              = "${var.cluster_identifier}-${count.index}"
   cluster_identifier      = aws_rds_cluster.default.id
   instance_class          = var.instance_class
@@ -12,6 +13,7 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
 resource "aws_rds_cluster" "default" {
   db_subnet_group_name = var.aws_db_subnet_group_name
 
+  engine                 = var.engine
   cluster_identifier     = var.cluster_identifier
   database_name          = var.database_name
   master_username        = var.username

--- a/infrastructure/critical/modules/rds/variables.tf
+++ b/infrastructure/critical/modules/rds/variables.tf
@@ -6,6 +6,10 @@ variable "username" {}
 
 variable "password" {}
 
+variable "engine" {
+  type = string
+}
+
 variable "db_security_group_id" {
   type = string
 }

--- a/infrastructure/critical/rds_id_minter.tf
+++ b/infrastructure/critical/rds_id_minter.tf
@@ -61,8 +61,8 @@ module "identifiers_delta_rds_cluster" {
 
   aws_db_subnet_group_name = aws_db_subnet_group.default.name
 
-  engine                   = "aurora-mysql"
-  db_parameter_group_name  = "default.aurora-mysql5.7"
+  engine                  = "aurora-mysql"
+  db_parameter_group_name = "default.aurora-mysql5.7"
 }
 
 resource "aws_security_group" "rds_ingress_security_group" {

--- a/infrastructure/critical/rds_id_minter.tf
+++ b/infrastructure/critical/rds_id_minter.tf
@@ -60,6 +60,9 @@ module "identifiers_delta_rds_cluster" {
   db_security_group_id = aws_security_group.database_sg.id
 
   aws_db_subnet_group_name = aws_db_subnet_group.default.name
+
+  engine                   = "aurora-mysql"
+  db_parameter_group_name  = "default.aurora-mysql5.7"
 }
 
 resource "aws_security_group" "rds_ingress_security_group" {

--- a/pipeline/id_minter/docker-compose.yml
+++ b/pipeline/id_minter/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   mysql:
-    image: "public.ecr.aws/docker/library/mysql:5.6"
+    image: "public.ecr.aws/docker/library/mysql:5.7"
     ports:
       - "3307:3306"
     environment:

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -126,7 +126,7 @@ object ExternalDependencies {
   val mySqlDependencies = Seq(
     "org.flywaydb" % "flyway-core" % "4.2.0",
     "org.scalikejdbc" %% "scalikejdbc" % "3.4.0",
-    "mysql" % "mysql-connector-java" % "6.0.6"
+    "mysql" % "mysql-connector-java" % "8.0.31"
   )
 
   val scalacheckDependencies = Seq(

--- a/tei_adapter/terraform/rds_id_extractor.tf
+++ b/tei_adapter/terraform/rds_id_extractor.tf
@@ -61,8 +61,8 @@ module "tei_id_extractor_rds_cluster" {
 
   aws_db_subnet_group_name = aws_db_subnet_group.default.name
 
-  engine                   = "aurora-mysql"
-  db_parameter_group_name  = aws_db_parameter_group.default.id
+  engine                  = "aurora-mysql"
+  db_parameter_group_name = aws_db_parameter_group.default.id
 }
 
 resource "aws_security_group" "rds_ingress_security_group" {
@@ -83,11 +83,11 @@ resource "aws_security_group" "rds_ingress_security_group" {
 }
 
 resource "aws_db_parameter_group" "default" {
-   name_prefix = "tei-rds"
-   family      = "aurora-mysql5.7"
+  name_prefix = "tei-rds"
+  family      = "aurora-mysql5.7"
 
-   parameter {
-     name  = "wait_timeout"
-     value = local.rds_lock_timeout_seconds
-   }
- }
+  parameter {
+    name  = "wait_timeout"
+    value = local.rds_lock_timeout_seconds
+  }
+}

--- a/tei_adapter/terraform/rds_id_extractor.tf
+++ b/tei_adapter/terraform/rds_id_extractor.tf
@@ -62,7 +62,7 @@ module "tei_id_extractor_rds_cluster" {
   aws_db_subnet_group_name = aws_db_subnet_group.default.name
 
   engine                   = "aurora-mysql"
-  db_parameter_group_name  = "default.aurora-mysql5.7"
+  db_parameter_group_name  = aws_db_parameter_group.default.id
 }
 
 resource "aws_security_group" "rds_ingress_security_group" {
@@ -81,3 +81,13 @@ resource "aws_security_group" "rds_ingress_security_group" {
     Name = "tei-adapter-rds-access"
   }
 }
+
+resource "aws_db_parameter_group" "default" {
+   name_prefix = "tei-rds"
+   family      = "aurora-mysql5.7"
+
+   parameter {
+     name  = "wait_timeout"
+     value = local.rds_lock_timeout_seconds
+   }
+ }

--- a/tei_adapter/terraform/rds_id_extractor.tf
+++ b/tei_adapter/terraform/rds_id_extractor.tf
@@ -60,7 +60,9 @@ module "tei_id_extractor_rds_cluster" {
   db_security_group_id = aws_security_group.database_sg.id
 
   aws_db_subnet_group_name = aws_db_subnet_group.default.name
-  db_parameter_group_name  = aws_db_parameter_group.default.id
+
+  engine                   = "aurora-mysql"
+  db_parameter_group_name  = "default.aurora-mysql5.7"
 }
 
 resource "aws_security_group" "rds_ingress_security_group" {
@@ -77,15 +79,5 @@ resource "aws_security_group" "rds_ingress_security_group" {
 
   tags = {
     Name = "tei-adapter-rds-access"
-  }
-}
-
-resource "aws_db_parameter_group" "default" {
-  name_prefix = "tei-rds"
-  family      = "aurora5.6"
-
-  parameter {
-    name  = "wait_timeout"
-    value = local.rds_lock_timeout_seconds
   }
 }

--- a/tei_adapter/terraform/terraform.tf
+++ b/tei_adapter/terraform/terraform.tf
@@ -48,4 +48,3 @@ data "terraform_remote_state" "monitoring" {
 locals {
   catalogue_vpcs = data.terraform_remote_state.accounts_catalogue.outputs
 }
-data "aws_caller_identity" "current" {}


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/catalogue-pipeline/issues/2267, closes https://github.com/wellcomecollection/platform/issues/5437

I applied these changes using the AWS console; the Terraform changes are just to get in into a "everything is up-to-date, no changes to apply" state.

This bumps our version of MySQL from 5.6 to 5.7, which requires a new version of our MySQL connector – the old version is from 2017 (!).