### PR TITLE
Add default code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,2 @@
-# To ensure only properly audited changes are run in CI, we require reviews
-# from @wellcomecollection/buildkite-admin when updating pipeline config
-
-/.buildkite/    @wellcomecollection/buildkite-admin
-/builds/      @wellcomecollection/buildkite-admin
+# These are default codeowners, later rules take precedence
+*	@wellcomecollection/scala-reviewers


### PR DESCRIPTION
## What does this change?

- `buildkite-admins` is not a team anymore, so I removed the lines that did nothing. If we want it back, we can re-add it once we've recreated the team if it feels usefuk.
- I've added a default code owner so they automatically get added to PRs as reviewers. Let me know if it should be a different Team? 

## How to test

I guess once it's in, and a PR gets created we could check it adds it automatically to reviewers?

## How can we measure success?

Are PRs not going unnoticed anymore 👀 

## Have we considered potential risks?

I don't think there is any, see the first point above about buildkite-admins, maybe we consider that a risk?

