### PR TITLE
Prevent spurious Terraform plan changes for index mappings

### DIFF
--- a/index_config/mappings.empty.json
+++ b/index_config/mappings.empty.json
@@ -1,3 +1,3 @@
 {
-  "dynamic": false
+  "dynamic": "false"
 }


### PR DESCRIPTION
Whenever we apply, tf tells us that we're going to do this:
```
~ mappings = jsonencode(
~  {
~     dynamic = "false" -> false
   }
)
```
I think that this change should stop that happening