### PR TITLE
Add wider net of approvers for changes to codeowners and buildkite

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,7 @@
 # These are default codeowners, later rules take precedence
 *	@wellcomecollection/scala-reviewers
+
+# To ensure only properly audited changes are run in CI, we require reviews
+# from @wellcomecollection/developers when updating pipeline config
+/CODEOWNERS	@wellcomecollection/developers
+/.buildkite/    @wellcomecollection/developers


### PR DESCRIPTION
## What does this change?

[Originally removed that bit as the team assigned didn't exist anymore](https://github.com/wellcomecollection/catalogue-pipeline/pull/2534). [We discussed wanting to re-add](https://wellcome.slack.com/archives/C3TQSF63C/p1706195974041699?thread_ts=1706115242.737549&cid=C3TQSF63C) it with `developers`. As I mentioned in [the `catalogue-api` PR for the same thing](https://github.com/wellcomecollection/catalogue-api/pull/748): 
> [...] The change means that it's not a smaller group that can approve PRs related to those folders/files, but a bigger one, it's changes that don't require Scala knowledge so I believe it makes sense to widen the net. Let me know if not.

## How to test

Once it's in, and a PR gets created we could check it adds it automatically to reviewers?

## How can we measure success?

✨ feeling secure? ✨ 

## Have we considered potential risks?
 None I can think of
