### PR TITLE
Actually publish lambda zip for EBSCO daapter

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -150,6 +150,7 @@ steps:
     matrix:
       - "calm_adapter/calm_window_generator"
       - "calm_adapter/calm_deletion_check_initiator"
+      - "ebsco_adapter/ebsco_adapter"
       - "common/window_generator"
       - "tei_adapter/tei_updater"
 


### PR DESCRIPTION
## What does this change?

Adds the EBSCO lambda publish step to the build

## How to test

Merge this and ensure that the zip file for this lambda is actually updated.

## How can we measure success?

A deployable adapter for EBSCO source data.