### PR TITLE
Provide apikey to reporting indexers

### DIFF
--- a/calm_adapter/terraform/.terraform.lock.hcl
+++ b/calm_adapter/terraform/.terraform.lock.hcl
@@ -4,6 +4,7 @@
 provider "registry.terraform.io/hashicorp/aws" {
   version = "5.22.0"
   hashes = [
+    "h1:4oAjE3Fn/vXruaORPWH1lH7q/+oPEqxNm6+KjOMeMrI=",
     "h1:XuU3tsGzElMt4Ti8SsM05pFllNMwSC4ScUxcfsOS140=",
     "zh:09b8475cd519c945423b1e1183b71a4209dd2927e0d289a88c5abeecb53c1753",
     "zh:2448e0c3ce9b991a5dd70f6a42d842366a6a2460cf63b31fb9bc5d2cc92ced19",

--- a/calm_adapter/terraform/indexer.tf
+++ b/calm_adapter/terraform/indexer.tf
@@ -28,8 +28,8 @@ module "calm_indexer" {
   omit_queue_url = true
 
   secret_env_vars = {
-    es_password = "reporting/calm_indexer/es_password"
-    es_host     = "reporting/es_host"
+    es_apikey = "reporting/calm_indexer/es_apikey"
+    es_host   = "reporting/es_host"
   }
 
   cpu    = 512

--- a/sierra_adapter/terraform/.terraform.lock.hcl
+++ b/sierra_adapter/terraform/.terraform.lock.hcl
@@ -1,26 +1,6 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/hashicorp/archive" {
-  version = "2.3.0"
-  hashes = [
-    "h1:NaDbOqAcA9d8DiAS5/6+5smXwN3/+twJGb3QRiz6pNw=",
-    "h1:pTPG9Kf1Qg2aPsZLXDa6OvLqsEXaMrKnp0Z4Q/TIBPA=",
-    "zh:0869128d13abe12b297b0cd13b8767f10d6bf047f5afc4215615aabc39c2eb4f",
-    "zh:481ed837d63ba3aa45dd8736da83e911e3509dee0e7961bf5c00ed2644f807b3",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:9f08fe2977e2166849be24fb9f394e4d2697414d463f7996fd0d7beb4e19a29c",
-    "zh:9fe566deeafd460d27999ca0bbfd85426a5fcfcb40007b23884deb76da127b6f",
-    "zh:a1bd9a60925d9769e0da322e4523330ee86af9dc2e770cba1d0247a999ef29cb",
-    "zh:bb4094c8149f74308b22a87e1ac19bcccca76e8ef021b571074d9bccf1c0c6f0",
-    "zh:c8984c9def239041ce41ec8e19bbd76a49e74ed2024ff736dad60429dee89bcc",
-    "zh:ea4bb5ae73db1de3a586e62f39106f5e56770804a55aa5e6b4f642df973e0e75",
-    "zh:f44a9d596ecc3a8c5653f56ba0cd202ad93b49f76767f4608daf7260b813289e",
-    "zh:f5c5e6cc9f7f070020ab7d95fcc9ed8e20d5cf219978295a71236e22cbb6d508",
-    "zh:fd2273f51dcc8f43403bf1e425ba9db08a57c3ddcba5ad7a51742ccde21ca611",
-  ]
-}
-
 provider "registry.terraform.io/hashicorp/aws" {
   version = "4.50.0"
   hashes = [

--- a/sierra_adapter/terraform/sierra_indexer/main.tf
+++ b/sierra_adapter/terraform/sierra_indexer/main.tf
@@ -24,8 +24,8 @@ module "sierra_indexer" {
   omit_queue_url = true
 
   secret_env_vars = {
-    es_password = "reporting/sierra_indexer/es_password"
-    es_host     = "reporting/es_host"
+    es_apikey = "reporting/sierra_indexer/es_apikey"
+    es_host   = "reporting/es_host"
   }
 
   cpu    = 1024


### PR DESCRIPTION
## What does this change?

The reporting indexers now use an API Key instead of a username and password.  This change provides that API Key in the ECS environment.

I have already deployed this change.

Fixes https://github.com/wellcomecollection/catalogue-pipeline/issues/2520

## How to test

Look at the [calm_indexer](https://eu-west-1.console.aws.amazon.com/ecs/v2/clusters/calm-adapter/services/calm_indexer/health?region=eu-west-1) and [sierra_indexer](https://eu-west-1.console.aws.amazon.com/ecs/v2/clusters/sierra-adapter-20200604/services/sierra-adapter-20200604-sierra_indexer/health?region=eu-west-1).  The deployment state should not be FAILED.

Look at the [calm indexer input queue](https://eu-west-1.console.aws.amazon.com/sqs/v3/home?region=eu-west-1#/queues/https%3A%2F%2Fsqs.eu-west-1.amazonaws.com%2F760097843905%2Fcalm-indexer-input) and the [Sierra indexer input queue](https://eu-west-1.console.aws.amazon.com/sqs/v3/home?region=eu-west-1#/queues/https%3A%2F%2Fsqs.eu-west-1.amazonaws.com%2F760097843905%2Fsierra-adapter-20200604-sierra_indexer_input).  The number of available messages should either be zero, or a very low number.  If it is a low number, then wait a bit (possibly looking at the above ECS instances.  The messages will be processed by them

## How can we measure success?

When new content is published in Sierra or CALM, we will be able to query it in Reporting.

## Have we considered potential risks?

This fixes something that has been broken for some months.  We should probably have an alarm that can alert us to this failure.  The indexers would not start, and messages were hitting their retention period and disappearing.  This change does not create any new alert, so if this happens again (e.g. if the API Key is removed), then we may suffer the same problem where we don't spot it until something nearby makes us look.  I have raised https://github.com/wellcomecollection/catalogue-pipeline/issues/2523 to put in an alert.

The API Key itself has been manually created (using the same permissions as the user that the indexers used to use), rather than managed by Terraform.  We should look at including this in the critical infrastructure tf, but AFAICT, the previous username/password approach was also manually managed, hence my decision to follow the same approach here