### PR TITLE
Use known compatible version of urllib3

### DIFF
--- a/calm_adapter/calm_deletion_check_initiator/src/requirements.txt
+++ b/calm_adapter/calm_deletion_check_initiator/src/requirements.txt
@@ -24,5 +24,5 @@ six==1.16.0
     # via python-dateutil
 tqdm==4.66.2
     # via -r requirements.in
-urllib3==2.0.7
+urllib3==1.26.18
     # via botocore


### PR DESCRIPTION
## What does this change?

This PR attempts to fix a [build failure](https://buildkite.com/wellcomecollection/catalogue-pipeline/builds/8577#018e7631-b3fb-4752-a217-09711802edce/135-172) caused by conflicting Python dependencies.

The `calm_window_generator` uses a different version of `urllib3` while also using the same version of `boto3` and it does build successfully. Try using the same version in `calm_deletion_checker` and hope it will still pass tests (and subsequently build).

## How to test

- [ ] Do the test tasks go green?
- [ ] Does the `calm_deletion_checker`  build properly after merge?

## How can we measure success?

The build actually works.