### PR TITLE
updates to account for changes in auth and APIs

### DIFF
--- a/scripts/_common.py
+++ b/scripts/_common.py
@@ -55,9 +55,12 @@ def get_api_es_client(date):
         session,
         secret_id=f"elasticsearch/pipeline_storage_{date}/catalogue_api/api_key",
     )
-    decoded_api_id_and_key = base64.b64decode(api_key).decode('utf-8').split(":")
+    decoded_api_id_and_key = base64.b64decode(api_key).decode("utf-8").split(":")
 
-    return Elasticsearch(f"{protocol}://{host}:{port}", api_key=(decoded_api_id_and_key[0], decoded_api_id_and_key[1]))
+    return Elasticsearch(
+        f"{protocol}://{host}:{port}",
+        api_key=(decoded_api_id_and_key[0], decoded_api_id_and_key[1]),
+    )
 
 
 def get_ingestor_es_client(date, doc_type):
@@ -70,9 +73,12 @@ def get_ingestor_es_client(date, doc_type):
         session,
         secret_id=f"elasticsearch/pipeline_storage_{date}/{doc_type}_ingestor/api_key",
     )
-    decoded_api_id_and_key = base64.b64decode(api_key).decode('utf-8').split(":")
+    decoded_api_id_and_key = base64.b64decode(api_key).decode("utf-8").split(":")
 
-    return Elasticsearch(f"{protocol}://{host}:{port}", api_key=(decoded_api_id_and_key[0], decoded_api_id_and_key[1]))
+    return Elasticsearch(
+        f"{protocol}://{host}:{port}",
+        api_key=(decoded_api_id_and_key[0], decoded_api_id_and_key[1]),
+    )
 
 
 def get_date_from_index_name(index_name):

--- a/scripts/_common.py
+++ b/scripts/_common.py
@@ -2,6 +2,7 @@ import concurrent.futures
 import itertools
 import re
 import subprocess
+import base64
 
 import boto3
 from elasticsearch import Elasticsearch
@@ -50,16 +51,13 @@ def get_api_es_client(date):
     """
     session = get_session(role_arn="arn:aws:iam::756629837203:role/catalogue-developer")
     host, port, protocol = _get_pipeline_cluster(session, date=date)
-    username = get_secret_string(
+    api_key = get_secret_string(
         session,
-        secret_id=f"elasticsearch/pipeline_storage_{date}/catalogue_api/es_username",
+        secret_id=f"elasticsearch/pipeline_storage_{date}/catalogue_api/api_key",
     )
-    password = get_secret_string(
-        session,
-        secret_id=f"elasticsearch/pipeline_storage_{date}/catalogue_api/es_password",
-    )
+    decoded_api_id_and_key = base64.b64decode(api_key).decode('utf-8').split(":")
 
-    return Elasticsearch(f"{protocol}://{username}:{password}@{host}:{port}")
+    return Elasticsearch(f"{protocol}://{host}:{port}", api_key=(decoded_api_id_and_key[0], decoded_api_id_and_key[1]))
 
 
 def get_ingestor_es_client(date, doc_type):
@@ -68,16 +66,13 @@ def get_ingestor_es_client(date, doc_type):
     """
     session = get_session(role_arn="arn:aws:iam::760097843905:role/platform-developer")
     host, port, protocol = _get_pipeline_cluster(session, date=date)
-    username = get_secret_string(
+    api_key = get_secret_string(
         session,
-        secret_id=f"elasticsearch/pipeline_storage_{date}/{doc_type}_ingestor/es_username",
+        secret_id=f"elasticsearch/pipeline_storage_{date}/{doc_type}_ingestor/api_key",
     )
-    password = get_secret_string(
-        session,
-        secret_id=f"elasticsearch/pipeline_storage_{date}/{doc_type}_ingestor/es_password",
-    )
+    decoded_api_id_and_key = base64.b64decode(api_key).decode('utf-8').split(":")
 
-    return Elasticsearch(f"{protocol}://{username}:{password}@{host}:{port}")
+    return Elasticsearch(f"{protocol}://{host}:{port}", api_key=(decoded_api_id_and_key[0], decoded_api_id_and_key[1]))
 
 
 def get_date_from_index_name(index_name):

--- a/scripts/miro_updates.py
+++ b/scripts/miro_updates.py
@@ -178,7 +178,7 @@ def _remove_image_from_elasticsearch(*, miro_id):
 
     # Remove the work from the works index
     works_resp = api_es_client(pipeline_date).search(
-        index=works_index, body={"query": {"term": {"query.allIdentifiers": miro_id}}}
+        index=works_index, body={"query": {"term": {"query.identifiers.value": miro_id}}}
     )
 
     try:
@@ -236,8 +236,7 @@ def _remove_image_from_dlcs(*, miro_id):
     resp = dlcs_api_client().delete(
         f"https://api.dlcs.io/customers/2/spaces/8/images/{miro_id}"
     )
-    resp.raise_for_status()
-    assert resp.json()["success"] == "true", resp.json()
+    assert resp.status_code == 204, resp
 
 
 def _remove_image_from_cloudfront(*, miro_id):
@@ -255,6 +254,7 @@ def _remove_image_from_cloudfront(*, miro_id):
 def suppress_image(*, miro_id, message: str):
     """
     Hide a Miro image from wellcomecollection.org.
+    These operations must happen in a specific order: _set_image_availability first, as the DDB table is the source of truth for Miro images when building pipelines
     """
     _set_image_availability(miro_id=miro_id, message=message, is_available=False)
 

--- a/scripts/miro_updates.py
+++ b/scripts/miro_updates.py
@@ -178,7 +178,8 @@ def _remove_image_from_elasticsearch(*, miro_id):
 
     # Remove the work from the works index
     works_resp = api_es_client(pipeline_date).search(
-        index=works_index, body={"query": {"term": {"query.identifiers.value": miro_id}}}
+        index=works_index,
+        body={"query": {"term": {"query.identifiers.value": miro_id}}},
     )
 
     try:


### PR DESCRIPTION
A few changes came up when I was suppressing the Brought to Life images
- authenticating to ES with api key rather than username/password. The python `Elasticsearch` client want it decoded so it can encode it back again in the request... 
- the works index has changed and has no `allIdentifiers` in the `query`. Now found at `query.identifiers.value` 
- dlcs server only responds with 204 and no body in case of success 