### PR TITLE
Allow 2 instances in the image inferrer ASG, not 1

### DIFF
--- a/pipeline/terraform/stack/cluster.tf
+++ b/pipeline/terraform/stack/cluster.tf
@@ -15,8 +15,14 @@ module "inference_capacity_provider" {
 
   # When we're not reindexing, we halve the size of these instances and
   # the corresponding tasks, because they won't be getting as many updates.
-  instance_type           = var.reindexing_state.scale_up_tasks ? "c5.2xlarge" : "c5.xlarge"
-  max_instances           = var.reindexing_state.scale_up_tasks ? 12 : 1
+  #
+  # Note: although we only run one task at a time when we're not reindexing,
+  # we need to allow spiking to 2 instances, because when ECS does a
+  # blue-green deployment of an image inferrer task, it's (briefly) running
+  # two tasks at once: the old task and the new task.
+  instance_type = var.reindexing_state.scale_up_tasks ? "c5.2xlarge" : "c5.xlarge"
+  max_instances = var.reindexing_state.scale_up_tasks ? 12 : 2
+
   use_spot_purchasing     = true
   scaling_action_cooldown = 240
 


### PR DESCRIPTION
This is to work around an issue we've seen with deployments and autoscaling:

1.  When we deploy new tasks, ECS tries to do a blue-green deployment by starting a new task first, then stopping the old task.

    This fails, because there isn't enough capacity in the EC2 container hosts to run two tasks at the same time.  And the ASG that provides the EC2 hosts can't start new instances to accommodate.

    This causes deployments of new image inferrer code to fail.

2.  When the autoscaling alarms try to turn down the image inferrer, they fail with this error:

     > not in a scalable state due to reason: Service had at least one ACTIVE deployment

These two errors mean the image inferrer can get "stuck open" -- it can't deploy new code, can't stop old code, and the expensive EC2 instance is running 24/7.

Allowing the ASG to increase to 2 instances when necessary means it can start a second instance during blue-green deployments, which means:

1.  New images can deploy successfully
2.  The deployment can reach the PRIMARY state
3.  The autoscaling alarms can stop the image inferrer when the queue is empty

I applied this change this morning, and immediately the image inferrer did the right thing – it added a new instance, completed a successful deploy, and autoscaled away because its queue was actually empty.

I thought I'd have to muck around with `deployment_minimum_healthy_percent = 0` on the image inferrer tasks, but I think this approach is better (hence getting ready to plumb it in with #2291), because it means we keep the nice blue-green deploy behaviour.

Closes https://github.com/wellcomecollection/catalogue-pipeline/issues/2290