### PR TITLE
Common marc

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -211,6 +211,13 @@ lazy val transformer_common = setupProject(
   externalDependencies = CatalogueDependencies.transformerCommonDependencies
 )
 
+lazy val transformer_marc_common = setupProject(
+  project,
+  folder = "pipeline/transformer/transformer_marc_common",
+  localDependencies = Seq(transformer_common),
+  externalDependencies = CatalogueDependencies.transformerMarcCommonDependencies
+)
+
 lazy val transformer_miro = setupProject(
   project,
   folder = "pipeline/transformer/transformer_miro",
@@ -221,7 +228,7 @@ lazy val transformer_miro = setupProject(
 lazy val transformer_sierra = setupProject(
   project,
   folder = "pipeline/transformer/transformer_sierra",
-  localDependencies = Seq(transformer_common),
+  localDependencies = Seq(transformer_common, transformer_marc_common),
   externalDependencies = CatalogueDependencies.sierraTransformerDependencies
 )
 

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/exceptions/ShouldNotTransformException.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/exceptions/ShouldNotTransformException.scala
@@ -1,4 +1,4 @@
-package weco.pipeline.transformer.sierra.exceptions
+package weco.pipeline.transformer.exceptions
 
 class ShouldNotTransformException(message: String)
     extends RuntimeException(message)

--- a/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/models/MarcField.scala
+++ b/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/models/MarcField.scala
@@ -1,0 +1,10 @@
+package weco.pipeline.transformer.marc_common.models
+
+case class MarcField(
+  marcTag: String,
+  subfields: Seq[MarcSubfield] = Nil,
+  content: Option[String] = None,
+  fieldTag: Option[String] = None,
+  indicator1: String = " ",
+  indicator2: String = " "
+)

--- a/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/models/MarcRecord.scala
+++ b/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/models/MarcRecord.scala
@@ -1,0 +1,9 @@
+package weco.pipeline.transformer.marc_common.models
+
+/*
+ * Represents a MARC record,
+ * This provides an interface for retrieving fields, subfields, and values
+ * */
+trait MarcRecord {
+  def fieldsWithTags(tags: String*): Seq[MarcField]
+}

--- a/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/models/MarcSubfield.scala
+++ b/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/models/MarcSubfield.scala
@@ -1,0 +1,3 @@
+package weco.pipeline.transformer.marc_common.models
+
+case class MarcSubfield(tag: String, content: String)

--- a/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcDataTransformer.scala
+++ b/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcDataTransformer.scala
@@ -1,0 +1,9 @@
+package weco.pipeline.transformer.marc_common.transformers
+
+import weco.pipeline.transformer.marc_common.models.MarcRecord
+
+trait MarcDataTransformer {
+  type Output
+
+  def apply(record: MarcRecord): Output
+}

--- a/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcTitle.scala
+++ b/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcTitle.scala
@@ -1,0 +1,84 @@
+package weco.pipeline.transformer.marc_common.transformers
+import grizzled.slf4j.Logging
+import weco.pipeline.transformer.exceptions.ShouldNotTransformException
+import weco.pipeline.transformer.marc_common.models.{MarcRecord, MarcSubfield}
+
+object MarcTitle extends MarcDataTransformer with Logging {
+
+  type Output = Option[String]
+
+  // Populate wwork:title.  The rules are as follows:
+  //
+  //    Join MARC field 245 subfields ǂa, ǂb, ǂc, ǂh, ǂn and ǂp with a space.
+  //    They should be joined in the same order as the original subfields.
+  //
+  //    Remove anything in square brackets from ǂh; this is legacy data we don't
+  //    want to expose.
+  //
+  // MARC 245 is non-repeatable, as are subfields ǂa, ǂb and ǂc.  However,
+  // there are records in Wellcome's catalogue that repeat them, so we deviate
+  // from the MARC spec here.
+  //
+  // http://www.loc.gov/marc/bibliographic/bd245.html
+  def apply(record: MarcRecord): Option[String] = {
+    val marc245Field = record
+      .fieldsWithTags("245") match {
+      case Seq(field) => field
+      case Nil =>
+        throw new ShouldNotTransformException(
+          "Could not find field 245 to create title"
+        )
+      case fields =>
+        // This should not be allowed, but a small set of records in Sierra have multiple 245s
+        // Eventually, when these are fixed, we can turn this into an exception.
+        // For now, it just logs a warning and makes a best-effort attempt at understanding it.
+        warn(
+          s"Multiple instances of non-repeatable varfield with tag 245: $fields"
+        )
+        fields.head
+    }
+
+    val selectedSubfields =
+      marc245Field.subfields
+        .filter {
+          sf =>
+            Seq("a", "b", "c", "h", "n", "p").contains { sf.tag }
+        }
+
+    val components =
+      selectedSubfields
+        .filterNot {
+          sf =>
+            // We only care about subfield ǂh for joining punctuation.
+            // If it's the last subfield, there's nothing to join it to, so
+            // we remove it.
+            //
+            // Note: this code doesn't cover pathological cases (e.g. multiple
+            // instances of subfield ǂh at the end of the record) because they
+            // don't seem to occur in practice, and if they do we should fix
+            // them in Sierra.  This code is deliberately simple.
+            sf.tag == "h" && selectedSubfields.last == sf
+        }
+        .map {
+          // This slightly convoluted regex is meant to remove anything
+          // in square brackets, e.g.
+          //
+          //    "[electronic resource] :" ~> " :"
+          //
+          case MarcSubfield("h", content) =>
+            content
+              .replaceAll("\\[[^\\]]+\\]", "")
+              .trim
+
+          case MarcSubfield(_, content) => content
+        }
+
+    if (components.isEmpty) {
+      throw new ShouldNotTransformException(
+        "No subfields in field 245 for constructing the title"
+      )
+    }
+
+    Some(components.mkString(" "))
+  }
+}

--- a/pipeline/transformer/transformer_marc_common/src/test/scala/weco/pipeline/transformer/marc_common/generators/MarcTestRecord.scala
+++ b/pipeline/transformer/transformer_marc_common/src/test/scala/weco/pipeline/transformer/marc_common/generators/MarcTestRecord.scala
@@ -1,0 +1,16 @@
+package weco.pipeline.transformer.marc_common.generators
+
+import org.scalatest.LoneElement
+import weco.pipeline.transformer.marc_common.models.{MarcField, MarcRecord}
+
+case class MarcTestRecord(fields: Seq[MarcField])
+    extends MarcRecord
+    with LoneElement {
+
+  def fieldsWithTags(tags: String*): Seq[MarcField] =
+    fields.filter(field => tags.contains(field.marcTag))
+
+  def nonRepeatableFieldWithTag(tag: String): Option[MarcField] =
+    Some(fieldsWithTags(tag).loneElement)
+
+}

--- a/pipeline/transformer/transformer_marc_common/src/test/scala/weco/pipeline/transformer/marc_common/transformers/MarcTitleTest.scala
+++ b/pipeline/transformer/transformer_marc_common/src/test/scala/weco/pipeline/transformer/marc_common/transformers/MarcTitleTest.scala
@@ -98,7 +98,7 @@ class MarcTitleTest extends AnyFunSpec with Matchers {
       ).get shouldBe "cyntaf ail trydydd pedwerydd pumed chweched saithfed"
     }
 
-    it("ignores a trailing 'h' subfield") {
+    it("ignores a trailing h subfield") {
       MarcTitle(
         MarcTestRecord(
           fields = Seq(
@@ -166,6 +166,7 @@ class MarcTitleTest extends AnyFunSpec with Matchers {
         "No subfields in field 245 for constructing the title"
       )
     }
+
     it("throws if the only suitable subfield has tag h") {
       info("although h is a suitable subfield, a trailing h is discarded")
       info("as a result, this is the same as there being no subfields at all")

--- a/pipeline/transformer/transformer_marc_common/src/test/scala/weco/pipeline/transformer/marc_common/transformers/MarcTitleTest.scala
+++ b/pipeline/transformer/transformer_marc_common/src/test/scala/weco/pipeline/transformer/marc_common/transformers/MarcTitleTest.scala
@@ -1,0 +1,194 @@
+package weco.pipeline.transformer.marc_common.transformers
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import weco.pipeline.transformer.exceptions.ShouldNotTransformException
+import weco.pipeline.transformer.marc_common.generators.MarcTestRecord
+import weco.pipeline.transformer.marc_common.models.{MarcField, MarcSubfield}
+
+class MarcTitleTest extends AnyFunSpec with Matchers {
+  info("The title is extracted from the MARC 245 field")
+  describe("finding the 245 field") {
+    it("constructs a title from the content of the 245 field") {
+      MarcTitle(
+        MarcTestRecord(
+          fields = Seq(
+            marc245With(Seq(("a", "hello")))
+          )
+        )
+      ).get shouldBe "hello"
+
+    }
+    it("uses the first 245 field if there are (erroneously) more than one") {
+      // Ideally, this branch would throw an exception, but there are still some
+      // records in Sierra that erroneously contain extra 245s. Once they have been fixed,
+      // we can make it an error and move this test into the "can't create a title" block
+      // All EBSCO content is expected to be compliant, and we should explicitly reject it if it is not.
+      MarcTitle(
+        MarcTestRecord(
+          fields = Seq(
+            MarcField(marcTag = "001"),
+            marc245With(Seq(("a", "hello world"))),
+            marc245With(Seq(("a", "hello dolly")))
+          )
+        )
+      ).get shouldBe "hello world"
+    }
+  }
+
+  describe("constructing the title from the subfields") {
+    it("constructs the title from subfields a, b, c, h, n, p") {
+      MarcTitle(
+        MarcTestRecord(
+          fields = Seq(
+            marc245With(
+              Seq(
+                "a" -> "cyntaf",
+                "b" -> "ail",
+                "c" -> "trydydd",
+                "h" -> "pedwerydd",
+                "n" -> "pumed",
+                "p" -> "chweched",
+                "k" -> "saithfed"
+              )
+            )
+          )
+        )
+      ).get shouldBe "cyntaf ail trydydd pedwerydd pumed chweched"
+    }
+    it("constructs the title from the chosen subfields in document order") {
+      MarcTitle(
+        MarcTestRecord(
+          fields = Seq(
+            marc245With(
+              Seq(
+                "h" -> "cyntaf",
+                "p" -> "ail",
+                "c" -> "trydydd",
+                "n" -> "pedwerydd",
+                "a" -> "pumed",
+                "b" -> "chweched",
+                "k" -> "saithfed"
+              )
+            )
+          )
+        )
+      ).get shouldBe "cyntaf ail trydydd pedwerydd pumed chweched"
+    }
+    it("supports repeated subfields") {
+      info(
+        "technically, only p and n can be repeated, but the transformer is not picky about that"
+      )
+      MarcTitle(
+        MarcTestRecord(
+          fields = Seq(
+            marc245With(
+              Seq(
+                "n" -> "cyntaf",
+                "p" -> "ail",
+                "n" -> "trydydd",
+                "p" -> "pedwerydd",
+                "h" -> "pumed",
+                "p" -> "chweched",
+                "p" -> "saithfed"
+              )
+            )
+          )
+        )
+      ).get shouldBe "cyntaf ail trydydd pedwerydd pumed chweched saithfed"
+    }
+
+    it("ignores a trailing 'h' subfield") {
+      MarcTitle(
+        MarcTestRecord(
+          fields = Seq(
+            marc245With(
+              Seq(
+                "a" -> "cyntaf",
+                "h" -> "ail",
+                "p" -> "trydydd",
+                "h" -> "ignore me, I'm not here!"
+              )
+            )
+          )
+        )
+      ).get shouldBe "cyntaf ail trydydd"
+    }
+
+    it("discards square bracket content in h subfields") {
+      MarcTitle(
+        MarcTestRecord(
+          fields = Seq(
+            marc245With(
+              Seq(
+                "a" -> "cyntaf [un]",
+                "h" -> "ail [dau]",
+                "p" -> "trydydd"
+              )
+            )
+          )
+        )
+      ).get shouldBe "cyntaf [un] ail trydydd"
+    }
+
+  }
+
+  describe("throws a ShouldNotTransformException if it can't create a title") {
+    it("throws if there is no MARC field 245") {
+      val caught = intercept[ShouldNotTransformException] {
+        MarcTitle(MarcTestRecord(fields = Nil))
+      }
+      caught.getMessage should startWith(
+        "Could not find field 245 to create title"
+      )
+    }
+
+    it("throws if there are no subfields") {
+      val caught = intercept[ShouldNotTransformException] {
+        MarcTitle(MarcTestRecord(fields = Seq(MarcField(marcTag = "245"))))
+      }
+      caught.getMessage should startWith(
+        "No subfields in field 245 for constructing the title"
+      )
+    }
+
+    it("throws if there are no *suitable* subfields") {
+      val caught = intercept[ShouldNotTransformException] {
+        MarcTitle(
+          MarcTestRecord(
+            fields = Seq(
+              marc245With(Seq(("7", "the back of a lorry")))
+            )
+          )
+        )
+      }
+      caught.getMessage should startWith(
+        "No subfields in field 245 for constructing the title"
+      )
+    }
+    it("throws if the only suitable subfield has tag h") {
+      info("although h is a suitable subfield, a trailing h is discarded")
+      info("as a result, this is the same as there being no subfields at all")
+      val caught = intercept[ShouldNotTransformException] {
+        MarcTitle(
+          MarcTestRecord(
+            fields = Seq(
+              marc245With(Seq(("h", "the back of a lorry"))),
+              marc245With(Seq(("7", "the back of a lorry")))
+            )
+          )
+        )
+      }
+      caught.getMessage should startWith(
+        "No subfields in field 245 for constructing the title"
+      )
+    }
+  }
+
+  private def marc245With(subfields: Seq[(String, String)]) = MarcField(
+    marcTag = "245",
+    subfields = subfields map {
+      case (tag, content) => MarcSubfield(tag = tag, content = content)
+    }
+  )
+}

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/SierraTransformer.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/SierraTransformer.scala
@@ -16,10 +16,8 @@ import weco.catalogue.source_model.sierra._
 import weco.catalogue.source_model.Implicits._
 import weco.json.JsonUtil.fromJson
 import weco.json.exceptions.JsonDecodingError
-import weco.pipeline.transformer.sierra.exceptions.{
-  ShouldNotTransformException,
-  SierraTransformerException
-}
+import weco.pipeline.transformer.exceptions.ShouldNotTransformException
+import weco.pipeline.transformer.sierra.exceptions.SierraTransformerException
 import weco.pipeline.transformer.sierra.transformers._
 import weco.sierra.models.data.{
   SierraBibData,

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/data/BibDataAsMarcRecord.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/data/BibDataAsMarcRecord.scala
@@ -1,0 +1,48 @@
+package weco.pipeline.transformer.sierra.data
+
+import weco.pipeline.transformer.marc_common.models.{
+  MarcField,
+  MarcRecord,
+  MarcSubfield
+}
+import weco.sierra.models.SierraQueryOps
+import weco.sierra.models.data.SierraBibData
+import weco.sierra.models.marc.{Subfield, VarField}
+
+trait SierraMarcDataConversions {
+  import scala.language.implicitConversions
+
+  /* TODO:
+   * This implicit conversion stuff exists to temporarily implement SierraBibData
+   * as a subclass of MarcRecord until I move it out of the scala-libs project
+   * work out exactly what we _do_ need it to look like, and implement the
+   * interface directly on it.
+   * */
+  implicit def bibDataToMarcRecord(bibData: SierraBibData): MarcRecord =
+    new BibDataAsMarcRecord(bibData)
+
+  implicit def varFieldToMarcField(varField: VarField): MarcField =
+    MarcField(
+      marcTag = varField.marcTag.get,
+      subfields = varField.subfields.map(sierraSubfieldToMarcSubField),
+      content = None,
+      fieldTag = varField.fieldTag,
+      indicator1 = varField.indicator1.getOrElse(" "),
+      indicator2 = varField.indicator2.getOrElse(" ")
+    )
+
+  implicit def sierraSubfieldToMarcSubField(subfield: Subfield): MarcSubfield =
+    MarcSubfield(tag = subfield.tag, content = subfield.content)
+}
+object SierraMarcDataConversions extends SierraMarcDataConversions {}
+
+class BibDataAsMarcRecord(bibData: SierraBibData)
+    extends MarcRecord
+    with SierraQueryOps {
+
+  override def fieldsWithTags(tags: String*): Seq[MarcField] =
+    bibData
+      .varfieldsWithTags(tags: _*)
+      .map(SierraMarcDataConversions.varFieldToMarcField)
+
+}

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraTitle.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraTitle.scala
@@ -1,11 +1,12 @@
 package weco.pipeline.transformer.sierra.transformers
 
-import weco.pipeline.transformer.sierra.exceptions.ShouldNotTransformException
-import weco.sierra.models.SierraQueryOps
+import weco.pipeline.transformer.sierra.data.SierraMarcDataConversions
+import weco.pipeline.transformer.marc_common.transformers.MarcTitle
 import weco.sierra.models.data.SierraBibData
-import weco.sierra.models.marc.Subfield
 
-object SierraTitle extends SierraDataTransformer with SierraQueryOps {
+object SierraTitle
+    extends SierraDataTransformer
+    with SierraMarcDataConversions {
 
   type Output = Option[String]
 
@@ -23,55 +24,6 @@ object SierraTitle extends SierraDataTransformer with SierraQueryOps {
   //
   // http://www.loc.gov/marc/bibliographic/bd245.html
   def apply(bibData: SierraBibData): Option[String] = {
-    val marc245Field = bibData
-      .nonrepeatableVarfieldWithTag("245")
-      .getOrElse(
-        throw new ShouldNotTransformException(
-          "Could not find field 245 to create title"
-        )
-      )
-
-    val selectedSubfields =
-      marc245Field.subfields
-        .filter {
-          sf =>
-            Seq("a", "b", "c", "h", "n", "p").contains { sf.tag }
-        }
-
-    val components =
-      selectedSubfields
-        .filterNot {
-          sf =>
-            // We only care about subfield ǂh for joining punctuation.
-            // If it's the last subfield, there's nothing to join it to, so
-            // we remove it.
-            //
-            // Note: this code doesn't cover pathological cases (e.g. multiple
-            // instances of subfield ǂh at the end of the record) because they
-            // don't seem to occur in practice, and if they do we should fix
-            // them in Sierra.  This code is deliberately simple.
-            sf.tag == "h" && selectedSubfields.last == sf
-        }
-        .map {
-          // This slightly convoluted regex is meant to remove anything
-          // in square brackets, e.g.
-          //
-          //    "[electronic resource] :" ~> " :"
-          //
-          case Subfield("h", content) =>
-            content
-              .replaceAll("\\[[^\\]]+\\]", "")
-              .trim
-
-          case Subfield(_, content) => content
-        }
-
-    if (components.isEmpty) {
-      throw new ShouldNotTransformException(
-        "No subfields in field 245 for constructing the title"
-      )
-    }
-
-    Some(components.mkString(" "))
+    MarcTitle(bibData)
   }
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraTitleTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraTitleTest.scala
@@ -3,7 +3,6 @@ package weco.pipeline.transformer.sierra.transformers
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks._
-import weco.pipeline.transformer.sierra.exceptions.ShouldNotTransformException
 import weco.sierra.generators.SierraDataGenerators
 import weco.sierra.models.marc.{Subfield, VarField}
 
@@ -12,7 +11,7 @@ class SierraTitleTest
     with Matchers
     with SierraDataGenerators {
 
-  val titleTestCases = Table(
+  private val titleTestCases = Table(
     ("subfields", "expectedTitle"),
     (
       List(Subfield(tag = "a", content = "[Man smoking at window].")),
@@ -24,7 +23,8 @@ class SierraTitleTest
         Subfield(
           tag = "b",
           content =
-            "official organ of the American Association for Cancer Research, Inc.")
+            "official organ of the American Association for Cancer Research, Inc."
+        )
       ),
       "Cancer research : official organ of the American Association for Cancer Research, Inc."
     ),
@@ -52,7 +52,8 @@ class SierraTitleTest
         Subfield(tag = "n", content = "Embryology /"),
         Subfield(
           tag = "c",
-          content = "edited by Edward Albert Schäfer and George Dancer Thane.")
+          content = "edited by Edward Albert Schäfer and George Dancer Thane."
+        )
       ),
       "Quain's elements of anatomy. Vol. I, Part I, Embryology / edited by Edward Albert Schäfer and George Dancer Thane."
     ),
@@ -63,7 +64,8 @@ class SierraTitleTest
         Subfield(tag = "h", content = "[electronic resource] :"),
         Subfield(
           tag = "b",
-          content = "a Christian perspective on issues in bioethics.")
+          content = "a Christian perspective on issues in bioethics."
+        )
       ),
       "Ethics & medicine : a Christian perspective on issues in bioethics."
     ),
@@ -72,11 +74,12 @@ class SierraTitleTest
       List(
         Subfield(
           tag = "a",
-          content = "Nordic Journal of International Law, The"),
-        Subfield(tag = "h", content = "[electronic resource]."),
+          content = "Nordic Journal of International Law, The"
+        ),
+        Subfield(tag = "h", content = "[electronic resource].")
       ),
       "Nordic Journal of International Law, The"
-    ),
+    )
   )
 
   it("constructs a title from MARC 245") {
@@ -118,10 +121,12 @@ class SierraTitleTest
             Subfield(tag = "a", content = "The Book of common prayer:"),
             Subfield(
               tag = "b",
-              content = "together with the Psalter or Psalms of David,"),
+              content = "together with the Psalter or Psalms of David,"
+            ),
             Subfield(
               tag = "b",
-              content = "and the form and manner of making bishops")
+              content = "and the form and manner of making bishops"
+            )
           )
         )
       )
@@ -132,32 +137,4 @@ class SierraTitleTest
     )
   }
 
-  describe("throws a ShouldNotTransformException if it can't create a title") {
-    it("if there is no MARC field 245") {
-      val bibData = createSierraBibDataWith(
-        varFields = List.empty
-      )
-      val caught = intercept[ShouldNotTransformException] {
-        SierraTitle(bibData)
-      }
-      caught.getMessage should startWith(
-        "Could not find field 245 to create title")
-    }
-
-    it("if there are no subfields a, b or c") {
-      val bibData = createSierraBibDataWith(
-        varFields = List(
-          VarField(
-            marcTag = "245",
-            subfields = List()
-          )
-        )
-      )
-      val caught = intercept[ShouldNotTransformException] {
-        SierraTitle(bibData)
-      }
-      caught.getMessage should startWith(
-        "No subfields in field 245 for constructing the title")
-    }
-  }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -211,6 +211,9 @@ object CatalogueDependencies {
     WellcomeDependencies.storageLibrary ++
       ExternalDependencies.parseDependencies ++ ExternalDependencies.circeOpticsDependencies
 
+  val transformerMarcCommonDependencies: Seq[ModuleID] =
+    Nil
+
   val idminterDependencies: Seq[ModuleID] =
     ExternalDependencies.mySqlDependencies ++
       ExternalDependencies.circeOpticsDependencies ++


### PR DESCRIPTION
IN PROGRESS.

## What does this change?

https://github.com/wellcomecollection/catalogue-pipeline/issues/2563

This should be strictly a refactoring of existing code.  The end result when processing real data will be unchanged.

Previously, all MARC content came from Sierra in JSON format.  In preparation for MARC from EBSCO in XML format, I am pulling common  field transformations out from the Sierra transformer into a set of common MARC transformers.

In doing so, I am defining a common interface for both JSON and XML formats of MARC.  A problem arising from the difference between the formats is that they both divide the fields into different groups, which are both meaningless to the pipeline.

JSON divides fields between fixed and variable fields, whereas the XML format presents control fields and data fields as the important distinction.

The transformers just want fields with a given tag, they don't care whether the field in question is fixed, data, variable or control.

Also related to this is the potential removal of code from scala-libs that is currently only being used in the Sierra transformer.

## How to test

There should, be no change in behaviour.

## How can we measure success?

Accepting a new format of MARC data should be as simple as implementing the new trait to extract the fields. Accepting it from a new source will still require us to do all the work around that, including deciding exactly which fields we want to extract.

## Have we considered potential risks?

This is potentially quite a large refactor, and it may turn out that I make some mistake.  To mitigate the risks, I am leaving the Sierra field transformers in situ, but now they do nothing but call their common MARC counterpart.  I am also trying to distinguish between Sierra-specific tests (e.g. those derived from real data), which will be left in-situ, as they are a useful record and tool for describing the behaviour to librarians, and more internally functional or abstract tests, which are being moved and/or enhanced in the new suite.
