### PR TITLE
Add an analyzer which lowercases whitespace tokens

### DIFF
--- a/index_config/analysis.works_indexed.2023-11-09.json
+++ b/index_config/analysis.works_indexed.2023-11-09.json
@@ -345,6 +345,13 @@
       ],
       "type": "custom",
       "tokenizer": "whitespace"
+    },
+    "lowercase_whitespace_tokens": {
+      "filter": [
+        "lowercase"
+      ],
+      "type": "custom",
+      "tokenizer": "whitespace"
     }
   }
 }

--- a/index_config/mappings.works_indexed.2023-11-09.json
+++ b/index_config/mappings.works_indexed.2023-11-09.json
@@ -143,7 +143,7 @@
                 "path": {
                   "type": "text",
                   "analyzer": "path_analyzer",
-                  "search_analyzer": "whitespace"
+                  "search_analyzer": "lowercase_whitespace_tokens"
                 }
               }
             },
@@ -154,7 +154,7 @@
                 "path": {
                   "type": "text",
                   "analyzer": "path_analyzer",
-                  "search_analyzer": "whitespace"
+                  "search_analyzer": "lowercase_whitespace_tokens"
                 }
               }
             }
@@ -535,7 +535,7 @@
             "path": {
               "type": "text",
               "analyzer": "path_analyzer",
-              "search_analyzer": "whitespace"
+              "search_analyzer": "lowercase_whitespace_tokens"
             }
           }
         },


### PR DESCRIPTION
The whitespace analyzer didn't lowercase, and the lowercase analyzer did bizarre word delimiter graph stuff that didn't work with identifiers. This is already applied.