### PR TITLE
Put mergeCandidates in the indexed debug information

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Work.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Work.scala
@@ -237,7 +237,7 @@ object WorkState {
     sourceModifiedTime: Instant,
     availabilities: Set[Availability],
     relations: Relations = Relations.none,
-    mergeCandidates: List[MergeCandidate[IdState.Identified]] = Nil,
+    mergeCandidates: List[MergeCandidate[IdState.Identified]] = Nil
   ) extends WorkState {
 
     type WorkDataState = DataState.Identified

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Work.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Work.scala
@@ -216,7 +216,8 @@ object WorkState {
     mergedTime: Instant,
     sourceModifiedTime: Instant,
     availabilities: Set[Availability] = Set.empty,
-    relations: Relations = Relations.none
+    relations: Relations = Relations.none,
+    mergeCandidates: List[MergeCandidate[IdState.Identified]] = Nil
   ) extends WorkState {
 
     type WorkDataState = DataState.Identified
@@ -235,7 +236,8 @@ object WorkState {
     mergedTime: Instant,
     sourceModifiedTime: Instant,
     availabilities: Set[Availability],
-    relations: Relations = Relations.none
+    relations: Relations = Relations.none,
+    mergeCandidates: List[MergeCandidate[IdState.Identified]] = Nil,
   ) extends WorkState {
 
     type WorkDataState = DataState.Identified
@@ -285,7 +287,8 @@ object WorkFsm {
         mergedTime = mergedTime,
         sourceModifiedTime = state.sourceModifiedTime,
         availabilities = Availabilities.forWorkData(data),
-        relations = state.relations
+        relations = state.relations,
+        mergeCandidates = state.mergeCandidates
       )
 
     def data(data: WorkData[DataState.Identified]) = data
@@ -306,7 +309,8 @@ object WorkFsm {
           mergedTime = state.mergedTime,
           sourceModifiedTime = state.sourceModifiedTime,
           availabilities = state.availabilities,
-          relations = state.relations + relations
+          relations = state.relations + relations,
+          mergeCandidates = state.mergeCandidates
         )
 
       def data(data: WorkData[DataState.Identified]) = data

--- a/common/internal_model/src/test/resources/WorksIndexConfig.json
+++ b/common/internal_model/src/test/resources/WorksIndexConfig.json
@@ -63,6 +63,9 @@
         "properties": {
           "indexedTime": {
             "type": "date"
+          },
+          "mergeCandidates.id.canonicalId": {
+            "type": "keyword"
           }
         }
       },

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/generators/WorkGenerators.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/generators/WorkGenerators.scala
@@ -71,7 +71,8 @@ trait WorkGenerators
     sourceIdentifier: SourceIdentifier = createSourceIdentifier,
     canonicalId: CanonicalId = createCanonicalId,
     modifiedTime: Instant = randomInstant,
-    relations: Relations = Relations.none
+    relations: Relations = Relations.none,
+    mergeCandidates: List[MergeCandidate[IdState.Identified]] = Nil
   ): Work.Visible[Denormalised] = {
     val data = initData[DataState.Identified]
     Work.Visible[Denormalised](
@@ -81,7 +82,8 @@ trait WorkGenerators
         mergedTime = modifiedTime,
         sourceModifiedTime = modifiedTime,
         availabilities = Availabilities.forWorkData(data),
-        relations = relations
+        relations = relations,
+        mergeCandidates = mergeCandidates
       ),
       data = data,
       version = createVersion

--- a/index_config/mappings.works_indexed.2024-01-09.json
+++ b/index_config/mappings.works_indexed.2024-01-09.json
@@ -125,6 +125,9 @@
       "properties": {
         "indexedTime": {
           "type": "date"
+        },
+        "mergeCandidates.id.canonicalId": {
+          "type": "keyword"
         }
       }
     },

--- a/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/WorkTransformer.scala
+++ b/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/WorkTransformer.scala
@@ -30,7 +30,7 @@ trait WorkTransformer {
       )
 
       work match {
-        case visibleWork @ Work.Visible(_, _, _, redirectSources) => {
+        case visibleWork @ Work.Visible(_, _, state, redirectSources) => {
           val display = DisplayWork(visibleWork).asJson.deepDropNullValues
 
           IndexedWork.Visible(
@@ -38,7 +38,8 @@ trait WorkTransformer {
               source = source,
               mergedTime = mergedTime,
               indexedTime = indexedTime,
-              redirectSources = redirectSources
+              redirectSources = redirectSources,
+              mergeCandidates = state.mergeCandidates
             ),
             display = display,
             query = WorkQueryableValues(visibleWork),
@@ -47,33 +48,36 @@ trait WorkTransformer {
           )
         }
 
-        case Work.Invisible(_, _, _, invisibilityReasons) =>
+        case Work.Invisible(_, _, state, invisibilityReasons) =>
           IndexedWork.Invisible(
             debug = DebugInformation.Invisible(
               source = source,
               mergedTime = mergedTime,
               indexedTime = indexedTime,
-              invisibilityReasons = invisibilityReasons
+              invisibilityReasons = invisibilityReasons,
+              mergeCandidates = state.mergeCandidates
             )
           )
 
-        case Work.Redirected(_, redirectTarget, _) =>
+        case Work.Redirected(_, redirectTarget, state) =>
           IndexedWork.Redirected(
             debug = DebugInformation.Redirected(
               source = source,
               mergedTime = mergedTime,
-              indexedTime = indexedTime
+              indexedTime = indexedTime,
+              mergeCandidates = state.mergeCandidates
             ),
             redirectTarget = redirectTarget
           )
 
-        case Work.Deleted(_, _, deletedReason) =>
+        case Work.Deleted(_, state, deletedReason) =>
           IndexedWork.Deleted(
             debug = DebugInformation.Deleted(
               source = source,
               mergedTime = mergedTime,
               indexedTime = indexedTime,
-              deletedReason = deletedReason
+              deletedReason = deletedReason,
+              mergeCandidates = state.mergeCandidates
             )
           )
       }

--- a/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/DebugInformation.scala
+++ b/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/DebugInformation.scala
@@ -1,8 +1,16 @@
 package weco.pipeline.ingestor.works.models
 
 import java.time.Instant
-import weco.catalogue.internal_model.identifiers.{CanonicalId, IdState, SourceIdentifier}
-import weco.catalogue.internal_model.work.{DeletedReason, InvisibilityReason, MergeCandidate}
+import weco.catalogue.internal_model.identifiers.{
+  CanonicalId,
+  IdState,
+  SourceIdentifier
+}
+import weco.catalogue.internal_model.work.{
+  DeletedReason,
+  InvisibilityReason,
+  MergeCandidate
+}
 
 /** This is information we put in the Elasticsearch index because it's useful
   * when we're debugging the pipeline, but not something we'd want to display in

--- a/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/DebugInformation.scala
+++ b/pipeline/ingestor/ingestor_works/src/main/scala/weco/pipeline/ingestor/works/models/DebugInformation.scala
@@ -1,12 +1,8 @@
 package weco.pipeline.ingestor.works.models
 
 import java.time.Instant
-import weco.catalogue.internal_model.identifiers.{
-  CanonicalId,
-  IdState,
-  SourceIdentifier
-}
-import weco.catalogue.internal_model.work.{DeletedReason, InvisibilityReason}
+import weco.catalogue.internal_model.identifiers.{CanonicalId, IdState, SourceIdentifier}
+import weco.catalogue.internal_model.work.{DeletedReason, InvisibilityReason, MergeCandidate}
 
 /** This is information we put in the Elasticsearch index because it's useful
   * when we're debugging the pipeline, but not something we'd want to display in
@@ -31,26 +27,30 @@ object DebugInformation {
     source: SourceWorkDebugInformation,
     mergedTime: Instant,
     indexedTime: Instant,
-    redirectSources: Seq[IdState.Identified]
+    redirectSources: Seq[IdState.Identified],
+    mergeCandidates: Seq[MergeCandidate[IdState.Identified]]
   ) extends DebugInformation
 
   case class Invisible(
     source: SourceWorkDebugInformation,
     mergedTime: Instant,
     indexedTime: Instant,
-    invisibilityReasons: List[InvisibilityReason]
+    invisibilityReasons: List[InvisibilityReason],
+    mergeCandidates: Seq[MergeCandidate[IdState.Identified]]
   ) extends DebugInformation
 
   case class Redirected(
     source: SourceWorkDebugInformation,
     mergedTime: Instant,
-    indexedTime: Instant
+    indexedTime: Instant,
+    mergeCandidates: Seq[MergeCandidate[IdState.Identified]]
   ) extends DebugInformation
 
   case class Deleted(
     source: SourceWorkDebugInformation,
     mergedTime: Instant,
     indexedTime: Instant,
-    deletedReason: DeletedReason
+    deletedReason: DeletedReason,
+    mergeCandidates: Seq[MergeCandidate[IdState.Identified]]
   ) extends DebugInformation
 }

--- a/pipeline/ingestor/test_documents/work-production.1098.json
+++ b/pipeline/ingestor/test_documents/work-production.1098.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 1098",
-  "createdAt" : "2023-11-21T15:39:30.574731Z",
+  "createdAt" : "2024-02-16T15:36:44.229565Z",
   "id" : "guav7chy",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1947-04-11T10:50:49Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/work-production.1900.json
+++ b/pipeline/ingestor/test_documents/work-production.1900.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 1900",
-  "createdAt" : "2023-11-21T15:39:30.404815Z",
+  "createdAt" : "2024-02-16T15:36:44.190107Z",
   "id" : "rbnro6wx",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1935-04-27T19:39:17Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/work-production.1904.json
+++ b/pipeline/ingestor/test_documents/work-production.1904.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 1904",
-  "createdAt" : "2023-11-21T15:39:30.487946Z",
+  "createdAt" : "2024-02-16T15:36:44.209947Z",
   "id" : "aiv95swj",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1949-02-28T00:19:38Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/work-production.1976.json
+++ b/pipeline/ingestor/test_documents/work-production.1976.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 1976",
-  "createdAt" : "2023-11-21T15:39:30.477810Z",
+  "createdAt" : "2024-02-16T15:36:44.199498Z",
   "id" : "5vjghupy",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1970-01-23T23:11:47Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/work-production.2020.json
+++ b/pipeline/ingestor/test_documents/work-production.2020.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 2020",
-  "createdAt" : "2023-11-21T15:39:30.557158Z",
+  "createdAt" : "2024-02-16T15:36:44.223193Z",
   "id" : "0fucriyr",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1936-06-08T14:59:50Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/work-thumbnail.json
+++ b/pipeline/ingestor/test_documents/work-thumbnail.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a thumbnail",
-  "createdAt" : "2023-11-21T15:39:30.223722Z",
+  "createdAt" : "2024-02-16T15:36:44.151896Z",
   "id" : "sahqcluh",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2052-06-26T19:25:07Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/work-title-dodo.json
+++ b/pipeline/ingestor/test_documents/work-title-dodo.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with 'dodo' in the title",
-  "createdAt" : "2023-11-21T15:39:30.307804Z",
+  "createdAt" : "2024-02-16T15:36:44.167559Z",
   "id" : "ezagik4b",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1965-10-11T02:36:15Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/work-title-mouse.json
+++ b/pipeline/ingestor/test_documents/work-title-mouse.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with 'mouse' in the title",
-  "createdAt" : "2023-11-21T15:39:30.352571Z",
+  "createdAt" : "2024-02-16T15:36:44.172159Z",
   "id" : "lnn17cwk",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2003-09-07T11:20:18Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/work-with-edition-and-duration.json
+++ b/pipeline/ingestor/test_documents/work-with-edition-and-duration.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with optional top-level fields",
-  "createdAt" : "2023-11-21T15:39:30.130747Z",
+  "createdAt" : "2024-02-16T15:36:44.133193Z",
   "id" : "gsruvqwf",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1967-09-14T08:19:27Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/work.invisible.title-mouse.json
+++ b/pipeline/ingestor/test_documents/work.invisible.title-mouse.json
@@ -1,6 +1,6 @@
 {
   "description" : "an invisible work with 'mouse' in the title",
-  "createdAt" : "2023-03-23T12:52:18.683072Z",
+  "createdAt" : "2024-02-16T15:36:44.232704Z",
   "id" : "ehd2s7ek",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2006-12-05T07:13:26Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "invisibilityReasons" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "type" : "Invisible"

--- a/pipeline/ingestor/test_documents/work.items-with-location-types.0.json
+++ b/pipeline/ingestor/test_documents/work.items-with-location-types.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "items with different location types",
-  "createdAt" : "2023-11-21T15:39:34.678455Z",
+  "createdAt" : "2024-02-16T15:36:44.948303Z",
   "id" : "tnnwysoe",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1968-08-04T13:15:13Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/work.items-with-location-types.1.json
+++ b/pipeline/ingestor/test_documents/work.items-with-location-types.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "items with different location types",
-  "createdAt" : "2023-11-21T15:39:34.681898Z",
+  "createdAt" : "2024-02-16T15:36:44.949159Z",
   "id" : "feri8p7w",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2033-07-23T10:10:36Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/work.items-with-location-types.2.json
+++ b/pipeline/ingestor/test_documents/work.items-with-location-types.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "items with different location types",
-  "createdAt" : "2023-11-21T15:39:34.684280Z",
+  "createdAt" : "2024-02-16T15:36:44.949861Z",
   "id" : "xzwsggki",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1950-04-09T22:30:42Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/work.visible.everything.0.json
+++ b/pipeline/ingestor/test_documents/work.visible.everything.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "a list of work with all the include-able fields",
-  "createdAt" : "2023-11-21T15:39:33.067849Z",
+  "createdAt" : "2024-02-16T15:36:44.682166Z",
   "id" : "tmdfbk5k",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2033-04-23T09:14:15Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/work.visible.everything.1.json
+++ b/pipeline/ingestor/test_documents/work.visible.everything.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "a list of work with all the include-able fields",
-  "createdAt" : "2023-11-21T15:39:33.142621Z",
+  "createdAt" : "2024-02-16T15:36:44.697471Z",
   "id" : "dhzcyeul",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1954-10-07T06:00:15Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/work.visible.everything.2.json
+++ b/pipeline/ingestor/test_documents/work.visible.everything.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "a list of work with all the include-able fields",
-  "createdAt" : "2023-11-21T15:39:33.161811Z",
+  "createdAt" : "2024-02-16T15:36:44.706563Z",
   "id" : "kspmagtl",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2040-10-31T18:04:56Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.collection-path.NUFFINK.json
+++ b/pipeline/ingestor/test_documents/works.collection-path.NUFFINK.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a collection path",
-  "createdAt" : "2023-11-21T15:39:34.288810Z",
+  "createdAt" : "2024-02-16T15:36:44.882889Z",
   "id" : "xngls6zs",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2068-10-10T17:34:06Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.collection-path.PPCRI.json
+++ b/pipeline/ingestor/test_documents/works.collection-path.PPCRI.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a collection path",
-  "createdAt" : "2023-11-21T15:39:34.267974Z",
+  "createdAt" : "2024-02-16T15:36:44.880426Z",
   "id" : "ynrhjtvf",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2059-06-02T08:31:27Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.contributor.0.json
+++ b/pipeline/ingestor/test_documents/works.contributor.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different contributor",
-  "createdAt" : "2023-11-21T15:39:34.094815Z",
+  "createdAt" : "2024-02-16T15:36:44.852063Z",
   "id" : "5qgfzto1",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1982-10-06T05:52:54Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.contributor.1.json
+++ b/pipeline/ingestor/test_documents/works.contributor.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different contributor",
-  "createdAt" : "2023-11-21T15:39:34.100726Z",
+  "createdAt" : "2024-02-16T15:36:44.853574Z",
   "id" : "a8uyvixy",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1959-06-29T05:37:32Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.contributor.2.json
+++ b/pipeline/ingestor/test_documents/works.contributor.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different contributor",
-  "createdAt" : "2023-11-21T15:39:34.112633Z",
+  "createdAt" : "2024-02-16T15:36:44.857789Z",
   "id" : "toypx23i",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1988-05-28T08:48:11Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.contributor.3.json
+++ b/pipeline/ingestor/test_documents/works.contributor.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different contributor",
-  "createdAt" : "2023-11-21T15:39:34.113225Z",
+  "createdAt" : "2024-02-16T15:36:44.858500Z",
   "id" : "mudchggm",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2002-10-09T11:02:18Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.deleted.0.json
+++ b/pipeline/ingestor/test_documents/works.deleted.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of deleted works",
-  "createdAt" : "2022-10-03T10:25:18.803Z",
+  "createdAt" : "2024-02-16T15:36:44.110356Z",
   "id" : "pnwuzuig",
   "document" : {
     "debug" : {
@@ -21,7 +21,9 @@
       "deletedReason" : {
         "info" : "tests",
         "type" : "DeletedFromSource"
-      }
+      },
+      "mergeCandidates" : [
+      ]
     },
     "type" : "Deleted"
   }

--- a/pipeline/ingestor/test_documents/works.deleted.1.json
+++ b/pipeline/ingestor/test_documents/works.deleted.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of deleted works",
-  "createdAt" : "2022-10-03T10:25:18.803Z",
+  "createdAt" : "2024-02-16T15:36:44.110947Z",
   "id" : "drwubxen",
   "document" : {
     "debug" : {
@@ -21,7 +21,9 @@
       "deletedReason" : {
         "info" : "tests",
         "type" : "DeletedFromSource"
-      }
+      },
+      "mergeCandidates" : [
+      ]
     },
     "type" : "Deleted"
   }

--- a/pipeline/ingestor/test_documents/works.deleted.2.json
+++ b/pipeline/ingestor/test_documents/works.deleted.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of deleted works",
-  "createdAt" : "2022-10-03T10:25:18.803Z",
+  "createdAt" : "2024-02-16T15:36:44.111210Z",
   "id" : "93ber84x",
   "document" : {
     "debug" : {
@@ -21,7 +21,9 @@
       "deletedReason" : {
         "info" : "tests",
         "type" : "DeletedFromSource"
-      }
+      },
+      "mergeCandidates" : [
+      ]
     },
     "type" : "Deleted"
   }

--- a/pipeline/ingestor/test_documents/works.deleted.3.json
+++ b/pipeline/ingestor/test_documents/works.deleted.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of deleted works",
-  "createdAt" : "2022-10-03T10:25:18.804Z",
+  "createdAt" : "2024-02-16T15:36:44.111475Z",
   "id" : "0tkkvzgo",
   "document" : {
     "debug" : {
@@ -21,7 +21,9 @@
       "deletedReason" : {
         "info" : "tests",
         "type" : "DeletedFromSource"
-      }
+      },
+      "mergeCandidates" : [
+      ]
     },
     "type" : "Deleted"
   }

--- a/pipeline/ingestor/test_documents/works.every-format.0.json
+++ b/pipeline/ingestor/test_documents/works.every-format.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2023-11-21T15:39:34.318612Z",
+  "createdAt" : "2024-02-16T15:36:44.887738Z",
   "id" : "w2ap82cs",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1966-01-30T11:53:55Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.every-format.1.json
+++ b/pipeline/ingestor/test_documents/works.every-format.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2023-11-21T15:39:34.321997Z",
+  "createdAt" : "2024-02-16T15:36:44.888746Z",
   "id" : "jminkez1",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1999-04-12T11:49:15Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.every-format.10.json
+++ b/pipeline/ingestor/test_documents/works.every-format.10.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2023-11-21T15:39:34.370840Z",
+  "createdAt" : "2024-02-16T15:36:44.894946Z",
   "id" : "5lq8kfis",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1971-04-04T14:11:16Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.every-format.11.json
+++ b/pipeline/ingestor/test_documents/works.every-format.11.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2023-11-21T15:39:34.371319Z",
+  "createdAt" : "2024-02-16T15:36:44.895813Z",
   "id" : "kkzdnfal",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2033-08-12T07:52:47Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.every-format.12.json
+++ b/pipeline/ingestor/test_documents/works.every-format.12.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2023-11-21T15:39:34.371721Z",
+  "createdAt" : "2024-02-16T15:36:44.896529Z",
   "id" : "02pauy4p",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2046-09-07T08:09:38Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.every-format.13.json
+++ b/pipeline/ingestor/test_documents/works.every-format.13.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2023-11-21T15:39:34.372105Z",
+  "createdAt" : "2024-02-16T15:36:44.897106Z",
   "id" : "83tyy1gh",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1933-08-01T22:54:00Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.every-format.14.json
+++ b/pipeline/ingestor/test_documents/works.every-format.14.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2023-11-21T15:39:34.372460Z",
+  "createdAt" : "2024-02-16T15:36:44.897549Z",
   "id" : "vwzsza7o",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2057-06-21T22:52:30Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.every-format.15.json
+++ b/pipeline/ingestor/test_documents/works.every-format.15.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2023-11-21T15:39:34.372811Z",
+  "createdAt" : "2024-02-16T15:36:44.898016Z",
   "id" : "9vihnjwg",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2016-04-26T09:59:06Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.every-format.16.json
+++ b/pipeline/ingestor/test_documents/works.every-format.16.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2023-11-21T15:39:34.373166Z",
+  "createdAt" : "2024-02-16T15:36:44.898454Z",
   "id" : "4blsy3iy",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1989-12-01T18:27:04Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.every-format.17.json
+++ b/pipeline/ingestor/test_documents/works.every-format.17.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2023-11-21T15:39:34.373547Z",
+  "createdAt" : "2024-02-16T15:36:44.898929Z",
   "id" : "9is9e3tz",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1948-09-05T03:31:20Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.every-format.18.json
+++ b/pipeline/ingestor/test_documents/works.every-format.18.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2023-11-21T15:39:34.381102Z",
+  "createdAt" : "2024-02-16T15:36:44.899391Z",
   "id" : "4pxxngz8",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2057-05-14T23:40:17Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.every-format.19.json
+++ b/pipeline/ingestor/test_documents/works.every-format.19.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2023-11-21T15:39:34.383923Z",
+  "createdAt" : "2024-02-16T15:36:44.899867Z",
   "id" : "pujta45z",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2013-08-30T03:43:43Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.every-format.2.json
+++ b/pipeline/ingestor/test_documents/works.every-format.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2023-11-21T15:39:34.324957Z",
+  "createdAt" : "2024-02-16T15:36:44.889455Z",
   "id" : "cinepzd4",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2011-07-10T12:40:11Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.every-format.20.json
+++ b/pipeline/ingestor/test_documents/works.every-format.20.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2023-11-21T15:39:34.386217Z",
+  "createdAt" : "2024-02-16T15:36:44.900335Z",
   "id" : "qph7iot8",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2068-04-15T09:23:35Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.every-format.21.json
+++ b/pipeline/ingestor/test_documents/works.every-format.21.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2023-11-21T15:39:34.386734Z",
+  "createdAt" : "2024-02-16T15:36:44.901048Z",
   "id" : "3ygkb1yd",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1961-01-11T18:15:01Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.every-format.22.json
+++ b/pipeline/ingestor/test_documents/works.every-format.22.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2023-11-21T15:39:34.387108Z",
+  "createdAt" : "2024-02-16T15:36:44.901570Z",
   "id" : "ccfchgq4",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1989-01-21T00:50:14Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.every-format.3.json
+++ b/pipeline/ingestor/test_documents/works.every-format.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2023-11-21T15:39:34.326526Z",
+  "createdAt" : "2024-02-16T15:36:44.890037Z",
   "id" : "btrlxjc4",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1936-05-06T07:13:48Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.every-format.4.json
+++ b/pipeline/ingestor/test_documents/works.every-format.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2023-11-21T15:39:34.327485Z",
+  "createdAt" : "2024-02-16T15:36:44.890452Z",
   "id" : "ifz9zadf",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2033-01-05T00:41:56Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.every-format.5.json
+++ b/pipeline/ingestor/test_documents/works.every-format.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2023-11-21T15:39:34.327921Z",
+  "createdAt" : "2024-02-16T15:36:44.890899Z",
   "id" : "xlcpwdx8",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1970-09-11T12:17:13Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.every-format.6.json
+++ b/pipeline/ingestor/test_documents/works.every-format.6.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2023-11-21T15:39:34.335195Z",
+  "createdAt" : "2024-02-16T15:36:44.891661Z",
   "id" : "cmz25207",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2057-11-24T19:37:10Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.every-format.7.json
+++ b/pipeline/ingestor/test_documents/works.every-format.7.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2023-11-21T15:39:34.340900Z",
+  "createdAt" : "2024-02-16T15:36:44.892202Z",
   "id" : "6qjgnqbc",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1984-05-15T14:09:35Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.every-format.8.json
+++ b/pipeline/ingestor/test_documents/works.every-format.8.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2023-11-21T15:39:34.352797Z",
+  "createdAt" : "2024-02-16T15:36:44.893353Z",
   "id" : "cwpfpixj",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1978-04-30T17:23:35Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.every-format.9.json
+++ b/pipeline/ingestor/test_documents/works.every-format.9.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2023-11-21T15:39:34.362927Z",
+  "createdAt" : "2024-02-16T15:36:44.894269Z",
   "id" : "6visru7m",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1993-10-03T02:48:28Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.0.json
+++ b/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2023-11-21T15:39:35.343671Z",
+  "createdAt" : "2024-02-16T15:36:45.088363Z",
   "id" : "i2iqani2",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1994-07-09T07:36:53Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.1.json
+++ b/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2023-11-21T15:39:35.344370Z",
+  "createdAt" : "2024-02-16T15:36:45.088997Z",
   "id" : "lqwyh6sk",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2025-11-25T23:47:59Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.2.json
+++ b/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2023-11-21T15:39:35.345820Z",
+  "createdAt" : "2024-02-16T15:36:45.090347Z",
   "id" : "vcuqhxox",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1934-03-30T22:58:00Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.3.json
+++ b/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2023-11-21T15:39:35.349835Z",
+  "createdAt" : "2024-02-16T15:36:45.090952Z",
   "id" : "phodmv5g",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2040-01-22T01:35:50Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.4.json
+++ b/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2023-11-21T15:39:35.352123Z",
+  "createdAt" : "2024-02-16T15:36:45.091476Z",
   "id" : "tq4mfefg",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2012-04-21T19:28:19Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.5.json
+++ b/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2023-11-21T15:39:35.355242Z",
+  "createdAt" : "2024-02-16T15:36:45.091973Z",
   "id" : "phdnojlc",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2032-11-02T13:47:49Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.6.json
+++ b/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.6.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2023-11-21T15:39:35.372091Z",
+  "createdAt" : "2024-02-16T15:36:45.092595Z",
   "id" : "vh87ts9v",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1979-11-26T18:18:50Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.0.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2023-11-21T15:39:34.736346Z",
+  "createdAt" : "2024-02-16T15:36:44.959157Z",
   "id" : "kbmotyqc",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2014-03-15T15:15:55Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.1.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2023-11-21T15:39:34.739055Z",
+  "createdAt" : "2024-02-16T15:36:44.959790Z",
   "id" : "ulwn0n8f",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1933-06-27T10:36:37Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.10.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.10.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2023-11-21T15:39:34.802218Z",
+  "createdAt" : "2024-02-16T15:36:44.967342Z",
   "id" : "uoi8tp8u",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1966-02-08T17:51:28Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.11.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.11.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2023-11-21T15:39:34.803299Z",
+  "createdAt" : "2024-02-16T15:36:44.968441Z",
   "id" : "xgqiid3b",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2024-03-26T00:53:12Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.12.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.12.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2023-11-21T15:39:34.803990Z",
+  "createdAt" : "2024-02-16T15:36:44.970024Z",
   "id" : "tqemj6yt",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1982-09-21T18:42:16Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.13.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.13.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2023-11-21T15:39:34.818288Z",
+  "createdAt" : "2024-02-16T15:36:44.970667Z",
   "id" : "bsxzfe7h",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1998-08-02T02:39:28Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.14.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.14.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2023-11-21T15:39:34.820722Z",
+  "createdAt" : "2024-02-16T15:36:44.971237Z",
   "id" : "rdsofxpt",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2033-03-18T16:57:24Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.15.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.15.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2023-11-21T15:39:34.822119Z",
+  "createdAt" : "2024-02-16T15:36:44.972630Z",
   "id" : "fzrzebxx",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1939-09-12T19:57:56Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.16.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.16.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2023-11-21T15:39:34.822685Z",
+  "createdAt" : "2024-02-16T15:36:44.973723Z",
   "id" : "iautlnkw",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1945-03-21T21:20:18Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.17.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.17.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2023-11-21T15:39:34.823194Z",
+  "createdAt" : "2024-02-16T15:36:44.974663Z",
   "id" : "3tm3cnoq",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2019-08-09T21:38:32Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.18.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.18.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2023-11-21T15:39:34.823687Z",
+  "createdAt" : "2024-02-16T15:36:44.975362Z",
   "id" : "sihntejb",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1968-01-10T17:53:21Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.19.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.19.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2023-11-21T15:39:34.824171Z",
+  "createdAt" : "2024-02-16T15:36:44.977010Z",
   "id" : "4hdjmnto",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1970-06-23T06:21:51Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.2.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2023-11-21T15:39:34.742326Z",
+  "createdAt" : "2024-02-16T15:36:44.960883Z",
   "id" : "msgkyj11",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2025-06-19T20:45:06Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.20.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.20.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2023-11-21T15:39:34.828116Z",
+  "createdAt" : "2024-02-16T15:36:44.977595Z",
   "id" : "kldauk4g",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2064-03-27T14:42:18Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.21.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.21.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2023-11-21T15:39:34.836907Z",
+  "createdAt" : "2024-02-16T15:36:44.978357Z",
   "id" : "tr1wn4ml",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1949-02-04T09:29:35Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.22.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.22.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2023-11-21T15:39:34.837730Z",
+  "createdAt" : "2024-02-16T15:36:44.979281Z",
   "id" : "vuylz3bd",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1943-07-01T12:05:25Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.3.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2023-11-21T15:39:34.744309Z",
+  "createdAt" : "2024-02-16T15:36:44.962044Z",
   "id" : "5axbzov3",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1958-04-28T22:37:25Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.4.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2023-11-21T15:39:34.745008Z",
+  "createdAt" : "2024-02-16T15:36:44.962814Z",
   "id" : "kvukzd4h",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1934-09-28T19:42:39Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.5.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2023-11-21T15:39:34.749310Z",
+  "createdAt" : "2024-02-16T15:36:44.963850Z",
   "id" : "vkukqiog",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1942-01-27T06:45:07Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.6.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.6.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2023-11-21T15:39:34.751943Z",
+  "createdAt" : "2024-02-16T15:36:44.964704Z",
   "id" : "q7ypgqb2",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2012-02-21T12:08:18Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.7.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.7.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2023-11-21T15:39:34.754297Z",
+  "createdAt" : "2024-02-16T15:36:44.965373Z",
   "id" : "cdqpxiaz",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1975-05-07T19:46:33Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.8.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.8.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2023-11-21T15:39:34.781507Z",
+  "createdAt" : "2024-02-16T15:36:44.966109Z",
   "id" : "bfaov6iz",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2060-01-23T11:20:20Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.9.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.9.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2023-11-21T15:39:34.799311Z",
+  "createdAt" : "2024-02-16T15:36:44.966741Z",
   "id" : "q84crgj5",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2034-10-22T02:22:22Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.availabilities.closed-only.json
+++ b/pipeline/ingestor/test_documents/works.examples.availabilities.closed-only.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for availabilities tests",
-  "createdAt" : "2023-11-23T15:20:26.262787Z",
+  "createdAt" : "2024-02-16T15:36:45.121848Z",
   "id" : "bb4tv6zd",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1969-11-05T18:12:49Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.availabilities.everywhere.json
+++ b/pipeline/ingestor/test_documents/works.examples.availabilities.everywhere.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for availabilities tests",
-  "createdAt" : "2023-11-23T15:20:26.272086Z",
+  "createdAt" : "2024-02-16T15:36:45.131921Z",
   "id" : "ntlrk7nw",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2003-11-23T19:57:31Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.availabilities.nowhere.json
+++ b/pipeline/ingestor/test_documents/works.examples.availabilities.nowhere.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for availabilities tests",
-  "createdAt" : "2023-11-23T15:20:26.268730Z",
+  "createdAt" : "2024-02-16T15:36:45.129878Z",
   "id" : "cc2ql7v8",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1994-05-11T15:38:25Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.availabilities.online-only.json
+++ b/pipeline/ingestor/test_documents/works.examples.availabilities.online-only.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for availabilities tests",
-  "createdAt" : "2023-11-23T15:20:26.266067Z",
+  "createdAt" : "2024-02-16T15:36:45.128092Z",
   "id" : "pgf0nj3t",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2066-01-29T23:42:50Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.availabilities.open-only.json
+++ b/pipeline/ingestor/test_documents/works.examples.availabilities.open-only.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for availabilities tests",
-  "createdAt" : "2023-11-23T15:20:26.254403Z",
+  "createdAt" : "2024-02-16T15:36:45.115828Z",
   "id" : "jwvjyz6g",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2067-09-08T00:34:22Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.0.json
+++ b/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2023-11-21T15:39:35.242599Z",
+  "createdAt" : "2024-02-16T15:36:45.062360Z",
   "id" : "dklf9ebg",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2026-01-09T00:00:01Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.1.json
+++ b/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2023-11-21T15:39:35.248180Z",
+  "createdAt" : "2024-02-16T15:36:45.063531Z",
   "id" : "r7wachux",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1986-10-13T12:45:40Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.2.json
+++ b/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2023-11-21T15:39:35.249714Z",
+  "createdAt" : "2024-02-16T15:36:45.064224Z",
   "id" : "wmvuppum",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1945-07-07T10:18:32Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.3.json
+++ b/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2023-11-21T15:39:35.250267Z",
+  "createdAt" : "2024-02-16T15:36:45.064708Z",
   "id" : "vcba0kh0",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2043-08-15T21:52:17Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.4.json
+++ b/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2023-11-21T15:39:35.263302Z",
+  "createdAt" : "2024-02-16T15:36:45.065295Z",
   "id" : "moftow5b",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1950-07-15T20:46:42Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.5.json
+++ b/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2023-11-21T15:39:35.268782Z",
+  "createdAt" : "2024-02-16T15:36:45.065713Z",
   "id" : "tru6joq4",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2022-09-30T14:40:50Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.different-work-types.Collection.json
+++ b/pipeline/ingestor/test_documents/works.examples.different-work-types.Collection.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples of works with different types",
-  "createdAt" : "2023-11-21T15:39:35.003600Z",
+  "createdAt" : "2024-02-16T15:36:45.015019Z",
   "id" : "ujg4jncr",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1951-02-24T01:30:35Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.different-work-types.Section.json
+++ b/pipeline/ingestor/test_documents/works.examples.different-work-types.Section.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples of works with different types",
-  "createdAt" : "2023-11-21T15:39:35.000950Z",
+  "createdAt" : "2024-02-16T15:36:45.013530Z",
   "id" : "pflggfra",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1996-07-06T15:31:03Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.different-work-types.Series.json
+++ b/pipeline/ingestor/test_documents/works.examples.different-work-types.Series.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples of works with different types",
-  "createdAt" : "2023-11-21T15:39:35.005029Z",
+  "createdAt" : "2024-02-16T15:36:45.016661Z",
   "id" : "velydjdv",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1960-03-11T19:55:05Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.0.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2023-11-21T15:39:35.404947Z",
+  "createdAt" : "2024-02-16T15:36:45.101384Z",
   "id" : "o0u9h1wt",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1998-09-03T03:15:10Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.1.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2023-11-21T15:39:35.409030Z",
+  "createdAt" : "2024-02-16T15:36:45.101879Z",
   "id" : "1ndk3ton",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1942-02-08T16:28:55Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.2.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2023-11-21T15:39:35.409657Z",
+  "createdAt" : "2024-02-16T15:36:45.102261Z",
   "id" : "8xiun5qm",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1992-09-20T01:47:13Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.3.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2023-11-21T15:39:35.410007Z",
+  "createdAt" : "2024-02-16T15:36:45.102644Z",
   "id" : "vguputez",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2031-04-11T11:09:11Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.4.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2023-11-21T15:39:35.410336Z",
+  "createdAt" : "2024-02-16T15:36:45.103067Z",
   "id" : "xsbqgayk",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2065-03-14T20:41:38Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.5.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2023-11-21T15:39:35.410651Z",
+  "createdAt" : "2024-02-16T15:36:45.103483Z",
   "id" : "c3ls9khw",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2041-05-31T20:04:19Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.6.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.6.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2023-11-21T15:39:35.410964Z",
+  "createdAt" : "2024-02-16T15:36:45.103865Z",
   "id" : "cpyuhtp8",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1958-09-25T01:35:38Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.7.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.7.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2023-11-21T15:39:35.420376Z",
+  "createdAt" : "2024-02-16T15:36:45.104231Z",
   "id" : "nx7u2kmr",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2059-06-20T15:32:07Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.8.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.8.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2023-11-21T15:39:35.421406Z",
+  "createdAt" : "2024-02-16T15:36:45.104627Z",
   "id" : "u1amc1nv",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1945-11-08T14:38:47Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.9.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.9.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2023-11-21T15:39:35.421772Z",
+  "createdAt" : "2024-02-16T15:36:45.104986Z",
   "id" : "qwuhqead",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1940-07-03T22:01:02Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.0.json
+++ b/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2023-11-21T15:39:35.041320Z",
+  "createdAt" : "2024-02-16T15:36:45.019745Z",
   "id" : "oxbsq4ck",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2011-03-12T19:27:33Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.1.json
+++ b/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2023-11-21T15:39:35.042124Z",
+  "createdAt" : "2024-02-16T15:36:45.020567Z",
   "id" : "wdnn2etp",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1953-09-20T12:06:56Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.2.json
+++ b/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2023-11-21T15:39:35.042645Z",
+  "createdAt" : "2024-02-16T15:36:45.022420Z",
   "id" : "d5kj1fx3",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2047-04-18T16:27:14Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.3.json
+++ b/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2023-11-21T15:39:35.043180Z",
+  "createdAt" : "2024-02-16T15:36:45.028118Z",
   "id" : "9dwdlo2r",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2067-03-09T21:26:20Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.4.json
+++ b/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2023-11-21T15:39:35.043776Z",
+  "createdAt" : "2024-02-16T15:36:45.029540Z",
   "id" : "gqd3shrq",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1996-04-23T23:20:16Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.5.json
+++ b/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2023-11-21T15:39:35.044218Z",
+  "createdAt" : "2024-02-16T15:36:45.030091Z",
   "id" : "90vab5q4",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1955-01-25T23:49:35Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.0.json
+++ b/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2023-11-21T15:39:35.203349Z",
+  "createdAt" : "2024-02-16T15:36:45.048867Z",
   "id" : "inoolbps",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1988-02-26T07:09:16Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.1.json
+++ b/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2023-11-21T15:39:35.207896Z",
+  "createdAt" : "2024-02-16T15:36:45.049770Z",
   "id" : "6vp3bulw",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2034-03-26T04:42:25Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.2.json
+++ b/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2023-11-21T15:39:35.209365Z",
+  "createdAt" : "2024-02-16T15:36:45.050554Z",
   "id" : "cerujhar",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2050-03-03T12:29:26Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.3.json
+++ b/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2023-11-21T15:39:35.210827Z",
+  "createdAt" : "2024-02-16T15:36:45.051501Z",
   "id" : "igluyxyl",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2014-07-17T10:56:43Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.4.json
+++ b/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2023-11-21T15:39:35.219837Z",
+  "createdAt" : "2024-02-16T15:36:45.052824Z",
   "id" : "t8hhmnzs",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2013-05-09T02:35:31Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.5.json
+++ b/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2023-11-21T15:39:35.221783Z",
+  "createdAt" : "2024-02-16T15:36:45.053499Z",
   "id" : "peojwvfe",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1989-01-11T05:04:05Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.formats.0.Books.json
+++ b/pipeline/ingestor/test_documents/works.formats.0.Books.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2023-11-21T15:39:33.387267Z",
+  "createdAt" : "2024-02-16T15:36:44.748853Z",
   "id" : "cfrzpe3b",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1960-07-19T22:15:33Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.formats.1.Books.json
+++ b/pipeline/ingestor/test_documents/works.formats.1.Books.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2023-11-21T15:39:33.459784Z",
+  "createdAt" : "2024-02-16T15:36:44.757519Z",
   "id" : "oz3lidvn",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1992-05-05T01:31:58Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.formats.2.Books.json
+++ b/pipeline/ingestor/test_documents/works.formats.2.Books.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2023-11-21T15:39:33.502810Z",
+  "createdAt" : "2024-02-16T15:36:44.761211Z",
   "id" : "7y59ny1n",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1945-04-09T22:12:25Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.formats.3.Books.json
+++ b/pipeline/ingestor/test_documents/works.formats.3.Books.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2023-11-21T15:39:33.540144Z",
+  "createdAt" : "2024-02-16T15:36:44.764132Z",
   "id" : "qzquhbnz",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1946-10-01T09:18:22Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.formats.4.Journals.json
+++ b/pipeline/ingestor/test_documents/works.formats.4.Journals.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2023-11-21T15:39:33.573Z",
+  "createdAt" : "2024-02-16T15:36:44.765831Z",
   "id" : "rbbzqhyt",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1956-07-19T10:08:24Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.formats.5.Journals.json
+++ b/pipeline/ingestor/test_documents/works.formats.5.Journals.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2023-11-21T15:39:33.584710Z",
+  "createdAt" : "2024-02-16T15:36:44.769242Z",
   "id" : "ftxlgr2v",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1985-11-10T14:57:32Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.formats.6.Journals.json
+++ b/pipeline/ingestor/test_documents/works.formats.6.Journals.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2023-11-21T15:39:33.588938Z",
+  "createdAt" : "2024-02-16T15:36:44.770933Z",
   "id" : "o5wujppw",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2064-12-19T06:39:42Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.formats.7.Audio.json
+++ b/pipeline/ingestor/test_documents/works.formats.7.Audio.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2023-11-21T15:39:33.594339Z",
+  "createdAt" : "2024-02-16T15:36:44.772839Z",
   "id" : "jtqzypmq",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2029-04-07T22:56:33Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.formats.8.Audio.json
+++ b/pipeline/ingestor/test_documents/works.formats.8.Audio.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2023-11-21T15:39:33.604033Z",
+  "createdAt" : "2024-02-16T15:36:44.775373Z",
   "id" : "qgk6jumb",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1988-04-07T05:47:45Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.formats.9.Pictures.json
+++ b/pipeline/ingestor/test_documents/works.formats.9.Pictures.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2023-11-21T15:39:33.616019Z",
+  "createdAt" : "2024-02-16T15:36:44.781028Z",
   "id" : "wvcw0lp9",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1938-05-13T23:46:55Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.genres.json
+++ b/pipeline/ingestor/test_documents/works.genres.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with different concepts in the genre",
-  "createdAt" : "2023-11-21T15:39:33.884759Z",
+  "createdAt" : "2024-02-16T15:36:44.831608Z",
   "id" : "jlp05mgl",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1978-12-03T12:21:42Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.invisible.0.json
+++ b/pipeline/ingestor/test_documents/works.invisible.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of invisible works",
-  "createdAt" : "2022-10-03T10:25:18.781Z",
+  "createdAt" : "2024-02-16T15:36:44.079633Z",
   "id" : "rczekocx",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2001-07-02T19:43:15Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "invisibilityReasons" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "type" : "Invisible"

--- a/pipeline/ingestor/test_documents/works.invisible.1.json
+++ b/pipeline/ingestor/test_documents/works.invisible.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of invisible works",
-  "createdAt" : "2022-10-03T10:25:18.781Z",
+  "createdAt" : "2024-02-16T15:36:44.080467Z",
   "id" : "60edujsq",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2030-05-24T10:04:01Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "invisibilityReasons" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "type" : "Invisible"

--- a/pipeline/ingestor/test_documents/works.invisible.2.json
+++ b/pipeline/ingestor/test_documents/works.invisible.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of invisible works",
-  "createdAt" : "2022-10-03T10:25:18.782Z",
+  "createdAt" : "2024-02-16T15:36:44.081589Z",
   "id" : "0uk2wzxd",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2056-08-06T12:14:07Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "invisibilityReasons" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "type" : "Invisible"

--- a/pipeline/ingestor/test_documents/works.items-with-licenses.0.json
+++ b/pipeline/ingestor/test_documents/works.items-with-licenses.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with licensed digital items",
-  "createdAt" : "2023-11-21T15:39:33.735122Z",
+  "createdAt" : "2024-02-16T15:36:44.813923Z",
   "id" : "uh8gnkqk",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2004-04-05T10:15:53Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.items-with-licenses.1.json
+++ b/pipeline/ingestor/test_documents/works.items-with-licenses.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with licensed digital items",
-  "createdAt" : "2023-11-21T15:39:33.737394Z",
+  "createdAt" : "2024-02-16T15:36:44.814531Z",
   "id" : "sojyedta",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2030-04-29T05:27:13Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.items-with-licenses.2.json
+++ b/pipeline/ingestor/test_documents/works.items-with-licenses.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with licensed digital items",
-  "createdAt" : "2023-11-21T15:39:33.737959Z",
+  "createdAt" : "2024-02-16T15:36:44.815039Z",
   "id" : "fxryjmiz",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1984-06-01T20:55:52Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.items-with-licenses.3.json
+++ b/pipeline/ingestor/test_documents/works.items-with-licenses.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with licensed digital items",
-  "createdAt" : "2023-11-21T15:39:33.738490Z",
+  "createdAt" : "2024-02-16T15:36:44.815616Z",
   "id" : "ub2i8snt",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2066-07-14T02:52:53Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.items-with-licenses.4.json
+++ b/pipeline/ingestor/test_documents/works.items-with-licenses.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with licensed digital items",
-  "createdAt" : "2023-11-21T15:39:33.758219Z",
+  "createdAt" : "2024-02-16T15:36:44.816062Z",
   "id" : "abt11p2s",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1983-08-27T05:28:32Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.items-with-other-identifiers.0.json
+++ b/pipeline/ingestor/test_documents/works.items-with-other-identifiers.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2023-11-21T15:39:34.204242Z",
+  "createdAt" : "2024-02-16T15:36:44.866711Z",
   "id" : "hdjyypp6",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2066-12-22T15:52:01Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.items-with-other-identifiers.1.json
+++ b/pipeline/ingestor/test_documents/works.items-with-other-identifiers.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2023-11-21T15:39:34.208379Z",
+  "createdAt" : "2024-02-16T15:36:44.867879Z",
   "id" : "jemj47jb",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2047-01-04T09:41:20Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.items-with-other-identifiers.2.json
+++ b/pipeline/ingestor/test_documents/works.items-with-other-identifiers.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2023-11-21T15:39:34.230763Z",
+  "createdAt" : "2024-02-16T15:36:44.870332Z",
   "id" : "si1cs1lq",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2062-07-20T12:04:39Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.items-with-other-identifiers.3.json
+++ b/pipeline/ingestor/test_documents/works.items-with-other-identifiers.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2023-11-21T15:39:34.233749Z",
+  "createdAt" : "2024-02-16T15:36:44.871148Z",
   "id" : "pdufpdhz",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1978-09-15T00:40:32Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.items-with-other-identifiers.4.json
+++ b/pipeline/ingestor/test_documents/works.items-with-other-identifiers.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2023-11-21T15:39:34.235211Z",
+  "createdAt" : "2024-02-16T15:36:44.872360Z",
   "id" : "rzcvxgso",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1974-02-26T09:34:25Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.languages.0.eng.json
+++ b/pipeline/ingestor/test_documents/works.languages.0.eng.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2023-11-21T15:39:33.635518Z",
+  "createdAt" : "2024-02-16T15:36:44.789216Z",
   "id" : "9pon81hb",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2020-11-07T23:22:13Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.languages.1.eng.json
+++ b/pipeline/ingestor/test_documents/works.languages.1.eng.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2023-11-21T15:39:33.639167Z",
+  "createdAt" : "2024-02-16T15:36:44.791139Z",
   "id" : "mye6nsw6",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2013-07-14T10:05:38Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.languages.2.eng.json
+++ b/pipeline/ingestor/test_documents/works.languages.2.eng.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2023-11-21T15:39:33.641061Z",
+  "createdAt" : "2024-02-16T15:36:44.793553Z",
   "id" : "giiyodfc",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2047-09-30T13:44:39Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.languages.3.eng+swe.json
+++ b/pipeline/ingestor/test_documents/works.languages.3.eng+swe.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2023-11-21T15:39:33.646566Z",
+  "createdAt" : "2024-02-16T15:36:44.796122Z",
   "id" : "taqruniu",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1953-09-06T15:14:14Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.languages.4.eng+swe+tur.json
+++ b/pipeline/ingestor/test_documents/works.languages.4.eng+swe+tur.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2023-11-21T15:39:33.658782Z",
+  "createdAt" : "2024-02-16T15:36:44.798157Z",
   "id" : "oagougti",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2039-12-01T11:37:40Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.languages.5.swe.json
+++ b/pipeline/ingestor/test_documents/works.languages.5.swe.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2023-11-21T15:39:33.668669Z",
+  "createdAt" : "2024-02-16T15:36:44.800935Z",
   "id" : "olhrstrz",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2026-09-11T17:29:57Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.languages.6.tur.json
+++ b/pipeline/ingestor/test_documents/works.languages.6.tur.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2023-11-21T15:39:33.671680Z",
+  "createdAt" : "2024-02-16T15:36:44.803590Z",
   "id" : "6navwg1c",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1934-12-30T03:15:39Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.production.multi-year.0.json
+++ b/pipeline/ingestor/test_documents/works.production.multi-year.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2023-11-21T15:39:34.511402Z",
+  "createdAt" : "2024-02-16T15:36:44.928327Z",
   "id" : "cgfghm8m",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1945-01-10T19:58:56Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.production.multi-year.1.json
+++ b/pipeline/ingestor/test_documents/works.production.multi-year.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2023-11-21T15:39:34.517522Z",
+  "createdAt" : "2024-02-16T15:36:44.929055Z",
   "id" : "bjh2wrdd",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2062-07-25T05:57:54Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.production.multi-year.2.json
+++ b/pipeline/ingestor/test_documents/works.production.multi-year.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2023-11-21T15:39:34.531807Z",
+  "createdAt" : "2024-02-16T15:36:44.930504Z",
   "id" : "mse28reu",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1981-12-24T12:24:54Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.production.multi-year.3.json
+++ b/pipeline/ingestor/test_documents/works.production.multi-year.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2023-11-21T15:39:34.536309Z",
+  "createdAt" : "2024-02-16T15:36:44.931264Z",
   "id" : "ukbghz72",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2004-01-03T14:20:07Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.production.multi-year.4.json
+++ b/pipeline/ingestor/test_documents/works.production.multi-year.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2023-11-21T15:39:34.537007Z",
+  "createdAt" : "2024-02-16T15:36:44.931948Z",
   "id" : "56tujbhy",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2056-06-05T14:49:37Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.production.multi-year.5.json
+++ b/pipeline/ingestor/test_documents/works.production.multi-year.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2023-11-21T15:39:34.537632Z",
+  "createdAt" : "2024-02-16T15:36:44.932459Z",
   "id" : "wn4ahfd3",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1951-03-21T03:54:08Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.redirected.0.json
+++ b/pipeline/ingestor/test_documents/works.redirected.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of redirected works",
-  "createdAt" : "2022-10-03T10:25:18.789Z",
+  "createdAt" : "2024-02-16T15:36:44.094272Z",
   "id" : "4nwkprdt",
   "document" : {
     "debug" : {
@@ -17,7 +17,9 @@
         "modifiedTime" : "2044-05-21T11:37:26Z"
       },
       "mergedTime" : "2044-05-21T11:37:26Z",
-      "indexedTime" : "2001-01-01T01:01:01Z"
+      "indexedTime" : "2001-01-01T01:01:01Z",
+      "mergeCandidates" : [
+      ]
     },
     "redirectTarget" : {
       "canonicalId" : "mv6kix0n",

--- a/pipeline/ingestor/test_documents/works.redirected.1.json
+++ b/pipeline/ingestor/test_documents/works.redirected.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of redirected works",
-  "createdAt" : "2022-10-03T10:25:18.789Z",
+  "createdAt" : "2024-02-16T15:36:44.094660Z",
   "id" : "6yu7udsf",
   "document" : {
     "debug" : {
@@ -17,7 +17,9 @@
         "modifiedTime" : "2018-10-24T16:12:55Z"
       },
       "mergedTime" : "2018-10-24T16:12:55Z",
-      "indexedTime" : "2001-01-01T01:01:01Z"
+      "indexedTime" : "2001-01-01T01:01:01Z",
+      "mergeCandidates" : [
+      ]
     },
     "redirectTarget" : {
       "canonicalId" : "7wax09hv",

--- a/pipeline/ingestor/test_documents/works.subjects.0.json
+++ b/pipeline/ingestor/test_documents/works.subjects.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different subjects",
-  "createdAt" : "2023-11-21T15:39:33.959940Z",
+  "createdAt" : "2024-02-16T15:36:44.835880Z",
   "id" : "njj1gugw",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2009-03-20T11:29:10Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.subjects.1.json
+++ b/pipeline/ingestor/test_documents/works.subjects.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different subjects",
-  "createdAt" : "2023-11-21T15:39:33.975270Z",
+  "createdAt" : "2024-02-16T15:36:44.836941Z",
   "id" : "7xjjhlpg",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2055-06-09T03:30:20Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.subjects.2.json
+++ b/pipeline/ingestor/test_documents/works.subjects.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different subjects",
-  "createdAt" : "2023-11-21T15:39:33.978227Z",
+  "createdAt" : "2024-02-16T15:36:44.837567Z",
   "id" : "ixapupnn",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2038-11-26T21:07:39Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.subjects.3.json
+++ b/pipeline/ingestor/test_documents/works.subjects.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different subjects",
-  "createdAt" : "2023-11-21T15:39:33.987107Z",
+  "createdAt" : "2024-02-16T15:36:44.838390Z",
   "id" : "opaupm4b",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1963-02-18T22:51:22Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.subjects.4.json
+++ b/pipeline/ingestor/test_documents/works.subjects.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different subjects",
-  "createdAt" : "2023-11-21T15:39:33.987809Z",
+  "createdAt" : "2024-02-16T15:36:44.838807Z",
   "id" : "el28gega",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1997-06-19T05:13:34Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.title-query-parens.json
+++ b/pipeline/ingestor/test_documents/works.title-query-parens.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work whose title has parens meant to trip up ES",
-  "createdAt" : "2023-11-21T15:39:33.618987Z",
+  "createdAt" : "2024-02-16T15:36:44.786561Z",
   "id" : "1sxjupdc",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2025-04-27T22:28:23Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.title-query-syntax.json
+++ b/pipeline/ingestor/test_documents/works.title-query-syntax.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work whose title has lots of ES query syntax operators",
-  "createdAt" : "2023-11-21T15:39:33.617819Z",
+  "createdAt" : "2024-02-16T15:36:44.782951Z",
   "id" : "mdg1yvuv",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1967-11-04T04:23:34Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.visible.0.json
+++ b/pipeline/ingestor/test_documents/works.visible.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of visible works",
-  "createdAt" : "2023-11-21T15:38:56.668994Z",
+  "createdAt" : "2024-02-16T15:36:43.992275Z",
   "id" : "2twopft1",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1972-02-10T18:53:31Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.visible.1.json
+++ b/pipeline/ingestor/test_documents/works.visible.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of visible works",
-  "createdAt" : "2023-11-21T15:38:59.351372Z",
+  "createdAt" : "2024-02-16T15:36:44.001281Z",
   "id" : "dph7sjip",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1971-11-19T03:42:42Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.visible.2.json
+++ b/pipeline/ingestor/test_documents/works.visible.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of visible works",
-  "createdAt" : "2023-11-21T15:38:59.368168Z",
+  "createdAt" : "2024-02-16T15:36:44.005118Z",
   "id" : "fyqts0co",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1979-01-28T05:43:24Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.visible.3.json
+++ b/pipeline/ingestor/test_documents/works.visible.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of visible works",
-  "createdAt" : "2023-11-21T15:38:59.384069Z",
+  "createdAt" : "2024-02-16T15:36:44.008952Z",
   "id" : "raob2ruv",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "1966-03-23T00:51:51Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {

--- a/pipeline/ingestor/test_documents/works.visible.4.json
+++ b/pipeline/ingestor/test_documents/works.visible.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of visible works",
-  "createdAt" : "2023-11-21T15:38:59.396452Z",
+  "createdAt" : "2024-02-16T15:36:44.014158Z",
   "id" : "vbi1ii19",
   "document" : {
     "debug" : {
@@ -19,6 +19,8 @@
       "mergedTime" : "2024-12-13T21:31:42Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
+      ],
+      "mergeCandidates" : [
       ]
     },
     "display" : {


### PR DESCRIPTION
This is in service of building a matcher-graph-visualiser which doesn't need access to DynamoDB (which also leads me to wonder whether the next version of the matcher/merger even needs DynamoDB itself) 