### PR TITLE
replace the hyphens char filter with a punctuation token filter

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksAnalysis.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksAnalysis.scala
@@ -103,14 +103,22 @@ object WorksAnalysis {
   val shingleAsciifoldingAnalyzer = CustomAnalyzer(
     "shingle_asciifolding_analyzer",
     tokenizer = "standard",
-    tokenFilters =
-      List("lowercase", punctuationTokenFilter.name, shingleTokenFilter.name, asciiFoldingTokenFilter.name),
+    tokenFilters = List(
+      "lowercase",
+      punctuationTokenFilter.name,
+      shingleTokenFilter.name,
+      asciiFoldingTokenFilter.name
+    )
   )
 
   val shingleCasedAnalyzer = CustomAnalyzer(
     "shingle_cased_analyzer",
     tokenizer = "standard",
-    tokenFilters = List(punctuationTokenFilter.name, shingleTokenFilter.name, asciiFoldingTokenFilter.name),
+    tokenFilters = List(
+      punctuationTokenFilter.name,
+      shingleTokenFilter.name,
+      asciiFoldingTokenFilter.name
+    )
   )
 
   val whitespaceAnalyzer = CustomAnalyzer(

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksAnalysis.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksAnalysis.scala
@@ -12,7 +12,7 @@ object WorksAnalysis {
   val punctuationTokenFilter =
     PatternReplaceTokenFilter(
       "punctuation",
-      pattern = "[^\\w\\s]",
+      pattern = "[^0-9\\p{L}\\s]",
       replacement = ""
     )
 

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksAnalysis.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksAnalysis.scala
@@ -8,12 +8,11 @@ object WorksAnalysis {
   val slashesCharFilter =
     MappingCharFilter("slashes_char_filter", mappings = Map("/" -> " __"))
 
-  // This analyzer "keeps" the hyphen, by removing it and treating hyphenated
-  // tokens as a single token.
-  val hyphensCharFilter =
-    PatternReplaceCharFilter(
-      "hyphens_char_filter",
-      pattern = "-",
+  // This char filter removes all punctuation
+  val punctuationTokenFilter =
+    PatternReplaceTokenFilter(
+      "punctuation",
+      pattern = "[^\\w\\s]",
       replacement = ""
     )
 
@@ -105,15 +104,13 @@ object WorksAnalysis {
     "shingle_asciifolding_analyzer",
     tokenizer = "standard",
     tokenFilters =
-      List("lowercase", shingleTokenFilter.name, asciiFoldingTokenFilter.name),
-    charFilters = List(hyphensCharFilter.name)
+      List("lowercase", punctuationTokenFilter.name, shingleTokenFilter.name, asciiFoldingTokenFilter.name),
   )
 
   val shingleCasedAnalyzer = CustomAnalyzer(
     "shingle_cased_analyzer",
     tokenizer = "standard",
-    tokenFilters = List(shingleTokenFilter.name, asciiFoldingTokenFilter.name),
-    charFilters = List(hyphensCharFilter.name)
+    tokenFilters = List(punctuationTokenFilter.name, shingleTokenFilter.name, asciiFoldingTokenFilter.name),
   )
 
   val whitespaceAnalyzer = CustomAnalyzer(
@@ -154,10 +151,11 @@ object WorksAnalysis {
         asciiFoldingTokenFilter,
         shingleTokenFilter,
         englishStemmerTokenFilter,
-        englishPossessiveStemmerTokenFilter
+        englishPossessiveStemmerTokenFilter,
+        punctuationTokenFilter
       ) ++ languageFiltersAndAnalyzers.map(_._1),
       normalizers = List(lowercaseNormalizer),
-      charFilters = List(slashesCharFilter, hyphensCharFilter)
+      charFilters = List(slashesCharFilter)
     )
   }
 }

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksAnalysis.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/index/WorksAnalysis.scala
@@ -8,7 +8,14 @@ object WorksAnalysis {
   val slashesCharFilter =
     MappingCharFilter("slashes_char_filter", mappings = Map("/" -> " __"))
 
-  // This char filter removes all punctuation
+  // This filter removes any character which isn't
+  // - a number (0-9)
+  // - a character in any language (\p{L})
+  // - whitespace (\s)
+  //
+  // We use \p{L} instead of \w because \w doesn't include accented or
+  // non-Latin characters.
+  // See https://github.com/wellcomecollection/catalogue-pipeline/pull/2334#discussion_r1126687056
   val punctuationTokenFilter =
     PatternReplaceTokenFilter(
       "punctuation",

--- a/common/internal_model/src/test/resources/ImagesIndexConfig.json
+++ b/common/internal_model/src/test/resources/ImagesIndexConfig.json
@@ -613,6 +613,11 @@
     "index": {
       "analysis": {
         "filter": {
+          "punctuation": {
+            "type": "pattern_replace",
+            "pattern": "[^\\w\\s]",
+            "replacement": ""
+          },
           "english_stemmer": {
             "name": "english",
             "type": "stemmer"
@@ -661,11 +666,6 @@
             "mappings": [
               "/=> __"
             ]
-          },
-          "hyphens_char_filter": {
-            "pattern": "-",
-            "type": "pattern_replace",
-            "replacement": ""
           }
         },
         "normalizer": {
@@ -681,15 +681,6 @@
             "filter": [
               "lowercase",
               "hindi_stemmer"
-            ],
-            "type": "custom",
-            "tokenizer": "standard"
-          },
-          "english_cased_analyzer": {
-            "filter": [
-              "asciifolding_token_filter",
-              "english_stemmer",
-              "english_possessive_stemmer"
             ],
             "type": "custom",
             "tokenizer": "standard"
@@ -724,6 +715,15 @@
             "type": "custom",
             "tokenizer": "standard"
           },
+          "english_cased_analyzer": {
+            "filter": [
+              "asciifolding_token_filter",
+              "english_stemmer",
+              "english_possessive_stemmer"
+            ],
+            "type": "custom",
+            "tokenizer": "standard"
+          },
           "bengali_analyzer": {
             "filter": [
               "lowercase",
@@ -751,17 +751,6 @@
             "type": "custom",
             "tokenizer": "standard"
           },
-          "shingle_cased_analyzer": {
-            "filter": [
-              "shingle_token_filter",
-              "asciifolding_token_filter"
-            ],
-            "char_filter": [
-              "hyphens_char_filter"
-            ],
-            "type": "custom",
-            "tokenizer": "standard"
-          },
           "clean_path_analyzer": {
             "filter": [
               "lowercase",
@@ -773,11 +762,18 @@
           "shingle_asciifolding_analyzer": {
             "filter": [
               "lowercase",
+              "punctuation",
               "shingle_token_filter",
               "asciifolding_token_filter"
             ],
-            "char_filter": [
-              "hyphens_char_filter"
+            "type": "custom",
+            "tokenizer": "standard"
+          },
+          "shingle_cased_analyzer": {
+            "filter": [
+              "punctuation",
+              "shingle_token_filter",
+              "asciifolding_token_filter"
             ],
             "type": "custom",
             "tokenizer": "standard"

--- a/common/internal_model/src/test/resources/ImagesIndexConfig.json
+++ b/common/internal_model/src/test/resources/ImagesIndexConfig.json
@@ -615,7 +615,7 @@
         "filter": {
           "punctuation": {
             "type": "pattern_replace",
-            "pattern": "[^\\w\\s]",
+            "pattern": "[^0-9\\p{L}\\s]",
             "replacement": ""
           },
           "english_stemmer": {

--- a/common/internal_model/src/test/resources/WorksIndexConfig.json
+++ b/common/internal_model/src/test/resources/WorksIndexConfig.json
@@ -648,8 +648,8 @@
                 "analyzer": "italian_analyzer"
               },
               "shingles": {
-                "type" : "text",
-                "analyzer" : "shingle_asciifolding_analyzer"
+                "type": "text",
+                "analyzer": "shingle_asciifolding_analyzer"
               },
               "english_cased": {
                 "type": "text",
@@ -684,7 +684,7 @@
         "filter": {
           "punctuation": {
             "type": "pattern_replace",
-            "pattern": "[^\\w\\s]",
+            "pattern": "[^0-9\\p{L}\\s]",
             "replacement": ""
           },
           "english_stemmer": {

--- a/common/internal_model/src/test/resources/WorksIndexConfig.json
+++ b/common/internal_model/src/test/resources/WorksIndexConfig.json
@@ -631,10 +631,6 @@
                 "type": "text",
                 "analyzer": "english_analyzer"
               },
-              "english_cased": {
-                "type": "text",
-                "analyzer": "english_cased_analyzer"
-              },
               "french": {
                 "type": "text",
                 "analyzer": "french_analyzer"
@@ -652,8 +648,12 @@
                 "analyzer": "italian_analyzer"
               },
               "shingles": {
+                "type" : "text",
+                "analyzer" : "shingle_asciifolding_analyzer"
+              },
+              "english_cased": {
                 "type": "text",
-                "analyzer": "shingle_asciifolding_analyzer"
+                "analyzer": "english_cased_analyzer"
               },
               "shingles_cased": {
                 "type": "text",
@@ -682,6 +682,11 @@
     "index": {
       "analysis": {
         "filter": {
+          "punctuation": {
+            "type": "pattern_replace",
+            "pattern": "[^\\w\\s]",
+            "replacement": ""
+          },
           "english_stemmer": {
             "name": "english",
             "type": "stemmer"
@@ -725,11 +730,6 @@
           }
         },
         "char_filter": {
-          "hyphens_char_filter": {
-            "pattern": "-",
-            "type": "pattern_replace",
-            "replacement": ""
-          },
           "slashes_char_filter": {
             "type": "mapping",
             "mappings": [
@@ -831,22 +831,18 @@
           "shingle_asciifolding_analyzer": {
             "filter": [
               "lowercase",
+              "punctuation",
               "shingle_token_filter",
               "asciifolding_token_filter"
-            ],
-            "char_filter": [
-              "hyphens_char_filter"
             ],
             "type": "custom",
             "tokenizer": "standard"
           },
           "shingle_cased_analyzer": {
             "filter": [
+              "punctuation",
               "shingle_token_filter",
               "asciifolding_token_filter"
-            ],
-            "char_filter": [
-              "hyphens_char_filter"
             ],
             "type": "custom",
             "tokenizer": "standard"


### PR DESCRIPTION
Part of https://github.com/wellcomecollection/catalogue-api/issues/624

Instead of stripping only hyphens from tokens in our shingled fields, we now strip all punctuation. This should solve the problems described [here](https://github.com/wellcomecollection/catalogue-api/issues/623)

This change requires a reindex, [and a new query](https://github.com/wellcomecollection/catalogue-api/pull/625) in `catalogue-api` to be merged and deployed alongside it to see the full benefit.