### PR TITLE
Add indexedTime to images, to match works

### DIFF
--- a/common/internal_model/src/main/resources/imagesIndexProperties.json
+++ b/common/internal_model/src/main/resources/imagesIndexProperties.json
@@ -595,5 +595,13 @@
         }
       }
     }
+  },
+  "debug": {
+    "dynamic": "false",
+    "properties": {
+      "indexedTime": {
+        "type": "date"
+      }
+    }
   }
 }

--- a/common/internal_model/src/test/resources/ImagesIndexConfig.json
+++ b/common/internal_model/src/test/resources/ImagesIndexConfig.json
@@ -598,6 +598,14 @@
             }
           }
         }
+      },
+      "debug": {
+        "dynamic": "false",
+        "properties": {
+          "indexedTime": {
+            "type": "date"
+          }
+        }
       }
     }
   },

--- a/pipeline/ingestor/ingestor_images/src/main/scala/weco/pipeline/ingestor/images/ImageTransformer.scala
+++ b/pipeline/ingestor/ingestor_images/src/main/scala/weco/pipeline/ingestor/images/ImageTransformer.scala
@@ -28,7 +28,7 @@ trait ImageTransformer {
         ),
         aggregatableValues = ImageAggregatableValues(image.source),
         debug = DebugInformation(indexedTime = getIndexedTime)
-      )
+    )
 
   // This is a def rather than an inline call so we can override it in the
   // tests; in particular we want it to be deterministic when we're creating

--- a/pipeline/ingestor/ingestor_images/src/main/scala/weco/pipeline/ingestor/images/ImageTransformer.scala
+++ b/pipeline/ingestor/ingestor_images/src/main/scala/weco/pipeline/ingestor/images/ImageTransformer.scala
@@ -3,6 +3,7 @@ package weco.pipeline.ingestor.images
 import weco.catalogue.display_model.image.DisplayImage
 import weco.catalogue.internal_model.image.{Image, ImageState}
 import weco.pipeline.ingestor.images.models.{
+  DebugInformation,
   ImageAggregatableValues,
   ImageQueryableValues,
   IndexedImage
@@ -10,7 +11,9 @@ import weco.pipeline.ingestor.images.models.{
 import weco.catalogue.display_model.Implicits._
 import io.circe.syntax._
 
-object ImageTransformer {
+import java.time.Instant
+
+trait ImageTransformer {
   val deriveData: Image[ImageState.Augmented] => IndexedImage =
     image =>
       IndexedImage(
@@ -23,6 +26,14 @@ object ImageTransformer {
           inferredData = image.state.inferredData,
           source = image.source
         ),
-        aggregatableValues = ImageAggregatableValues(image.source)
-    )
+        aggregatableValues = ImageAggregatableValues(image.source),
+        debug = DebugInformation(indexedTime = getIndexedTime)
+      )
+
+  // This is a def rather than an inline call so we can override it in the
+  // tests; in particular we want it to be deterministic when we're creating
+  // example documents to send to the API repo.
+  protected def getIndexedTime: Instant = Instant.now()
 }
+
+object ImageTransformer extends ImageTransformer

--- a/pipeline/ingestor/ingestor_images/src/main/scala/weco/pipeline/ingestor/images/models/DebugInformation.scala
+++ b/pipeline/ingestor/ingestor_images/src/main/scala/weco/pipeline/ingestor/images/models/DebugInformation.scala
@@ -1,0 +1,7 @@
+package weco.pipeline.ingestor.images.models
+
+import java.time.Instant
+
+case class DebugInformation(
+  indexedTime: Instant
+)

--- a/pipeline/ingestor/ingestor_images/src/main/scala/weco/pipeline/ingestor/images/models/IndexedImage.scala
+++ b/pipeline/ingestor/ingestor_images/src/main/scala/weco/pipeline/ingestor/images/models/IndexedImage.scala
@@ -10,6 +10,7 @@ case class IndexedImage(
   display: Json,
   query: ImageQueryableValues,
   aggregatableValues: ImageAggregatableValues,
+  debug: DebugInformation
 )
 
 case object IndexedImage {

--- a/pipeline/ingestor/ingestor_images/src/test/scala/weco/pipeline/ingestor/images/CreateTestImageDocuments.scala
+++ b/pipeline/ingestor/ingestor_images/src/test/scala/weco/pipeline/ingestor/images/CreateTestImageDocuments.scala
@@ -574,7 +574,14 @@ class CreateTestImageDocuments
   }
 
   implicit class ImageOps(image: Image[ImageState.Augmented]) {
-    def toDocument: Json =
-      ImageTransformer.deriveData(image).asJson
+    def toDocument: Json = {
+      // This is a fixed date so we get consistent values in the indexedTime
+      // field in the generated documents.
+      val transformer = new ImageTransformer {
+        override protected def getIndexedTime: Instant =
+          Instant.parse("2001-01-01T01:01:01.00Z")
+      }
+      transformer.deriveData(image).asJson
+    }
   }
 }

--- a/pipeline/ingestor/test_documents/images.contributors.0.json
+++ b/pipeline/ingestor/test_documents/images.contributors.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different contributors",
-  "createdAt" : "2022-12-01T11:10:59.643824Z",
+  "createdAt" : "2023-02-02T16:21:29.369392Z",
   "id" : "73tnjige",
   "document" : {
     "modifiedTime" : "2002-01-08T08:34:31Z",
@@ -5404,6 +5404,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.contributors.1.json
+++ b/pipeline/ingestor/test_documents/images.contributors.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different contributors",
-  "createdAt" : "2022-12-01T11:10:59.648421Z",
+  "createdAt" : "2023-02-02T16:21:29.411554Z",
   "id" : "jeemhoot",
   "document" : {
     "modifiedTime" : "1952-11-05T03:29:53Z",
@@ -5416,6 +5416,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.contributors.2.json
+++ b/pipeline/ingestor/test_documents/images.contributors.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different contributors",
-  "createdAt" : "2022-12-01T11:10:59.653064Z",
+  "createdAt" : "2023-02-02T16:21:29.425229Z",
   "id" : "djyysnlu",
   "document" : {
     "modifiedTime" : "1943-04-05T08:45:13Z",
@@ -5414,6 +5414,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.different-licenses.0.json
+++ b/pipeline/ingestor/test_documents/images.different-licenses.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different licenses",
-  "createdAt" : "2022-12-01T11:10:59.491389Z",
+  "createdAt" : "2023-02-02T16:21:28.473942Z",
   "id" : "w8nqm655",
   "document" : {
     "modifiedTime" : "1961-05-12T23:03:44Z",
@@ -5395,6 +5395,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.different-licenses.1.json
+++ b/pipeline/ingestor/test_documents/images.different-licenses.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different licenses",
-  "createdAt" : "2022-12-01T11:10:59.495193Z",
+  "createdAt" : "2023-02-02T16:21:28.523018Z",
   "id" : "kanbhqyr",
   "document" : {
     "modifiedTime" : "1977-10-28T23:46:23Z",
@@ -5397,6 +5397,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.different-licenses.2.json
+++ b/pipeline/ingestor/test_documents/images.different-licenses.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different licenses",
-  "createdAt" : "2022-12-01T11:10:59.498559Z",
+  "createdAt" : "2023-02-02T16:21:28.532554Z",
   "id" : "by60ajvp",
   "document" : {
     "modifiedTime" : "1956-05-21T11:24:15Z",
@@ -5395,6 +5395,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.different-licenses.3.json
+++ b/pipeline/ingestor/test_documents/images.different-licenses.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different licenses",
-  "createdAt" : "2022-12-01T11:10:59.500821Z",
+  "createdAt" : "2023-02-02T16:21:28.543779Z",
   "id" : "wa8l0stc",
   "document" : {
     "modifiedTime" : "2030-07-20T06:46:25Z",
@@ -5397,6 +5397,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.different-licenses.4.json
+++ b/pipeline/ingestor/test_documents/images.different-licenses.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different licenses",
-  "createdAt" : "2022-12-01T11:10:59.502857Z",
+  "createdAt" : "2023-02-02T16:21:28.553884Z",
   "id" : "m0dcqyqe",
   "document" : {
     "modifiedTime" : "2019-12-18T05:46:55Z",
@@ -5399,6 +5399,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.different-licenses.5.json
+++ b/pipeline/ingestor/test_documents/images.different-licenses.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different licenses",
-  "createdAt" : "2022-12-01T11:10:59.505723Z",
+  "createdAt" : "2023-02-02T16:21:28.558605Z",
   "id" : "cqamwwme",
   "document" : {
     "modifiedTime" : "1994-03-14T09:51:03Z",
@@ -5399,6 +5399,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.different-licenses.6.json
+++ b/pipeline/ingestor/test_documents/images.different-licenses.6.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different licenses",
-  "createdAt" : "2022-12-01T11:10:59.507785Z",
+  "createdAt" : "2023-02-02T16:21:28.563258Z",
   "id" : "oezlsnsk",
   "document" : {
     "modifiedTime" : "2068-05-01T18:33:42Z",
@@ -5395,6 +5395,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.everything.json
+++ b/pipeline/ingestor/test_documents/images.everything.json
@@ -1,6 +1,6 @@
 {
   "description" : "an image with every include",
-  "createdAt" : "2022-12-06T10:45:24.733691Z",
+  "createdAt" : "2023-02-02T16:21:31.478608Z",
   "id" : "ygqouuku",
   "document" : {
     "modifiedTime" : "1968-08-19T12:21:11Z",
@@ -5476,6 +5476,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.examples.bread-baguette.json
+++ b/pipeline/ingestor/test_documents/images.examples.bread-baguette.json
@@ -1,6 +1,6 @@
 {
   "description" : "an example of images with work metadata for the API tests",
-  "createdAt" : "2022-12-06T10:45:24.775337Z",
+  "createdAt" : "2023-02-02T16:21:31.603071Z",
   "id" : "nh7p8uim",
   "document" : {
     "modifiedTime" : "2007-07-09T13:04:17Z",
@@ -5392,6 +5392,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.examples.bread-focaccia.json
+++ b/pipeline/ingestor/test_documents/images.examples.bread-focaccia.json
@@ -1,6 +1,6 @@
 {
   "description" : "an example of images with work metadata for the API tests",
-  "createdAt" : "2022-12-06T10:45:24.781572Z",
+  "createdAt" : "2023-02-02T16:21:31.616414Z",
   "id" : "5p3p1zjo",
   "document" : {
     "modifiedTime" : "1980-03-21T22:03:52Z",
@@ -5390,6 +5390,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.examples.bread-mantou.json
+++ b/pipeline/ingestor/test_documents/images.examples.bread-mantou.json
@@ -1,6 +1,6 @@
 {
   "description" : "an example of images with work metadata for the API tests",
-  "createdAt" : "2022-12-06T10:45:24.795687Z",
+  "createdAt" : "2023-02-02T16:21:31.675669Z",
   "id" : "bj7sufo1",
   "document" : {
     "modifiedTime" : "2021-01-01T12:11:01Z",
@@ -5394,6 +5394,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.examples.bread-schiacciata.json
+++ b/pipeline/ingestor/test_documents/images.examples.bread-schiacciata.json
@@ -1,6 +1,6 @@
 {
   "description" : "an example of images with work metadata for the API tests",
-  "createdAt" : "2022-12-06T10:45:24.789008Z",
+  "createdAt" : "2023-02-02T16:21:31.631166Z",
   "id" : "w7oywlp2",
   "document" : {
     "modifiedTime" : "2015-02-25T16:02:02Z",
@@ -5392,6 +5392,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.examples.color-filter-tests.blue.json
+++ b/pipeline/ingestor/test_documents/images.examples.color-filter-tests.blue.json
@@ -1,6 +1,6 @@
 {
   "description" : "example for the color filter tests",
-  "createdAt" : "2022-12-06T10:45:24.720728Z",
+  "createdAt" : "2023-02-02T16:21:31.451198Z",
   "id" : "qjks3afx",
   "document" : {
     "modifiedTime" : "1983-06-10T09:26:51Z",
@@ -5315,6 +5315,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.examples.color-filter-tests.even-less-red.json
+++ b/pipeline/ingestor/test_documents/images.examples.color-filter-tests.even-less-red.json
@@ -1,6 +1,6 @@
 {
   "description" : "example for the color filter tests",
-  "createdAt" : "2022-12-06T10:45:24.715811Z",
+  "createdAt" : "2023-02-02T16:21:31.439974Z",
   "id" : "8ogq66sn",
   "document" : {
     "modifiedTime" : "1975-04-19T18:52:15Z",
@@ -5298,6 +5298,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.examples.color-filter-tests.red.json
+++ b/pipeline/ingestor/test_documents/images.examples.color-filter-tests.red.json
@@ -1,6 +1,6 @@
 {
   "description" : "example for the color filter tests",
-  "createdAt" : "2022-12-06T10:45:24.706020Z",
+  "createdAt" : "2023-02-02T16:21:31.413877Z",
   "id" : "noapixti",
   "document" : {
     "modifiedTime" : "1979-12-22T11:02:42Z",
@@ -5304,6 +5304,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.examples.color-filter-tests.slightly-less-red.json
+++ b/pipeline/ingestor/test_documents/images.examples.color-filter-tests.slightly-less-red.json
@@ -1,6 +1,6 @@
 {
   "description" : "example for the color filter tests",
-  "createdAt" : "2022-12-06T10:45:24.710624Z",
+  "createdAt" : "2023-02-02T16:21:31.427078Z",
   "id" : "xzxjzjp8",
   "document" : {
     "modifiedTime" : "1948-02-24T02:32:48Z",
@@ -5297,6 +5297,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.examples.contributor-filter-tests.0.json
+++ b/pipeline/ingestor/test_documents/images.examples.contributor-filter-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-12-06T10:45:24.646157Z",
+  "createdAt" : "2023-02-02T16:21:30.865657Z",
   "id" : "vy5qd7rp",
   "document" : {
     "modifiedTime" : "2046-05-29T23:55:07Z",
@@ -5402,6 +5402,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.examples.contributor-filter-tests.1.json
+++ b/pipeline/ingestor/test_documents/images.examples.contributor-filter-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-12-06T10:45:24.647225Z",
+  "createdAt" : "2023-02-02T16:21:30.879574Z",
   "id" : "a8fd7kej",
   "document" : {
     "modifiedTime" : "2041-10-04T05:15:25Z",
@@ -5402,6 +5402,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.examples.contributor-filter-tests.2.json
+++ b/pipeline/ingestor/test_documents/images.examples.contributor-filter-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-12-06T10:45:24.648018Z",
+  "createdAt" : "2023-02-02T16:21:30.890118Z",
   "id" : "7lvle51y",
   "document" : {
     "modifiedTime" : "1949-08-03T14:01:35Z",
@@ -5396,6 +5396,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.examples.genre-filter-tests.0.json
+++ b/pipeline/ingestor/test_documents/images.examples.genre-filter-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre filter tests",
-  "createdAt" : "2022-12-06T10:45:24.679163Z",
+  "createdAt" : "2023-02-02T16:21:31.306377Z",
   "id" : "uqt2ge05",
   "document" : {
     "modifiedTime" : "1989-11-24T12:20:38Z",
@@ -5415,6 +5415,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.examples.genre-filter-tests.1.json
+++ b/pipeline/ingestor/test_documents/images.examples.genre-filter-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre filter tests",
-  "createdAt" : "2022-12-06T10:45:24.679944Z",
+  "createdAt" : "2023-02-02T16:21:31.311524Z",
   "id" : "y3ynqyzu",
   "document" : {
     "modifiedTime" : "1968-12-28T00:26:45Z",
@@ -5394,6 +5394,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.examples.genre-filter-tests.2.json
+++ b/pipeline/ingestor/test_documents/images.examples.genre-filter-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre filter tests",
-  "createdAt" : "2022-12-06T10:45:24.680864Z",
+  "createdAt" : "2023-02-02T16:21:31.318106Z",
   "id" : "3uluswms",
   "document" : {
     "modifiedTime" : "1967-08-27T21:13:16Z",
@@ -5440,6 +5440,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.examples.linked-with-another-work.json
+++ b/pipeline/ingestor/test_documents/images.examples.linked-with-another-work.json
@@ -1,6 +1,6 @@
 {
   "description" : "images linked with another work",
-  "createdAt" : "2022-12-06T10:45:24.765111Z",
+  "createdAt" : "2023-02-02T16:21:31.577654Z",
   "id" : "qa5geeg0",
   "document" : {
     "modifiedTime" : "2027-11-17T09:19:23Z",
@@ -5392,6 +5392,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.examples.linked-with-the-same-work.0.json
+++ b/pipeline/ingestor/test_documents/images.examples.linked-with-the-same-work.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "images linked with the same work",
-  "createdAt" : "2022-12-06T10:45:24.748175Z",
+  "createdAt" : "2023-02-02T16:21:31.516102Z",
   "id" : "2qlugijz",
   "document" : {
     "modifiedTime" : "2014-09-15T19:51:18Z",
@@ -5392,6 +5392,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.examples.linked-with-the-same-work.1.json
+++ b/pipeline/ingestor/test_documents/images.examples.linked-with-the-same-work.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "images linked with the same work",
-  "createdAt" : "2022-12-06T10:45:24.748593Z",
+  "createdAt" : "2023-02-02T16:21:31.517421Z",
   "id" : "xroyzdii",
   "document" : {
     "modifiedTime" : "1988-06-16T17:39:53Z",
@@ -5394,6 +5394,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.examples.linked-with-the-same-work.2.json
+++ b/pipeline/ingestor/test_documents/images.examples.linked-with-the-same-work.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "images linked with the same work",
-  "createdAt" : "2022-12-06T10:45:24.748968Z",
+  "createdAt" : "2023-02-02T16:21:31.518871Z",
   "id" : "yyotij66",
   "document" : {
     "modifiedTime" : "2013-01-25T06:33:09Z",
@@ -5392,6 +5392,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.examples.linked-with-the-same-work.3.json
+++ b/pipeline/ingestor/test_documents/images.examples.linked-with-the-same-work.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "images linked with the same work",
-  "createdAt" : "2022-12-06T10:45:24.749332Z",
+  "createdAt" : "2023-02-02T16:21:31.520608Z",
   "id" : "izsephvy",
   "document" : {
     "modifiedTime" : "2040-01-22T20:17:06Z",
@@ -5394,6 +5394,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.genres.0.json
+++ b/pipeline/ingestor/test_documents/images.genres.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different genres",
-  "createdAt" : "2022-12-01T11:10:59.695879Z",
+  "createdAt" : "2023-02-02T16:21:29.619241Z",
   "id" : "tsre2wp4",
   "document" : {
     "modifiedTime" : "2028-03-14T11:20:28Z",
@@ -5398,6 +5398,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.genres.1.json
+++ b/pipeline/ingestor/test_documents/images.genres.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different genres",
-  "createdAt" : "2022-12-01T11:10:59.697134Z",
+  "createdAt" : "2023-02-02T16:21:29.631574Z",
   "id" : "6nlqpfst",
   "document" : {
     "modifiedTime" : "1949-09-28T13:28:06Z",
@@ -5394,6 +5394,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.genres.2.json
+++ b/pipeline/ingestor/test_documents/images.genres.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different genres",
-  "createdAt" : "2022-12-01T11:10:59.698649Z",
+  "createdAt" : "2023-02-02T16:21:29.661215Z",
   "id" : "fdwebvir",
   "document" : {
     "modifiedTime" : "2037-08-01T17:07:49Z",
@@ -5418,6 +5418,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.inferred-data.none.json
+++ b/pipeline/ingestor/test_documents/images.inferred-data.none.json
@@ -1,6 +1,6 @@
 {
   "description" : "an image without any inferred data",
-  "createdAt" : "2022-12-06T10:45:24.613052Z",
+  "createdAt" : "2023-02-02T16:21:30.637401Z",
   "id" : "2hf08w7o",
   "document" : {
     "modifiedTime" : "2008-09-17T07:09:47Z",
@@ -157,6 +157,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.inferred-data.wrong-format.json
+++ b/pipeline/ingestor/test_documents/images.inferred-data.wrong-format.json
@@ -1,6 +1,6 @@
 {
   "description" : "an image with inferred data in the wrong format",
-  "createdAt" : "2022-12-06T10:45:24.619937Z",
+  "createdAt" : "2023-02-02T16:21:30.688782Z",
   "id" : "cap1allo",
   "document" : {
     "modifiedTime" : "2027-12-29T00:13:45Z",
@@ -5382,6 +5382,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.similar-features-and-palettes.0.json
+++ b/pipeline/ingestor/test_documents/images.similar-features-and-palettes.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar features and palettes",
-  "createdAt" : "2022-12-02T13:54:50.809218Z",
+  "createdAt" : "2023-02-02T16:21:30.004397Z",
   "id" : "yvhu0n8f",
   "document" : {
     "modifiedTime" : "2051-06-03T17:43:47Z",
@@ -5394,6 +5394,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.similar-features-and-palettes.1.json
+++ b/pipeline/ingestor/test_documents/images.similar-features-and-palettes.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar features and palettes",
-  "createdAt" : "2022-12-02T13:54:50.810114Z",
+  "createdAt" : "2023-02-02T16:21:30.007763Z",
   "id" : "dvxnimsc",
   "document" : {
     "modifiedTime" : "2053-09-14T04:08:15Z",
@@ -5394,6 +5394,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.similar-features-and-palettes.2.json
+++ b/pipeline/ingestor/test_documents/images.similar-features-and-palettes.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar features and palettes",
-  "createdAt" : "2022-12-02T13:54:50.811209Z",
+  "createdAt" : "2023-02-02T16:21:30.011367Z",
   "id" : "ux8r74li",
   "document" : {
     "modifiedTime" : "1934-06-23T02:21:17Z",
@@ -5396,6 +5396,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.similar-features-and-palettes.3.json
+++ b/pipeline/ingestor/test_documents/images.similar-features-and-palettes.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar features and palettes",
-  "createdAt" : "2022-12-02T13:54:50.812408Z",
+  "createdAt" : "2023-02-02T16:21:30.015160Z",
   "id" : "cu6p92or",
   "document" : {
     "modifiedTime" : "2034-01-03T15:38:18Z",
@@ -5394,6 +5394,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.similar-features-and-palettes.4.json
+++ b/pipeline/ingestor/test_documents/images.similar-features-and-palettes.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar features and palettes",
-  "createdAt" : "2022-12-02T13:54:50.813697Z",
+  "createdAt" : "2023-02-02T16:21:30.023752Z",
   "id" : "xctlvvat",
   "document" : {
     "modifiedTime" : "1996-08-28T19:25:27Z",
@@ -5392,6 +5392,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.similar-features-and-palettes.5.json
+++ b/pipeline/ingestor/test_documents/images.similar-features-and-palettes.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar features and palettes",
-  "createdAt" : "2022-12-02T13:54:50.815239Z",
+  "createdAt" : "2023-02-02T16:21:30.032041Z",
   "id" : "ej0cb179",
   "document" : {
     "modifiedTime" : "2062-01-01T01:59:37Z",
@@ -5394,6 +5394,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.similar-features.0.json
+++ b/pipeline/ingestor/test_documents/images.similar-features.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar features",
-  "createdAt" : "2022-12-02T13:54:50.923385Z",
+  "createdAt" : "2023-02-02T16:21:30.332505Z",
   "id" : "cdhn21eb",
   "document" : {
     "modifiedTime" : "2000-07-08T03:20:23Z",
@@ -5394,6 +5394,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.similar-features.1.json
+++ b/pipeline/ingestor/test_documents/images.similar-features.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar features",
-  "createdAt" : "2022-12-02T13:54:50.924417Z",
+  "createdAt" : "2023-02-02T16:21:30.335695Z",
   "id" : "pquzghlq",
   "document" : {
     "modifiedTime" : "1946-05-21T19:48:27Z",
@@ -5396,6 +5396,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.similar-features.2.json
+++ b/pipeline/ingestor/test_documents/images.similar-features.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar features",
-  "createdAt" : "2022-12-02T13:54:50.925429Z",
+  "createdAt" : "2023-02-02T16:21:30.339770Z",
   "id" : "rqql9qrk",
   "document" : {
     "modifiedTime" : "1947-12-18T01:22:23Z",
@@ -5394,6 +5394,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.similar-features.3.json
+++ b/pipeline/ingestor/test_documents/images.similar-features.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar features",
-  "createdAt" : "2022-12-02T13:54:50.926457Z",
+  "createdAt" : "2023-02-02T16:21:30.344288Z",
   "id" : "wbandvl5",
   "document" : {
     "modifiedTime" : "2006-06-05T03:27:37Z",
@@ -5394,6 +5394,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.similar-features.4.json
+++ b/pipeline/ingestor/test_documents/images.similar-features.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar features",
-  "createdAt" : "2022-12-02T13:54:50.927490Z",
+  "createdAt" : "2023-02-02T16:21:30.347779Z",
   "id" : "s4o48spo",
   "document" : {
     "modifiedTime" : "2024-02-02T15:50:22Z",
@@ -5394,6 +5394,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.similar-features.5.json
+++ b/pipeline/ingestor/test_documents/images.similar-features.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar features",
-  "createdAt" : "2022-12-02T13:54:50.928503Z",
+  "createdAt" : "2023-02-02T16:21:30.354539Z",
   "id" : "g5i54jm1",
   "document" : {
     "modifiedTime" : "2007-09-19T13:54:14Z",
@@ -5394,6 +5394,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.similar-palettes.0.json
+++ b/pipeline/ingestor/test_documents/images.similar-palettes.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar palettes",
-  "createdAt" : "2022-12-06T10:45:24.542968Z",
+  "createdAt" : "2023-02-02T16:21:30.497962Z",
   "id" : "fpghqvjp",
   "document" : {
     "modifiedTime" : "2028-04-20T23:50:25Z",
@@ -5394,6 +5394,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.similar-palettes.1.json
+++ b/pipeline/ingestor/test_documents/images.similar-palettes.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar palettes",
-  "createdAt" : "2022-12-06T10:45:24.544373Z",
+  "createdAt" : "2023-02-02T16:21:30.512754Z",
   "id" : "of3sweb3",
   "document" : {
     "modifiedTime" : "1960-08-13T19:29:45Z",
@@ -5392,6 +5392,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.similar-palettes.2.json
+++ b/pipeline/ingestor/test_documents/images.similar-palettes.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar palettes",
-  "createdAt" : "2022-12-06T10:45:24.545929Z",
+  "createdAt" : "2023-02-02T16:21:30.520473Z",
   "id" : "9zjrcykh",
   "document" : {
     "modifiedTime" : "1965-08-16T07:36:47Z",
@@ -5394,6 +5394,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.similar-palettes.3.json
+++ b/pipeline/ingestor/test_documents/images.similar-palettes.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar palettes",
-  "createdAt" : "2022-12-06T10:45:24.547624Z",
+  "createdAt" : "2023-02-02T16:21:30.523858Z",
   "id" : "cy08b8dx",
   "document" : {
     "modifiedTime" : "2031-05-03T00:06:41Z",
@@ -5392,6 +5392,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.similar-palettes.4.json
+++ b/pipeline/ingestor/test_documents/images.similar-palettes.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar palettes",
-  "createdAt" : "2022-12-06T10:45:24.549230Z",
+  "createdAt" : "2023-02-02T16:21:30.527194Z",
   "id" : "8rpqrwtj",
   "document" : {
     "modifiedTime" : "1979-09-02T11:36:46Z",
@@ -5394,6 +5394,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.similar-palettes.5.json
+++ b/pipeline/ingestor/test_documents/images.similar-palettes.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar palettes",
-  "createdAt" : "2022-12-06T10:45:24.550935Z",
+  "createdAt" : "2023-02-02T16:21:30.534101Z",
   "id" : "ttvshbny",
   "document" : {
     "modifiedTime" : "1974-03-20T04:50:30Z",
@@ -5392,6 +5392,9 @@
       ],
       "source.subjects.label" : [
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.subjects.screwdrivers-1.json
+++ b/pipeline/ingestor/test_documents/images.subjects.screwdrivers-1.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different subjects",
-  "createdAt" : "2022-12-06T10:45:24.830303Z",
+  "createdAt" : "2023-02-02T16:21:31.781405Z",
   "id" : "s5qpaltk",
   "document" : {
     "modifiedTime" : "1972-01-08T04:13:54Z",
@@ -5402,6 +5402,9 @@
       "source.subjects.label" : [
         "{\"label\":\"Simple screwdrivers\",\"concepts\":[],\"type\":\"Subject\"}"
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.subjects.screwdrivers-2.json
+++ b/pipeline/ingestor/test_documents/images.subjects.screwdrivers-2.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different subjects",
-  "createdAt" : "2022-12-06T10:45:24.841250Z",
+  "createdAt" : "2023-02-02T16:21:31.799387Z",
   "id" : "izjbvwop",
   "document" : {
     "modifiedTime" : "2038-12-31T01:38:51Z",
@@ -5404,6 +5404,9 @@
       "source.subjects.label" : [
         "{\"label\":\"Simple screwdrivers\",\"concepts\":[],\"type\":\"Subject\"}"
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.subjects.sounds.json
+++ b/pipeline/ingestor/test_documents/images.subjects.sounds.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different subjects",
-  "createdAt" : "2022-12-06T10:45:24.819931Z",
+  "createdAt" : "2023-02-02T16:21:31.769211Z",
   "id" : "czppqd9r",
   "document" : {
     "modifiedTime" : "1948-05-28T09:36:35Z",
@@ -5398,6 +5398,9 @@
       "source.subjects.label" : [
         "{\"label\":\"Square sounds\",\"concepts\":[],\"type\":\"Subject\"}"
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.subjects.squirrel,sample.json
+++ b/pipeline/ingestor/test_documents/images.subjects.squirrel,sample.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different subjects",
-  "createdAt" : "2022-12-06T10:45:24.852197Z",
+  "createdAt" : "2023-02-02T16:21:31.811543Z",
   "id" : "jf27ko0m",
   "document" : {
     "modifiedTime" : "1955-01-03T04:26:20Z",
@@ -5410,6 +5410,9 @@
         "{\"label\":\"Squashed squirrels\",\"concepts\":[],\"type\":\"Subject\"}",
         "{\"label\":\"Struck samples\",\"concepts\":[],\"type\":\"Subject\"}"
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }

--- a/pipeline/ingestor/test_documents/images.subjects.squirrel,screwdriver.json
+++ b/pipeline/ingestor/test_documents/images.subjects.squirrel,screwdriver.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different subjects",
-  "createdAt" : "2022-12-06T10:45:24.862073Z",
+  "createdAt" : "2023-02-02T16:21:31.823291Z",
   "id" : "vzrqbquz",
   "document" : {
     "modifiedTime" : "2007-06-27T07:12:23Z",
@@ -5412,6 +5412,9 @@
         "{\"label\":\"Squashed squirrels\",\"concepts\":[],\"type\":\"Subject\"}",
         "{\"label\":\"Simple screwdrivers\",\"concepts\":[],\"type\":\"Subject\"}"
       ]
+    },
+    "debug" : {
+      "indexedTime" : "2001-01-01T01:01:01Z"
     }
   }
 }


### PR DESCRIPTION
This field is used by the snapshot reporter for works - I thought I might as well do this properly and add it to images as well. Part of https://github.com/wellcomecollection/platform/issues/5478