### PR TITLE
CALM items can have a Safeguarded access status

### DIFF
--- a/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/transformers/CalmAccessStatus.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/transformers/CalmAccessStatus.scala
@@ -12,6 +12,7 @@ object CalmAccessStatus extends CalmRecordOps with Logging {
       case Some("Open with advisory") => Some(AccessStatus.OpenWithAdvisory)
       case Some("Closed")             => Some(AccessStatus.Closed)
       case Some("Restricted")         => Some(AccessStatus.Restricted)
+      case Some("Safeguarded")        => Some(AccessStatus.Safeguarded)
       case Some(s) if s.toLowerCase == "certain restrictions apply" =>
         Some(AccessStatus.Restricted)
       case Some(s)


### PR DESCRIPTION
This was simpler than I thought! Resolves https://github.com/wellcomecollection/catalogue-pipeline/issues/2580 by mapping the controlled term in the CALM `AccessStatus` field to our own access status.

Seems to be no need to handle the AccessConditions as this is already dealt with by `CalmTermsOfUse`, but a bigger and existing product question as to whether this inconsistency between CALM items (terms of use displayed in the work's notes) and Sierra items (access notes displayed alongside items listing) is indeed what we want.