### PR TITLE
Transformer marc xml

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -218,6 +218,13 @@ lazy val transformer_marc_common = setupProject(
   externalDependencies = CatalogueDependencies.transformerMarcCommonDependencies
 )
 
+lazy val transformer_marc_xml = setupProject(
+  project,
+  folder = "pipeline/transformer/transformer_marc_xml",
+  localDependencies = Seq(transformer_marc_common),
+  externalDependencies = CatalogueDependencies.transformerMarcXMLDependencies
+)
+
 lazy val transformer_miro = setupProject(
   project,
   folder = "pipeline/transformer/transformer_miro",

--- a/pipeline/transformer/transformer_marc_xml/src/main/scala/weco/pipeline/transformer/marc/xml/data/MarcXMLDataField.scala
+++ b/pipeline/transformer/transformer_marc_xml/src/main/scala/weco/pipeline/transformer/marc/xml/data/MarcXMLDataField.scala
@@ -1,0 +1,20 @@
+package weco.pipeline.transformer.marc.xml.data
+
+import weco.pipeline.transformer.marc_common.models.{MarcField, MarcSubfield}
+
+import scala.xml.Node
+
+object MarcXMLDataField {
+  def apply(elem: Node): MarcField =
+    MarcField(
+      marcTag = elem \@ "tag",
+      indicator1 = elem \@ "ind1",
+      indicator2 = elem \@ "ind2",
+      subfields = elem \ "subfield" map (MarcXMLSubfield(_))
+    )
+}
+
+object MarcXMLSubfield {
+  def apply(elem: Node): MarcSubfield =
+    MarcSubfield(tag = elem \@ "code", content = elem.text)
+}

--- a/pipeline/transformer/transformer_marc_xml/src/main/scala/weco/pipeline/transformer/marc/xml/data/MarcXMLDocument.scala
+++ b/pipeline/transformer/transformer_marc_xml/src/main/scala/weco/pipeline/transformer/marc/xml/data/MarcXMLDocument.scala
@@ -1,0 +1,13 @@
+package weco.pipeline.transformer.marc.xml.data
+
+import scala.xml.Node
+
+/*
+ * Represents a MARC XML Document as sent by EBSCO
+ *
+ * A Document consists of a <collection> element containing multiple <record> elements
+ * */
+case class MarcXMLDocument(collectionElement: Node) {
+  def records: Seq[MarcXMLRecord] =
+    (collectionElement \ "records").view.map(MarcXMLRecord)
+}

--- a/pipeline/transformer/transformer_marc_xml/src/main/scala/weco/pipeline/transformer/marc/xml/data/MarcXMLRecord.scala
+++ b/pipeline/transformer/transformer_marc_xml/src/main/scala/weco/pipeline/transformer/marc/xml/data/MarcXMLRecord.scala
@@ -1,0 +1,55 @@
+package weco.pipeline.transformer.marc.xml.data
+
+import weco.pipeline.transformer.marc_common.models.{
+  MarcField,
+  MarcRecord,
+  MarcSubfield
+}
+
+import scala.xml.{Node, NodeSeq}
+
+/*
+ * Represents a MARC XML Record as sent by EBSCO
+ * A <record> consists of a <leader> element, some <controlfield> elements and some <datafield> elements.
+ * This class knows nothing of the behaviour and meaning of any MARC fields.
+ * It provides functionality to access fields by their tags.
+ * */
+case class MarcXMLRecord(recordElement: Node) extends MarcRecord {
+
+  lazy val leader: String = recordElement \ "leader" text
+  def controlField(tag: String): Option[String] =
+    recordElement \ "controlfield" filter hasTag(tag) match {
+      case NodeSeq.Empty => None
+      case Seq(node)     => Some(node.text)
+      case _ =>
+        None // TODO: warn that there are multiple matches and return (head.text)?
+    }
+
+  def fieldsWithTags(tags: String*): Seq[MarcField] =
+    recordElement \ "datafield" filter hasTag(tags: _*) map (MarcXMLDataField(
+      _
+    ))
+
+  def fieldsWithTag(tag: String): Seq[MarcField] =
+    fieldsWithTags(tag)
+
+  def subfieldsWithTags(tags: (String, String)*): List[MarcSubfield] =
+    tags.toList.flatMap {
+      case (tag, subfieldTag) =>
+        (recordElement \ "datafield" filter hasTag(
+          tag
+        )) \ "subfield" filter hasTag(subfieldTag) map (MarcXMLSubfield(_))
+    }
+
+  private def hasTag(values: String*)(node: Node) = {
+    values.contains(node \@ "tag")
+  }
+  //  private def hasTagAndSubfieldTag(values: (String, String)*)(node: Node) = {
+  //    values.exists {
+  //      value =>
+  //        node \@ "tag" == value._1
+  //        node \ "subfield" \@ "tag" == value._2
+  //    }
+  //  }
+
+}

--- a/pipeline/transformer/transformer_marc_xml/src/main/scala/weco/pipeline/transformer/marc/xml/transformers/MarcXMLRecordTransformer.scala
+++ b/pipeline/transformer/transformer_marc_xml/src/main/scala/weco/pipeline/transformer/marc/xml/transformers/MarcXMLRecordTransformer.scala
@@ -1,0 +1,43 @@
+package weco.pipeline.transformer.marc.xml.transformers
+
+import weco.catalogue.internal_model.identifiers.{
+  DataState,
+  IdentifierType,
+  SourceIdentifier
+}
+import weco.catalogue.internal_model.work.WorkState.Source
+import weco.catalogue.internal_model.work.{Work, WorkData}
+import weco.pipeline.transformer.marc.xml.data.MarcXMLRecord
+import weco.pipeline.transformer.marc_common.transformers.MarcTitle
+
+import java.time.Instant
+
+object MarcXMLRecordTransformer {
+
+  def apply(record: MarcXMLRecord): Work.Visible[Source] = {
+    // TODO: The state stuff here is EBSCO-specific.  Move it when the EBSCO transformer is implemented
+    val state = Source(
+      sourceIdentifier = SourceIdentifier(
+        identifierType = IdentifierType.EbscoAltLookup,
+        ontologyType = "Work",
+        value = record.controlField("001").get
+      ),
+      // TODO: I don't think we get sourceModifiedTime in the XML records from EBSCO,
+      // but we might be able to work something out
+      sourceModifiedTime = Instant.now
+    )
+    Work.Visible[Source](
+      version = 0,
+      state = state,
+      data = workDataFromMarcRecord(record)
+    )
+  }
+
+  def workDataFromMarcRecord(
+    record: MarcXMLRecord
+  ): WorkData[DataState.Unidentified] = {
+    WorkData[DataState.Unidentified](
+      title = MarcTitle(record)
+    )
+  }
+}

--- a/pipeline/transformer/transformer_marc_xml/src/main/scala/weco/pipeline/transformer/marc/xml/transformers/MarcXMLRecordTransformer.scala
+++ b/pipeline/transformer/transformer_marc_xml/src/main/scala/weco/pipeline/transformer/marc/xml/transformers/MarcXMLRecordTransformer.scala
@@ -23,7 +23,7 @@ object MarcXMLRecordTransformer {
         value = record.controlField("001").get
       ),
       // TODO: I don't think we get sourceModifiedTime in the XML records from EBSCO,
-      // but we might be able to work something out
+      //   but we might be able to work something out
       sourceModifiedTime = Instant.now
     )
     Work.Visible[Source](

--- a/pipeline/transformer/transformer_marc_xml/src/test/scala/weco/pipeline/transformer/marc/xml/data/MarcXMLRecordTest.scala
+++ b/pipeline/transformer/transformer_marc_xml/src/test/scala/weco/pipeline/transformer/marc/xml/data/MarcXMLRecordTest.scala
@@ -1,0 +1,191 @@
+package weco.pipeline.transformer.marc.xml.data
+
+import org.scalatest.LoneElement
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class MarcXMLRecordTest extends AnyFunSpec with Matchers with LoneElement {
+  describe("extracting the leader") {
+    it("returns the leader as a string") {
+      MarcXMLRecord(
+        <record xmlns="http://www.loc.gov/MARC21/slim">
+          <leader>00000nas a22000003 4500</leader>
+        </record>
+      ).leader shouldBe "00000nas a22000003 4500"
+
+    }
+  }
+
+  describe("extracting controlfields from an MarcXML Record") {
+    it("returns the string value of a control field by its MARC tag") {
+      MarcXMLRecord(
+        <record xmlns="http://www.loc.gov/MARC21/slim">
+          <controlfield tag="001">ebs1234567890e</controlfield>
+          <controlfield tag="003">EBZ</controlfield>
+        </record>
+      ).controlField("003").get shouldBe "EBZ"
+    }
+
+    it("returns None if the requested field does not exist") {
+      MarcXMLRecord(
+        <record>
+          <controlfield tag="001">ebs1234567890e</controlfield>
+        </record>
+      ).controlField("003") shouldBe None
+    }
+
+    it("returns None if multiple controlfields with the same tag exist") {
+      info("controlfields are expected to be unique")
+      MarcXMLRecord(
+        <record>
+          <controlfield tag="001">hello</controlfield>
+          <controlfield tag="001">world</controlfield>
+        </record>
+      ).controlField("001") shouldBe None
+    }
+  }
+
+  describe("extracting datafields from an Ebsco MARC record") {
+    describe("given a single marcTag") {
+      it("returns nothing if no field with the requested tag exists") {
+        MarcXMLRecord(
+          <record>
+            <datafield tag="321">
+              <subfield tag="a">1234-5678</subfield>
+            </datafield>
+          </record>
+        ).fieldsWithTag("123") shouldBe empty
+      }
+
+      it("returns a single datafield with the requested tag") {
+        val datafield = MarcXMLRecord(
+          <record  xmlns="http://www.loc.gov/MARC21/slim">
+            <datafield tag="022">
+              <subfield tag="a">1234-5678</subfield>
+            </datafield>
+            <datafield tag="999">
+              <subfield tag="x">baad-f00d</subfield>
+            </datafield>
+          </record>
+        ).fieldsWithTag("022").loneElement
+
+        datafield should have(
+          'marcTag("022")
+        )
+        datafield.subfields.loneElement should have(
+          'tag("a"),
+          'content("1234-5678")
+        )
+      }
+
+      it("returns multiple datafields with the requested tag") {
+        val Seq(first, second) = MarcXMLRecord(
+          <record>
+            <datafield tag="022">
+              <subfield tag="a">1234-5678</subfield>
+            </datafield>
+            <datafield tag="999">
+              <subfield tag="x">baad-f00d</subfield>
+            </datafield>
+            <datafield tag="022">
+              <subfield tag="b">g00d-cafe</subfield>
+            </datafield>
+          </record>
+        ).fieldsWithTag("022")
+
+        first.subfields.loneElement should have(
+          'tag("a"),
+          'content("1234-5678")
+        )
+        second.subfields.loneElement should have(
+          'tag("b"),
+          'content("g00d-cafe")
+        )
+      }
+    }
+    describe("given multiple marcTags") {
+      it(
+        "returns the datafields in document order, ignoring the order of tags in the request"
+      ) {
+        MarcXMLRecord(
+          <record>
+            <datafield tag="655" />
+            <datafield tag="999" />
+            <datafield tag="651" />
+            <datafield tag="650" />
+          </record>
+        ).fieldsWithTags("651", "655", "650").map(_.marcTag) shouldBe Seq(
+          "655",
+          "651",
+          "650"
+        )
+      }
+      it(
+        "returns any that it can find, even if not all tags are present"
+      ) {
+        MarcXMLRecord(
+          <record>
+            <datafield tag="655" />
+            <datafield tag="650" />
+            <datafield tag="999" />
+            <datafield tag="655" />
+            <datafield tag="650" />
+          </record>
+        ).fieldsWithTags("I'm not there", "655", "650")
+          .map(_.marcTag) shouldBe Seq(
+          "655",
+          "650",
+          "655",
+          "650"
+        )
+      }
+    }
+  }
+
+  describe("extracting subfields from an Ebsco MARC record") {
+    it("returns nothing if there are no matching subfields") {
+      MarcXMLRecord(
+        <record>
+          <datafield tag="655">
+            <subfield tag="x">Hello Mike</subfield>
+          </datafield>
+          <datafield tag="651">
+            <subfield tag="a">Hello Joe</subfield>
+          </datafield>
+        </record>
+      ).subfieldsWithTags("655" -> "a", "651" -> "x") shouldBe empty
+    }
+    it("returns the subfields in the requested order") {
+      info("this is the same as in Sierra")
+      info(
+        "it would be nice were this to be in doc order, but it doesn't seem worth the bother"
+      )
+      MarcXMLRecord(
+        <record>
+          <datafield tag="650">
+            <subfield tag="a">Hello Mike</subfield>
+          </datafield>
+          <datafield tag="655">
+            <subfield tag="a">Hello Robert</subfield>
+            <subfield tag="0">n93000068</subfield>
+          </datafield>
+          <datafield tag="651">
+            <subfield tag="a">Hello Joe</subfield>
+            <subfield tag="0">n93000065</subfield>
+          </datafield>
+        </record>
+      ).subfieldsWithTags(
+        "655" -> "0",
+        "651" -> "a",
+        "655" -> "a",
+        "650" -> "a",
+        "650" -> "0"
+      ).map(_.content) shouldBe Seq(
+        "n93000068",
+        "Hello Joe",
+        "Hello Robert",
+        "Hello Mike"
+      )
+    }
+  }
+}

--- a/pipeline/transformer/transformer_marc_xml/src/test/scala/weco/pipeline/transformer/marc/xml/data/MarcXMLRecordTest.scala
+++ b/pipeline/transformer/transformer_marc_xml/src/test/scala/weco/pipeline/transformer/marc/xml/data/MarcXMLRecordTest.scala
@@ -61,10 +61,10 @@ class MarcXMLRecordTest extends AnyFunSpec with Matchers with LoneElement {
         val datafield = MarcXMLRecord(
           <record  xmlns="http://www.loc.gov/MARC21/slim">
             <datafield tag="022">
-              <subfield tag="a">1234-5678</subfield>
+              <subfield code="a">1234-5678</subfield>
             </datafield>
             <datafield tag="999">
-              <subfield tag="x">baad-f00d</subfield>
+              <subfield code="x">baad-f00d</subfield>
             </datafield>
           </record>
         ).fieldsWithTag("022").loneElement
@@ -82,13 +82,13 @@ class MarcXMLRecordTest extends AnyFunSpec with Matchers with LoneElement {
         val Seq(first, second) = MarcXMLRecord(
           <record>
             <datafield tag="022">
-              <subfield tag="a">1234-5678</subfield>
+              <subfield code="a">1234-5678</subfield>
             </datafield>
             <datafield tag="999">
-              <subfield tag="x">baad-f00d</subfield>
+              <subfield code="x">baad-f00d</subfield>
             </datafield>
             <datafield tag="022">
-              <subfield tag="b">g00d-cafe</subfield>
+              <subfield code="b">g00d-cafe</subfield>
             </datafield>
           </record>
         ).fieldsWithTag("022")

--- a/pipeline/transformer/transformer_marc_xml/src/test/scala/weco/pipeline/transformer/marc/xml/transformers/MarcXMLRecordTransformerTest.scala
+++ b/pipeline/transformer/transformer_marc_xml/src/test/scala/weco/pipeline/transformer/marc/xml/transformers/MarcXMLRecordTransformerTest.scala
@@ -22,9 +22,6 @@ class MarcXMLRecordTransformerTest extends AnyFunSpec with Matchers {
         )
       )
       work.state.sourceIdentifier.value shouldBe "3PaDhRp"
-      // TODO: The SUT currently assigns a type of EBSCO to the source identifier, but it shouldn't
-      //    that belongs in the ebsco-specific transformer.  Sort that all out when it's time.
-
       work.data should equal(
         WorkData[DataState.Unidentified](title = Some("matacologian"))
       )

--- a/pipeline/transformer/transformer_marc_xml/src/test/scala/weco/pipeline/transformer/marc/xml/transformers/MarcXMLRecordTransformerTest.scala
+++ b/pipeline/transformer/transformer_marc_xml/src/test/scala/weco/pipeline/transformer/marc/xml/transformers/MarcXMLRecordTransformerTest.scala
@@ -1,0 +1,33 @@
+package weco.pipeline.transformer.marc.xml.transformers
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import weco.catalogue.internal_model.identifiers.DataState
+import weco.catalogue.internal_model.work.WorkData
+import weco.pipeline.transformer.marc.xml.data.MarcXMLRecord
+
+class MarcXMLRecordTransformerTest extends AnyFunSpec with Matchers {
+
+  describe("a minimal XML record") {
+    it("generates a Work with a sourceIdentifier") {
+      info("at minimum, a Work from an XML record needs an id and a title")
+      val work = MarcXMLRecordTransformer(
+        MarcXMLRecord(
+          <record xmlns="http://www.loc.gov/MARC21/slim">
+            <controlfield tag="001">3PaDhRp</controlfield>
+            <datafield tag ="245">
+              <subfield code="a">matacologian</subfield>
+            </datafield>
+          </record>
+        )
+      )
+      work.state.sourceIdentifier.value shouldBe "3PaDhRp"
+      // TODO: The SUT currently assigns a type of EBSCO to the source identifier, but it shouldn't
+      //    that belongs in the ebsco-specific transformer.  Sort that all out when it's time.
+
+      work.data should equal(
+        WorkData[DataState.Unidentified](title = Some("matacologian"))
+      )
+    }
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -214,6 +214,8 @@ object CatalogueDependencies {
   val transformerMarcCommonDependencies: Seq[ModuleID] =
     Nil
 
+  val transformerMarcXMLDependencies: Seq[ModuleID] = Nil
+
   val idminterDependencies: Seq[ModuleID] =
     ExternalDependencies.mySqlDependencies ++
       ExternalDependencies.circeOpticsDependencies ++


### PR DESCRIPTION
## What does this change?

This introduces a MarcXML transformer library that exercises the common MARC transformations.

The immediate intent is just to prove that the abstraction and interface defined in transformer.marc.common are appropriate to allow us to transform data from both formats.

There are a few lines that are EBSCO-specific in here, which relate to the creation of a document identifier.  These should eventually be moved to the proper EBSCO transformer when it is implemented.

Part of https://github.com/wellcomecollection/catalogue-pipeline/issues/2563

## How to test

This work is still abstract, in the sense that there is no application wired up to exercise it with live data and a real pipeline.

As such, it is only testable through the test suite..

## How can we measure success?

As more fields are moved from the Sierra transformer to the common MARC transformer, it should be simple to incorporate them into the MARC XML transformer by calling them from `MarcXMLRecordTransformer` and devising some new tests against XML data. 

## Have we considered potential risks?

This work is a mitigation of risk in itself.  There was a risk that refactoring Sierra transformer objects and moving them into `marc.common` could bring along some Sierra~ or JSON~ specific practices, thereby not making the EBSCO/XML transformer as simple to implement as hoped for.  Similarly, if implemented directly as part of the upcoming EBSCO transformer, we may have had to do some of this extraction work again in the future when we start ingesting other sources of MARC XML.
