### PR TITLE
Include language from $l subtag

### DIFF
--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraAgents.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraAgents.scala
@@ -22,7 +22,8 @@ trait SierraAgents
   //
   def getPerson(
     subfields: List[Subfield],
-    normalisePerson: Boolean = false): Option[Person[IdState.Unminted]] =
+    normalisePerson: Boolean = false
+  ): Option[Person[IdState.Unminted]] =
     getLabel(subfields).map { label =>
       val person =
         Person(
@@ -51,7 +52,8 @@ trait SierraAgents
   //    in the label.
   //
   def getOrganisation(
-    subfields: List[Subfield]): Option[Organisation[IdState.Unminted]] =
+    subfields: List[Subfield]
+  ): Option[Organisation[IdState.Unminted]] =
     getLabel(subfields.filterNot(_.tag == "n"))
       .map { Organisation(_).normalised }
 
@@ -82,7 +84,8 @@ trait SierraAgents
   // For consistency, we remove all whitespace and some punctuation
   // before continuing.
   protected def getIdentifierSubfieldContents(
-    varField: VarField): List[String] =
+    varField: VarField
+  ): List[String] =
     varField.subfields.collect {
       case Subfield("0", content) => content.replaceAll("[.,\\s]", "")
     }.distinct
@@ -90,7 +93,8 @@ trait SierraAgents
   protected def maybeAddIdentifier(
     ontologyType: String,
     varField: VarField,
-    identifierSubfieldContent: String): IdState.Unminted =
+    identifierSubfieldContent: String
+  ): IdState.Unminted =
     IdState.Identifiable(
       SourceIdentifier(
         identifierType = IdentifierType.LCNames,
@@ -106,7 +110,7 @@ trait SierraAgents
     val contents =
       subfields
         .filter { s =>
-          List("a", "b", "c", "d", "t", "p", "n", "q").contains(s.tag)
+          List("a", "b", "c", "d", "t", "p", "n", "q", "l").contains(s.tag)
         }
         .filterNot { _.content.trim.isEmpty }
         .map { _.content }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraContributorsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraContributorsTest.scala
@@ -816,7 +816,7 @@ class SierraContributorsTest
           ),
           Subfield(tag = "l", content = "Latin."),
           Subfield(tag = "f", content = "1561."),
-          Subfield(tag = "0", content = "n  79005643")
+          Subfield(tag = "0", content = "n  79005643") // This identifier is for Hippocrates only
         )
       )
     )
@@ -834,7 +834,7 @@ class SierraContributorsTest
             )
           ),
           label =
-            "Hippocrates. Epistolae. Ad Ptolemaeum regem de hominis fabrica."
+            "Hippocrates. Epistolae. Ad Ptolemaeum regem de hominis fabrica. Latin."
         ),
         roles = List.empty,
         primary = false

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/matchers/SubjectMatchers.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/matchers/SubjectMatchers.scala
@@ -11,12 +11,15 @@ import weco.catalogue.internal_model.work.{AbstractRootConcept, Subject}
 
 trait SubjectMatchers {
 
-  def labelDerivedSubjectId(value: String, ontologyType: String = "Subject")
-    : HavePropertyMatcher[HasId[IdState.Unminted], String] =
+  def labelDerivedSubjectId(
+    value: String,
+    ontologyType: String = "Subject"
+  ): HavePropertyMatcher[HasId[IdState.Unminted], String] =
     new HasIdMatchers.HasIdentifier(
       identifierType = IdentifierType.LabelDerived,
       ontologyType = ontologyType,
-      value = value)
+      value = value
+    )
 
   implicit class SubjectTestOps[State](subject: Subject[State]) {
 
@@ -34,7 +37,8 @@ trait SubjectMatchers {
         case Seq(singleConcept) => singleConcept
         case _ =>
           fail(
-            s"Subject expected to have exactly one concept, found: ${subject.concepts}")
+            s"Subject expected to have exactly one concept, found: ${subject.concepts}"
+          )
       }
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/subjects/SierraPersonSubjectsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/subjects/SierraPersonSubjectsTest.scala
@@ -323,6 +323,32 @@ class SierraPersonSubjectsTest
     it("in the label") {
       subject.label shouldBe "Aristophanes. Birds."
     }
+
+    it("with the $l subfield") {
+      // From b30764701 (https://wellcomecollection.org/works/vbpkxhgv), among other places
+      // This work contains a subject referring to https://id.loc.gov/authorities/names/n85221892.html
+      // in which $l the language portion of the subject title, forms a distinguishing part
+      // of the title as a whole as distinct from
+      //  - the unmarked version n80119944, found in b13149143,
+      //  - or the French version nr2006002530, found in b2201679x
+      SierraPersonSubjects(
+        bibId,
+        createSierraBibDataWith(
+          varFields = List(
+            VarField(
+              marcTag = "600",
+              subfields = List(
+                Subfield(tag = "a", content = "Hippocrates."),
+                Subfield(tag = "t", content = "Aphorisms."),
+                Subfield(tag = "l", content = "Latin."),
+                Subfield(tag = "0", content = "n85221892")
+              )
+            )
+          )
+        )
+      ).onlySubject.label shouldBe "Hippocrates. Aphorisms. Latin."
+    }
+
   }
 
   it("doesn't remove a trailing ellipsis from a subject label") {

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/subjects/SierraPersonSubjectsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/subjects/SierraPersonSubjectsTest.scala
@@ -308,7 +308,7 @@ class SierraPersonSubjectsTest
       )
     )
 
-    val subject = SierraPersonSubjects(bibId, bibData).onlySubject
+    val List(subject) = SierraPersonSubjects(bibId, bibData)
 
     it("in the concepts") {
       subject.onlyConcept shouldBe a[Person[_]]
@@ -329,7 +329,7 @@ class SierraPersonSubjectsTest
       // of the title as a whole as distinct from
       //  - the unmarked version n80119944, found in b13149143,
       //  - or the French version nr2006002530, found in b2201679x
-      val subjectsWithLanguage = SierraPersonSubjects(
+      val List(subjectWithLanguage)= SierraPersonSubjects(
         bibId,
         createSierraBibDataWith(
           varFields = List(
@@ -345,7 +345,7 @@ class SierraPersonSubjectsTest
           )
         )
       )
-      subjectsWithLanguage.onlySubject.label shouldBe "Hippocrates. Aphorisms. Latin."
+      subjectWithLanguage.label shouldBe "Hippocrates. Aphorisms. Latin."
     }
 
   }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/subjects/SierraPersonSubjectsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/subjects/SierraPersonSubjectsTest.scala
@@ -308,9 +308,7 @@ class SierraPersonSubjectsTest
       )
     )
 
-    val actualSubjects = SierraPersonSubjects(bibId, bibData)
-    actualSubjects should have size 1
-    val subject = actualSubjects.head
+    val subject = SierraPersonSubjects(bibId, bibData).onlySubject
 
     it("in the concepts") {
       subject.onlyConcept shouldBe a[Person[_]]
@@ -331,7 +329,7 @@ class SierraPersonSubjectsTest
       // of the title as a whole as distinct from
       //  - the unmarked version n80119944, found in b13149143,
       //  - or the French version nr2006002530, found in b2201679x
-      SierraPersonSubjects(
+      val subjectsWithLanguage = SierraPersonSubjects(
         bibId,
         createSierraBibDataWith(
           varFields = List(
@@ -346,7 +344,8 @@ class SierraPersonSubjectsTest
             )
           )
         )
-      ).onlySubject.label shouldBe "Hippocrates. Aphorisms. Latin."
+      )
+      subjectsWithLanguage.onlySubject.label shouldBe "Hippocrates. Aphorisms. Latin."
     }
 
   }


### PR DESCRIPTION
This mitigates https://github.com/wellcomecollection/catalogue-pipeline/issues/2308 (though this issue is more widespread than just that document)

Some of those Iliads use $s to differentiate themselves, but I think this is the only place where that construction is used in that way,  Including $s would be wrong in other situations.

Also, these Iliads look wrong anyway, so we shouldn't try too hard to accommodate them.