### PR TITLE
Combine the lettering (246 .6) and lettering note (514) for visual material

### DIFF
--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraNotes.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraNotes.scala
@@ -69,6 +69,11 @@ object SierraNotes extends SierraDataTransformer with SierraQueryOps {
         case vf @ VarField(_, Some("561"), _, Some("1"), _, _) =>
           Some((vf, Some(createNoteFromContents(NoteType.OwnershipNote))))
 
+        // For visual material (matType k) we want to put 514 in the lettering
+        // field, not as a lettering note.  See comment on SierraLettering.
+        case VarField(_, Some("514"), _, _, _, _) if bibData.materialType.map(_.code).contains("k") =>
+          None
+
         case vf @ VarField(_, Some(marcTag), _, _, _, _) =>
           Some((vf, notesFields.get(marcTag)))
         case _ => None

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraLetteringTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraLetteringTest.scala
@@ -3,6 +3,7 @@ package weco.pipeline.transformer.sierra.transformers
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.sierra.generators.{MarcGenerators, SierraDataGenerators}
+import weco.sierra.models.fields.SierraMaterialType
 import weco.sierra.models.marc.{Subfield, VarField}
 
 class SierraLetteringTest
@@ -98,6 +99,45 @@ class SierraLetteringTest
       expectedLettering = Some(
         "Daring dalmations dance with danger\n\nEnterprising eskimos exile every eagle")
     )
+  }
+
+  describe("lettering for visual material") {
+    it("uses both 246 .6 ǂa and 514 for visual material") {
+      // This is based on b16529888
+      val bibData = createSierraBibDataWith(
+        materialType = Some(SierraMaterialType("k")),
+        varFields = List(
+          VarField(marcTag = "514", subfields = List(Subfield(tag = "a", content = "Lettering continues: Comment va  le malade? H\\u00e9las Monsieur, il est mort ce matin \\u00e0 six heures! Ah il est mort le gaillard! .. Il n'a donc pas pris ma potion? Si Monsieur. Il en a donc trop pris? Non Monsieur. C'est qu'il n'en a assez pris. H.D."))),
+          VarField(
+            marcTag = Some("246"),
+            indicator2 = Some("6"),
+            subfields = List(
+              Subfield(tag = "a", content = "Le m\u00e9decin et la garde malade. H.D. ...")
+            )
+          )
+        )
+      )
+
+      SierraLettering(bibData) shouldBe Some("Le m\u00e9decin et la garde malade. H.D. ...\n\nLettering continues: Comment va  le malade? H\\u00e9las Monsieur, il est mort ce matin \\u00e0 six heures! Ah il est mort le gaillard! .. Il n'a donc pas pris ma potion? Si Monsieur. Il en a donc trop pris? Non Monsieur. C'est qu'il n'en a assez pris. H.D.")
+    }
+
+    it("only uses both 246 .6 ǂa for non-visual material") {
+      val bibData = createSierraBibDataWith(
+        materialType = Some(SierraMaterialType("not-k")),
+        varFields = List(
+          VarField(marcTag = "514", subfields = List(Subfield(tag = "a", content = "Lettering continues: Comment va  le malade? H\\u00e9las Monsieur, il est mort ce matin \\u00e0 six heures! Ah il est mort le gaillard! .. Il n'a donc pas pris ma potion? Si Monsieur. Il en a donc trop pris? Non Monsieur. C'est qu'il n'en a assez pris. H.D."))),
+          VarField(
+            marcTag = Some("246"),
+            indicator2 = Some("6"),
+            subfields = List(
+              Subfield(tag = "a", content = "Le m\u00e9decin et la garde malade. H.D. ...")
+            )
+          )
+        )
+      )
+
+      SierraLettering(bibData) shouldBe Some("Le m\u00e9decin et la garde malade. H.D. ...")
+    }
   }
 
   private def assertFindsCorrectLettering(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraNotesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraNotesTest.scala
@@ -5,6 +5,7 @@ import org.scalatest.matchers.should.Matchers
 import weco.catalogue.internal_model.work._
 import weco.sierra.generators.{MarcGenerators, SierraDataGenerators}
 import weco.sierra.models.data.SierraBibData
+import weco.sierra.models.fields.SierraMaterialType
 import weco.sierra.models.marc.{Subfield, VarField}
 
 class SierraNotesTest
@@ -418,6 +419,50 @@ class SierraNotesTest
         Note(
           contents = "Times (London, England :  1788). May 27, 2004. (OCoLC)6967919",
           noteType = NoteType.RelatedMaterial
+        )
+      )
+    }
+  }
+
+  describe("lettering for visual material") {
+    it("uses both 246 .6 ǂa and 514 for visual material") {
+      // This is based on b16529888
+      val bibData = createSierraBibDataWith(
+        materialType = Some(SierraMaterialType("k")),
+        varFields = List(
+          VarField(marcTag = "514", subfields = List(Subfield(tag = "a", content = "Lettering continues: Comment va  le malade? H\\u00e9las Monsieur, il est mort ce matin \\u00e0 six heures! Ah il est mort le gaillard! .. Il n'a donc pas pris ma potion? Si Monsieur. Il en a donc trop pris? Non Monsieur. C'est qu'il n'en a assez pris. H.D."))),
+          VarField(
+            marcTag = Some("246"),
+            indicator2 = Some("6"),
+            subfields = List(
+              Subfield(tag = "a", content = "Le m\u00e9decin et la garde malade. H.D. ...")
+            )
+          )
+        )
+      )
+
+      SierraNotes(bibData) shouldBe empty
+    }
+
+    it("only uses both 246 .6 ǂa for non-visual material") {
+      val bibData = createSierraBibDataWith(
+        materialType = Some(SierraMaterialType("not-k")),
+        varFields = List(
+          VarField(marcTag = "514", subfields = List(Subfield(tag = "a", content = "Lettering continues: Comment va  le malade? H\\u00e9las Monsieur, il est mort ce matin \\u00e0 six heures! Ah il est mort le gaillard! .. Il n'a donc pas pris ma potion? Si Monsieur. Il en a donc trop pris? Non Monsieur. C'est qu'il n'en a assez pris. H.D."))),
+          VarField(
+            marcTag = Some("246"),
+            indicator2 = Some("6"),
+            subfields = List(
+              Subfield(tag = "a", content = "Le m\u00e9decin et la garde malade. H.D. ...")
+            )
+          )
+        )
+      )
+
+      SierraNotes(bibData) shouldBe List(
+        Note(
+          noteType = NoteType.LetteringNote,
+          contents = "Lettering continues: Comment va  le malade? H\\u00e9las Monsieur, il est mort ce matin \\u00e0 six heures! Ah il est mort le gaillard! .. Il n'a donc pas pris ma potion? Si Monsieur. Il en a donc trop pris? Non Monsieur. C'est qu'il n'en a assez pris. H.D."
         )
       )
     }


### PR DESCRIPTION
This is a request from the Collections team; they want the lettering note from 514 to appear in the same place as the lettering (246 .6) on the works page, so it makes sense to combine them in the pipeline.

Closes https://github.com/wellcomecollection/catalogue-pipeline/issues/2330