### PR TITLE
Missed propagation of mergeCandidates

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Work.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Work.scala
@@ -197,7 +197,7 @@ object WorkState {
     sourceIdentifier: SourceIdentifier,
     canonicalId: CanonicalId,
     sourceModifiedTime: Instant,
-    mergeCandidates: List[MergeCandidate[IdState.Identified]],
+    mergeCandidates: List[MergeCandidate[IdState.Identified]] = Nil,
     internalWorkStubs: List[InternalWork.Identified] = Nil,
     relations: Relations = Relations.none
   ) extends WorkState {

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Work.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Work.scala
@@ -197,7 +197,7 @@ object WorkState {
     sourceIdentifier: SourceIdentifier,
     canonicalId: CanonicalId,
     sourceModifiedTime: Instant,
-    mergeCandidates: List[MergeCandidate[IdState.Identified]] = Nil,
+    mergeCandidates: List[MergeCandidate[IdState.Identified]],
     internalWorkStubs: List[InternalWork.Identified] = Nil,
     relations: Relations = Relations.none
   ) extends WorkState {

--- a/pipeline/merger/src/main/scala/weco/pipeline/merger/services/Merger.scala
+++ b/pipeline/merger/src/main/scala/weco/pipeline/merger/services/Merger.scala
@@ -153,7 +153,8 @@ trait Merger extends MergerLogging {
         sourceIdentifier = source.sourceIdentifier,
         canonicalId = source.state.canonicalId,
         sourceModifiedTime = source.state.sourceModifiedTime,
-        internalWorkStubs = Nil
+        mergeCandidates = source.state.mergeCandidates,
+        internalWorkStubs = Nil,
       ),
       redirectTarget =
         IdState.Identified(target.state.canonicalId, target.sourceIdentifier)

--- a/pipeline/merger/src/main/scala/weco/pipeline/merger/services/Merger.scala
+++ b/pipeline/merger/src/main/scala/weco/pipeline/merger/services/Merger.scala
@@ -154,7 +154,7 @@ trait Merger extends MergerLogging {
         canonicalId = source.state.canonicalId,
         sourceModifiedTime = source.state.sourceModifiedTime,
         mergeCandidates = source.state.mergeCandidates,
-        internalWorkStubs = Nil,
+        internalWorkStubs = Nil
       ),
       redirectTarget =
         IdState.Identified(target.state.canonicalId, target.sourceIdentifier)


### PR DESCRIPTION
Annoyingly, I missed that the action of redirecting needs mergeCandidates to be "manually" propagated 