### PR TITLE
Marc identifiers

### DIFF
--- a/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/models/MarcRecord.scala
+++ b/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/models/MarcRecord.scala
@@ -8,4 +8,6 @@ trait MarcRecord {
 
   val fields: Seq[MarcField]
   def fieldsWithTags(tags: String*): Seq[MarcField]
+
+  def subfieldsWithTag(tag: (String, String)): List[MarcSubfield]
 }

--- a/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/models/MarcRecord.scala
+++ b/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/models/MarcRecord.scala
@@ -9,5 +9,5 @@ trait MarcRecord {
   val fields: Seq[MarcField]
   def fieldsWithTags(tags: String*): Seq[MarcField]
 
-  def subfieldsWithTag(tag: (String, String)): List[MarcSubfield]
+  def subfieldsWithTag(tagPair: (String, String)): List[MarcSubfield]
 }

--- a/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcInternationalStandardIdentifiers.scala
+++ b/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcInternationalStandardIdentifiers.scala
@@ -1,0 +1,62 @@
+package weco.pipeline.transformer.marc_common.transformers
+
+import weco.catalogue.internal_model.identifiers.{
+  IdentifierType,
+  SourceIdentifier
+}
+import weco.pipeline.transformer.marc_common.models.MarcRecord
+
+trait MarcInternationalStandardIdentifiers {
+
+  private def getInternationalStandardNumber(
+    record: MarcRecord,
+    identifierType: IdentifierType
+  ): Seq[SourceIdentifier] = {
+    val marcTag = identifierType match {
+      case IdentifierType.ISBN => "020"
+      case IdentifierType.ISSN => "022"
+      case _                   => throw new Exception()
+    }
+    record
+      .subfieldsWithTag(marcTag -> "a")
+      .map(_.content)
+      .distinct
+      .map {
+        value =>
+          SourceIdentifier(
+            identifierType = identifierType,
+            ontologyType = "Work",
+            value = value.trim
+          )
+      }
+  }
+
+  /** Find ISBN (International Standard Book Number) identifiers from MARC 020
+    * ǂa.
+    *
+    * This field is repeatable. See
+    * https://www.loc.gov/marc/bibliographic/bd020.html
+    */
+  protected def getIsbnIdentifiers(
+    record: MarcRecord
+  ): Seq[SourceIdentifier] =
+    getInternationalStandardNumber(record, IdentifierType.ISBN)
+
+  /** Find ISSN (International Standard Serial Number) identifiers from MARC 022
+    * ǂa.
+    *
+    * This field is repeatable. See
+    * https://www.loc.gov/marc/bibliographic/bd022.html
+    */
+  protected def getIssnIdentifiers(
+    record: MarcRecord
+  ): Seq[SourceIdentifier] =
+    getInternationalStandardNumber(record, IdentifierType.ISSN)
+
+}
+
+object MarcInternationalStandardIdentifiers
+    extends MarcInternationalStandardIdentifiers {
+  def apply(record: MarcRecord): Seq[SourceIdentifier] =
+    (getIsbnIdentifiers(record) ++ getIssnIdentifiers(record)).distinct
+}

--- a/pipeline/transformer/transformer_marc_common/src/test/scala/weco/pipeline/transformer/marc_common/generators/MarcTestRecord.scala
+++ b/pipeline/transformer/transformer_marc_common/src/test/scala/weco/pipeline/transformer/marc_common/generators/MarcTestRecord.scala
@@ -1,7 +1,11 @@
 package weco.pipeline.transformer.marc_common.generators
 
 import org.scalatest.LoneElement
-import weco.pipeline.transformer.marc_common.models.{MarcField, MarcRecord}
+import weco.pipeline.transformer.marc_common.models.{
+  MarcField,
+  MarcRecord,
+  MarcSubfield
+}
 
 case class MarcTestRecord(
   fields: Seq[MarcField]
@@ -12,5 +16,14 @@ case class MarcTestRecord(
 
   def nonRepeatableFieldWithTag(tag: String): Option[MarcField] =
     Some(fieldsWithTags(tag).loneElement)
+
+  override def subfieldsWithTag(tagPair: (String, String)): List[MarcSubfield] =
+    tagPair match {
+      case (tag, subfieldTag) =>
+        fieldsWithTags(tag)
+          .flatMap(_.subfields)
+          .filter(_.tag == subfieldTag)
+          .toList
+    }
 
 }

--- a/pipeline/transformer/transformer_marc_common/src/test/scala/weco/pipeline/transformer/marc_common/transformers/MarcInternationalStandardIdentifiersTest.scala
+++ b/pipeline/transformer/transformer_marc_common/src/test/scala/weco/pipeline/transformer/marc_common/transformers/MarcInternationalStandardIdentifiersTest.scala
@@ -1,0 +1,179 @@
+package weco.pipeline.transformer.marc_common.transformers
+
+import org.scalatest.LoneElement
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import weco.catalogue.internal_model.identifiers.{
+  IdentifierType,
+  SourceIdentifier
+}
+import weco.pipeline.transformer.marc_common.generators.MarcTestRecord
+import weco.pipeline.transformer.marc_common.models.{MarcField, MarcSubfield}
+
+class MarcInternationalStandardIdentifiersTest
+    extends AnyFunSpec
+    with Matchers
+    with LoneElement {
+
+  describe(
+    "Extracting International Standard Numbers (ISBN & ISSN) from 020 and 022"
+  ) {
+    info("https://www.loc.gov/marc/bibliographic/bd020.html")
+    info("https://www.loc.gov/marc/bibliographic/bd022.html")
+    info("ISBNs and ISSNs represent Identifiers in the Internal Model")
+    it("extracts ISBN from MARC 020") {
+      val record = MarcTestRecord(fields =
+        Seq(
+          MarcField(
+            "020",
+            subfields =
+              Seq(MarcSubfield(tag = "a", content = "978-1-890159-02-3"))
+          )
+        )
+      )
+      val sourceId: SourceIdentifier =
+        MarcInternationalStandardIdentifiers(record).loneElement
+      sourceId should have(
+        'identifierType(IdentifierType.ISBN),
+        'value("978-1-890159-02-3")
+      )
+    }
+    it("extracts ISSN from MARC 022") {
+      val record = MarcTestRecord(fields =
+        Seq(
+          MarcField(
+            "022",
+            subfields = Seq(MarcSubfield(tag = "a", content = "2153-3601"))
+          )
+        )
+      )
+      val sourceId: SourceIdentifier =
+        MarcInternationalStandardIdentifiers(record).loneElement
+      sourceId should have(
+        'identifierType(IdentifierType.ISSN),
+        'value("2153-3601")
+      )
+    }
+
+    it("strips whitespace") {
+      val record = MarcTestRecord(fields =
+        Seq(
+          MarcField(
+            "020",
+            subfields =
+              Seq(MarcSubfield(tag = "a", content = "   978-1-890159-02-3   "))
+          ),
+          MarcField(
+            "022",
+            subfields = Seq(MarcSubfield(tag = "a", content = "  2153-3601  "))
+          )
+        )
+      )
+      MarcInternationalStandardIdentifiers(record).map(
+        _.value
+      ) should contain theSameElementsAs Seq("978-1-890159-02-3", "2153-3601")
+
+    }
+
+    it("can extract multiple identifiers") {
+      info("both 020 and 022 are repeatable")
+      val record = MarcTestRecord(fields =
+        Seq(
+          MarcField(
+            "020",
+            subfields =
+              Seq(MarcSubfield(tag = "a", content = "   0870334336   "))
+          ),
+          MarcField(
+            "022",
+            subfields = Seq(MarcSubfield(tag = "a", content = "   0026-9662"))
+          ),
+          MarcField(
+            "020",
+            subfields =
+              Seq(MarcSubfield(tag = "a", content = "   978-1-890159-02-3   "))
+          ),
+          MarcField(
+            "022",
+            subfields = Seq(MarcSubfield(tag = "a", content = "2153-3601"))
+          )
+        )
+      )
+      MarcInternationalStandardIdentifiers(record).map(
+        _.value
+      ) should contain theSameElementsAs Seq(
+        "0870334336",
+        "0026-9662",
+        "978-1-890159-02-3",
+        "2153-3601"
+      )
+    }
+    it("deduplicates identifiers") {
+      info("both 020 and 022 are repeatable,")
+      info("but we don't want to extract the same ID multiple times")
+      val record = MarcTestRecord(fields =
+        Seq(
+          MarcField(
+            "020",
+            subfields =
+              Seq(MarcSubfield(tag = "a", content = "   9781960227966   "))
+          ),
+          MarcField(
+            "022",
+            subfields = Seq(MarcSubfield(tag = "a", content = "   0026-9662"))
+          ),
+          MarcField(
+            "020",
+            subfields = Seq(MarcSubfield(tag = "a", content = "9781960227966 "))
+          ),
+          MarcField(
+            "022",
+            subfields = Seq(MarcSubfield(tag = "a", content = "0026-9662"))
+          )
+        )
+      )
+      MarcInternationalStandardIdentifiers(record).map(
+        _.value
+      ) should contain theSameElementsAs Seq(
+        "9781960227966",
+        "0026-9662"
+      )
+    }
+
+    it("ignores cancelled identifiers in $z") {
+      val record = MarcTestRecord(fields =
+        Seq(
+          MarcField(
+            "020",
+            subfields = Seq(MarcSubfield(tag = "z", content = "No!"))
+          ),
+          MarcField(
+            "022",
+            subfields = Seq(MarcSubfield(tag = "a", content = "   0026-9662"))
+          ),
+          MarcField(
+            "020",
+            subfields = Seq(MarcSubfield(tag = "a", content = "9781960227966 "))
+          ),
+          MarcField(
+            "022",
+            subfields = Seq(
+              MarcSubfield(
+                tag = "z",
+                content = "For more information, please re-read"
+              )
+            )
+          )
+        )
+      )
+      MarcInternationalStandardIdentifiers(record).map(
+        _.value
+      ) should contain theSameElementsAs Seq(
+        "9781960227966",
+        "0026-9662"
+      )
+
+    }
+  }
+
+}

--- a/pipeline/transformer/transformer_marc_xml/src/main/scala/weco/pipeline/transformer/marc/xml/data/MarcXMLRecord.scala
+++ b/pipeline/transformer/transformer_marc_xml/src/main/scala/weco/pipeline/transformer/marc/xml/data/MarcXMLRecord.scala
@@ -44,7 +44,7 @@ case class MarcXMLRecord(recordElement: Node) extends MarcRecord {
   private def hasTag(values: String*)(node: Node) = {
     values.contains(node \@ "tag")
   }
-  
+
   private def hasCode(values: String*)(node: Node) = {
     values.contains(node \@ "code")
   }

--- a/pipeline/transformer/transformer_marc_xml/src/main/scala/weco/pipeline/transformer/marc/xml/data/MarcXMLRecord.scala
+++ b/pipeline/transformer/transformer_marc_xml/src/main/scala/weco/pipeline/transformer/marc/xml/data/MarcXMLRecord.scala
@@ -38,22 +38,20 @@ case class MarcXMLRecord(recordElement: Node) extends MarcRecord {
       case (tag, subfieldTag) =>
         (recordElement \ "datafield" filter hasTag(
           tag
-        )) \ "subfield" filter hasTag(subfieldTag) map (MarcXMLSubfield(_))
+        )) \ "subfield" filter hasCode(subfieldTag) map (MarcXMLSubfield(_))
     }
 
   private def hasTag(values: String*)(node: Node) = {
     values.contains(node \@ "tag")
   }
-  //  private def hasTagAndSubfieldTag(values: (String, String)*)(node: Node) = {
-  //    values.exists {
-  //      value =>
-  //        node \@ "tag" == value._1
-  //        node \ "subfield" \@ "tag" == value._2
-  //    }
-  //  }
+  
+  private def hasCode(values: String*)(node: Node) = {
+    values.contains(node \@ "code")
+  }
 
   override val fields: Seq[MarcField] =
-    recordElement \ "datafield" map MarcXMLDataField
+    recordElement \ "datafield" map (node => MarcXMLDataField(node))
 
-  override def subfieldsWithTag(tag: (String, String)): List[MarcSubfield] = Nil
+  override def subfieldsWithTag(tagPair: (String, String)): List[MarcSubfield] =
+    subfieldsWithTags(tagPair)
 }

--- a/pipeline/transformer/transformer_marc_xml/src/main/scala/weco/pipeline/transformer/marc/xml/data/MarcXMLRecord.scala
+++ b/pipeline/transformer/transformer_marc_xml/src/main/scala/weco/pipeline/transformer/marc/xml/data/MarcXMLRecord.scala
@@ -52,4 +52,8 @@ case class MarcXMLRecord(recordElement: Node) extends MarcRecord {
   //    }
   //  }
 
+  override val fields: Seq[MarcField] =
+    recordElement \ "datafield" map MarcXMLDataField
+
+  override def subfieldsWithTag(tag: (String, String)): List[MarcSubfield] = Nil
 }

--- a/pipeline/transformer/transformer_marc_xml/src/main/scala/weco/pipeline/transformer/marc/xml/transformers/MarcXMLRecordTransformer.scala
+++ b/pipeline/transformer/transformer_marc_xml/src/main/scala/weco/pipeline/transformer/marc/xml/transformers/MarcXMLRecordTransformer.scala
@@ -8,7 +8,10 @@ import weco.catalogue.internal_model.identifiers.{
 import weco.catalogue.internal_model.work.WorkState.Source
 import weco.catalogue.internal_model.work.{Work, WorkData}
 import weco.pipeline.transformer.marc.xml.data.MarcXMLRecord
-import weco.pipeline.transformer.marc_common.transformers.MarcTitle
+import weco.pipeline.transformer.marc_common.transformers.{
+  MarcInternationalStandardIdentifiers,
+  MarcTitle
+}
 
 import java.time.Instant
 
@@ -37,7 +40,8 @@ object MarcXMLRecordTransformer {
     record: MarcXMLRecord
   ): WorkData[DataState.Unidentified] = {
     WorkData[DataState.Unidentified](
-      title = MarcTitle(record)
+      title = MarcTitle(record),
+      otherIdentifiers = MarcInternationalStandardIdentifiers(record).toList
     )
   }
 }

--- a/pipeline/transformer/transformer_marc_xml/src/test/scala/weco/pipeline/transformer/marc/xml/transformers/MarcXMLRecordTransformerTest.scala
+++ b/pipeline/transformer/transformer_marc_xml/src/test/scala/weco/pipeline/transformer/marc/xml/transformers/MarcXMLRecordTransformerTest.scala
@@ -27,4 +27,28 @@ class MarcXMLRecordTransformerTest extends AnyFunSpec with Matchers {
       )
     }
   }
+  describe("a maximal XML record") {
+    val work = MarcXMLRecordTransformer(
+      MarcXMLRecord(
+        <record xmlns="http://www.loc.gov/MARC21/slim">
+          <controlfield tag="001">3PaDhRp</controlfield>
+          <datafield tag ="245">
+            <subfield code="a">matacologian</subfield>
+          </datafield>
+          <datafield tag ="020">
+            <subfield code="a">8601416781396</subfield>
+          </datafield>
+          <datafield tag ="022">
+            <subfield code="a">1477-4615</subfield>
+          </datafield>
+        </record>
+      )
+    )
+
+    it("extracts ISBN and ISSN") {
+      work.data.otherIdentifiers.map(
+        _.value
+      ) should contain theSameElementsAs Seq("8601416781396", "1477-4615")
+    }
+  }
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/data/BibDataAsMarcRecord.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/data/BibDataAsMarcRecord.scala
@@ -53,4 +53,12 @@ class BibDataAsMarcRecord(bibData: SierraBibData)
       .varfieldsWithTags(tags: _*)
       .map(SierraMarcDataConversions.varFieldToMarcField)
 
+  def subfieldsWithTags(tags: (String, String)*): List[MarcSubfield] =
+    tags.toList.flatMap {
+      case (tag, subfieldTag) =>
+        fieldsWithTags(tag).flatMap(_.subfields).filter(_.tag == subfieldTag)
+    }
+
+  override def subfieldsWithTag(tag: (String, String)): List[MarcSubfield] =
+    subfieldsWithTags(tag)
 }

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraIdentifiers.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraIdentifiers.scala
@@ -4,6 +4,9 @@ import weco.catalogue.internal_model.identifiers.{
   IdentifierType,
   SourceIdentifier
 }
+import weco.pipeline.transformer.marc_common.transformers.MarcInternationalStandardIdentifiers
+import weco.pipeline.transformer.sierra.data.SierraMarcDataConversions
+
 import weco.sierra.models.SierraQueryOps
 import weco.sierra.models.data.SierraBibData
 import weco.sierra.models.identifiers.SierraBibNumber
@@ -22,8 +25,9 @@ object SierraIdentifiers
     bibData: SierraBibData
   ): List[SourceIdentifier] =
     createSierraIdentifier(bibId) ++
-      getIsbnIdentifiers(bibData) ++
-      getIssnIdentifiers(bibData) ++
+      MarcInternationalStandardIdentifiers(
+        SierraMarcDataConversions.bibDataToMarcRecord(bibData)
+      ) ++
       getDigcodes(bibData) ++
       getIconographicNumbers(bibData) ++
       getEstcReferences(bibData)
@@ -43,49 +47,6 @@ object SierraIdentifiers
         value = bibId.withoutCheckDigit
       )
     )
-
-  /** Find ISBN (International Serial Book Number) identifiers from MARC 020 ǂa.
-    *
-    * This field is repeatable. See
-    * https://www.loc.gov/marc/bibliographic/bd020.html
-    */
-  private def getIsbnIdentifiers(
-    bibData: SierraBibData
-  ): List[SourceIdentifier] =
-    bibData
-      .subfieldsWithTag("020" -> "a")
-      .contents
-      .distinct
-      .map {
-        value =>
-          SourceIdentifier(
-            identifierType = IdentifierType.ISBN,
-            ontologyType = "Work",
-            value = value.trim
-          )
-      }
-
-  /** Find ISSN (International Standard Serial Number) identifiers from MARC 022
-    * ǂa.
-    *
-    * This field is repeatable. See
-    * https://www.loc.gov/marc/bibliographic/bd022.html
-    */
-  private def getIssnIdentifiers(
-    bibData: SierraBibData
-  ): List[SourceIdentifier] =
-    bibData
-      .subfieldsWithTag("022" -> "a")
-      .contents
-      .distinct
-      .map {
-        value =>
-          SourceIdentifier(
-            identifierType = IdentifierType.ISSN,
-            ontologyType = "Work",
-            value = value.trim
-          )
-      }
 
   /** Find the digcodes from MARC 759 ǂa.
     *


### PR DESCRIPTION
## What does this change?

Part of https://github.com/wellcomecollection/catalogue-pipeline/issues/2563

This extracts the common SourceIdentifier code from Sierra into marc.common


