### PR TITLE
improve precedence tests

### DIFF
--- a/pipeline/merger/src/test/scala/weco/pipeline/merger/rules/TargetPrecedenceTest.scala
+++ b/pipeline/merger/src/test/scala/weco/pipeline/merger/rules/TargetPrecedenceTest.scala
@@ -26,42 +26,64 @@ class TargetPrecedenceTest
       TargetPrecedence
         .getTarget(
           Seq(
-            tei,
             calm,
             videoSierra,
+            tei,
             multiItemPhysicalSierra,
             digitalSierra,
-            miro)
+            miro
+          )
         )
         .value shouldBe tei
     }
     it("second, chooses a Calm work") {
       TargetPrecedence
         .getTarget(
-          Seq(calm, videoSierra, multiItemPhysicalSierra, digitalSierra, miro)
+          Seq(videoSierra, multiItemPhysicalSierra, digitalSierra, calm, miro)
         )
         .value shouldBe calm
     }
     it("third, chooses a Sierra e-video") {
       TargetPrecedence
         .getTarget(
-          Seq(videoSierra, multiItemPhysicalSierra, digitalSierra, miro)
+          Seq(multiItemPhysicalSierra, digitalSierra, miro, videoSierra)
         )
         .value shouldBe videoSierra
     }
     it("fourth, chooses a physical Sierra work") {
       TargetPrecedence
         .getTarget(
-          Seq(multiItemPhysicalSierra, digitalSierra, miro)
+          Seq(digitalSierra, multiItemPhysicalSierra, miro)
         )
         .value shouldBe multiItemPhysicalSierra
     }
     it("finally, chooses any remaining Sierra work") {
       TargetPrecedence
         .getTarget(
-          Seq(digitalSierra, miro)
+          Seq(miro, digitalSierra)
         )
         .value shouldBe digitalSierra
+    }
+
+    describe("when multiple works have the same precedence") {
+      it("chooses the first of them") {
+        // This test exists to document existing behaviour.
+        // If a better method for ensuring consistency is defined,
+        // then this test should be revised.
+        val digitalSierra2 = sierraDigitalIdentifiedWork()
+        TargetPrecedence
+          .getTarget(
+            Seq(miro, digitalSierra, digitalSierra2)
+          )
+          .value shouldBe digitalSierra
+
+        TargetPrecedence
+          .getTarget(
+            Seq(digitalSierra2, miro, digitalSierra)
+          )
+          .value shouldBe digitalSierra2
+
+      }
     }
   }
 


### PR DESCRIPTION
## What does this change?

This makes the the TargetPrecedenceTests more precise.  

Previously, 
- the tests could be passed by an implementation of `getTarget` that simply returned `works.headOption`
- there was no test for when two records are tied for priority.

I have shuffled the order of the input Seqs so that the expected return value for each test is in an arbitrary position in the input, and added a tiebreaker test.

## How to test

Run the tests.  This is a change to the unit test suite and not the behaviour of the application.  You could try changing the behaviour as suggested above and see the tests fail.


## Have we considered potential risks?

The addition of the tiebreaker test could crystallise the existing semi-arbitrary behaviour. As a mitigation, I have begun a Slack discussion about it, and included commentary pointing out that this is a descriptive, rather than prescriptive test.
