### PR TITLE
Use a common base for the inference manager builds

### DIFF
--- a/pipeline/inferrer/aspect_ratio_inferrer/Dockerfile
+++ b/pipeline/inferrer/aspect_ratio_inferrer/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/python:3.9-slim
+FROM public.ecr.aws/docker/library/python:3.8-slim
 
 RUN apt-get update && apt-get -y install gcc g++ libffi-dev curl
 

--- a/pipeline/inferrer/aspect_ratio_inferrer/Dockerfile
+++ b/pipeline/inferrer/aspect_ratio_inferrer/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/python:3.8-slim
+FROM public.ecr.aws/docker/library/python:3.9-slim
 
 RUN apt-get update && apt-get -y install gcc g++ libffi-dev curl
 

--- a/pipeline/inferrer/aspect_ratio_inferrer/Dockerfile
+++ b/pipeline/inferrer/aspect_ratio_inferrer/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/python:3.7-slim
+FROM public.ecr.aws/docker/library/python:3.8-slim
 
 RUN apt-get update && apt-get -y install gcc g++ libffi-dev curl
 

--- a/pipeline/inferrer/aspect_ratio_inferrer/tox.ini
+++ b/pipeline/inferrer/aspect_ratio_inferrer/tox.ini
@@ -1,8 +1,8 @@
 [tox]
-envlist = py37
+envlist = py39
 skipsdist = True
 
 [testenv]
-basepython = python3.7
+basepython = python3.9
 commands =
     python -m compileall {toxinidir}

--- a/pipeline/inferrer/aspect_ratio_inferrer/tox.ini
+++ b/pipeline/inferrer/aspect_ratio_inferrer/tox.ini
@@ -1,8 +1,8 @@
 [tox]
-envlist = py39
+envlist = py38
 skipsdist = True
 
 [testenv]
-basepython = python3.9
+basepython = python3.8
 commands =
     python -m compileall {toxinidir}

--- a/pipeline/inferrer/feature_inferrer/Dockerfile
+++ b/pipeline/inferrer/feature_inferrer/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/python:3.9-slim
+FROM public.ecr.aws/docker/library/python:3.8-slim
 
 RUN apt-get update && apt-get -y install gcc g++ libffi-dev curl
 

--- a/pipeline/inferrer/feature_inferrer/Dockerfile
+++ b/pipeline/inferrer/feature_inferrer/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/python:3.8-slim
+FROM public.ecr.aws/docker/library/python:3.9-slim
 
 RUN apt-get update && apt-get -y install gcc g++ libffi-dev curl
 

--- a/pipeline/inferrer/feature_inferrer/Dockerfile
+++ b/pipeline/inferrer/feature_inferrer/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/python:3.7-slim
+FROM public.ecr.aws/docker/library/python:3.8-slim
 
 RUN apt-get update && apt-get -y install gcc g++ libffi-dev curl
 

--- a/pipeline/inferrer/feature_inferrer/tox.ini
+++ b/pipeline/inferrer/feature_inferrer/tox.ini
@@ -1,8 +1,8 @@
 [tox]
-envlist = py37
+envlist = py39
 skipsdist = True
 
 [testenv]
-basepython = python3.7
+basepython = python3.9
 commands =
     python -m compileall {toxinidir}

--- a/pipeline/inferrer/feature_inferrer/tox.ini
+++ b/pipeline/inferrer/feature_inferrer/tox.ini
@@ -1,8 +1,8 @@
 [tox]
-envlist = py39
+envlist = py38
 skipsdist = True
 
 [testenv]
-basepython = python3.9
+basepython = python3.8
 commands =
     python -m compileall {toxinidir}

--- a/pipeline/inferrer/palette_inferrer/Dockerfile
+++ b/pipeline/inferrer/palette_inferrer/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/python:3.9-slim
+FROM public.ecr.aws/docker/library/python:3.8-slim
 
 RUN apt-get update && apt-get -y install gcc g++ libffi-dev curl
 

--- a/pipeline/inferrer/palette_inferrer/Dockerfile
+++ b/pipeline/inferrer/palette_inferrer/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/python:3.8-slim
+FROM public.ecr.aws/docker/library/python:3.9-slim
 
 RUN apt-get update && apt-get -y install gcc g++ libffi-dev curl
 

--- a/pipeline/inferrer/palette_inferrer/tox.ini
+++ b/pipeline/inferrer/palette_inferrer/tox.ini
@@ -1,8 +1,8 @@
 [tox]
-envlist = py37
+envlist = py39
 skipsdist = True
 
 [testenv]
-basepython = python3.7
+basepython = python3.9
 commands =
     python -m compileall {toxinidir}

--- a/pipeline/inferrer/palette_inferrer/tox.ini
+++ b/pipeline/inferrer/palette_inferrer/tox.ini
@@ -1,8 +1,8 @@
 [tox]
-envlist = py39
+envlist = py38
 skipsdist = True
 
 [testenv]
-basepython = python3.9
+basepython = python3.8
 commands =
     python -m compileall {toxinidir}


### PR DESCRIPTION
Following discussion at standup today, this patch switches all the inferrer apps to a Python 3.8 base. I considered upgrading to a newer Python, but that would mean upgrading our libraries/dependencies.

I additionally considered trying to get the Python dependencies onto common versions, but we have multiple versions of numpy/scipy which are fiddly to upgrade and probably the most expensive bit of the build.

For https://github.com/wellcomecollection/catalogue-pipeline/issues/2445