### PR TITLE
Send the Scala dependency graph

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -1,0 +1,23 @@
+# .github/workflows/dependency-graph.yml
+name: Update Dependency Graph
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependency-graph:
+    name: Update Dependency Graph
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: eu-west-1
+          role-to-assume: ${{ secrets.WECO_GHAWS_ROLE_ARN }}
+      - uses: scalacenter/sbt-dependency-submission@v2

--- a/build.sbt
+++ b/build.sbt
@@ -348,7 +348,7 @@ lazy val tei_adapter = setupProject(
 s3CredentialsProvider := {
   _ =>
     val builder = new STSAssumeRoleSessionCredentialsProvider.Builder(
-      "arn:aws:iam::760097843905:role/platform-ci",
+      "arn:aws:iam::760097843905:role/terraform-20210811133135108800000001",
       UUID.randomUUID().toString
     )
     builder.build()


### PR DESCRIPTION
## What does this change?

Follows https://github.com/wellcomecollection/catalogue-api/pull/766 this change pushes the scala dependency graph to the GitHub API to surface vulnerabilities.

We don't need access to S3 as with other similar pull requests as we're not pulling our own deps (we build them here).

Part of https://github.com/wellcomecollection/platform-infrastructure/issues/431

Depends on https://github.com/wellcomecollection/aws-account-infrastructure/pull/19

## How to test

- [ ] Does the build go green, can we see the dep graph after merging?

## How can we measure success?

Visibility on dependencies and vulnerabilities. 

## Have we considered potential risks?

This change should help manage / reduce risk.