### PR TITLE
Allow the AMI for the ECS EC2 instance cluster host to be set

### DIFF
--- a/infrastructure/modules/scaling_service/variables.tf
+++ b/infrastructure/modules/scaling_service/variables.tf
@@ -114,7 +114,6 @@ variable "queue_config" {
     visibility_timeout_seconds = number
     message_retention_seconds  = number
     max_receive_count          = number
-    message_retention_seconds  = number
     cooldown_period            = string
     dlq_alarm_arn              = string
   })

--- a/pipeline/terraform/2024-02-01/.terraform.lock.hcl
+++ b/pipeline/terraform/2024-02-01/.terraform.lock.hcl
@@ -5,7 +5,6 @@ provider "registry.terraform.io/elastic/ec" {
   version     = "0.2.1"
   constraints = "0.2.1"
   hashes = [
-    "h1:Njh3l0Del+s0OKnOwuKvPZLcTPSdwx7fnLa8Ex/VJrg=",
     "h1:xkKP1EYtPN3kXPjuE9f4Ywe2AA/kM4X3ZPKen8xUMTs=",
     "zh:145414eaa5015fcad546eb17bd78a14720cadcfcca781a46c9a6493722eb3ba8",
     "zh:1cb7bacfe088c1145834e0a7d053f7aa7a8897a3554d040becad004774aa45f4",
@@ -28,7 +27,6 @@ provider "registry.terraform.io/elastic/elasticstack" {
   constraints = "0.7.0"
   hashes = [
     "h1:O0FhECkmPg0FUMmFR6vzpXz3Tb+ACs1pFCzkNT2yPF4=",
-    "h1:S8ZSgFIHsn++WvglAY93tpB7jmsBqXbX/xe0mRbW9mc=",
     "zh:036576eaa4ed8caf8da11b81cdac26940173cf8295bb69b5471278453a8db78b",
     "zh:20f3fb2e7f364d8750a56e56829fe9db46a014388fe266bf08b93ca7b2d72ba4",
     "zh:3250c8f46a3915db8234b98f453d1b712542767241fe9813bf092c2bcb948a05",
@@ -47,25 +45,24 @@ provider "registry.terraform.io/elastic/elasticstack" {
 }
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version = "5.31.0"
+  version = "5.36.0"
   hashes = [
-    "h1:2eauBmfftzGMpzFQn9aHSXiyaO3Ve5cnihmXcKGGpgU=",
-    "h1:ltxyuBWIy9cq0kIKDJH1jeWJy/y7XJLjS4QrsQK4plA=",
-    "zh:0cdb9c2083bf0902442384f7309367791e4640581652dda456f2d6d7abf0de8d",
-    "zh:2fe4884cb9642f48a5889f8dff8f5f511418a18537a9dfa77ada3bcdad391e4e",
-    "zh:36d8bdd72fe61d816d0049c179f495bc6f1e54d8d7b07c45b62e5e1696882a89",
-    "zh:539dd156e3ec608818eb21191697b230117437a58587cbd02ce533202a4dd520",
-    "zh:6a53f4b57ac4eb3479fc0d8b6e301ca3a27efae4c55d9f8bd24071b12a03361c",
-    "zh:6faeb8ff6792ca7af1c025255755ad764667a300291cc10cea0c615479488c87",
-    "zh:7d9423149b323f6d0df5b90c4d9029e5455c670aea2a7eb6fef4684ba7eb2e0b",
-    "zh:8235badd8a5d0993421cacf5ead48fac73d3b5a25c8a68599706a404b1f70730",
-    "zh:860b4f60842b2879c5128b7e386c8b49adeda9287fed12c5cd74861bb659bbcd",
+    "h1:54QgAU2vY65WZsiZ9FligQfIf7hQUvwse4ezMwVMwgg=",
+    "zh:0da8409db879b2c400a7d9ed1311ba6d9eb1374ea08779eaf0c5ad0af00ac558",
+    "zh:1b7521567e1602bfff029f88ccd2a182cdf97861c9671478660866472c3333fa",
+    "zh:1cab4e6f3a1d008d01df44a52132a90141389e77dbb4ec4f6ac1119333242ecf",
+    "zh:1df9f73595594ce8293fb21287bcacf5583ae82b9f3a8e5d704109b8cf691646",
+    "zh:2b5909268db44b6be95ff6f9dc80d5f87ca8f63ba530fe66723c5fdeb17695fc",
+    "zh:37dd731eeb0bc1b20e3ec3a0cb5eb7a730edab425058ff40f2243438acc82830",
+    "zh:3e94c76a2b607a1174d10f5712aed16cb32216ac1c91bd6f21749d61a14045ac",
+    "zh:40e6ba3184d2d3bf283a07feed8b79c1bbc537a91215cac7b3521b9ccb3e503e",
+    "zh:67e52353fea47eb97825f6eb6fddd1935e0ff3b53a8861d23a70c2babf83ae51",
+    "zh:6d2e2f390e0c7b2cd2344b1d5d6eec8a1c11cf35d19f1d6f341286f2449e9e10",
+    "zh:7005483c43926800fad5bb18e27be883dac4339edb83a8f18ccdc7edf86fafc2",
+    "zh:7073fa7ccaa9b07c2cf7b24550a90e11f4880afd5c53afd51278eff0154692a0",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:b021fceaf9382c8fe3c6eb608c24d01dce3d11ba7e65bb443d51ca9b90e9b237",
-    "zh:b38b0bfc1c69e714e80cf1c9ea06e687ee86aa9f45694be28eb07adcebbe0489",
-    "zh:c972d155f6c01af9690a72adfb99cfc24ef5ef311ca92ce46b9b13c5c153f572",
-    "zh:e0dd29920ec84fdb6026acff44dcc1fb1a24a0caa093fa04cdbc713d384c651d",
-    "zh:e3127ebd2cb0374cd1808f911e6bffe2f4ac4d84317061381242353f3a7bc27d",
+    "zh:a6d48620e526c766faec9aeb20c40a98c1810c69b6699168d725f721dfe44846",
+    "zh:e29b651b5f39324656f466cd24a54861795cc423a1b58372f4e1d2d2112d10a0",
   ]
 }
 
@@ -73,7 +70,6 @@ provider "registry.terraform.io/hashicorp/null" {
   version = "3.2.2"
   hashes = [
     "h1:IMVAUHKoydFrlPrl9OzasDnw/8ntZFerCC9iXw1rXQY=",
-    "h1:vWAsYRd7MjYr3adj8BVKRohVfHpWQdvkIwUQ2Jf5FVM=",
     "zh:3248aae6a2198f3ec8394218d05bd5e42be59f43a3a7c0b71c66ec0df08b69e7",
     "zh:32b1aaa1c3013d33c245493f4a65465eab9436b454d250102729321a44c8ab9a",
     "zh:38eff7e470acb48f66380a73a5c7cdd76cc9b9c9ba9a7249c7991488abe22fe3",
@@ -93,7 +89,6 @@ provider "registry.terraform.io/hashicorp/random" {
   version = "3.6.0"
   hashes = [
     "h1:I8MBeauYA8J8yheLJ8oSMWqB0kovn16dF/wKZ1QTdkk=",
-    "h1:p6WG1IPHnqx1fnJVKNjv733FBaArIugqy58HRZnpPCk=",
     "zh:03360ed3ecd31e8c5dac9c95fe0858be50f3e9a0d0c654b5e504109c2159287d",
     "zh:1c67ac51254ba2a2bb53a25e8ae7e4d076103483f55f39b426ec55e47d1fe211",
     "zh:24a17bba7f6d679538ff51b3a2f378cedadede97af8a1db7dad4fd8d6d50f829",

--- a/pipeline/terraform/2024-02-01/main.tf
+++ b/pipeline/terraform/2024-02-01/main.tf
@@ -36,6 +36,6 @@ module "pipeline" {
   providers = {
     aws.catalogue = aws.catalogue
   }
-  
+
   ami_id = data.aws_ami.container_host_ami.image_id
 }

--- a/pipeline/terraform/2024-02-01/main.tf
+++ b/pipeline/terraform/2024-02-01/main.tf
@@ -1,3 +1,12 @@
+data "aws_ami" "container_host_ami" {
+  most_recent = true
+  owners      = ["self"]
+  filter {
+    name   = "name"
+    values = ["weco-amzn2-ecs-optimised-hvm-x86_64*"]
+  }
+}
+
 module "pipeline" {
   source = "../modules/stack"
 
@@ -27,4 +36,6 @@ module "pipeline" {
   providers = {
     aws.catalogue = aws.catalogue
   }
+  
+  ami_id = data.aws_ami.container_host_ami.image_id
 }

--- a/pipeline/terraform/modules/stack/cluster.tf
+++ b/pipeline/terraform/modules/stack/cluster.tf
@@ -32,4 +32,6 @@ module "inference_capacity_provider" {
   security_group_ids = [
     aws_security_group.egress.id,
   ]
+
+  ami_id = var.ami_id
 }

--- a/pipeline/terraform/modules/stack/variables.tf
+++ b/pipeline/terraform/modules/stack/variables.tf
@@ -77,7 +77,7 @@ variable "allow_delete_indices" {
 }
 
 variable "ami_id" {
-  type    = string
-  default = null // Uses the latest ECS-optimised AMI by default
+  type        = string
+  default     = null // Uses the latest ECS-optimised AMI by default
   description = "AMI to use for the ECS EC2 cluster host"
 }

--- a/pipeline/terraform/modules/stack/variables.tf
+++ b/pipeline/terraform/modules/stack/variables.tf
@@ -75,3 +75,9 @@ variable "allow_delete_indices" {
   type    = bool
   default = false
 }
+
+variable "ami_id" {
+  type    = string
+  default = null // Uses the latest ECS-optimised AMI by default
+  description = "AMI to use for the ECS EC2 cluster host"
+}


### PR DESCRIPTION
## What does this change?

This change allows setting of the AMI for EC2 ECS cluster host (used by the inferrer task) in order to fullfil: https://github.com/wellcomecollection/platform-infrastructure/issues/410

## How to test

Apply this change to a running pipeline, and ensure tasks are placed in the instance as required.

## How can we measure success?

This instance can be monitored via the CrowdStrike & Qualys agents.