### PR TITLE
Use the given access note for safeguarded items

### DIFF
--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -281,13 +281,12 @@ object SierraItemAccess extends SierraQueryOps with Logging {
             _,
             Some(Status.Safeguarded),
             Some(OpacMsg.ByApproval),
-            NotRequestable.SafeguardedItem(message),
+            _: NotRequestable.SafeguardedItem,
             _
           ) =>
         AccessCondition(
           method = AccessMethod.NotRequestable,
-          status = Some(AccessStatus.Safeguarded),
-          note = Some(message)
+          status = Some(AccessStatus.Safeguarded)
         )
 
       // If an item is on hold for another reader, it can't be requested -- even

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -357,7 +357,7 @@ class SierraItemAccessTest
             method(AccessMethod.NotRequestable),
             status(AccessStatus.Safeguarded),
             noTerms(),
-            note("Safeguarded item.")
+            noNote()
           )
         }
       }
@@ -583,6 +583,34 @@ class SierraItemAccessTest
         )
 
         itemNote shouldBe "uncoloured impression on paper mount"
+      }
+
+      it("if there's a display note about access for a safeguarded item") {
+        val itemData = createSierraItemDataWith(
+          fixedFields = Map(
+            "79" -> createLocationWith("scmac", "Closed stores Arch. & MSS"),
+            "88" -> createStatusWith("g", "Safeguarded"),
+            "108" -> createOpacMsgWith("p", "Safeguarded item.")
+          ),
+          varFields = List(
+            VarField(
+              fieldTag = "n",
+              content =
+                "This item requires safeguarded access. You will need to complete an application form before you will be allowed to view this item. Requests are considered on a case by case basis. Please contact collections@wellcomecollection.org for more details."
+            )
+          )
+        )
+
+        val (ac, _) = SierraItemAccess(
+          location = Some(LocationType.ClosedStores),
+          itemData = itemData
+        )
+
+        ac should have(
+          note(
+            "This item requires safeguarded access. You will need to complete an application form before you will be allowed to view this item. Requests are considered on a case by case basis. Please contact collections@wellcomecollection.org for more details."
+          )
+        )
       }
     }
   }


### PR DESCRIPTION
The first attempt at this used a hardcoded access note, but the items should have more specific notes on them (as with other statuses), so this PR changes the logic to use the given access note for Safeguarded items.

Explained by the text - these items will have specific instructions regarding access which will live in the item display note. We already filter out irrelevant display notes so this will work much like other manual request items.