### PR TITLE
Bump the SBT version from 1.4.1 to 1.9.8

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -94,7 +94,7 @@ object WellcomeDependencies {
 object ExternalDependencies {
   lazy val versions = new {
     val apacheCommons = "1.9"
-    val circe = "0.13.0"
+    val circe = "0.14.1"
     val diffJson = "4.1.1"
     val fastparse = "2.3.0"
     val scalatest = "3.2.3"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=1.4.1
+sbt.version=1.9.8
 


### PR DESCRIPTION
## What does this change?

This is another instance of https://github.com/wellcomecollection/catalogue-api/pull/737, needed to compile the app on new Macs.  Interestingly this also requires a circe bump to prevent [this failure](https://buildkite.com/wellcomecollection/catalogue-pipeline/builds/8368#018d375a-f46e-49d4-96ef-214469b32a71/135-238) when coupled with the `scala-libs` update.

## How to test?

The most recent version (1.9.8) of sbt seems to work with this project, so upgrading.

- [x] Build and test locally, does it succeed?
- [x] Does this PR get a green tick when running in CI?

## How can we measure success?

People working on this project with M1 macs can build and test it.