### PR TITLE
Give the snapshot generator permissions to read indexed images

### DIFF
--- a/pipeline/terraform/scripts/create_pipeline_storage_users.py
+++ b/pipeline/terraform/scripts/create_pipeline_storage_users.py
@@ -35,7 +35,7 @@ SERVICES = {
     "work_ingestor": ["works-denormalised_read", "works-indexed_write"],
     "inferrer": ["images-initial_read", "images-augmented_write"],
     "image_ingestor": ["images-augmented_read", "images-indexed_write"],
-    "snapshot_generator": ["works-indexed_read"],
+    "snapshot_generator": ["works-indexed_read", "images-indexed_read"],
     "catalogue_api": [
         "works-indexed_read", "images-indexed_read",
 


### PR DESCRIPTION
I'll be making this change manually for the current pipeline but it does remind me that this script can/should be replaced with Terraform now...