### PR TITLE
fix in/slash deprecation warning

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -6,7 +6,8 @@ object Common {
     scalaVersion := "2.12.8",
     organization := "weco",
     resolvers ++= Seq(
-      "Wellcome releases" at "s3://releases.mvn-repo.wellcomecollection.org/"),
+      "Wellcome releases" at "s3://releases.mvn-repo.wellcomecollection.org/"
+    ),
     scalacOptions ++= Seq(
       "-deprecation",
       "-unchecked",
@@ -21,9 +22,9 @@ object Common {
       "-Xcheckinit"
     ),
     updateOptions := updateOptions.value.withCachedResolution(true),
-    parallelExecution in Test := false,
+    Test / parallelExecution := false,
     // Don't build scaladocs
     // https://www.scala-sbt.org/sbt-native-packager/formats/universal.html#skip-packagedoc-task-on-stage
-    mappings in (Compile, packageDoc) := Nil
+    Compile / packageDoc / mappings := Nil
   )
 }


### PR DESCRIPTION
## What does this change?

Fixes these deprecation warnings on SBT builds:

```
[warn] /var/lib/buildkite-agent/builds/buildkite-elasticstack-scala-i-0e90845770832f6f8-1/wellcomecollection/catalogue-pipeline/project/Common.scala:24:23: method in in trait ScopingSetting is deprecated (since 1.5.0): `in` is deprecated; migrate to slash syntax - https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
[warn]     parallelExecution in Test := false,
[warn]                       ^
[warn] /var/lib/buildkite-agent/builds/buildkite-elasticstack-scala-i-0e90845770832f6f8-1/wellcomecollection/catalogue-pipeline/project/Common.scala:27:14: method in in trait ScopingSetting is deprecated (since 1.5.0): `in` is deprecated; migrate to slash syntax - https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
[warn]     mappings in (Compile, packageDoc) := Nil
[warn]              ^
```

## How to test

Look at the build output for any of the pipeline projects (locally or in buildkite).  It won't warn us about that sort of thing any more.

## How can we measure success?

* Migrating to later versions of SBT will be marginally simpler.
* Once this and one other build warning has been resolved, then the soft failure on the auto format stage will no longer happen.  Green lights everywhere!

## Have we considered potential risks?

I don't think there are any risks.  This syntax has been supported by SBT for a while, and is the recommended way to scope your keys. 