### PR TITLE
Tweak the memory available for the 1x image inferrer

### DIFF
--- a/pipeline/terraform/stack/service_image_inferrer.tf
+++ b/pipeline/terraform/stack/service_image_inferrer.tf
@@ -9,11 +9,14 @@ locals {
   shared_storage_name      = "shared_storage"
   shared_storage_path      = "/data"
 
+  # This is the CPU/memory available on an ECS instance which isn't running
+  # any tasks.  You can find it in the ECS console, in the list of
+  # capacity providers.
   base_2x_total_cpu = 8192
   base_1x_total_cpu = 4096
 
   base_2x_total_memory = 15463
-  base_1x_total_memory = 7623
+  base_1x_total_memory = 7611
 
   base_manager_memory      = 2048
   base_manager_cpu         = 1024


### PR DESCRIPTION
It looks like the amount of memory available has changed slightly at some point, and now image inferrer tasks on the 1x instances are failing to start because they don't have enough memory.  Correcting the amount of memory available should fix it.