### PR TITLE
Fix scaling_service terraform

### DIFF
--- a/infrastructure/modules/scaling_service/variables.tf
+++ b/infrastructure/modules/scaling_service/variables.tf
@@ -114,7 +114,6 @@ variable "queue_config" {
     visibility_timeout_seconds = number
     message_retention_seconds  = number
     max_receive_count          = number
-    message_retention_seconds  = number
     cooldown_period            = string
     dlq_alarm_arn              = string
   })

--- a/reindexer/terraform/.terraform.lock.hcl
+++ b/reindexer/terraform/.terraform.lock.hcl
@@ -4,6 +4,7 @@
 provider "registry.terraform.io/hashicorp/aws" {
   version = "3.67.0"
   hashes = [
+    "h1:aklPsOMmfFPD9iAHolEA4dMxi7cWeI2mosZN6/a2yFE=",
     "h1:p7CyS0dxRoxAMVeCBy7VS6yLm4hWkvl3ojhOvaog1n4=",
     "zh:0bf1ecb4fe3ff79da63c82454a5dd9e12f867d5372b6bb30e560376537dc7a53",
     "zh:0d5bedecf10ef6d8f8669661fe67b6ef572c7619a2322a825b9003ab2e93a396",


### PR DESCRIPTION
## What does this change?

This fixes a syntax error in the `scaling_service` module that prevented `terraform init` from proceeding. This change was discovered as part of re-applying terraform changes to fix logging in the reindexer.

Related: https://wellcome.slack.com/archives/C02ANCYL90E/p1707216525952379

## How to test

- [ ] Do a reindex, does the reindexer log to the expected index pattern now (service-logs-*) ?

## How can we measure success?

Less confusing elasticsearch configuration.

