### PR TITLE
Marc description

### DIFF
--- a/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/models/MarcFieldOps.scala
+++ b/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/models/MarcFieldOps.scala
@@ -1,0 +1,18 @@
+package weco.pipeline.transformer.marc_common.models
+
+import scala.util.{Failure, Success, Try}
+
+trait MarcFieldOps {
+  implicit class FieldOps(field: MarcField) {
+
+    def onlySubfieldWith(tag: String): Try[Option[MarcSubfield]] = {
+      field.subfields.filter(_.tag == tag) match {
+        case Seq(subfield) => Success(Some(subfield))
+        case Nil           => Success(None)
+        case _ =>
+          Failure(new Exception(s"found multiple non-repeating subfield $tag"))
+      }
+    }
+
+  }
+}

--- a/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcDescription.scala
+++ b/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcDescription.scala
@@ -1,0 +1,67 @@
+package weco.pipeline.transformer.marc_common.transformers
+import grizzled.slf4j.Logging
+import weco.pipeline.transformer.exceptions.ShouldNotTransformException
+import weco.pipeline.transformer.marc_common.logging.LoggingContext
+import weco.pipeline.transformer.marc_common.models.{
+  MarcField,
+  MarcFieldOps,
+  MarcRecord
+}
+
+import java.net.URL
+import scala.util.{Failure, Success, Try}
+
+object MarcDescription
+    extends MarcDataTransformerWithLoggingContext
+    with MarcFieldOps
+    with Logging {
+
+  override type Output = Option[String]
+
+  override def apply(record: MarcRecord)(
+    implicit ctx: LoggingContext
+  ): Option[String] = {
+    val description =
+      record.fieldsWithTags("520").map(descriptionFromField).mkString("\n")
+    if (description.nonEmpty) Some(description) else None
+  }
+
+  private def descriptionFromField(field: MarcField)(
+    implicit ctx: LoggingContext
+  ): String = {
+    Seq("a", "b", "c")
+      .flatMap {
+        tag: String =>
+          field.onlySubfieldWith(tag) match {
+            case Failure(exception) =>
+              throw new ShouldNotTransformException(exception.getMessage)
+            case Success(subfield) => subfield
+          }
+      }
+      .map(_.content.trim) ++ field.subfields
+      .filter(_.tag == "u")
+      .map(subfield => makeLink(subfield.content.trim)) match {
+      case Nil     => ""
+      case strings => s"<p>${strings.mkString(" ")}</p>"
+    }
+  }
+
+  private def makeLink(maybeURL: String)(
+    implicit ctx: LoggingContext
+  ): String =
+    if (isUrl(maybeURL))
+      s"""<a href="$maybeURL">$maybeURL</a>"""
+    else {
+      // The spec says that MARC 520 ǂu is "Uniform Resource Identifier", which
+      // isn't the same as being a URL.  We don't want to make non-URL text
+      // clickable; we're also not sure what the data that isn't a URL looks like.
+      //
+      // For now, log the value and don't make it clickable -- we can decide how
+      // best to handle it later.
+      warn(ctx(s"has MARC 520 ǂu which doesn't look like a URL: $maybeURL"))
+      maybeURL
+    }
+
+  private def isUrl(s: String): Boolean =
+    Try { new URL(s) }.isSuccess
+}

--- a/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcDescription.scala
+++ b/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcDescription.scala
@@ -11,6 +11,24 @@ import weco.pipeline.transformer.marc_common.models.{
 import java.net.URL
 import scala.util.{Failure, Success, Try}
 
+// Populate wwork:description.
+//
+// We use MARC field "520".  Rules:
+//
+//  - Join 520 ǂa, ǂb, ǂc and ǂu with a space
+//  - If the ǂu looks like a URL, we wrap it in <a> tags with the URL as the
+//    link text
+//  - Wrap resulting string in <p> tags
+//  - Join each occurrence of 520 into description
+//
+// Notes:
+//  - Both ǂa (summary) and ǂb (expansion of summary note) are
+//    non-repeatable subfields.  ǂu (Uniform Resource Identifier)
+//    is repeatable.
+//  - We never expect to see a record with $b but not $a.
+//
+// https://www.loc.gov/marc/bibliographic/bd520.html
+//
 object MarcDescription
     extends MarcDataTransformerWithLoggingContext
     with MarcFieldOps

--- a/pipeline/transformer/transformer_marc_common/src/test/scala/weco/pipeline/transformer/marc_common/transformers/MarcDescriptionTest.scala
+++ b/pipeline/transformer/transformer_marc_common/src/test/scala/weco/pipeline/transformer/marc_common/transformers/MarcDescriptionTest.scala
@@ -1,0 +1,212 @@
+package weco.pipeline.transformer.marc_common.transformers
+
+import org.scalatest.LoneElement
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import weco.pipeline.transformer.exceptions.ShouldNotTransformException
+import weco.pipeline.transformer.marc_common.generators.MarcTestRecord
+import weco.pipeline.transformer.marc_common.logging.LoggingContext
+import weco.pipeline.transformer.marc_common.models.{MarcField, MarcSubfield}
+import org.scalatest.prop.TableDrivenPropertyChecks._
+
+class MarcDescriptionTest extends AnyFunSpec with Matchers with LoneElement {
+  private implicit val ctx: LoggingContext = LoggingContext("")
+
+  describe("Extracting a description from MARC 520") {
+    info("https://www.loc.gov/marc/bibliographic/bd520.html")
+    describe("returning nothing") {
+      it("returns None if the record does not contain MARC 520") {
+        MarcDescription(MarcTestRecord(fields = Nil)) shouldBe None
+      }
+
+      it("returns None if no 520 fields contain subfields a, b, c, or u") {
+        MarcDescription(
+          MarcTestRecord(fields =
+            Seq(
+              MarcField(
+                marcTag = "520",
+                subfields = Seq(MarcSubfield("7", "not me!"))
+              )
+            )
+          )
+        ) shouldBe None
+
+      }
+      describe(
+        "non-repeating subfields"
+      ) {
+        info("a, b and c are all non-repeating")
+
+        forAll(
+          Table(
+            "subfieldCode",
+            "a",
+            "b",
+            "c"
+          )
+        ) {
+          subfieldCode =>
+            it(
+              s"throws when a 520 field has multiple ǂ$subfieldCode subfields"
+            ) {
+              // AFAICS, there are no existing records with illegal repeating subfields
+              assertThrows[ShouldNotTransformException] {
+                MarcDescription(
+                  MarcTestRecord(fields =
+                    Seq(
+                      MarcField(
+                        marcTag = "520",
+                        subfields = Seq(
+                          MarcSubfield(subfieldCode, "Cyntaf"),
+                          MarcSubfield(subfieldCode, "Ail")
+                        )
+                      )
+                    )
+                  )
+                )
+              }
+            }
+        }
+      }
+    }
+    describe("returning descriptions") {
+      info(
+        "each 520 field corresponds to one paragraph of the whole description"
+      )
+      info("each paragraph is marked up as an HTML <p> element")
+      it("returns a description from 520ǂa on its own") {
+        MarcDescription(
+          MarcTestRecord(fields =
+            Seq(
+              MarcField(
+                marcTag = "520",
+                subfields = Seq(
+                  MarcSubfield(
+                    "a",
+                    "Descriptions..are definitions of a more lax and fanciful kind."
+                  )
+                )
+              )
+            )
+          )
+        ).get shouldBe "<p>Descriptions..are definitions of a more lax and fanciful kind.</p>"
+      }
+
+      it("concatenates subfields a,b,c,u") {
+        MarcDescription(
+          MarcTestRecord(fields =
+            Seq(
+              MarcField(
+                marcTag = "520",
+                subfields = Seq(
+                  MarcSubfield(
+                    "a",
+                    "As there is a fine name, now-a-days, for every thing,"
+                  ),
+                  MarcSubfield(
+                    "b",
+                    "I suppose that ‘Hygeist’ is the polite description of quack doctor."
+                  ),
+                  MarcSubfield("c", "London Magazine, 1826"),
+                  MarcSubfield("u", "http://example.com/")
+                )
+              )
+            )
+          )
+        ).get shouldBe "<p>As there is a fine name, now-a-days, for every thing, I suppose that ‘Hygeist’ is the polite description of quack doctor. London Magazine, 1826 <a href=\"http://example.com/\">http://example.com/</a></p>"
+      }
+
+      it("forces the order of subfields to be a,b,c,u") {
+        MarcDescription(
+          MarcTestRecord(fields =
+            Seq(
+              MarcField(
+                marcTag = "520",
+                subfields = Seq(
+                  MarcSubfield("u", "http://example.com/"),
+                  MarcSubfield(
+                    "b",
+                    "I suppose that ‘Hygeist’ is the polite description of quack doctor."
+                  ),
+                  MarcSubfield(
+                    "a",
+                    "As there is a fine name, now-a-days, for every thing,"
+                  ),
+                  MarcSubfield("c", "London Magazine, 1826")
+                )
+              )
+            )
+          )
+        ).get shouldBe "<p>As there is a fine name, now-a-days, for every thing, I suppose that ‘Hygeist’ is the polite description of quack doctor. London Magazine, 1826 <a href=\"http://example.com/\">http://example.com/</a></p>"
+      }
+
+      it("concatenates multiple 520ǂu subfields") {
+        MarcDescription(
+          MarcTestRecord(fields =
+            Seq(
+              MarcField(
+                marcTag = "520",
+                subfields = Seq(
+                  MarcSubfield(
+                    "a",
+                    "For her owne person, It beggerd all discription."
+                  ),
+                  MarcSubfield("u", "http://example.com/6347939"),
+                  MarcSubfield("u", "http://example.com/5877688")
+                )
+              )
+            )
+          )
+        ).get shouldBe "<p>For her owne person, It beggerd all discription. <a href=\"http://example.com/6347939\">http://example.com/6347939</a> <a href=\"http://example.com/5877688\">http://example.com/5877688</a></p>"
+      }
+
+      it("trims superfluous whitespace surrounding the description") {
+        MarcDescription(
+          MarcTestRecord(fields =
+            Seq(
+              MarcField(
+                marcTag = "520",
+                subfields = Seq(
+                  MarcSubfield(
+                    "a",
+                    "\t   Shapen in maner of a lop-webbe aftur the olde descripcioun.   "
+                  )
+                )
+              )
+            )
+          )
+        ).get shouldBe "<p>Shapen in maner of a lop-webbe aftur the olde descripcioun.</p>"
+      }
+      it(
+        "concatenates multiple 520 fields into one string"
+      ) {
+        MarcDescription(
+          MarcTestRecord(fields =
+            Seq(
+              MarcField(
+                marcTag = "520",
+                subfields = Seq(
+                  MarcSubfield(
+                    "a",
+                    "This place perfectly answers the Description of the Elysian fields"
+                  )
+                )
+              ),
+              MarcField(
+                marcTag = "520",
+                subfields = Seq(
+                  MarcSubfield(
+                    "a",
+                    "Wherein also we have interspersed, under the several heads of villains, such descriptions and cautions as may better serve to promote this good end."
+                  )
+                )
+              )
+            )
+          )
+        ).get shouldBe "<p>This place perfectly answers the Description of the Elysian fields</p>" +
+          "\n<p>Wherein also we have interspersed, under the several heads of villains, such descriptions and cautions as may better serve to promote this good end.</p>"
+      }
+
+    }
+  }
+}

--- a/pipeline/transformer/transformer_marc_xml/src/main/scala/weco/pipeline/transformer/marc/xml/transformers/MarcXMLRecordTransformer.scala
+++ b/pipeline/transformer/transformer_marc_xml/src/main/scala/weco/pipeline/transformer/marc/xml/transformers/MarcXMLRecordTransformer.scala
@@ -10,6 +10,7 @@ import weco.catalogue.internal_model.work.{Work, WorkData}
 import weco.pipeline.transformer.marc.xml.data.MarcXMLRecord
 import weco.pipeline.transformer.marc_common.logging.LoggingContext
 import weco.pipeline.transformer.marc_common.transformers.{
+  MarcDescription,
   MarcDesignation,
   MarcEdition,
   MarcElectronicResources,
@@ -52,6 +53,7 @@ object MarcXMLRecordTransformer {
       title = MarcTitle(record),
       otherIdentifiers = MarcInternationalStandardIdentifiers(record).toList,
       designation = MarcDesignation(record).toList,
+      description = MarcDescription(record),
       edition = MarcEdition(record),
       items = MarcElectronicResources(record).toList
     )

--- a/pipeline/transformer/transformer_marc_xml/src/test/scala/weco/pipeline/transformer/marc/xml/transformers/MarcXMLRecordTransformerTest.scala
+++ b/pipeline/transformer/transformer_marc_xml/src/test/scala/weco/pipeline/transformer/marc/xml/transformers/MarcXMLRecordTransformerTest.scala
@@ -52,6 +52,9 @@ class MarcXMLRecordTransformerTest
           <datafield tag ="362">
             <subfield code="a">NX-326</subfield>
           </datafield>
+          <datafield tag ="520">
+            <subfield code="a">Some of them [sc. physicians] I know are ignorant beyond Description.</subfield>
+          </datafield>
           <datafield tag ="856">
             <subfield code="y">Hampster Dance</subfield>
             <subfield code="u">https://example.com/hampsterdance</subfield>
@@ -69,8 +72,13 @@ class MarcXMLRecordTransformerTest
     it("extracts the edition statement") {
       work.data.edition.get shouldBe "Director's cut"
     }
+
     it("extracts the designation") {
       work.data.designation.loneElement shouldBe "NX-326"
+    }
+
+    it("extracts a description") {
+      work.data.description.get shouldBe "<p>Some of them [sc. physicians] I know are ignorant beyond Description.</p>"
     }
 
     it("extracts an electronic resource") {

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraDescription.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/transformers/SierraDescription.scala
@@ -1,85 +1,20 @@
 package weco.pipeline.transformer.sierra.transformers
 
-import grizzled.slf4j.Logging
+import weco.pipeline.transformer.marc_common.logging.LoggingContext
+import weco.pipeline.transformer.marc_common.transformers.MarcDescription
+import weco.pipeline.transformer.sierra.data.SierraMarcDataConversions
 
-import java.net.URL
-import weco.sierra.models.SierraQueryOps
 import weco.sierra.models.data.SierraBibData
 import weco.sierra.models.identifiers.SierraBibNumber
-import weco.sierra.models.marc.{Subfield, VarField}
-
-import scala.util.Try
 
 object SierraDescription
     extends SierraIdentifiedDataTransformer
-    with SierraQueryOps
-    with Logging {
+    with SierraMarcDataConversions {
 
   type Output = Option[String]
 
-  // Populate wwork:description.
-  //
-  // We use MARC field "520".  Rules:
-  //
-  //  - Join 520 ǂa, ǂb, ǂc and ǂu with a space
-  //  - If the ǂu looks like a URL, we wrap it in <a> tags with the URL as the
-  //    link text
-  //  - Wrap resulting string in <p> tags
-  //  - Join each occurrence of 520 into description
-  //
-  // Notes:
-  //  - Both ǂa (summary) and ǂb (expansion of summary note) are
-  //    non-repeatable subfields.  ǂu (Uniform Resource Identifier)
-  //    is repeatable.
-  //  - We never expect to see a record with $b but not $a.
-  //
-  // https://www.loc.gov/marc/bibliographic/bd520.html
-  //
   def apply(bibId: SierraBibNumber, bibData: SierraBibData): Option[String] = {
-    val description = bibData
-      .varfieldsWithTag("520")
-      .map { descriptionFromVarfield(bibId, _) }
-      .mkString("\n")
-
-    if (description.nonEmpty) Some(description) else None
+    implicit val ctx: LoggingContext = LoggingContext(bibId.withCheckDigit)
+    MarcDescription(bibData)
   }
-
-  private def descriptionFromVarfield(
-    bibId: SierraBibNumber,
-    vf: VarField
-  ): String = {
-    val subfields =
-      Seq(
-        vf.nonrepeatableSubfieldWithTag(tag = "a"),
-        vf.nonrepeatableSubfieldWithTag(tag = "b"),
-        vf.nonrepeatableSubfieldWithTag(tag = "c")
-      ).flatten ++ vf.subfieldsWithTag("u")
-
-    val contents =
-      subfields
-        .map {
-          case Subfield("u", contents) if isUrl(contents) =>
-            s"""<a href="$contents">$contents</a>"""
-
-          // The spec says that MARC 520 ǂu is "Uniform Resource Identifier", which
-          // isn't the same as being a URL.  We don't want to make non-URL text
-          // clickable; we're also not sure what the data that isn't a URL looks like.
-          //
-          // For now, log the value and don't make it clickable -- we can decide how
-          // best to handle it later.
-          case Subfield("u", contents) =>
-            warn(
-              s"${bibId.withCheckDigit} has MARC 520 ǂu which doesn't look like a URL: $contents"
-            )
-            contents
-
-          case Subfield(_, contents) => contents
-        }
-        .mkString(" ")
-
-    s"<p>$contents</p>"
-  }
-
-  private def isUrl(s: String): Boolean =
-    Try { new URL(s) }.isSuccess
 }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraDescriptionTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraDescriptionTest.scala
@@ -83,13 +83,15 @@ class SierraDescriptionTest
             Subfield(
               tag = "a",
               content =
-                "\"This book is about the ethics of nursing and midwifery\""),
+                "\"This book is about the ethics of nursing and midwifery\""
+            ),
             Subfield(tag = "c", content = "Provided by publisher.")
           )
         )
       ),
       expectedDescription = Some(
-        "<p>\"This book is about the ethics of nursing and midwifery\" Provided by publisher.</p>")
+        "<p>\"This book is about the ethics of nursing and midwifery\" Provided by publisher.</p>"
+      )
     )
   }
 
@@ -142,7 +144,8 @@ class SierraDescriptionTest
     }
 
     it(
-      "does not wrap the contents of ǂu in <a> tags if it doesn't look like a URL") {
+      "does not wrap the contents of ǂu in <a> tags if it doesn't look like a URL"
+    ) {
       val url1 = "https://fruitpicking.org/"
       val uContents = "A website about fruitpicking"
 


### PR DESCRIPTION
## What does this change?

Part of https://github.com/wellcomecollection/catalogue-pipeline/issues/2563

Implements a common MARC description transformer

## Have we considered potential risks?

As with Designation, this now rejects documents with malformed 520 fields.  I have searched in reporting, and I don't believe there are any existing documents that would be rejected for this violation.
