### PR TITLE
i-numbers can have a dotted suffix

### DIFF
--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraIconographicNumber.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraIconographicNumber.scala
@@ -9,7 +9,7 @@ object SierraIconographicNumber
     with SierraQueryOps {
   override type Output = Option[String]
 
-  private val IconographicNumberMatch = "^([0-9]+i)$".r
+  private val IconographicNumberMatch = "^([0-9]+i(\\.[0-9]+)?)$".r
 
   override def apply(bibData: SierraBibData): Option[String] =
     bibData match {
@@ -20,7 +20,7 @@ object SierraIconographicNumber
           .collectFirst {
             // There are a handful of cases where the value in this field doesn't
             // look like an i-number, in which case we discard it.
-            case IconographicNumberMatch(number) => number
+            case IconographicNumberMatch(number, _) => number
           }
 
       case _ => None

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraIconographicNumber.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraIconographicNumber.scala
@@ -9,6 +9,13 @@ object SierraIconographicNumber
     with SierraQueryOps {
   override type Output = Option[String]
 
+  // This expression could be made slightly more exclusive.
+  // In practice, an i-number is between 1 and 8 digits before the `i`,
+  // and between 1 and 3 after the `.` if present.
+  // However, it is preferable to be slightly more permissive than necessary here.
+  // This will match any string that a human author would immediately recognise as an i-number
+  // and reject those that are obviously not.
+  // If a new i-number is coined with 9 leading digits, or four trailing ones, this will still work.
   private val IconographicNumberMatch = "^([0-9]+i(\\.[0-9]+)?)$".r
 
   override def apply(bibData: SierraBibData): Option[String] =

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraIconographicNumberTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraIconographicNumberTest.scala
@@ -47,8 +47,7 @@ class SierraIconographicNumberTest
     )
 
     SierraIconographicNumber(bibData) shouldBe None
-  }
-  // TODO: Add no *valid* 001 - i.e. there is one, but they are not i numbers
+  }  
   it("returns nothing if there is no 001") {
     val bibData = createSierraBibDataWith(
       materialType = Some(SierraMaterialType("r")),

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraIconographicNumberTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraIconographicNumberTest.scala
@@ -68,7 +68,7 @@ class SierraIconographicNumberTest
     )
     forAll(badINumbers) {
       case (iNumber, label) =>
-        it(s"An i-number can $label") {
+        it(s"An i-number cannot $label") {
           val bibData = createSierraBibDataWith(
             materialType = Some(SierraMaterialType("k")),
             varFields = List(

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraIconographicNumberTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraIconographicNumberTest.scala
@@ -2,6 +2,7 @@ package weco.pipeline.transformer.sierra.transformers
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks
 import weco.sierra.generators.SierraDataGenerators
 import weco.sierra.models.fields.SierraMaterialType
 import weco.sierra.models.marc.VarField
@@ -9,33 +10,29 @@ import weco.sierra.models.marc.VarField
 class SierraIconographicNumberTest
     extends AnyFunSpec
     with Matchers
-    with SierraDataGenerators {
-  it("uses the i-number from 001 if materialType = Pictures") {
-    val bibData = createSierraBibDataWith(
-      materialType = Some(SierraMaterialType("k")),
-      varFields = List(
-        VarField(
-          marcTag = Some("001"),
-          content = Some("12345i")
+    with SierraDataGenerators
+    with TableDrivenPropertyChecks {
+
+  private val matTypeTable = Table(
+    ("code", "label"),
+    ("k", "Pictures"),
+    ("r", "3-D Objects")
+  )
+
+  forAll(matTypeTable) {
+    case (code, label) =>
+      it(s"uses the i-number from 001 if materialType = $label") {
+        val bibData = createSierraBibDataWith(
+          materialType = Some(SierraMaterialType(code)),
+          varFields = List(
+            VarField(
+              marcTag = Some("001"),
+              content = Some("12345i")
+            )
+          )
         )
-      )
-    )
-
-    SierraIconographicNumber(bibData) shouldBe Some("12345i")
-  }
-
-  it("uses the i-number from 001 if materialType = 3-D Objects") {
-    val bibData = createSierraBibDataWith(
-      materialType = Some(SierraMaterialType("r")),
-      varFields = List(
-        VarField(
-          marcTag = Some("001"),
-          content = Some("56789i")
-        )
-      )
-    )
-
-    SierraIconographicNumber(bibData) shouldBe Some("56789i")
+        SierraIconographicNumber(bibData) shouldBe Some("12345i")
+      }
   }
 
   it("ignores the contents of 001 for other material types") {
@@ -51,7 +48,7 @@ class SierraIconographicNumberTest
 
     SierraIconographicNumber(bibData) shouldBe None
   }
-
+  // TODO: Add no *valid* 001 - i.e. there is one, but they are not i numbers
   it("returns nothing if there is no 001") {
     val bibData = createSierraBibDataWith(
       materialType = Some(SierraMaterialType("r")),
@@ -60,24 +57,94 @@ class SierraIconographicNumberTest
 
     SierraIconographicNumber(bibData) shouldBe None
   }
-
-  it("ignores a value that doesn't look like an i-number") {
-    def getIconographicNumber(s: String): Option[String] = {
-      val bibData = createSierraBibDataWith(
-        materialType = Some(SierraMaterialType("k")),
-        varFields = List(
-          VarField(
-            marcTag = Some("001"),
-            content = Some(s)
+  describe("validating i-numbers") {
+    val badINumbers = Table(
+      ("iNumber", "label"),
+      ("9", "be a single digit"),
+      ("i", "be just the letter i'"),
+      ("000x00000i", "contain non-numeric characters"),
+      ("123456789i.1.0", "have more than one numeric suffix"),
+      ("123456789i.a1", "contain non-numeric characters in the suffix")
+    )
+    forAll(badINumbers) {
+      case (iNumber, label) =>
+        it(s"An i-number can $label") {
+          val bibData = createSierraBibDataWith(
+            materialType = Some(SierraMaterialType("k")),
+            varFields = List(
+              VarField(
+                marcTag = Some("001"),
+                content = Some(iNumber)
+              )
+            )
           )
-        )
-      )
-
-      SierraIconographicNumber(bibData)
+          SierraIconographicNumber(bibData) shouldBe None
+        }
     }
 
-    getIconographicNumber("12345i") shouldBe Some("12345i")
-    getIconographicNumber("12345") shouldBe None
-    getIconographicNumber("i") shouldBe None
+    val iNumberVariations = Table(
+      ("iNumber", "label"),
+      ("9i", "be a single digit, followed by the letter i"),
+      (
+        "12345678900987654321i",
+        "be any number of digits followed by the letter i'"
+      ),
+      ("123456789i.1", "have a numeric suffix, separated by a dot '.'"),
+      ("123456789i.989898989891", "have a numeric suffix of any length")
+    )
+
+    forAll(iNumberVariations) {
+      case (iNumber, label) =>
+        it(s"An i-number can $label") {
+          val bibData = createSierraBibDataWith(
+            materialType = Some(SierraMaterialType("k")),
+            varFields = List(
+              VarField(
+                marcTag = Some("001"),
+                content = Some(iNumber)
+              )
+            )
+          )
+          SierraIconographicNumber(bibData) shouldBe Some(iNumber)
+        }
+    }
+  }
+
+  it(
+    "ignores a value that doesn't look like an i-number when there are multiple 001s"
+  ) {
+    val bibData = createSierraBibDataWith(
+      materialType = Some(SierraMaterialType("k")),
+      varFields = List(
+        VarField(
+          marcTag = Some("001"),
+          content = Some("b1234567x")
+        ),
+        VarField(
+          marcTag = Some("001"),
+          content = Some("12345i")
+        )
+      )
+    )
+    SierraIconographicNumber(bibData) shouldBe Some("12345i")
+  }
+
+  it(
+    "returns the first value that looks like an i-number when there are multiple 001s"
+  ) {
+    val bibData = createSierraBibDataWith(
+      materialType = Some(SierraMaterialType("k")),
+      varFields = List(
+        VarField(
+          marcTag = Some("001"),
+          content = Some("12345i")
+        ),
+        VarField(
+          marcTag = Some("001"),
+          content = Some("54321i")
+        )
+      )
+    )
+    SierraIconographicNumber(bibData) shouldBe Some("12345i")
   }
 }


### PR DESCRIPTION
## What does this change?
See https://github.com/wellcomecollection/wellcomecollection.org/issues/10565

There are some iconographic numbers (e.g. `3329263i.104`  on [vu3mwczx](https://wellcomecollection.org/works/vu3mwczx)) which have a numeric suffix after a dot.  These are currently being erroneously ignored by the validation that expects a number followed by `i`.

This fixes that bug.

## How to test

This is pretty well isolated, so the unit tests should cover it quite well.  When this has been deployed and the relevant records indexed, then records like vu3mwczx should show a `Reference` beneath the title (`Reference: 3329263i.104` in this case), in the same way as https://wellcomecollection.org/works/g8j7y2xh


## Have we considered potential risks?

It is syntactically possible that a Sierra record might have multiple valid `001` fields.  If a dotted one appears ahead of an undotted one, then the reference displayed for that record will change. 

1. I don't think that is likely
2. If it does happen, it will probably be more correct
3. I think this number is only for display, and no machines are relying on it to preferentially point to a dotless i-number
