### PR TITLE
ignore varfields without marcTags when translating Sierra fields to abstract MARC

### DIFF
--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/data/BibDataAsMarcRecord.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/data/BibDataAsMarcRecord.scala
@@ -40,7 +40,13 @@ class BibDataAsMarcRecord(bibData: SierraBibData)
     extends MarcRecord
     with SierraQueryOps {
   lazy val fields: Seq[MarcField] =
-    bibData.varFields.map(SierraMarcDataConversions.varFieldToMarcField)
+    bibData.varFields
+      // Only actual MARC varfields, with an actual MARC tag, are exercised
+      // as fields by the clients of MarcRecord.  However, the leader surfaces
+      // as a Varfield in Sierra content.
+      // Anything that doesn't have a tag can be ignored at this point.
+      .filter(_.marcTag.nonEmpty)
+      .map(SierraMarcDataConversions.varFieldToMarcField)
   lazy val materialTypeId: Option[String] = bibData.materialType.map(_.code)
   override def fieldsWithTags(tags: String*): Seq[MarcField] =
     bibData

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/data/BibDataAsMarcRecordTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/data/BibDataAsMarcRecordTest.scala
@@ -1,0 +1,68 @@
+package weco.pipeline.transformer.sierra.data
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import weco.pipeline.transformer.marc_common.models.MarcField
+import weco.sierra.generators.SierraDataGenerators
+import weco.sierra.models.marc.{Subfield, VarField}
+
+class BibDataAsMarcRecordTest
+    extends AnyFunSpec
+    with Matchers
+    with SierraDataGenerators
+    with SierraMarcDataConversions {
+
+  it("turns Varfields into MarcFields") {
+    val bibData = createSierraBibDataWith(varFields =
+      List(
+        VarField(
+          marcTag = Some("999"),
+          subfields = List(Subfield(tag = "a", content = "banana"))
+        ),
+        VarField(
+          marcTag = Some("123"),
+          subfields = List(Subfield(tag = "a", content = "coypu"))
+        )
+      )
+    )
+    val marcRecord = bibDataToMarcRecord(bibData)
+    marcRecord.fields should have length 2
+    marcRecord
+      .fieldsWithTags("123")
+      .head shouldBe a[MarcField]
+    marcRecord.fields.head.subfields.head should have(
+      'tag("a"),
+      'content("banana")
+    )
+
+  }
+
+  it("ignores VarFields without a marcTag") {
+    val bibData = createSierraBibDataWith(varFields =
+      List(
+        VarField(
+          marcTag = Some("999"),
+          subfields = List(Subfield(tag = "a", content = "topper"))
+        ),
+        VarField(
+          marcTag = None,
+          subfields = List(Subfield(tag = "a", content = "wayfarer"))
+        ),
+        VarField(fieldTag = "invalid", content = "laser"),
+        VarField(
+          marcTag = Some("123"),
+          subfields = List(Subfield(tag = "a", content = "coypu"))
+        )
+      )
+    )
+    val marcRecord = bibDataToMarcRecord(bibData)
+    marcRecord.fields should have length 2
+    val field123 = marcRecord.fieldsWithTags("123").head
+    field123.subfields.head should have(
+      'tag("a"),
+      'content("coypu")
+    )
+
+  }
+
+}


### PR DESCRIPTION
## What does this change?

Some Sierra Varfields do not have a marcTag.  The abstract MARC interface is only concerned with fields that can be referenced by their marcTag, so this ignores anything without one.

Counterintuitively, the MARC leader field is represented as a Varfield in the Sierra data.  The leader has no tag.  This means that records were failing because of the assumption that all Varfields have a tag.

## How to test

Redrive the Sierra Transformer DLQ, we should see those records sail through.  Should fix https://wellcome.slack.com/archives/C8X9YKM5X/p1710240423388299

## Have we considered potential risks?

Maybe I'll find a situation where the abstraction does need to look at one of these fields. I'll cross that bridge when I come to it.  I don't think they should be stored in the same collection as the actual tagged data fields.
