### PR TITLE
fix "29 feature warnings"

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,8 +1,9 @@
 import sbt._
-
+import scala.language.reflectiveCalls
 object WellcomeDependencies {
 
-  val defaultVersion = "32.40.4" // This is automatically bumped by the scala-libs release process, do not edit this line manually
+  val defaultVersion =
+    "32.40.4" // This is automatically bumped by the scala-libs release process, do not edit this line manually
 
   lazy val versions = new {
     val typesafe = defaultVersion

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,1 +1,5 @@
 scalaVersion := "2.12.16"
+scalacOptions ++= Seq(
+  "-deprecation",
+  "-feature"
+)


### PR DESCRIPTION
## What does this change?

This makes explicit the use of reflective calls in the Dependencies file.

## How to test

Look at buildkite, or `set reload` locally.  You will not see the following line
```
[warn] 29 feature warnings; re-run with -feature for details
```

You will also not see a bunch of lines that look a bit like this:

```
[warn] /Users/butcherp/Documents/GitHub/catalogue-pipeline/project/Dependencies.scala:25:24: reflective access of structural type member value fixtures should be enabled
[warn] by making the implicit value scala.language.reflectiveCalls visible.
[warn]     version = versions.fixtures
```

## How can we measure success?

Alongside https://github.com/wellcomecollection/catalogue-pipeline/pull/2532, this fixes the remaining warnings reported in sbt builds, so now Buildkite builds will be fully green, with no soft failure.

## Have we considered potential risks?
There should be no risks.  The changes here do two things:

1. Increase the detail reported for these warnings when building (no change to the runtime)
2. Make explicit something that was already there implicitly

