### PR TITLE
Fix the lookup of bib IDs on order records

### DIFF
--- a/sierra_adapter/sierra_reader/sierra_reader.py
+++ b/sierra_adapter/sierra_reader/sierra_reader.py
@@ -115,7 +115,7 @@ def to_scala_record(record):
     try:
         bib_ids = [str(bib_id) for bib_id in record["bibIds"]]
     except KeyError:
-        bib_ids = [url.split("/")[-1] for url in record["bibs"]]
+        bib_ids = [url.split("/")[-1] for url in record.get("bibs", [])]
 
     return json.dumps(
         {

--- a/sierra_adapter/sierra_reader/sierra_reader.py
+++ b/sierra_adapter/sierra_reader/sierra_reader.py
@@ -112,11 +112,16 @@ def to_scala_record(record):
     except KeyError:
         modified_date = record["updatedDate"]
 
+    try:
+        bib_ids = [str(bib_id) for bib_id in record["bibIds"]]
+    except KeyError:
+        bib_ids = [url.split("/")[-1] for url in record["bibs"]]
+
     return json.dumps(
         {
             "id": record["id"],
             "data": json.dumps(record),
-            "bibIds": [str(bib_id) for bib_id in record.get("bibIds", [])],
+            "bibIds": bib_ids,
             "modifiedDate": modified_date,
         }
     )

--- a/sierra_adapter/sierra_reader/test_sierra_reader.py
+++ b/sierra_adapter/sierra_reader/test_sierra_reader.py
@@ -5,6 +5,29 @@ from sierra_reader import to_scala_record
 
 
 class TestToScalaRecord(unittest.TestCase):
+    def test_it_handles_a_bib_record(self):
+        record = {
+            "author": "M'Kendrick, Archibald.",
+            "createdDate": "1999-11-01T16:36:51Z",
+            "fixedFields": {
+                "107": {"label": "MARCTYPE", "value": " "},
+                "24": {"display": "English", "label": "LANG", "value": "eng"},
+            },
+            "id": "1000002",
+            "title": "An x-ray atlas of the normal and abnormal structures of the body",
+            "updatedDate": "2022-07-21T20:01:39Z",
+        }
+
+        self.assertEqual(
+            json.loads(to_scala_record(record)),
+            {
+                "id": record["id"],
+                "data": json.dumps(record),
+                "bibIds": [],
+                "modifiedDate": record["updatedDate"],
+            },
+        )
+
     def test_it_handles_an_order_record(self):
         record = {
             "bibs": [
@@ -28,7 +51,7 @@ class TestToScalaRecord(unittest.TestCase):
                 "id": record["id"],
                 "data": json.dumps(record),
                 "bibIds": ["1320839"],
-                "modifiedDate": "2023-08-01T12:24:55Z",
+                "modifiedDate": record["updatedDate"],
             },
         )
 

--- a/sierra_adapter/sierra_reader/test_sierra_reader.py
+++ b/sierra_adapter/sierra_reader/test_sierra_reader.py
@@ -1,0 +1,37 @@
+import json
+import unittest
+
+from sierra_reader import to_scala_record
+
+
+class TestToScalaRecord(unittest.TestCase):
+    def test_it_handles_an_order_record(self):
+        record = {
+            "bibs": [
+                "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/bibs/1320839"
+            ],
+            "fixedFields": {
+                "1": {"label": "ACQ TYPE", "value": "d"},
+                "2": {
+                    "display": "Wellcome Library",
+                    "label": "LOCATION",
+                    "value": "acql ",
+                },
+            },
+            "id": 1000951,
+            "updatedDate": "2023-08-01T12:24:55Z",
+        }
+
+        self.assertEqual(
+            json.loads(to_scala_record(record)),
+            {
+                "id": record["id"],
+                "data": json.dumps(record),
+                "bibIds": ["1320839"],
+                "modifiedDate": "2023-08-01T12:24:55Z",
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
On order records, the linked bibs are supplied as a list of URLs to the resources in the Sierra API, and not a list of individual bib numbers. This patch updates the reader to extract the bib IDs from the URLs, which should fix the issue where order records aren't being linked correctly.

For https://github.com/wellcomecollection/platform/issues/5709

I've already deployed this change and I'm refetching all the order records right now.