### PR TITLE
Add a related material note based on MARC 787

### DIFF
--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraNotes.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraNotes.scala
@@ -128,15 +128,15 @@ object SierraNotes extends SierraDataTransformer with SierraQueryOps {
   // now a canned search is enough.
   private def createNoteFrom787(vf: VarField): Note = {
     val contents =
-      vf
-        .subfieldsWithoutTags(globallySuppressedSubfields.toSeq: _*)
+      vf.subfieldsWithoutTags(globallySuppressedSubfields.toSeq: _*)
         .map {
-          case Subfield("w", contents) => contents match {
-            case uklwPrefixRegex(bibNumber) =>
-              s"""(<a href="https://wellcomecollection.org/search/works?query=${bibNumber.trim}">${bibNumber.trim}</a>)"""
+          case Subfield("w", contents) =>
+            contents match {
+              case uklwPrefixRegex(bibNumber) =>
+                s"""(<a href="https://wellcomecollection.org/search/works?query=${bibNumber.trim}">${bibNumber.trim}</a>)"""
 
-            case _ => contents
-          }
+              case _ => contents
+            }
 
           case Subfield(_, contents) => contents
         }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraNotes.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraNotes.scala
@@ -8,6 +8,7 @@ import weco.sierra.models.marc.{Subfield, VarField}
 
 import java.net.URL
 import scala.util.Try
+import scala.util.matching.Regex
 
 object SierraNotes extends SierraDataTransformer with SierraQueryOps {
 
@@ -53,6 +54,7 @@ object SierraNotes extends SierraDataTransformer with SierraQueryOps {
       NoteType.GeneralNote,
       suppressedSubfields = Set("9")),
     "593" -> createNoteFromContents(NoteType.CopyrightNote),
+    "787" -> createNoteFrom787 _,
   )
 
   def apply(bibData: SierraBibData): List[Note] =
@@ -110,6 +112,38 @@ object SierraNotes extends SierraDataTransformer with SierraQueryOps {
         createNoteFromContents(NoteType.LocationOfDuplicatesNote)(vf)
       case _ => createNoteFromContents(NoteType.LocationOfOriginalNote)(vf)
     }
+
+  // This regex matches any string starting with (UkLW), followed by
+  // any number of spaces, and then captures everything after the
+  // space, which is the bib number we're interested in.
+  //
+  // The UkLW match is case insensitive because there are sufficient
+  // inconsistencies in the source data that it's easier to handle that here.
+  private val uklwPrefixRegex: Regex = """\((?i:UkLW)\)[\s]*(.+)""".r.anchored
+
+  // In MARC 787, subfield $w may contain a catalogue reference, in which
+  // case we want to create a clickable link.
+  //
+  // Eventually it'd be nice if these went direct to the works page, but for
+  // now a canned search is enough.
+  private def createNoteFrom787(vf: VarField): Note = {
+    val contents =
+      vf
+        .subfieldsWithoutTags(globallySuppressedSubfields.toSeq: _*)
+        .map {
+          case Subfield("w", contents) => contents match {
+            case uklwPrefixRegex(bibNumber) =>
+              s"""(<a href="https://wellcomecollection.org/search/works?query=${bibNumber.trim}">${bibNumber.trim}</a>)"""
+
+            case _ => contents
+          }
+
+          case Subfield(_, contents) => contents
+        }
+        .mkString(" ")
+
+    Note(contents = contents, noteType = NoteType.RelatedMaterial)
+  }
 
   private def isUrl(s: String): Boolean =
     Try { new URL(s) }.isSuccess

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraNotes.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraNotes.scala
@@ -86,8 +86,8 @@ object SierraNotes extends SierraDataTransformer with SierraQueryOps {
           .map {
             // We want to make ǂu into a clickable link, but only if it's a URL --
             // we don't want to make non-URLs into clickable objects.
-            case Subfield("u", contents) if isUrl(contents) =>
-              s"""<a href="$contents">$contents</a>"""
+            case Subfield("u", contents) if isUrl(contents.trim) =>
+              s"""<a href="${contents.trim}">${contents.trim}</a>"""
             case Subfield("u", contents) =>
               warn(s"Subfield ǂu which doesn't look like a URL: $contents")
               contents

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraNotesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraNotesTest.scala
@@ -353,6 +353,76 @@ class SierraNotesTest
     )
   }
 
+  describe("related material in MARC field 787") {
+    it("gets a related material note from 787") {
+      // This example is based on b33032440
+      val varFields = List(
+        VarField(
+          marcTag = "787",
+          subfields = List(
+            Subfield(tag = "t", content = "Daily telegraph."),
+            Subfield(tag = "g", content = "1989"),
+          )
+        )
+      )
+
+      val bibData = createSierraBibDataWith(varFields = varFields)
+
+      SierraNotes(bibData) shouldBe List(
+        Note(
+          contents = "Daily telegraph. 1989",
+          noteType = NoteType.RelatedMaterial
+        )
+      )
+    }
+
+    it("creates a search link for b-numbers in ǂw") {
+      // This example is based on b33039136
+      val varFields = List(
+        VarField(
+          marcTag = "787",
+          subfields = List(
+            Subfield(tag = "i", content = "Complemented by (work):"),
+            Subfield(tag = "t", content = "Depression ain't the sads."),
+            Subfield(tag = "w", content = "(UkLW)b33039112"),
+          )
+        )
+      )
+
+      val bibData = createSierraBibDataWith(varFields = varFields)
+
+      SierraNotes(bibData) shouldBe List(
+        Note(
+          contents = "Complemented by (work): Depression ain't the sads. (<a href=\"https://wellcomecollection.org/search/works?query=b33039112\">b33039112</a>)",
+          noteType = NoteType.RelatedMaterial
+        )
+      )
+    }
+
+    it("doesn't create a search link if ǂw isn't a b number") {
+      // This example is based on b15900976
+      val varFields = List(
+        VarField(
+          marcTag = "787",
+          subfields = List(
+            Subfield(tag = "s", content = "Times (London, England :  1788)."),
+            Subfield(tag = "g", content = "May 27, 2004."),
+            Subfield(tag = "w", content = "(OCoLC)6967919"),
+          )
+        )
+      )
+
+      val bibData = createSierraBibDataWith(varFields = varFields)
+
+      SierraNotes(bibData) shouldBe List(
+        Note(
+          contents = "Times (London, England :  1788). May 27, 2004. (OCoLC)6967919",
+          noteType = NoteType.RelatedMaterial
+        )
+      )
+    }
+  }
+
   def bibData(contents: List[(String, Note)]): SierraBibData =
     bibData(contents.map { case (tag, note) => (tag, note.contents) }: _*)
 

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraNotesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraNotesTest.scala
@@ -335,6 +335,24 @@ class SierraNotesTest
     )
   }
 
+  it("strips whitespace from the subfield ǂu") {
+    // This example is based on b33032440
+    val varFields = List(
+      VarField(
+        marcTag = "540",
+        subfields = List(
+          Subfield(tag = "u", content = "https://wellcomecollection.org/works/a65fex5m "),
+        )
+      )
+    )
+
+    val bibData = createSierraBibDataWith(varFields = varFields)
+
+    SierraNotes(bibData).map(_.contents) shouldBe List(
+      "<a href=\"https://wellcomecollection.org/works/a65fex5m\">https://wellcomecollection.org/works/a65fex5m</a>"
+    )
+  }
+
   def bibData(contents: List[(String, Note)]): SierraBibData =
     bibData(contents.map { case (tag, note) => (tag, note.contents) }: _*)
 


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5633

This looks for a b-number in 787 $w and creates a canned search; it'd be nice if we could map b-numbers to work URLs directly, but since this is only exploratory I don't want to do too much work on resolving identifiers in notes yet.