### PR TITLE
add a version and services heading to all docker-compose files

### DIFF
--- a/calm_adapter/calm_adapter/docker-compose.yml
+++ b/calm_adapter/calm_adapter/docker-compose.yml
@@ -1,6 +1,8 @@
-localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
-  environment:
-    - SERVICES=sqs
-  ports:
-    - "4566:4566"
+version: '3.3'
+services:
+  localstack:
+    image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
+    environment:
+      - SERVICES=sqs
+    ports:
+      - "4566:4566"

--- a/calm_adapter/calm_deletion_checker/docker-compose.yml
+++ b/calm_adapter/calm_deletion_checker/docker-compose.yml
@@ -1,11 +1,13 @@
-localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
-  environment:
-    - SERVICES=sqs
-  ports:
-    - "4566:4566"
+version: '3.3'
+services:
+  localstack:
+    image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
+    environment:
+      - SERVICES=sqs
+    ports:
+      - "4566:4566"
 
-dynamodb:
-  image: "public.ecr.aws/aws-dynamodb-local/aws-dynamodb-local"
-  ports:
-    - "45678:8000"
+  dynamodb:
+    image: "public.ecr.aws/aws-dynamodb-local/aws-dynamodb-local"
+    ports:
+      - "45678:8000"

--- a/calm_adapter/calm_indexer/docker-compose.yml
+++ b/calm_adapter/calm_indexer/docker-compose.yml
@@ -1,18 +1,20 @@
-localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
-  environment:
-    - SERVICES=sqs
-  ports:
-    - "4566:4566"
-elasticsearch:
-  image: "docker.elastic.co/elasticsearch/elasticsearch:8.4.0"
-  ports:
-    - "9200:9200"
-    - "9300:9300"
-  environment:
-    - "http.host=0.0.0.0"
-    - "transport.host=0.0.0.0"
-    - "cluster.name=wellcome"
-    - "ES_JAVA_OPTS=-Xms750m -Xmx750m"
-    - "discovery.type=single-node"
-    - "xpack.security.enabled=false"
+version: '3.3'
+services:
+  localstack:
+    image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
+    environment:
+      - SERVICES=sqs
+    ports:
+      - "4566:4566"
+  elasticsearch:
+    image: "docker.elastic.co/elasticsearch/elasticsearch:8.4.0"
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    environment:
+      - "http.host=0.0.0.0"
+      - "transport.host=0.0.0.0"
+      - "cluster.name=wellcome"
+      - "ES_JAVA_OPTS=-Xms750m -Xmx750m"
+      - "discovery.type=single-node"
+      - "xpack.security.enabled=false"

--- a/common/internal_model/docker-compose.yml
+++ b/common/internal_model/docker-compose.yml
@@ -1,12 +1,14 @@
-elasticsearch:
-  image: "docker.elastic.co/elasticsearch/elasticsearch:8.4.0"
-  ports:
-    - "9200:9200"
-    - "9300:9300"
-  environment:
-    - "http.host=0.0.0.0"
-    - "transport.host=0.0.0.0"
-    - "cluster.name=wellcome"
-    - "ES_JAVA_OPTS=-Xms750m -Xmx750m"
-    - "discovery.type=single-node"
-    - "xpack.security.enabled=false"
+version: "3.3"
+services:
+  elasticsearch:
+    image: "docker.elastic.co/elasticsearch/elasticsearch:8.4.0"
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    environment:
+      - "http.host=0.0.0.0"
+      - "transport.host=0.0.0.0"
+      - "cluster.name=wellcome"
+      - "ES_JAVA_OPTS=-Xms750m -Xmx750m"
+      - "discovery.type=single-node"
+      - "xpack.security.enabled=false"

--- a/common/pipeline_storage/docker-compose.yml
+++ b/common/pipeline_storage/docker-compose.yml
@@ -1,21 +1,23 @@
-localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
-  environment:
-    - SERVICES=sqs
-  ports:
-    - "4566:4566"
-elasticsearch:
-  image: "docker.elastic.co/elasticsearch/elasticsearch:8.4.0"
-  ports:
-    - "9200:9200"
-    - "9300:9300"
-  environment:
-    - "http.host=0.0.0.0"
-    - "transport.host=0.0.0.0"
-    - "cluster.name=wellcome"
-    - "discovery.type=single-node"
-    - "xpack.security.enabled=false"
-    # This is deliberately much lower than the default (100mb), because we want
-    # to test that our code works correctly when it exceeds this limit, but without
-    # queuing up 100mb+ of documents in-memory during tests.
-    - "http.max_content_length=1mb"
+version: '3.3'
+services:
+  localstack:
+    image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
+    environment:
+      - SERVICES=sqs
+    ports:
+      - "4566:4566"
+  elasticsearch:
+    image: "docker.elastic.co/elasticsearch/elasticsearch:8.4.0"
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    environment:
+      - "http.host=0.0.0.0"
+      - "transport.host=0.0.0.0"
+      - "cluster.name=wellcome"
+      - "discovery.type=single-node"
+      - "xpack.security.enabled=false"
+      # This is deliberately much lower than the default (100mb), because we want
+      # to test that our code works correctly when it exceeds this limit, but without
+      # queuing up 100mb+ of documents in-memory during tests.
+      - "http.max_content_length=1mb"

--- a/mets_adapter/mets_adapter/docker-compose.yml
+++ b/mets_adapter/mets_adapter/docker-compose.yml
@@ -1,10 +1,12 @@
-localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
-  environment:
-    - SERVICES=sqs
-  ports:
-    - "4566:4566"
-dynamodb:
-  image: "public.ecr.aws/aws-dynamodb-local/aws-dynamodb-local"
-  ports:
-    - "45678:8000"
+version: '3.3'
+services:
+  localstack:
+    image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
+    environment:
+      - SERVICES=sqs
+    ports:
+      - "4566:4566"
+  dynamodb:
+    image: "public.ecr.aws/aws-dynamodb-local/aws-dynamodb-local"
+    ports:
+      - "45678:8000"

--- a/pipeline/id_minter/docker-compose.yml
+++ b/pipeline/id_minter/docker-compose.yml
@@ -1,3 +1,4 @@
+version: '3.3'
 services:
   mysql:
     image: "public.ecr.aws/docker/library/mysql:5.7"

--- a/pipeline/inferrer/inference_manager/docker-compose.yml
+++ b/pipeline/inferrer/inference_manager/docker-compose.yml
@@ -1,43 +1,45 @@
-localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
-  environment:
-    - SERVICES=sqs
-  ports:
-    - "4566:4566"
+version: '3.3'
+services:
+  localstack:
+    image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
+    environment:
+      - SERVICES=sqs
+    ports:
+      - "4566:4566"
 
-feature_inferrer:
-  image: feature_inferrer
-  ports:
-    - "3141:80"
-  environment:
-    MODEL_OBJECT_KEY: test-model.pkl
-  volumes:
-    - ../test_data:/app/data
-    - $ROOT:$ROOT
-  links:
-    - "image_server:image_server"
+  feature_inferrer:
+    image: feature_inferrer
+    ports:
+      - "3141:80"
+    environment:
+      MODEL_OBJECT_KEY: test-model.pkl
+    volumes:
+      - ../test_data:/app/data
+      - $ROOT:$ROOT
+    links:
+      - "image_server:image_server"
 
-palette_inferrer:
-  image: palette_inferrer
-  ports:
-    - "3142:80"
-  volumes:
-    - $ROOT:$ROOT
-  links:
-    - "image_server:image_server"
+  palette_inferrer:
+    image: palette_inferrer
+    ports:
+      - "3142:80"
+    volumes:
+      - $ROOT:$ROOT
+    links:
+      - "image_server:image_server"
 
-aspect_ratio_inferrer:
-  image: aspect_ratio_inferrer
-  ports:
-    - "3143:80"
-  volumes:
-    - $ROOT:$ROOT
-  links:
-    - "image_server:image_server"
+  aspect_ratio_inferrer:
+    image: aspect_ratio_inferrer
+    ports:
+      - "3143:80"
+    volumes:
+      - $ROOT:$ROOT
+    links:
+      - "image_server:image_server"
 
-image_server:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/nginx"
-  ports:
-    - "2718:80"
-  volumes:
-    - ../test_data:/usr/share/nginx/html:ro
+  image_server:
+    image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/nginx"
+    ports:
+      - "2718:80"
+    volumes:
+      - ../test_data:/usr/share/nginx/html:ro

--- a/pipeline/matcher/docker-compose.yml
+++ b/pipeline/matcher/docker-compose.yml
@@ -1,21 +1,23 @@
-localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
-  environment:
-    - SERVICES=sqs
-  ports:
-    - "4566:4566"
-dynamodb:
-  image: "public.ecr.aws/aws-dynamodb-local/aws-dynamodb-local"
-  ports:
-    - "45678:8000"
-elasticsearch:
-  image: "docker.elastic.co/elasticsearch/elasticsearch:8.4.0"
-  ports:
-    - "9200:9200"
-    - "9300:9300"
-  environment:
-    - "http.host=0.0.0.0"
-    - "transport.host=0.0.0.0"
-    - "cluster.name=wellcome"
-    - "discovery.type=single-node"
-    - "xpack.security.enabled=false"
+version: '3.3'
+services:
+  localstack:
+    image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
+    environment:
+      - SERVICES=sqs
+    ports:
+      - "4566:4566"
+  dynamodb:
+    image: "public.ecr.aws/aws-dynamodb-local/aws-dynamodb-local"
+    ports:
+      - "45678:8000"
+  elasticsearch:
+    image: "docker.elastic.co/elasticsearch/elasticsearch:8.4.0"
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    environment:
+      - "http.host=0.0.0.0"
+      - "transport.host=0.0.0.0"
+      - "cluster.name=wellcome"
+      - "discovery.type=single-node"
+      - "xpack.security.enabled=false"

--- a/pipeline/relation_embedder/batcher/docker-compose.yml
+++ b/pipeline/relation_embedder/batcher/docker-compose.yml
@@ -1,6 +1,8 @@
-localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
-  environment:
-    - SERVICES=sqs
-  ports:
-    - "4566:4566"
+version: '3.3'
+services:
+  localstack:
+    image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
+    environment:
+      - SERVICES=sqs
+    ports:
+      - "4566:4566"

--- a/pipeline/relation_embedder/path_concatenator/docker-compose.yml
+++ b/pipeline/relation_embedder/path_concatenator/docker-compose.yml
@@ -1,18 +1,20 @@
-localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
-  environment:
-    - SERVICES=sqs
-  ports:
-    - "4566:4566"
-elasticsearch:
-  image: "docker.elastic.co/elasticsearch/elasticsearch:8.4.0"
-  ports:
-    - "9200:9200"
-    - "9300:9300"
-  environment:
-    - "http.host=0.0.0.0"
-    - "transport.host=0.0.0.0"
-    - "cluster.name=wellcome"
-    - "logger.level=DEBUG"
-    - "discovery.type=single-node"
-    - "xpack.security.enabled=false"
+version: '3.3'
+services:
+  localstack:
+    image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
+    environment:
+      - SERVICES=sqs
+    ports:
+      - "4566:4566"
+  elasticsearch:
+    image: "docker.elastic.co/elasticsearch/elasticsearch:8.4.0"
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    environment:
+      - "http.host=0.0.0.0"
+      - "transport.host=0.0.0.0"
+      - "cluster.name=wellcome"
+      - "logger.level=DEBUG"
+      - "discovery.type=single-node"
+      - "xpack.security.enabled=false"

--- a/pipeline/relation_embedder/relation_embedder/docker-compose.yml
+++ b/pipeline/relation_embedder/relation_embedder/docker-compose.yml
@@ -1,18 +1,20 @@
-localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
-  environment:
-    - SERVICES=sqs
-  ports:
-    - "4566:4566"
-elasticsearch:
-  image: "docker.elastic.co/elasticsearch/elasticsearch:8.4.0"
-  ports:
-    - "9200:9200"
-    - "9300:9300"
-  environment:
-    - "http.host=0.0.0.0"
-    - "transport.host=0.0.0.0"
-    - "cluster.name=wellcome"
-    - "logger.level=DEBUG"
-    - "discovery.type=single-node"
-    - "xpack.security.enabled=false"
+version: '3.3'
+services:
+  localstack:
+    image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
+    environment:
+      - SERVICES=sqs
+    ports:
+      - "4566:4566"
+  elasticsearch:
+    image: "docker.elastic.co/elasticsearch/elasticsearch:8.4.0"
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    environment:
+      - "http.host=0.0.0.0"
+      - "transport.host=0.0.0.0"
+      - "cluster.name=wellcome"
+      - "logger.level=DEBUG"
+      - "discovery.type=single-node"
+      - "xpack.security.enabled=false"

--- a/pipeline/relation_embedder/router/docker-compose.yml
+++ b/pipeline/relation_embedder/router/docker-compose.yml
@@ -1,6 +1,8 @@
-localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
-  environment:
-    - SERVICES=sqs
-  ports:
-    - "4566:4566"
+version: '3.3'
+services:
+  localstack:
+    image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
+    environment:
+      - SERVICES=sqs
+    ports:
+      - "4566:4566"

--- a/pipeline/transformer/transformer_calm/docker-compose.yml
+++ b/pipeline/transformer/transformer_calm/docker-compose.yml
@@ -1,6 +1,8 @@
-localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
-  environment:
-    - SERVICES=sqs
-  ports:
-    - "4566:4566"
+version: '3.3'
+services:
+  localstack:
+    image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
+    environment:
+      - SERVICES=sqs
+    ports:
+      - "4566:4566"

--- a/pipeline/transformer/transformer_common/docker-compose.yml
+++ b/pipeline/transformer/transformer_common/docker-compose.yml
@@ -1,6 +1,8 @@
-localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
-  environment:
-    - SERVICES=sqs
-  ports:
-    - "4566:4566"
+version: '3.3'
+services:
+  localstack:
+    image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
+    environment:
+      - SERVICES=sqs
+    ports:
+      - "4566:4566"

--- a/pipeline/transformer/transformer_mets/docker-compose.yml
+++ b/pipeline/transformer/transformer_mets/docker-compose.yml
@@ -1,6 +1,8 @@
-localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
-  environment:
-    - SERVICES=sqs
-  ports:
-    - "4566:4566"
+version: '3.3'
+services:
+  localstack:
+    image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
+    environment:
+      - SERVICES=sqs
+    ports:
+      - "4566:4566"

--- a/pipeline/transformer/transformer_miro/docker-compose.yml
+++ b/pipeline/transformer/transformer_miro/docker-compose.yml
@@ -1,6 +1,8 @@
-localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
-  environment:
-    - SERVICES=sqs
-  ports:
-    - "4566:4566"
+version: '3.3'
+services:
+  localstack:
+    image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
+    environment:
+      - SERVICES=sqs
+    ports:
+      - "4566:4566"

--- a/pipeline/transformer/transformer_sierra/docker-compose.yml
+++ b/pipeline/transformer/transformer_sierra/docker-compose.yml
@@ -1,6 +1,8 @@
-localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
-  environment:
-    - SERVICES=sqs
-  ports:
-    - "4566:4566"
+version: '3.3'
+services:
+  localstack:
+    image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
+    environment:
+      - SERVICES=sqs
+    ports:
+      - "4566:4566"

--- a/reindexer/reindex_worker/docker-compose.yml
+++ b/reindexer/reindex_worker/docker-compose.yml
@@ -1,10 +1,12 @@
-localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
-  environment:
-    - SERVICES=sqs
-  ports:
-    - "4566:4566"
-dynamodb:
-  image: "public.ecr.aws/aws-dynamodb-local/aws-dynamodb-local"
-  ports:
-    - "45678:8000"
+version: '3.3'
+services:
+  localstack:
+    image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
+    environment:
+      - SERVICES=sqs
+    ports:
+      - "4566:4566"
+  dynamodb:
+    image: "public.ecr.aws/aws-dynamodb-local/aws-dynamodb-local"
+    ports:
+      - "45678:8000"

--- a/sierra_adapter/sierra_indexer/docker-compose.yml
+++ b/sierra_adapter/sierra_indexer/docker-compose.yml
@@ -1,18 +1,20 @@
-localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
-  environment:
-    - SERVICES=sqs
-  ports:
-    - "4566:4566"
-elasticsearch:
-  image: "docker.elastic.co/elasticsearch/elasticsearch:8.4.0"
-  ports:
-    - "9200:9200"
-    - "9300:9300"
-  environment:
-    - "http.host=0.0.0.0"
-    - "transport.host=0.0.0.0"
-    - "cluster.name=wellcome"
-    - "ES_JAVA_OPTS=-Xms750m -Xmx750m"
-    - "discovery.type=single-node"
-    - "xpack.security.enabled=false"
+version: '3.3'
+services:
+  localstack:
+    image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
+    environment:
+      - SERVICES=sqs
+    ports:
+      - "4566:4566"
+  elasticsearch:
+    image: "docker.elastic.co/elasticsearch/elasticsearch:8.4.0"
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    environment:
+      - "http.host=0.0.0.0"
+      - "transport.host=0.0.0.0"
+      - "cluster.name=wellcome"
+      - "ES_JAVA_OPTS=-Xms750m -Xmx750m"
+      - "discovery.type=single-node"
+      - "xpack.security.enabled=false"

--- a/sierra_adapter/sierra_linker/docker-compose.yml
+++ b/sierra_adapter/sierra_linker/docker-compose.yml
@@ -1,6 +1,8 @@
-localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
-  environment:
-    - SERVICES=sqs
-  ports:
-    - "4566:4566"
+version: '3.3'
+services:
+  localstack:
+    image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
+    environment:
+      - SERVICES=sqs
+    ports:
+      - "4566:4566"

--- a/sierra_adapter/sierra_merger/docker-compose.yml
+++ b/sierra_adapter/sierra_merger/docker-compose.yml
@@ -1,6 +1,8 @@
-localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
-  environment:
-    - SERVICES=sqs
-  ports:
-    - "4566:4566"
+version: '3.3'
+services:
+  localstack:
+    image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
+    environment:
+      - SERVICES=sqs
+    ports:
+      - "4566:4566"

--- a/sierra_adapter/sierra_reader/docker-compose.yml
+++ b/sierra_adapter/sierra_reader/docker-compose.yml
@@ -1,12 +1,14 @@
-s3:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/zenko/cloudserver:8.1.8"
-  environment:
-    - "S3BACKEND=mem"
-  ports:
-    - "33333:8000"
-localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
-  environment:
-    - SERVICES=sqs
-  ports:
-    - "4566:4566"
+version: '3.3'
+services:
+  s3:
+    image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/zenko/cloudserver:8.1.8"
+    environment:
+      - "S3BACKEND=mem"
+    ports:
+      - "33333:8000"
+  localstack:
+    image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
+    environment:
+      - SERVICES=sqs
+    ports:
+      - "4566:4566"

--- a/tei_adapter/tei_adapter/docker-compose.yml
+++ b/tei_adapter/tei_adapter/docker-compose.yml
@@ -1,6 +1,8 @@
-localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
-  environment:
-    - SERVICES=sqs
-  ports:
-    - "4566:4566"
+version: '3.3'
+services:
+  localstack:
+    image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
+    environment:
+      - SERVICES=sqs
+    ports:
+      - "4566:4566"

--- a/tei_adapter/tei_id_extractor/docker-compose.yml
+++ b/tei_adapter/tei_id_extractor/docker-compose.yml
@@ -1,12 +1,14 @@
-localstack:
-  image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
-  environment:
-    - SERVICES=sqs
-  ports:
-    - "4566:4566"
-mysql:
-  image: "public.ecr.aws/docker/library/mysql:5.6"
-  ports:
-    - "3307:3306"
-  environment:
-    - "MYSQL_ROOT_PASSWORD=password"
+version: '3.3'
+services:
+  localstack:
+    image: "760097843905.dkr.ecr.eu-west-1.amazonaws.com/localstack/localstack:0.12.5"
+    environment:
+      - SERVICES=sqs
+    ports:
+      - "4566:4566"
+  mysql:
+    image: "public.ecr.aws/docker/library/mysql:5.6"
+    ports:
+      - "3307:3306"
+    environment:
+      - "MYSQL_ROOT_PASSWORD=password"


### PR DESCRIPTION
Trying to spin up a local elastic cluster fails with the following error:
```
➜ docker compose up --build -d
(root) Additional property elasticsearch is not allowed
```

Adding a `version` and `services:` heading to the files solves that problem