### PR TITLE
Fix the Sierra adapter deployment

### DIFF
--- a/sierra_adapter/sierra_progress_reporter/deploy.sh
+++ b/sierra_adapter/sierra_progress_reporter/deploy.sh
@@ -6,22 +6,26 @@ set -o errexit
 set -o nounset
 
 ROOT=$(git rev-parse --show-toplevel)
+S3_BUCKET="wellcomecollection-platform-infra"
+S3_KEY="lambdas/sierra_adapter/sierra_progress_reporter.zip"
+FUNCTION_NAME="sierra-adapter-20200604-sierra_progress_reporter"
 
+echo "Building sierra_progress_reporter.zip"
 pushd "$ROOT/sierra_adapter/sierra_progress_reporter"
   pip3 install \
     --target . \
     --platform manylinux2014_x86_64 \
     --only-binary=:all: \
     -r requirements.txt
-  zip -r ../sierra_progress_reporter.zip *
+
+  zip -r ../sierra_progress_reporter.zip ./*
+
+  echo "Uploading to s3://$S3_BUCKET/$S3_KEY"
+  aws s3 cp ../sierra_progress_reporter.zip "s3://$S3_BUCKET/$S3_KEY"
 popd
 
-S3_BUCKET="wellcomecollection-platform-infra"
-S3_KEY="lambdas/sierra_adapter/sierra_progress_reporter.zip"
-
-aws s3 cp sierra_progress_reporter.zip "s3://$S3_BUCKET/$S3_KEY"
-
+echo "Updating $FUNCTION_NAME"
 aws lambda update-function-code \
-  --function-name "sierra-adapter-20200604-sierra_progress_reporter" \
+  --function-name "$FUNCTION_NAME" \
   --s3-bucket "$S3_BUCKET" \
   --s3-key "$S3_KEY"


### PR DESCRIPTION
## What does this change?

The sierra adapter deployment has been failing for a long time, the cause from some time in may seeming to be updating the sierra_reader & sierra_progress_reporter lambdas. Specifically they've been looking for the upload zip artefact in the wrong place. 

Broken since:
<img width="1159" alt="Screenshot 2024-01-24 at 16 24 15" src="https://github.com/wellcomecollection/catalogue-pipeline/assets/953792/6718a4a0-eccb-459f-8eca-3c79e3a54efe">

Fixed briefly:
<img width="1159" alt="Screenshot 2024-01-24 at 16 44 51" src="https://github.com/wellcomecollection/catalogue-pipeline/assets/953792/5b5ef575-5c16-41cf-9d89-9b2dfac8f1c8">

This change fixes the build scripts for those lambdas to find the zip file where it's built and add some more output.

## How to test

These scripts can be run locally:

```sh
./sierra_adapter/sierra_progress_reporter/deploy.sh
./sierra_adapter/sierra_reader/deploy.sh
```

They run successfully when the correct AWS profile is assumed (when testing I commented out the lambda update step, so that will be exercised in CI when this is merged).

## How can we measure success?

These lambdas are not being kept up to date, and incorrectly show the failure of the adapter build in buildkite. This change should fix those problems.

## Have we considered potential risks?

This will be the first time these lambdas are updated since May 2023, so if there have been code changes since then we won't have tried them out anywhere. That does unfortunately seem to be the case (https://github.com/wellcomecollection/catalogue-pipeline/pull/2358), and the change was significant although I suspect the deployment was done manually and the code is unchanged since this update.

We can confirm by comparing the currently in use lambdas to the deployment artefact we generate.
