### PR TITLE
METS: Stop premature normalisation

### DIFF
--- a/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/MetsData.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/MetsData.scala
@@ -14,8 +14,10 @@ import weco.pipeline.transformer.mets.transformers.{
   MetsAccessConditions,
   MetsImageData,
   MetsLocation,
-  MetsThumbnail
+  MetsThumbnail,
+  MetsTitle
 }
+import weco.pipeline.transformer.result.Result
 
 sealed trait MetsData {
   val recordIdentifier: String
@@ -132,4 +134,20 @@ case class InvisibleMetsData(
             )
         }
     }
+}
+
+object InvisibleMetsData {
+  def apply(root: MetsXml, filesRoot: MetsXml): Result[InvisibleMetsData] = {
+    for {
+      id <- root.recordIdentifier
+      title <- MetsTitle(root.root)
+      accessConditions <- filesRoot.accessConditions
+    } yield InvisibleMetsData(
+      recordIdentifier = id,
+      title = title,
+      accessConditions = accessConditions,
+      fileReferences = filesRoot.fileReferences(id),
+      thumbnailReference = filesRoot.thumbnailReference
+    )
+  }
 }

--- a/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/MetsData.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/MetsData.scala
@@ -146,7 +146,7 @@ object InvisibleMetsData {
       recordIdentifier = id,
       title = title,
       accessConditions = accessConditions,
-      fileReferences = filesRoot.fileReferences(id),
+      fileReferences = filesRoot.fileReferences,
       thumbnailReference = filesRoot.thumbnailReference
     )
   }

--- a/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/MetsXml.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/MetsXml.scala
@@ -17,7 +17,7 @@ trait MetsXml {
   val root: Elem
   val thumbnailReference: Option[FileReference]
   def firstManifestationFilename: Either[Exception, String]
-  def fileReferences(bnumber: String): List[FileReference]
+  def fileReferences: List[FileReference]
   def recordIdentifier: Either[Exception, String]
 
   def accessConditions: Either[Throwable, MetsAccessConditions]
@@ -55,7 +55,7 @@ case class GoobiMetsXml(root: Elem) extends MetsXml with XMLOps {
   /** Here we use the the items defined in the physicalStructMap to look up file
     * IDs in the (normalised) fileObjects mapping
     */
-  def fileReferences(bnumber: String): List[FileReference] =
+  def fileReferences: List[FileReference] =
     physicalFileIds.flatMap(fileId => getFileReferences(fileId)).toList
 
   /** Returns the first href to a manifestation in the logical structMap

--- a/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/MetsXml.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/MetsXml.scala
@@ -56,11 +56,7 @@ case class GoobiMetsXml(root: Elem) extends MetsXml with XMLOps {
     * IDs in the (normalised) fileObjects mapping
     */
   def fileReferences(bnumber: String): List[FileReference] =
-    physicalFileIds.flatMap {
-      case fileId =>
-        getFileReferences(fileId)
-          .map(ref => normaliseLocation(bnumber, ref))
-    }.toList
+    physicalFileIds.flatMap(fileId => getFileReferences(fileId)).toList
 
   /** Returns the first href to a manifestation in the logical structMap
     */
@@ -110,25 +106,6 @@ case class GoobiMetsXml(root: Elem) extends MetsXml with XMLOps {
       .filterByAttribute("TYPE", "PHYSICAL")
       .descendentsWithTag("div")
       .sortByAttribute("ORDER") \ "fptr").map(_ \@ "FILEID")
-
-  /** Filenames in DLCS are always prefixed with the bnumber (uppercase or
-    * lowercase) to ensure uniqueness. However they might not be prefixed with
-    * the bnumber in the METS file. So we need to do two things:
-    *   - strip the "objects/" part of the location
-    *   - prepend the bnumber followed by an underscore if it's not already
-    *     present (uppercase or lowercase)
-    */
-  private def normaliseLocation(
-    bnumber: String,
-    fileReference: FileReference
-  ): FileReference =
-    fileReference.copy(
-      location = fileReference.location.replaceFirst("objects/", "") match {
-        case fileName if fileName.toLowerCase.startsWith(bnumber.toLowerCase) =>
-          fileName
-        case fileName => s"${bnumber}_$fileName"
-      }
-    )
 
   /** The METS XML contains locations of associated files, contained in a
     * mapping with the following format:

--- a/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/MetsXmlTransformer.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/MetsXmlTransformer.scala
@@ -23,13 +23,16 @@ class MetsXmlTransformer(store: Readable[S3ObjectLocation, String])
     metsSourceData: MetsSourceData,
     version: Int
   ): Result[Work[WorkState.Source]] =
-    for {
-      metsData <- transform(id, metsSourceData)
-      work <- metsData.toWork(
-        version = metsSourceData.version,
-        modifiedTime = metsSourceData.createdDate
-      )
-    } yield work
+    transform(id, metsSourceData) match {
+      case Right(metsData: MetsData) =>
+        Right(
+          metsData.toWork(
+            version = metsSourceData.version,
+            modifiedTime = metsSourceData.createdDate
+          )
+        )
+      case Left(t) => Left(t)
+    }
 
   def transform(id: String, metsSourceData: MetsSourceData): Result[MetsData] =
     metsSourceData match {

--- a/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/MetsXmlTransformer.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/MetsXmlTransformer.scala
@@ -8,7 +8,6 @@ import weco.catalogue.source_model.mets.{
   MetsSourceData
 }
 import weco.pipeline.transformer.Transformer
-import weco.pipeline.transformer.mets.transformers.MetsTitle
 import weco.pipeline.transformer.result.Result
 import weco.storage.Identified
 import weco.storage.providers.s3.S3ObjectLocation

--- a/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/MetsXmlTransformer.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/MetsXmlTransformer.scala
@@ -59,36 +59,18 @@ class MetsXmlTransformer(store: Readable[S3ObjectLocation, String])
   private def transformWithoutManifestations(
     root: MetsXml
   ): Result[InvisibleMetsData] = {
-    for {
-      id <- root.recordIdentifier
-      title <- MetsTitle(root.root)
-      accessConditions <- root.accessConditions
-    } yield InvisibleMetsData(
-      recordIdentifier = id,
-      title = title,
-      accessConditions = accessConditions,
-      fileReferences = root.fileReferences(id),
-      thumbnailReference = root.thumbnailReference
-    )
+    InvisibleMetsData(root, root)
   }
 
   private def transformWithManifestations(
     root: MetsXml,
     manifestations: List[S3ObjectLocation]
   ): Result[InvisibleMetsData] = {
-
-    for {
-      id <- root.recordIdentifier
-      title <- MetsTitle(root.root)
-      filesRoot <- getFirstManifestation(root, manifestations)
-      accessConditions <- filesRoot.accessConditions
-    } yield InvisibleMetsData(
-      recordIdentifier = id,
-      title = title,
-      accessConditions = accessConditions,
-      fileReferences = filesRoot.fileReferences(id),
-      thumbnailReference = filesRoot.thumbnailReference
-    )
+    getFirstManifestation(root, manifestations) match {
+      case Right(filesRoot) =>
+        InvisibleMetsData(root, filesRoot)
+      case Left(t) => Left(t)
+    }
   }
 
   private def getFirstManifestation(

--- a/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformer/GoobiMetsXmlTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformer/GoobiMetsXmlTest.scala
@@ -103,44 +103,6 @@ class GoobiMetsXmlTest
       .location shouldBe "b30246039_0001.jp2"
   }
 
-  it("parses thumbnail if filename doesn't start with bnumber") {
-    val bnumber = "b30246039"
-    val filePrefix = "V000012"
-
-    val metsXml =
-      MetsXml(
-        metsXmlWith(
-          recordIdentifier = bnumber,
-          fileSec = fileSec(filePrefix),
-          structMap = structMap
-        )
-      ).value
-
-    metsXml
-      .fileReferences(bnumber)
-      .head
-      .location shouldBe s"${bnumber}_${filePrefix}_0001.jp2"
-  }
-
-  it("parses thumbnail if filename starts with uppercase bnumber") {
-    val bnumber = "b30246039"
-    val filePrefix = bnumber.toUpperCase
-
-    val metsXml =
-      MetsXml(
-        metsXmlWith(
-          recordIdentifier = bnumber,
-          fileSec = fileSec(filePrefix),
-          structMap = structMap
-        )
-      ).value
-
-    metsXml
-      .fileReferences(bnumber)
-      .head
-      .location shouldBe s"${filePrefix}_0001.jp2"
-  }
-
   it("cannot parse thumbnail when invalid file ID") {
     MetsXml(xmlInvalidFileId("b30246039")).value
       .fileReferences("b30246039")

--- a/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformer/GoobiMetsXmlTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformer/GoobiMetsXmlTest.scala
@@ -41,9 +41,7 @@ class GoobiMetsXmlTest
   }
 
   it("parses file references mapping from XML") {
-    MetsXml(xml).value.fileReferences(
-      "b30246039"
-    ) shouldBe List(
+    MetsXml(xml).value.fileReferences shouldBe List(
       FileReference(
         id = "FILE_0001_OBJECTS",
         location = "objects/b30246039_0001.jp2",
@@ -78,10 +76,9 @@ class GoobiMetsXmlTest
   }
 
   it("parses thumbnail from XML") {
-    MetsXml(xml).value
-      .fileReferences("b30246039")
-      .head
-      .location shouldBe "objects/b30246039_0001.jp2"
+    MetsXml(
+      xml
+    ).value.fileReferences.head.location shouldBe "objects/b30246039_0001.jp2"
   }
 
   it("parses first thumbnail when no ORDER attribute") {
@@ -90,23 +87,21 @@ class GoobiMetsXmlTest
       fileSec = fileSec(filePrefix = "b30246039"),
       structMap = structMap
     )
-    MetsXml(str).value
-      .fileReferences("b30246039")
-      .head
-      .location shouldBe "objects/b30246039_0001.jp2"
+    MetsXml(
+      str
+    ).value.fileReferences.head.location shouldBe "objects/b30246039_0001.jp2"
   }
 
   it("parses thumbnail using ORDER attrib when non-sequential order") {
-    MetsXml(xmlNonSequentialOrder("b30246039")).value
-      .fileReferences("b30246039")
-      .head
-      .location shouldBe "objects/b30246039_0001.jp2"
+    MetsXml(
+      xmlNonSequentialOrder("b30246039")
+    ).value.fileReferences.head.location shouldBe "objects/b30246039_0001.jp2"
   }
 
   it("cannot parse thumbnail when invalid file ID") {
-    MetsXml(xmlInvalidFileId("b30246039")).value
-      .fileReferences("b30246039")
-      .headOption shouldBe None
+    MetsXml(
+      xmlInvalidFileId("b30246039")
+    ).value.fileReferences.headOption shouldBe None
   }
 
   it("parses first manifestation filename when present") {

--- a/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformer/GoobiMetsXmlTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformer/GoobiMetsXmlTest.scala
@@ -46,32 +46,32 @@ class GoobiMetsXmlTest
     ) shouldBe List(
       FileReference(
         id = "FILE_0001_OBJECTS",
-        location = "b30246039_0001.jp2",
+        location = "objects/b30246039_0001.jp2",
         listedMimeType = Some("image/jp2")
       ),
       FileReference(
         id = "FILE_0002_OBJECTS",
-        location = "b30246039_0002.jp2",
+        location = "objects/b30246039_0002.jp2",
         listedMimeType = Some("image/jp2")
       ),
       FileReference(
         id = "FILE_0003_OBJECTS",
-        location = "b30246039_0003.jp2",
+        location = "objects/b30246039_0003.jp2",
         listedMimeType = Some("image/jp2")
       ),
       FileReference(
         id = "FILE_0004_OBJECTS",
-        location = "b30246039_0004.jp2",
+        location = "objects/b30246039_0004.jp2",
         listedMimeType = Some("image/jp2")
       ),
       FileReference(
         id = "FILE_0005_OBJECTS",
-        location = "b30246039_0005.jp2",
+        location = "objects/b30246039_0005.jp2",
         listedMimeType = Some("image/jp2")
       ),
       FileReference(
         id = "FILE_0006_OBJECTS",
-        location = "b30246039_0006.jp2",
+        location = "objects/b30246039_0006.jp2",
         listedMimeType = Some("image/jp2")
       )
     )
@@ -81,7 +81,7 @@ class GoobiMetsXmlTest
     MetsXml(xml).value
       .fileReferences("b30246039")
       .head
-      .location shouldBe "b30246039_0001.jp2"
+      .location shouldBe "objects/b30246039_0001.jp2"
   }
 
   it("parses first thumbnail when no ORDER attribute") {
@@ -93,14 +93,14 @@ class GoobiMetsXmlTest
     MetsXml(str).value
       .fileReferences("b30246039")
       .head
-      .location shouldBe "b30246039_0001.jp2"
+      .location shouldBe "objects/b30246039_0001.jp2"
   }
 
   it("parses thumbnail using ORDER attrib when non-sequential order") {
     MetsXml(xmlNonSequentialOrder("b30246039")).value
       .fileReferences("b30246039")
       .head
-      .location shouldBe "b30246039_0001.jp2"
+      .location shouldBe "objects/b30246039_0001.jp2"
   }
 
   it("cannot parse thumbnail when invalid file ID") {

--- a/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformer/MetsDataTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformer/MetsDataTest.scala
@@ -54,7 +54,7 @@ class MetsDataTest
 
     val unidentifiableItem =
       Item(id = IdState.Unidentifiable, locations = List(digitalLocation))
-    metsData.toWork(version, createdDate).right.get shouldBe Work
+    metsData.toWork(version, createdDate) shouldBe Work
       .Invisible[Source](
         version = version,
         state = Source(
@@ -91,7 +91,7 @@ class MetsDataTest
 
     val createdDate = Instant.now()
 
-    metsData.toWork(version, createdDate).right.get shouldBe Work
+    metsData.toWork(version, createdDate) shouldBe Work
       .Deleted[Source](
         version = version,
         state = Source(expectedSourceIdentifier, createdDate),
@@ -126,7 +126,7 @@ class MetsDataTest
 
     val unidentifiableItem =
       Item(id = IdState.Unidentifiable, locations = List(digitalLocation))
-    metsData.toWork(version, createdDate).right.get shouldBe Work
+    metsData.toWork(version, createdDate) shouldBe Work
       .Invisible[Source](
         version = version,
         state = Source(
@@ -165,7 +165,7 @@ class MetsDataTest
       accessConditionDz = Some("in copyright")
     )
 
-    inside(metsData.toWork(1, Instant.now()).right.get.data.items) {
+    inside(metsData.toWork(1, Instant.now()).data.items) {
       case List(
             Item(
               IdState.Unidentifiable,
@@ -183,7 +183,7 @@ class MetsDataTest
       accessConditionDz = Some("In copyright")
     )
 
-    inside(metsData.toWork(1, Instant.now()).right.get.data.items) {
+    inside(metsData.toWork(1, Instant.now()).data.items) {
       case List(
             Item(
               IdState.Unidentifiable,
@@ -200,7 +200,7 @@ class MetsDataTest
     val metsData = createMetsDataWith(
       accessConditionDz = Some(License.InCopyright.url)
     )
-    inside(metsData.toWork(1, Instant.now()).right.get.data.items) {
+    inside(metsData.toWork(1, Instant.now()).data.items) {
       case List(
             Item(
               IdState.Unidentifiable,
@@ -219,7 +219,7 @@ class MetsDataTest
     )
     val result = metsData.toWork(1, Instant.now())
 
-    inside(result.right.get.data.items) {
+    inside(result.data.items) {
       case List(
             Item(
               IdState.Unidentifiable,
@@ -240,7 +240,7 @@ class MetsDataTest
     )
     val result = metsData.toWork(1, Instant.now())
 
-    inside(result.right.get.data.items) {
+    inside(result.data.items) {
       case List(
             Item(
               IdState.Unidentifiable,
@@ -259,7 +259,7 @@ class MetsDataTest
     )
     val result = metsData.toWork(1, Instant.now())
 
-    inside(result.right.get.data.items) {
+    inside(result.data.items) {
       case List(
             Item(
               IdState.Unidentifiable,
@@ -279,8 +279,7 @@ class MetsDataTest
         Some(FileReference("l", "location.jp2", Some("image/jp2")))
     )
     val result = metsData.toWork(1, Instant.now())
-    result shouldBe a[Right[_, _]]
-    result.right.get.data.thumbnail shouldBe Some(
+    result.data.thumbnail shouldBe Some(
       DigitalLocation(
         url =
           s"https://iiif.wellcomecollection.org/thumbs/${metsData.recordIdentifier}_location.jp2/full/!200,200/0/default.jpg",
@@ -301,8 +300,7 @@ class MetsDataTest
         Some(FileReference("l", "title.jp2", Some("image/jp2")))
     )
     val result = metsData.toWork(1, Instant.now())
-    result shouldBe a[Right[_, _]]
-    result.right.get.data.thumbnail shouldBe Some(
+    result.data.thumbnail shouldBe Some(
       DigitalLocation(
         url =
           s"https://iiif.wellcomecollection.org/thumbs/${metsData.recordIdentifier}_title.jp2/full/!200,200/0/default.jpg",
@@ -321,8 +319,7 @@ class MetsDataTest
       )
     )
     val result = metsData.toWork(1, Instant.now())
-    result shouldBe a[Right[_, _]]
-    result.right.get.data.thumbnail shouldBe None
+    result.data.thumbnail shouldBe None
   }
 
   it("serves the thumbnail from wellcomelibrary for PDFs") {
@@ -336,8 +333,7 @@ class MetsDataTest
       thumbnailReference = Some(FileReference("l", "location.pdf"))
     )
     val result = metsData.toWork(1, Instant.now())
-    result shouldBe a[Right[_, _]]
-    result.right.get.data.thumbnail shouldBe Some(
+    result.data.thumbnail shouldBe Some(
       DigitalLocation(
         url = s"https://iiif.wellcomecollection.org/thumb/$bibNumber",
         locationType = LocationType.ThumbnailImage,
@@ -354,8 +350,7 @@ class MetsDataTest
       )
     )
     val result = metsData.toWork(1, Instant.now())
-    result shouldBe a[Right[_, _]]
-    result.right.get.data.thumbnail shouldBe None
+    result.data.thumbnail shouldBe None
   }
 
   it("does not add a thumbnail if the file is an audio") {
@@ -366,8 +361,7 @@ class MetsDataTest
       )
     )
     val result = metsData.toWork(1, Instant.now())
-    result shouldBe a[Right[_, _]]
-    result.right.get.data.thumbnail shouldBe None
+    result.data.thumbnail shouldBe None
   }
 
   it("uses both the IIIF manifest and image for imageData locations") {
@@ -378,8 +372,7 @@ class MetsDataTest
       )
     )
     val result = metsData.toWork(1, Instant.now())
-    result shouldBe a[Right[_, _]]
-    result.right.get.data.imageData.head.locations shouldBe List(
+    result.data.imageData.head.locations shouldBe List(
       DigitalLocation(
         url =
           s"https://iiif.wellcomecollection.org/image/${metsData.recordIdentifier}_location.jp2/info.json",
@@ -401,8 +394,7 @@ class MetsDataTest
     )
 
     val result = metsData.toWork(1, Instant.now())
-    result shouldBe a[Right[_, _]]
-    inside(result.right.get.data.items.head.locations.head) {
+    inside(result.data.items.head.locations.head) {
       case DigitalLocation(_, _, _, _, _, accessConditions) =>
         accessConditions shouldBe List(
           AccessCondition(
@@ -429,8 +421,7 @@ class MetsDataTest
     )
 
     val result = metsData.toWork(1, Instant.now())
-    result shouldBe a[Right[_, _]]
-    val images = result.right.get.data.imageData
+    val images = result.data.imageData
     images should have length 3
     images.map(
       _.id.allSourceIdentifiers.head.value
@@ -451,8 +442,7 @@ class MetsDataTest
       )
     )
     val result = metsData.toWork(1, Instant.now())
-    result shouldBe a[Right[_, _]]
-    result.right.get.data.imageData shouldBe empty
+    result.data.imageData shouldBe empty
   }
 
   it("creates a work with a single accessCondition including usage terms") {
@@ -461,8 +451,7 @@ class MetsDataTest
       accessConditionUsage = Some("Please ask nicely")
     )
     val result = metsData.toWork(1, Instant.now())
-    result shouldBe a[Right[_, _]]
-    inside(result.right.get.data.items.head.locations.head) {
+    inside(result.data.items.head.locations.head) {
       case DigitalLocation(_, _, _, _, _, accessConditions) =>
         accessConditions shouldBe List(
           AccessCondition(
@@ -480,8 +469,7 @@ class MetsDataTest
       accessConditionUsage = None
     )
     val result = metsData.toWork(1, Instant.now())
-    result shouldBe a[Right[_, _]]
-    inside(result.right.get.data.items.head.locations.head) {
+    inside(result.data.items.head.locations.head) {
       case DigitalLocation(_, _, _, _, _, accessConditions) =>
         accessConditions shouldBe List()
     }
@@ -492,8 +480,7 @@ class MetsDataTest
       accessConditionStatus = Some("Restricted files")
     )
     val result = metsData.toWork(1, Instant.now())
-    result shouldBe a[Right[_, _]]
-    inside(result.right.get.data.items.head.locations.head) {
+    inside(result.data.items.head.locations.head) {
       case DigitalLocation(_, _, _, _, _, accessConditions) =>
         accessConditions shouldBe
           List(
@@ -516,7 +503,7 @@ class MetsDataTest
   it("lowercases the b number") {
     val metsData = createMetsDataWith(bibNumber = "B12345678")
 
-    val work = metsData.toWork(version = 1, modifiedTime = Instant.now()).value
+    val work = metsData.toWork(version = 1, modifiedTime = Instant.now())
 
     work.sourceIdentifier shouldBe SourceIdentifier(
       identifierType = IdentifierType.METS,

--- a/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformer/MetsDataTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformer/MetsDataTest.scala
@@ -432,6 +432,27 @@ class MetsDataTest
     )
   }
 
+  it("normalises image locations for use with DLCS") {
+    val bibNumber = createBibNumberString
+    val metsData = createMetsDataWith(
+      bibNumber = bibNumber,
+      accessConditionDz = Some("CC-BY-NC"),
+      fileReferences = List(
+        FileReference("A", "location1.jp2", Some("image/jp2")),
+        FileReference("B", "objects/location2.jp2", Some("image/jp2"))
+      )
+    )
+
+    val result = metsData.toWork(1, Instant.now())
+    val images = result.data.imageData
+    images.map(
+      _.locations.head.url
+    ) should contain theSameElementsAs List(
+      s"https://iiif.wellcomecollection.org/image/${bibNumber}_location1.jp2/info.json",
+      s"https://iiif.wellcomecollection.org/image/${bibNumber}_location2.jp2/info.json"
+    )
+  }
+
   it("creates a work without images for restricted access statuses") {
     val metsData = createMetsDataWith(
       accessConditionDz = Some("CC-BY-NC"),

--- a/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformer/MetsXmlTransformerTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformer/MetsXmlTransformerTest.scala
@@ -36,9 +36,7 @@ class MetsXmlTransformerTest
           usage = Some("Some terms")
         ),
         fileReferences = fileReferences,
-        // TODO: temp - when fileReferences stop normalising in the wrong place, this can be just thumbnailRef
-        thumbnailReference =
-          Some(thumbnailRef.copy(location = "objects/" + thumbnailRef.location))
+        thumbnailReference = Some(thumbnailRef)
       )
     )
   }
@@ -83,9 +81,7 @@ class MetsXmlTransformerTest
           accessStatus = Some(AccessStatus.Open)
         ),
         fileReferences = fileReferences,
-        // TODO: temp - when fileReferences stop normalising in the wrong place, this can be just thumbnailRef
-        thumbnailReference =
-          Some(thumbnailRef.copy(location = "objects/" + thumbnailRef.location))
+        thumbnailReference = Some(thumbnailRef)
       )
     )
   }
@@ -125,9 +121,7 @@ class MetsXmlTransformerTest
         title = title,
         MetsAccessConditions(licence = Some(License.InCopyright)),
         fileReferences = createFileReferences(2, "b30246039"),
-        // TODO: temp - when fileReferences stop normalising in the wrong place, this can be just thumbnailRef
-        thumbnailReference =
-          Some(thumbnailRef.copy(location = "objects/" + thumbnailRef.location))
+        thumbnailReference = Some(thumbnailRef)
       )
     )
   }
@@ -189,8 +183,8 @@ class MetsXmlTransformerTest
         FileReference(
           f"FILE_$i%04d_OBJECTS",
           manifestN match {
-            case None    => f"$bumber%s_$i%04d.jp2"
-            case Some(n) => f"$bumber%s_$n%04d_$i%04d.jp2"
+            case None    => f"objects/$bumber%s_$i%04d.jp2"
+            case Some(n) => f"objects/$bumber%s_$n%04d_$i%04d.jp2"
           },
           Some("image/jp2")
         )

--- a/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformers/MetsImageDataTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformers/MetsImageDataTest.scala
@@ -1,0 +1,95 @@
+package weco.pipeline.transformer.mets.transformers
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import weco.catalogue.internal_model.identifiers.IdState
+import weco.catalogue.internal_model.image.ImageData
+import weco.catalogue.internal_model.locations.LocationType.OnlineResource
+import weco.catalogue.internal_model.locations.DigitalLocation
+import weco.pipeline.transformer.mets.transformer.models.FileReference
+
+class MetsImageDataTest extends AnyFunSpec with Matchers {
+  describe("imageData URLs") {
+    it("wraps the fileReference location with the rest of the URL") {
+      imageDataWith(
+        recordIdentifier = "b",
+        fileReference = FileReference("a", "b_my_location")
+      ).locations.head.url shouldBe "https://iiif.wellcomecollection.org/image/b_my_location/info.json"
+    }
+
+    it(
+      "prepends the record identifier to the file reference location"
+    ) {
+      imageDataWith(
+        recordIdentifier = "b30246039",
+        fileReference = FileReference("a", "my_location")
+      ).locations.head.url should include(
+        "/image/b30246039_my_location/"
+      )
+    }
+
+    describe("when the path starts with the record identifier") {
+      it(
+        "does not prepend another copy of the identifier"
+      ) {
+        imageDataWith(
+          recordIdentifier = "b30246039",
+          fileReference = FileReference("a", "b30246039_my_location")
+        ).locations.head.url should include(
+          "/image/b30246039_my_location/"
+        )
+      }
+
+      it(
+        "is case-insensitive in detecting the leading identifier"
+      ) {
+        imageDataWith(
+          recordIdentifier = "b30246039",
+          fileReference = FileReference("a", "B30246039_my_location")
+        ).locations.head.url should include(
+          "/image/B30246039_my_location/"
+        )
+      }
+    }
+
+    describe("when the path starts with objects/") {
+      it(
+        "strips leading objects/ path part before prepending the record identifier"
+      ) {
+        imageDataWith(
+          recordIdentifier = "b30246039",
+          fileReference = FileReference("a", "objects/my_location")
+        ).locations.head.url should include(
+          "/image/b30246039_my_location/"
+        )
+      }
+
+      it(
+        "does not insert an extra identifier if it is already there"
+      ) {
+        imageDataWith(
+          recordIdentifier = "b30246039",
+          fileReference = FileReference("a", "objects/b30246039_my_location")
+        ).locations.head.url should include(
+          "/image/b30246039_my_location/"
+        )
+      }
+    }
+  }
+
+  private val nowhere = DigitalLocation(url = "", locationType = OnlineResource)
+
+  private def imageDataWith(
+    recordIdentifier: String,
+    fileReference: FileReference
+  ): ImageData[IdState.Identifiable] = {
+    MetsImageData(
+      recordIdentifier,
+      1,
+      None,
+      nowhere,
+      fileReference
+    )
+  }
+
+}


### PR DESCRIPTION
Ideally (If I understand the existing pattern properly), the MetsXML class pulls relevant data as-is out of the XML file, and then the transformer transforms it for use downstream.

This is a place where that wasn't the case.  The MetsXML class was transforming URLs from their source data form into one compatible with DLCS. 

This PR sorts that out and pushes that transformation a bit to the right.