### PR TITLE
JSON de/serialisation in the CALM adapter, attempt 2

### DIFF
--- a/calm_adapter/calm_adapter/src/main/scala/weco/pipeline/calm_adapter/CalmRetriever.scala
+++ b/calm_adapter/calm_adapter/src/main/scala/weco/pipeline/calm_adapter/CalmRetriever.scala
@@ -7,13 +7,13 @@ import weco.catalogue.source_model.calm.CalmRecord
 import weco.pipeline.calm_api_client.{
   CalmApiClient,
   CalmHttpResponseParser,
-  CalmQuery,
+  CalmQueryBase,
   CalmSession,
   CalmSummaryRequest
 }
 
 trait CalmRetriever {
-  def apply(query: CalmQuery): Source[CalmRecord, NotUsed]
+  def apply(query: CalmQueryBase): Source[CalmRecord, NotUsed]
 }
 
 class ApiCalmRetriever(
@@ -23,7 +23,7 @@ class ApiCalmRetriever(
 ) extends CalmRetriever
     with Logging {
 
-  def apply(query: CalmQuery): Source[CalmRecord, NotUsed] =
+  def apply(query: CalmQueryBase): Source[CalmRecord, NotUsed] =
     Source
       .future(apiClient.search(query))
       .mapConcat {

--- a/calm_adapter/calm_adapter/src/test/scala/weco/pipeline/calm_adapter/CalmAdapterWorkerServiceTest.scala
+++ b/calm_adapter/calm_adapter/src/test/scala/weco/pipeline/calm_adapter/CalmAdapterWorkerServiceTest.scala
@@ -26,7 +26,7 @@ import weco.catalogue.source_model.calm.CalmRecord
 import weco.catalogue.source_model.fixtures.SourceVHSFixture
 import weco.catalogue.source_model.store.SourceVHS
 import weco.catalogue.source_model.Implicits._
-import weco.pipeline.calm_api_client.CalmQuery
+import weco.pipeline.calm_api_client.{CalmQuery, CalmQueryBase}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
@@ -130,7 +130,7 @@ class CalmAdapterWorkerServiceTest
 
   it("sends the message to the DLQ if publishing of any record fails") {
     val retriever = new CalmRetriever {
-      def apply(query: CalmQuery): Source[CalmRecord, NotUsed] = {
+      def apply(query: CalmQueryBase): Source[CalmRecord, NotUsed] = {
         val timestamp = Instant.now
         val records = List(
           CalmRecord("A", Map.empty, timestamp),
@@ -195,8 +195,8 @@ class CalmAdapterWorkerServiceTest
 
   def calmRetriever(records: List[CalmRecord]) =
     new CalmRetriever {
-      var previousQuery: Option[CalmQuery] = None
-      def apply(query: CalmQuery): Source[CalmRecord, NotUsed] = {
+      var previousQuery: Option[CalmQueryBase] = None
+      def apply(query: CalmQueryBase): Source[CalmRecord, NotUsed] = {
         previousQuery = Some(query)
         Source(records)
       }

--- a/calm_adapter/calm_api_client/src/main/scala/weco/pipeline/calm_api_client/CalmApiClient.scala
+++ b/calm_adapter/calm_api_client/src/main/scala/weco/pipeline/calm_api_client/CalmApiClient.scala
@@ -25,7 +25,7 @@ trait CalmApiClient {
   ): Future[Request#Response]
 
   def search(
-    query: CalmQuery,
+    query: CalmQueryBase,
     cookie: Option[Cookie] = None
   ): Future[CalmSession] =
     request(request = CalmSearchRequest(query), cookie = cookie)

--- a/calm_adapter/calm_api_client/src/main/scala/weco/pipeline/calm_api_client/CalmXmlRequest.scala
+++ b/calm_adapter/calm_api_client/src/main/scala/weco/pipeline/calm_api_client/CalmXmlRequest.scala
@@ -23,7 +23,7 @@ trait CalmXmlRequest {
     </soap12:Envelope>
 }
 
-case class CalmSearchRequest(query: CalmQuery, dbName: String = "Catalog")
+case class CalmSearchRequest(query: CalmQueryBase, dbName: String = "Catalog")
     extends CalmXmlRequest {
   type Response = CalmSession
   val action = "Search"

--- a/calm_adapter/calm_api_client/src/test/scala/weco/pipeline/calm_api_client/fixtures/CalmApiClientFixtures.scala
+++ b/calm_adapter/calm_api_client/src/test/scala/weco/pipeline/calm_api_client/fixtures/CalmApiClientFixtures.scala
@@ -13,7 +13,7 @@ import weco.pipeline.calm_api_client.{
   CalmAbandonRequest,
   CalmApiClient,
   CalmHttpResponseParser,
-  CalmQuery,
+  CalmQueryBase,
   CalmSearchRequest,
   CalmSession,
   CalmSummaryRequest,
@@ -43,9 +43,9 @@ trait CalmApiClientFixtures extends Akka {
     }
 
   def withTestCalmApiClient[R](
-    handleSearch: CalmQuery => CalmSession = _ => throw new NotImplementedError,
-    handleSummary: Int => CalmRecord = _ => throw new NotImplementedError,
-    handleAbandon: Cookie => Done = _ => throw new NotImplementedError,
+                                handleSearch: CalmQueryBase => CalmSession = _ => throw new NotImplementedError,
+                                handleSummary: Int => CalmRecord = _ => throw new NotImplementedError,
+                                handleAbandon: Cookie => Done = _ => throw new NotImplementedError,
   )(testWith: TestWith[TestCalmApiClient, R]): R =
     withMaterializer { mat =>
       testWith(
@@ -83,9 +83,9 @@ trait CalmApiClientFixtures extends Akka {
   }
 
   class TestCalmApiClient(
-    handleSearch: CalmQuery => CalmSession,
-    handleSummary: Int => CalmRecord,
-    handleAbandon: Cookie => Done
+                           handleSearch: CalmQueryBase => CalmSession,
+                           handleSummary: Int => CalmRecord,
+                           handleAbandon: Cookie => Done
   ) extends CalmApiClient {
     var requests: List[(CalmXmlRequest, Option[Cookie])] = Nil
 

--- a/calm_adapter/calm_deletion_checker/src/main/scala/weco/pipeline/calm_deletion_checker/DefectiveChecker.scala
+++ b/calm_adapter/calm_deletion_checker/src/main/scala/weco/pipeline/calm_deletion_checker/DefectiveChecker.scala
@@ -1,9 +1,8 @@
 package weco.pipeline.calm_deletion_checker
 
 import grizzled.slf4j.Logging
-import weco.pipeline.calm_api_client.CalmApiClient
+import weco.pipeline.calm_api_client.{CalmApiClient, CalmQuery, CalmQueryBase, CalmSession}
 import weco.catalogue.source_model.CalmSourcePayload
-import weco.pipeline.calm_api_client.{CalmApiClient, CalmQuery, CalmSession}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -74,7 +73,7 @@ class ApiDeletionChecker(calmApiClient: CalmApiClient)(
         .search(
           records
             .map(record => CalmQuery.RecordId(record.id))
-            .reduce[CalmQuery](_ or _)
+            .reduce[CalmQueryBase](_ or _)
         )
       // Performing a search creates a new session which we'll never use.
       // Abandon it here to give the Calm API a chance.

--- a/calm_adapter/calm_deletion_checker/src/main/scala/weco/pipeline/calm_deletion_checker/DefectiveChecker.scala
+++ b/calm_adapter/calm_deletion_checker/src/main/scala/weco/pipeline/calm_deletion_checker/DefectiveChecker.scala
@@ -1,7 +1,12 @@
 package weco.pipeline.calm_deletion_checker
 
 import grizzled.slf4j.Logging
-import weco.pipeline.calm_api_client.{CalmApiClient, CalmQuery, CalmQueryBase, CalmSession}
+import weco.pipeline.calm_api_client.{
+  CalmApiClient,
+  CalmQuery,
+  CalmQueryBase,
+  CalmSession
+}
 import weco.catalogue.source_model.CalmSourcePayload
 
 import scala.concurrent.{ExecutionContext, Future}


### PR DESCRIPTION
One of the many issues with Circe magic is that the types can give you a false sense of security - I realised that the changes I made yesterday ignored what the actual JSON that gets (de)serialised looks like.

This is actually closer to how it was before  https://github.com/wellcomecollection/catalogue-pipeline/pull/2407, but with a better designed type hierarchy that respects the difference between data containers (ie JSON) and utility classes. 