### PR TITLE
Add safeguarded access status

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessStatus.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessStatus.scala
@@ -47,7 +47,7 @@ object AccessStatus extends Enum[AccessStatus] {
   // Wellcome Collection's Access Policy.
   // See https://wellcomecollection.org/pages/Wvmu3yAAAIUQ4C7F#access-policy
   //
-  // This is based on §12 Research access, as retrieved 8 February 2021
+  // This is based on §12 Research access, as retrieved 5 March 2024
   //
   case object Open extends AccessStatus {
     override val id: String = "open"
@@ -62,6 +62,11 @@ object AccessStatus extends Enum[AccessStatus] {
   case object Restricted extends AccessStatus {
     override val id: String = "restricted"
     override val label: String = "Restricted"
+  }
+
+  case object Safeguarded extends AccessStatus {
+    override val id: String = "safeguarded"
+    override val label: String = "Safeguarded"
   }
 
   case object ByAppointment extends AccessStatus {

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessStatus.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessStatus.scala
@@ -32,6 +32,7 @@ sealed trait AccessStatus extends EnumEntry { this: AccessStatus =>
     case AccessStatus.ByAppointment      => true
     case AccessStatus.Closed             => true
     case AccessStatus.PermissionRequired => true
+    case AccessStatus.Safeguarded        => true
     case _                               => false
   }
 }

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/RulesForRequestingResult.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/RulesForRequestingResult.scala
@@ -10,6 +10,7 @@ object NotRequestable {
   case class NeedsManualRequest(message: String) extends NotRequestable
 
   case class ItemClosed(message: String) extends NotRequestable
+  case class SafeguardedItem(message: String) extends NotRequestable
   case class ItemMissing(message: String) extends NotRequestable
   case class ItemOnSearch(message: String) extends NotRequestable
   case class ItemUnavailable(message: String) extends NotRequestable

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -276,6 +276,20 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           note = Some(message)
         )
 
+        //
+      case (
+            _,
+            Some(Status.Safeguarded),
+            Some(OpacMsg.ByApproval),
+            NotRequestable.SafeguardedItem(message),
+            _
+          ) =>
+        AccessCondition(
+          method = AccessMethod.NotRequestable,
+          status = Some(AccessStatus.Safeguarded),
+          note = Some(message)
+        )
+
       // If an item is on hold for another reader, it can't be requested -- even
       // if it would ordinarily be requestable.
       //

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -276,7 +276,7 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           note = Some(message)
         )
 
-        //
+      //
       case (
             _,
             Some(Status.Safeguarded),

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala
@@ -34,8 +34,8 @@ import weco.sierra.models.data.SierraItemData
   *   - Variable length fields on items
   *     https://documentation.iii.com/sierrahelp/Content/sril/sril_records_varfld_types_item.html
   *
-  * This was last checked against Sierra based on a set of rules sent from Liz
-  * Richens on 31 January 2022.
+  * This was last checked against Sierra based on a set of rules provided by
+  * Natalie Pollecutt on 8th February 2024
   */
 object SierraRulesForRequesting {
   def apply(itemData: SierraItemData): RulesForRequestingResult =
@@ -50,6 +50,7 @@ object SierraRulesForRequesting {
       //    q|i||88||=|z||
       //    q|i||88||=|v||This item is with conservation.
       //    q|i||88||=|h||This item is closed.
+      //    q|i||88||=|g||Safeguarded item.
       //
       // These rules mean "if fixed field 88 on the item has a given value,
       // show this message".
@@ -67,6 +68,8 @@ object SierraRulesForRequesting {
         NotRequestable.AtConservation("This item is with conservation.")
       case i if i.fixedField("88").contains("h") =>
         NotRequestable.ItemClosed("This item is closed.")
+      case i if i.fixedField("88").contains("g") =>
+        NotRequestable.SafeguardedItem("Safeguarded item.")
 
       // These cases cover the lines:
       //

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/source/OpacMsg.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/source/OpacMsg.scala
@@ -11,4 +11,5 @@ object OpacMsg {
   val StaffUseOnly = "s"
   val AskAtDesk = "i"
   val Restricted = "c"
+  val ByApproval = "p"
 }

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/source/Status.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/source/Status.scala
@@ -6,6 +6,7 @@ object Status {
   val Missing = "m"
   val Unavailable = "r"
   val Closed = "h"
+  val Safeguarded = "g"
   val OnHoldshelf = "!"
   val Withdrawn = "x"
 }

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -338,6 +338,28 @@ class SierraItemAccessTest
             noTerms()
           )
         }
+
+        it("if the item is safeguarded") {
+          val itemData = createSierraItemDataWith(
+            fixedFields = Map(
+              "79" -> createLocationWith("scmac", "Closed stores Arch. & MSS"),
+              "88" -> createStatusWith("g", "Safeguarded"),
+              "108" -> createOpacMsgWith("p", "Safeguarded item.")
+            )
+          )
+
+          val (ac, _) = SierraItemAccess(
+            location = Some(LocationType.ClosedStores),
+            itemData = itemData
+          )
+
+          ac should have(
+            method(AccessMethod.NotRequestable),
+            status(AccessStatus.Safeguarded),
+            noTerms(),
+            note("Safeguarded item.")
+          )
+        }
       }
     }
 

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequestingTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequestingTest.scala
@@ -30,6 +30,7 @@ class SierraRulesForRequestingTest
         NotRequestable.OnExhibition(
           "On exhibition. Please ask at Enquiry Desk.")),
       ("y", NotRequestable.NoPublicMessage("fixed field 88 = y")),
+      ("g", NotRequestable.SafeguardedItem("Safeguarded item."))
     )
 
     forAll(testCases) {


### PR DESCRIPTION
This is in service of https://github.com/wellcomecollection/catalogue-api/issues/753

As well as handling the Sierra access status, it adds a new one to our own model in order to represent the collections access policy. It shouldn't change any behaviour - next I will need to update the rules for requesting in the items API, then work out how/whether to reflect the new status on the website.