### PR TITLE
Add EBSCO merge candidate

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/IdentifierType.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/IdentifierType.scala
@@ -51,6 +51,11 @@ object IdentifierType extends Enum[IdentifierType] {
     val label = "Sierra identifier"
   }
 
+  case object EbscoAltLookup extends IdentifierType {
+    val id = "ebsco-alt-lookup"
+    val label = "EBSCO lookup identifier"
+  }
+
   case object LCGraphicMaterials extends IdentifierType {
     val id = "lc-gmgpc"
     val label = "Library of Congress Thesaurus for Graphic Materials"

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraMergeCandidates.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraMergeCandidates.scala
@@ -42,17 +42,16 @@ object SierraMergeCandidates
   // pattern for EBSCO alt lookup identifiers.
   private val ebscoAltLookupRegex: Regex = """^(ebs\d+e)$""".r.anchored
 
-  /** We can merge a sierra bib with an EBSCO e-resource record.  The
-    * identifier is stored in the MARC 001 control number field. Sierra
-    * bibs with an 001 field that matches the ebscoAltLookupRegex are
-    * merge candidates.
+  /** We can merge a sierra bib with an EBSCO e-resource record. The identifier
+    * is stored in the MARC 001 control number field. Sierra bibs with an 001
+    * field that matches the ebscoAltLookupRegex are merge candidates.
     *
-    * We perform an extra check that the 003 field is set to "EBZ",
-    * ensuring the control ngumber identifier is for an EBSCO e-resource.
+    * We perform an extra check that the 003 field is set to "EBZ", ensuring the
+    * control ngumber identifier is for an EBSCO e-resource.
     *
-    * This allows us to move to EBSCO e-resource records as the primary
-    * source of metadata for e-resources while maintaining redirection
-    * from the original work identifiers generated from Sierra records.
+    * This allows us to move to EBSCO e-resource records as the primary source
+    * of metadata for e-resources while maintaining redirection from the
+    * original work identifiers generated from Sierra records.
     *
     * If the identifier matches the ebscoAltLookupRegex, we use the control
     * field value as a merge candidate.
@@ -61,12 +60,15 @@ object SierraMergeCandidates
     bibData: SierraBibData
   ): Option[MergeCandidate[IdState.Identifiable]] = {
     // EBZ is the control number identifier for EBSCO e-resources
-    val ebzControlNumberIdentifier = bibData.nonrepeatableVarfieldWithTag("003")
-      .flatMap(_.content).exists(_.equals("EBZ"))
+    val ebzControlNumberIdentifier = bibData
+      .nonrepeatableVarfieldWithTag("003")
+      .flatMap(_.content)
+      .exists(_.equals("EBZ"))
 
     // If the bib has an 003 field with the value "EBZ", we look for an 001 field
     if (ebzControlNumberIdentifier) {
-      bibData.nonrepeatableVarfieldWithTag("001")
+      bibData
+        .nonrepeatableVarfieldWithTag("001")
         .flatMap(_.content)
         .flatMap {
           case ebscoAltLookupRegex(ebscoId) =>

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraMergeCandidates.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraMergeCandidates.scala
@@ -37,19 +37,27 @@ object SierraMergeCandidates
   // inconsistencies in the source data that it's easier to handle that here.
   private val uklwPrefixRegex: Regex = """\((?i:UkLW)\)[\s]*(.+)""".r.anchored
 
+  private val ebscoAltLookupRegex: Regex = """^(ebs\d+e)$""".r.anchored
+
   private def getEbscoMergeCandidates(
     bibData: SierraBibData
-  ): List[MergeCandidate[IdState.Identifiable]] = {
-    List(
-      MergeCandidate(
-        identifier = SourceIdentifier(
-          identifierType = IdentifierType.EbscoAltLookup,
-          ontologyType = "Work",
-          value = "ebs12345e"
-        ),
-        reason = "EBSCO/Sierra e-resource"
-      )
-    )
+  ): Option[MergeCandidate[IdState.Identifiable]] = {
+    bibData.nonrepeatableVarfieldWithTag("001")
+      .flatMap(_.content)
+      .flatMap {
+        case ebscoAltLookupRegex(ebscoId) =>
+            Some(
+              MergeCandidate(
+                  identifier = SourceIdentifier(
+                  identifierType = IdentifierType.EbscoAltLookup,
+                  ontologyType = "Work",
+                  value = ebscoId
+                  ),
+                  reason = "EBSCO/Sierra e-resource"
+              )
+            )
+        case _ => None
+    }
   }
 
   /** We can merge a bib and the digitised version of that bib. The number of

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraMergeCandidates.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraMergeCandidates.scala
@@ -27,7 +27,7 @@ object SierraMergeCandidates
     get776mergeCandidates(bibId, bibData) ++
       getSinglePageMiroMergeCandidates(bibData) ++ get035CalmMergeCandidates(
         bibData
-      )
+      ) ++ getEbscoMergeCandidates(bibData)
 
   // This regex matches any string starting with (UkLW), followed by
   // any number of spaces, and then captures everything after the
@@ -36,6 +36,21 @@ object SierraMergeCandidates
   // The UkLW match is case insensitive because there are sufficient
   // inconsistencies in the source data that it's easier to handle that here.
   private val uklwPrefixRegex: Regex = """\((?i:UkLW)\)[\s]*(.+)""".r.anchored
+
+  private def getEbscoMergeCandidates(
+    bibData: SierraBibData
+  ): List[MergeCandidate[IdState.Identifiable]] = {
+    List(
+      MergeCandidate(
+        identifier = SourceIdentifier(
+          identifierType = IdentifierType.EbscoAltLookup,
+          ontologyType = "Work",
+          value = "ebs12345e"
+        ),
+        reason = "EBSCO/Sierra e-resource"
+      )
+    )
+  }
 
   /** We can merge a bib and the digitised version of that bib. The number of
     * the other bib comes from MARC tag 776 subfield $w.

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraMergeCandidates.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraMergeCandidates.scala
@@ -37,8 +37,23 @@ object SierraMergeCandidates
   // inconsistencies in the source data that it's easier to handle that here.
   private val uklwPrefixRegex: Regex = """\((?i:UkLW)\)[\s]*(.+)""".r.anchored
 
+  // This regex matches any string starting with (ebs), followed by any
+  // number of digits, and then ending with (e), which seems to be the
+  // pattern for EBSCO alt lookup identifiers.
   private val ebscoAltLookupRegex: Regex = """^(ebs\d+e)$""".r.anchored
 
+  /** We can merge a sierra bib with an EBSCO e-resource record.  The
+    * identifier is stored in the MARC 001 control field. Sierra bibs
+    * with an 001 field that matches the ebscoAltLookupRegex are merge
+    * candidates.
+    *
+    * This allows us to move to EBSCO e-resource records as the primary
+    * source of metadata for e-resources while maintaining redirection
+    * from the original work identifiers generated from Sierra records.
+    *
+    * If the identifier matches the ebscoAltLookupRegex, we use the control
+    * field value as a merge candidate.
+    */
   private def getEbscoMergeCandidates(
     bibData: SierraBibData
   ): Option[MergeCandidate[IdState.Identifiable]] = {

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraMergeCandidatesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraMergeCandidatesTest.scala
@@ -311,6 +311,25 @@ class SierraMergeCandidatesTest
         )
       )
     }
+
+    it("only creates an EBSCO merge candidate if the control number matches the expected format") {
+      // These are all control numbers that we've seen in Sierra records
+      val bibDataA = bibDataWith001("23734725")
+      getMergeCandidates(bibDataA) should be(empty)
+
+      val bibDataB = bibDataWith001("EPH607A:215")
+      getMergeCandidates(bibDataB) should be(empty)
+
+      val bibDataC = bibDataWith001("SA/MWF/E")
+      getMergeCandidates(bibDataC) should be(empty)
+
+      val bibDataD = bibDataWith001("978-1-4939-0320-7")
+      getMergeCandidates(bibDataD) should be(empty)
+
+      // Hypothetical control numbers with the right prefix and suffix, but not the right format
+      val bibDataE = bibDataWith001("ebse")
+      getMergeCandidates(bibDataE) should be(empty)
+    }
   }
 
   describe("physical/digital and single-page merges across works") {

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraMergeCandidatesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraMergeCandidatesTest.scala
@@ -298,7 +298,7 @@ class SierraMergeCandidatesTest
 
   describe("EBSCO/Sierra e-resource") {
     it("creates an EBSCO merge candidate from the 001 control number field") {
-      val bibData = bibDataWith001("ebs12345e")
+      val bibData = bibDataWith001And003("ebs12345e", "EBZ")
 
       getMergeCandidates(bibData) should contain theSameElementsAs List(
         MergeCandidate(
@@ -314,21 +314,30 @@ class SierraMergeCandidatesTest
 
     it("only creates an EBSCO merge candidate if the control number matches the expected format") {
       // These are all control numbers that we've seen in Sierra records
-      val bibDataA = bibDataWith001("23734725")
+      val bibDataA = bibDataWith001And003("23734725", "DE-He213")
       getMergeCandidates(bibDataA) should be(empty)
 
-      val bibDataB = bibDataWith001("EPH607A:215")
+      val bibDataB = bibDataWith001And003("EPH607A:215", "DE-He213")
       getMergeCandidates(bibDataB) should be(empty)
 
-      val bibDataC = bibDataWith001("SA/MWF/E")
+      val bibDataC = bibDataWith001And003("SA/MWF/E", "DE-He213")
       getMergeCandidates(bibDataC) should be(empty)
 
-      val bibDataD = bibDataWith001("978-1-4939-0320-7")
+      val bibDataD = bibDataWith001And003("978-1-4939-0320-7", "DE-He213")
       getMergeCandidates(bibDataD) should be(empty)
 
-      // Hypothetical control numbers with the right prefix and suffix, but not the right format
-      val bibDataE = bibDataWith001("ebse")
+      // Hypothetical control numbers
+      val bibDataE = bibDataWith001And003("ebs12345e", "DE-He213")
       getMergeCandidates(bibDataE) should be(empty)
+
+      val bibDataF = bibDataWith001And003("ebse", "EBZ")
+      getMergeCandidates(bibDataF) should be(empty)
+
+      val bibDataG = bibDataWith001And003("12345e", "EBZ")
+      getMergeCandidates(bibDataG) should be(empty)
+
+      val bibDataH = bibDataWith001And003("ebs12345", "EBZ")
+      getMergeCandidates(bibDataH) should be(empty)
     }
   }
 
@@ -405,9 +414,14 @@ class SierraMergeCandidatesTest
     }
   }
 
-  private def bibDataWith001(controlNumber: String) =
+  private def bibDataWith001And003(controlNumber: String, controlNumberIdentifier: String) =
     createSierraBibDataWith(
       varFields = List(
+        VarField(
+          content = Some(controlNumberIdentifier),
+          marcTag = Some("003"),
+          fieldTag = Some("y")
+        ),
         VarField(
           content = Some(controlNumber),
           marcTag = Some("001"),

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraMergeCandidatesTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraMergeCandidatesTest.scala
@@ -22,7 +22,8 @@ class SierraMergeCandidatesTest
   val miroID = "A0123456"
 
   def getMergeCandidates(
-    bibData: SierraBibData): List[MergeCandidate[IdState.Identifiable]] =
+    bibData: SierraBibData
+  ): List[MergeCandidate[IdState.Identifiable]] =
     SierraMergeCandidates(createSierraBibNumber, bibData)
 
   describe("physical/digital Sierra work") {
@@ -76,12 +77,13 @@ class SierraMergeCandidatesTest
 
     it("checks for the (UkLW) prefix case-insensitively") {
       val casingVariations = List("UkLW", "uklw", "UkLw", "UKLW")
-      val sierraData = casingVariations.map { uklw =>
-        createSierraBibDataWith(
-          varFields = create776subfieldsWith(
-            ids = List(s"($uklw)$mergeCandidateBibNumber")
+      val sierraData = casingVariations.map {
+        uklw =>
+          createSierraBibDataWith(
+            varFields = create776subfieldsWith(
+              ids = List(s"($uklw)$mergeCandidateBibNumber")
+            )
           )
-        )
       }
       val mergeCandidates = sierraData.map(getMergeCandidates)
 
@@ -100,7 +102,8 @@ class SierraMergeCandidatesTest
     }
 
     it(
-      "does not create a merge candidate if there are multiple distinct instances of 776$$w") {
+      "does not create a merge candidate if there are multiple distinct instances of 776$$w"
+    ) {
       val bibData = createSierraBibDataWith(
         varFields = create776subfieldsWith(
           ids = List(s"(UkLW)  $mergeCandidateBibNumber", "(UkLW)b12345678")
@@ -111,13 +114,14 @@ class SierraMergeCandidatesTest
     }
 
     it(
-      "creates a merge candidate if there are multiple 776$$w for the same value") {
+      "creates a merge candidate if there are multiple 776$$w for the same value"
+    ) {
       val bibData = createSierraBibDataWith(
         varFields = create776subfieldsWith(
           ids = List(
             s"(UkLW)  $mergeCandidateBibNumber",
             s"(UkLW)  $mergeCandidateBibNumber",
-            s"(UkLW)$mergeCandidateBibNumber",
+            s"(UkLW)$mergeCandidateBibNumber"
           )
         )
       )
@@ -131,7 +135,7 @@ class SierraMergeCandidatesTest
         varFields = create776subfieldsWith(
           ids = List(
             s"(OCLC)123456789",
-            s"(UkLW)$mergeCandidateBibNumber",
+            s"(UkLW)$mergeCandidateBibNumber"
           )
         )
       )
@@ -145,7 +149,7 @@ class SierraMergeCandidatesTest
         varFields = create776subfieldsWith(
           ids = List(
             s"(UkLW)bxxxxxxxx",
-            s"(UkLW)$mergeCandidateBibNumber",
+            s"(UkLW)$mergeCandidateBibNumber"
           )
         )
       )
@@ -165,7 +169,8 @@ class SierraMergeCandidatesTest
     }
 
     it(
-      "Puts a merge candidate for multiple distinct instances of 962 subfield u") {
+      "Puts a merge candidate for multiple distinct instances of 962 subfield u"
+    ) {
       val bibData = createPictureWithUrls(
         urls = List(
           s"http://wellcomeimages.org/indexplus/image/$miroID.html",
@@ -192,7 +197,8 @@ class SierraMergeCandidatesTest
     it("does not create a merge candidate if the URL is unrecognised") {
       val bibData = createPictureWithUrls(
         urls = List(
-          "http://film.wellcome.ac.uk:15151/mediaplayer.html?fug_7340-1&pw=524ph=600.html")
+          "http://film.wellcome.ac.uk:15151/mediaplayer.html?fug_7340-1&pw=524ph=600.html"
+        )
       )
 
       getMergeCandidates(bibData) shouldBe Nil
@@ -211,23 +217,27 @@ class SierraMergeCandidatesTest
 
     // - - - - - - -  089 fields - - - - - - -
     it(
-      "merges a MIRO ID for a picture with MARC tag 089 subfield a if there is no 962 tag") {
+      "merges a MIRO ID for a picture with MARC tag 089 subfield a if there is no 962 tag"
+    ) {
       val bibData = createPictureWith(
         varFields = create089subfieldsWith(List("V 13889"))
       )
 
       getMergeCandidates(bibData) shouldBe miroMergeCandidate(
-        miroID = "V0013889")
+        miroID = "V0013889"
+      )
     }
 
     it(
-      "merges a MIRO ID for a digital image with MARC tag 089 subfield a if there is no 962 tag") {
+      "merges a MIRO ID for a digital image with MARC tag 089 subfield a if there is no 962 tag"
+    ) {
       val bibData = createDigitalImageWith(
         varFields = create089subfieldsWith(List("V 13889"))
       )
 
       getMergeCandidates(bibData) shouldBe miroMergeCandidate(
-        miroID = "V0013889")
+        miroID = "V0013889"
+      )
     }
 
     it("Merges multiple ids in MARC tag 089") {
@@ -242,9 +252,8 @@ class SierraMergeCandidatesTest
 
     it("Merge from tag 962 as well as 089 tag") {
       val bibData = createPictureWith(
-        varFields =
-          create962subfieldsForWellcomeImageUrl(miroID)
-            ++ create089subfieldsWith(List("V 13889"))
+        varFields = create962subfieldsForWellcomeImageUrl(miroID)
+          ++ create089subfieldsWith(List("V 13889"))
       )
 
       getMergeCandidates(bibData) should contain theSameElementsAs
@@ -252,7 +261,8 @@ class SierraMergeCandidatesTest
     }
 
     it(
-      "overrides non-suffixed Miro IDs with suffixed ones where those are present") {
+      "overrides non-suffixed Miro IDs with suffixed ones where those are present"
+    ) {
       val bibData = createPictureWith(
         varFields = create089subfieldsWith(List("V0036036")) ++
           create962subfieldsForWellcomeImageUrl("V0036036EL")
@@ -268,12 +278,14 @@ class SierraMergeCandidatesTest
           create962subfieldsForWellcomeImageUrl(miroID)
       )
 
-      getMergeCandidates(bibData) should contain theSameElementsAs miroMergeCandidate(
-        miroID)
+      getMergeCandidates(
+        bibData
+      ) should contain theSameElementsAs miroMergeCandidate(miroID)
     }
 
     it(
-      "retains non-suffixed Miro IDs when there is no matching suffixed ID present") {
+      "retains non-suffixed Miro IDs when there is no matching suffixed ID present"
+    ) {
       val bibData = createPictureWith(
         varFields = create089subfieldsWith(List("V0036036")) ++
           create962subfieldsForWellcomeImageUrl("V0012345EBR")
@@ -284,9 +296,27 @@ class SierraMergeCandidatesTest
     }
   }
 
+  describe("EBSCO/Sierra e-resource") {
+    it("creates an EBSCO merge candidate from the 001 control number field") {
+      val bibData = bibDataWith001("ebs12345e")
+
+      getMergeCandidates(bibData) should contain theSameElementsAs List(
+        MergeCandidate(
+          identifier = SourceIdentifier(
+            identifierType = IdentifierType.EbscoAltLookup,
+            ontologyType = "Work",
+            value = "ebs12345e"
+          ),
+          reason = "EBSCO/Sierra e-resource"
+        )
+      )
+    }
+  }
+
   describe("physical/digital and single-page merges across works") {
     it(
-      "creates merge candidates for both physical/digital Sierra works and Miro works") {
+      "creates merge candidates for both physical/digital Sierra works and Miro works"
+    ) {
       val varFields =
         create776subfieldsWith(ids = List(s"(UkLW)$mergeCandidateBibNumber")) ++
           create962subfieldsForWellcomeImageUrl(miroID)
@@ -316,7 +346,8 @@ class SierraMergeCandidatesTest
       val bibData = bibDataWith035(List(calmId))
 
       getMergeCandidates(bibData) shouldBe List(
-        createCalmMergeCandidate(calmId))
+        createCalmMergeCandidate(calmId)
+      )
     }
     it("adds multiple Calm IDs as mergeCandidates") {
       val calmIds = (1 to 5).map(_ => randomUUID.toString)
@@ -332,7 +363,8 @@ class SierraMergeCandidatesTest
       getMergeCandidates(bibData) shouldBe calmIds.map(createCalmMergeCandidate)
     }
     it(
-      "creates calm merge candidates if it has a mix of calm and non calm identifiers") {
+      "creates calm merge candidates if it has a mix of calm and non calm identifiers"
+    ) {
       val calmIds = (1 to 5).map(_ => randomUUID.toString)
       val otherIds = (1 to 5).map(_.toString)
       val bibData = bibDataWith035(otherIds ++ calmIds)
@@ -354,13 +386,26 @@ class SierraMergeCandidatesTest
     }
   }
 
+  private def bibDataWith001(controlNumber: String) =
+    createSierraBibDataWith(
+      varFields = List(
+        VarField(
+          content = Some(controlNumber),
+          marcTag = Some("001"),
+          fieldTag = Some("o")
+        )
+      )
+    )
+
   private def bibDataWith035(calmIds: Seq[String]) =
     createSierraBibDataWith(
       varFields = List(
         VarField(
           marcTag = "035",
           subfields = calmIds.map(Subfield("a", _)).toList
-        )))
+        )
+      )
+    )
 
   private def createCalmMergeCandidate(calmId: String) = MergeCandidate(
     identifier = SourceIdentifier(
@@ -380,8 +425,10 @@ class SierraMergeCandidatesTest
   private def createDigitalImageWith(varFields: List[VarField]): SierraBibData =
     createBibDataWith(varFields = varFields, materialTypeCode = 'q')
 
-  private def createBibDataWith(varFields: List[VarField],
-                                materialTypeCode: Char) = {
+  private def createBibDataWith(
+    varFields: List[VarField],
+    materialTypeCode: Char
+  ) = {
     createSierraBibDataWith(
       materialType = Some(SierraMaterialType(code = materialTypeCode.toString)),
       varFields = varFields
@@ -389,23 +436,25 @@ class SierraMergeCandidatesTest
   }
 
   private def create776subfieldsWith(ids: List[String]): List[VarField] =
-    ids.map { idString =>
-      VarField(
-        marcTag = "776",
-        subfields = List(
-          Subfield(tag = "w", content = idString)
+    ids.map {
+      idString =>
+        VarField(
+          marcTag = "776",
+          subfields = List(
+            Subfield(tag = "w", content = idString)
+          )
         )
-      )
     }
 
   private def create962subfieldsWith(urls: List[String]): List[VarField] =
-    urls.map { url =>
-      VarField(
-        marcTag = "962",
-        subfields = List(
-          Subfield(tag = "u", content = url)
+    urls.map {
+      url =>
+        VarField(
+          marcTag = "962",
+          subfields = List(
+            Subfield(tag = "u", content = url)
+          )
         )
-      )
     }
 
   private def create962subfieldsForWellcomeImageUrl(miroId: String) =
@@ -414,17 +463,19 @@ class SierraMergeCandidatesTest
     )
 
   private def create089subfieldsWith(miroIds: List[String]): List[VarField] =
-    miroIds.map { miroId =>
-      VarField(
-        marcTag = "089",
-        subfields = List(
-          Subfield(tag = "a", content = miroId)
+    miroIds.map {
+      miroId =>
+        VarField(
+          marcTag = "089",
+          subfields = List(
+            Subfield(tag = "a", content = miroId)
+          )
         )
-      )
     }
 
   private def physicalAndDigitalSierraMergeCandidate(
-    bibNumber: String): List[MergeCandidate[IdState.Identifiable]] =
+    bibNumber: String
+  ): List[MergeCandidate[IdState.Identifiable]] =
     List(
       MergeCandidate(
         identifier = SourceIdentifier(
@@ -436,9 +487,10 @@ class SierraMergeCandidatesTest
       )
     )
 
-  private def miroMergeCandidate(miroID: String,
-                                 reason: String = "Miro/Sierra work")
-    : List[MergeCandidate[IdState.Identifiable]] =
+  private def miroMergeCandidate(
+    miroID: String,
+    reason: String = "Miro/Sierra work"
+  ): List[MergeCandidate[IdState.Identifiable]] =
     List(
       MergeCandidate(
         identifier = SourceIdentifier(


### PR DESCRIPTION
## What does this change?

This change adds an `EbscoAltLookup` identifier type and extracts merge candidates in the sierra transformer from the MARC control number: https://www.loc.gov/marc/bibliographic/bd001.html, as a step towards receiving e-journal data directly from EBSCO rather than via Sierra.

There is an extra check on MARC 003 the "control number identifier" field that identifies the source system as "EBZ" where we want to merge to as an extra check, protect us against any future records having a matching identifier pattern.

Part of https://github.com/wellcomecollection/platform-infrastructure/issues/426

## How to test

- [x] Run the tests!

## How can we measure success?

Works created from Sierra bib records imported as EBSCO e-resources have merge candidates including the EBSCO lookup number, enabling us to redirect from Sierra records to EBSCO records in the future.

## Have we considered potential risks?

We must pick a unique identifier reliably available on all records we wish to merge from both systems. Investigating the data available in Sierra and from EBSCO indicate the `EbscoAltLookup` field meets this criterion.

