### PR TITLE
EBSCO adapter message sending fix

### DIFF
--- a/ebsco_adapter/ebsco_adapter/src/sns_publisher.py
+++ b/ebsco_adapter/ebsco_adapter/src/sns_publisher.py
@@ -32,15 +32,14 @@ class SnsPublisher:
                     }
                 )
 
-                response = self.sns_client.publish_batch(
-                    TopicArn=self.sns_topic_arn,
-                    PublishBatchRequestEntries=batched_requests,
-                )
+            response = self.sns_client.publish_batch(
+                TopicArn=self.sns_topic_arn,
+                PublishBatchRequestEntries=batched_requests,
+            )
 
-                if "Failed" in response and len(response["Failed"]) > 0:
-                    print(response)
-                    raise ValueError(
-                        f"Failed to publish messages: {response['Failed']}"
-                    )
+            if "Failed" in response and len(response["Failed"]) > 0:
+                raise ValueError(
+                    f"Failed to publish messages: {response['Failed']}"
+                )
 
         print(f"Published {len(messages)} messages in {len(batches)} batches.")

--- a/ebsco_adapter/ebsco_adapter/src/sns_publisher.py
+++ b/ebsco_adapter/ebsco_adapter/src/sns_publisher.py
@@ -38,8 +38,6 @@ class SnsPublisher:
             )
 
             if "Failed" in response and len(response["Failed"]) > 0:
-                raise ValueError(
-                    f"Failed to publish messages: {response['Failed']}"
-                )
+                raise ValueError(f"Failed to publish messages: {response['Failed']}")
 
         print(f"Published {len(messages)} messages in {len(batches)} batches.")

--- a/ebsco_adapter/ebsco_adapter/src/test_fixtures.py
+++ b/ebsco_adapter/ebsco_adapter/src/test_fixtures.py
@@ -1,4 +1,33 @@
+import json
 import os
+
+
+class FakeSnsClient:
+
+    def __init__(self):
+        self.published_messages = []
+
+    def test_get_published_messages(self):
+        return self.published_messages
+
+    def publish_batch(self, TopicArn, PublishBatchRequestEntries):
+        success_response = {
+            "Id": "string",
+            "MessageId": "string",
+            "MD5OfMessageBody": "string",
+            "MD5OfMessageAttributes": "string",
+            "SequenceNumber": "string",
+        }
+
+        for entry in PublishBatchRequestEntries:
+            self.published_messages.append(json.loads(entry["Message"]))
+
+        success_responses = [success_response for _ in PublishBatchRequestEntries]
+
+        return {
+            "Successful": success_responses,
+            "Failed": []
+        }
 
 
 class FakeEbscoFtp:

--- a/ebsco_adapter/ebsco_adapter/src/test_fixtures.py
+++ b/ebsco_adapter/ebsco_adapter/src/test_fixtures.py
@@ -3,7 +3,6 @@ import os
 
 
 class FakeSnsClient:
-
     def __init__(self):
         self.published_messages = []
 
@@ -24,10 +23,7 @@ class FakeSnsClient:
 
         success_responses = [success_response for _ in PublishBatchRequestEntries]
 
-        return {
-            "Successful": success_responses,
-            "Failed": []
-        }
+        return {"Successful": success_responses, "Failed": []}
 
 
 class FakeEbscoFtp:

--- a/ebsco_adapter/ebsco_adapter/src/test_update_notifier.py
+++ b/ebsco_adapter/ebsco_adapter/src/test_update_notifier.py
@@ -1,0 +1,63 @@
+from update_notifier import update_notifier
+from test_fixtures import FakeS3Client, FakeSnsClient
+from s3_store import S3Store
+from sns_publisher import SnsPublisher
+
+
+def test_update_notifier():
+    s3_bucket = "test_bucket"
+    xml_s3_prefix = "test_prefix"
+    topic_arn = "test_topic_arn"
+    notify_for_batch = "test_batch"
+
+    fake_s3_client = FakeS3Client()
+    fake_sns_client = FakeSnsClient()
+
+    sns_publisher = SnsPublisher(topic_arn, fake_sns_client)
+    s3_store = S3Store(s3_bucket, fake_s3_client)
+
+    number_of_updates = 100
+    number_of_deleted = 50
+
+    updates = {
+        "updated": {
+            f"update-{i}": {
+                "s3_key": f"test_prefix/update-{i}.xml",
+                "sha256": "test_sha256",
+            } for i in range(number_of_updates)
+        },
+        "deleted": [f"delete-{i}" for i in range(number_of_deleted)]
+    }
+
+    expected_update_messages = [
+        {
+            "id": f"update-{i}",
+            "location": {
+                "bucket": s3_bucket,
+                "key": f"test_prefix/update-{i}.xml",
+            },
+            "version": 1,
+            "deleted": False,
+            "sha256": "test_sha256",
+        } for i in range(number_of_updates)
+    ]
+
+    expected_deleted_messages = [
+        {
+            "id": f"delete-{i}",
+            "location": None,
+            "version": 1,
+            "deleted": True,
+            "sha256": None,
+        } for i in range(number_of_deleted)
+    ]
+
+    expected_messages = expected_update_messages + expected_deleted_messages
+
+    update_notifier(updates, notify_for_batch, s3_store, s3_bucket, xml_s3_prefix, sns_publisher)
+    published_messages = fake_sns_client.test_get_published_messages()
+
+    assert len(published_messages) == number_of_updates + number_of_deleted, \
+        f"Expected {number_of_updates} update messages to be published, but got {len(published_messages)}"
+
+    assert published_messages == expected_messages

--- a/ebsco_adapter/ebsco_adapter/src/test_update_notifier.py
+++ b/ebsco_adapter/ebsco_adapter/src/test_update_notifier.py
@@ -24,9 +24,10 @@ def test_update_notifier():
             f"update-{i}": {
                 "s3_key": f"test_prefix/update-{i}.xml",
                 "sha256": "test_sha256",
-            } for i in range(number_of_updates)
+            }
+            for i in range(number_of_updates)
         },
-        "deleted": [f"delete-{i}" for i in range(number_of_deleted)]
+        "deleted": [f"delete-{i}" for i in range(number_of_deleted)],
     }
 
     expected_update_messages = [
@@ -39,7 +40,8 @@ def test_update_notifier():
             "version": 1,
             "deleted": False,
             "sha256": "test_sha256",
-        } for i in range(number_of_updates)
+        }
+        for i in range(number_of_updates)
     ]
 
     expected_deleted_messages = [
@@ -49,15 +51,19 @@ def test_update_notifier():
             "version": 1,
             "deleted": True,
             "sha256": None,
-        } for i in range(number_of_deleted)
+        }
+        for i in range(number_of_deleted)
     ]
 
     expected_messages = expected_update_messages + expected_deleted_messages
 
-    update_notifier(updates, notify_for_batch, s3_store, s3_bucket, xml_s3_prefix, sns_publisher)
+    update_notifier(
+        updates, notify_for_batch, s3_store, s3_bucket, xml_s3_prefix, sns_publisher
+    )
     published_messages = fake_sns_client.test_get_published_messages()
 
-    assert len(published_messages) == number_of_updates + number_of_deleted, \
-        f"Expected {number_of_updates} update messages to be published, but got {len(published_messages)}"
+    assert (
+        len(published_messages) == number_of_updates + number_of_deleted
+    ), f"Expected {number_of_updates} update messages to be published, but got {len(published_messages)}"
 
     assert published_messages == expected_messages

--- a/ebsco_adapter/ebsco_adapter/src/update_notifier.py
+++ b/ebsco_adapter/ebsco_adapter/src/update_notifier.py
@@ -7,30 +7,32 @@ def update_notifier(
     update_messages = []
     deleted_messages = []
 
-    for update_id, update in dict(updates["updated"]).items():
-        update_messages.append(
-            {
-                "id": update_id,
-                "location": {
-                    "bucket": s3_bucket,
-                    "key": update["s3_key"],
-                },
-                "version": 1,
-                "deleted": False,
-                "sha256": update["sha256"],
-            }
-        )
+    if updates["updated"] is not None:
+        for update_id, update in dict(updates["updated"]).items():
+            update_messages.append(
+                {
+                    "id": update_id,
+                    "location": {
+                        "bucket": s3_bucket,
+                        "key": update["s3_key"],
+                    },
+                    "version": 1,
+                    "deleted": False,
+                    "sha256": update["sha256"],
+                }
+            )
 
-    for delete_id in updates["deleted"]:
-        deleted_messages.append(
-            {
-                "id": delete_id,
-                "location": None,
-                "version": 1,
-                "deleted": True,
-                "sha256": None,
-            }
-        )
+    if updates["deleted"] is not None:
+        for delete_id in updates["deleted"]:
+            deleted_messages.append(
+                {
+                    "id": delete_id,
+                    "location": None,
+                    "version": 1,
+                    "deleted": True,
+                    "sha256": None,
+                }
+            )
 
     print(
         f"Sending {len(update_messages)} update messages and {len(deleted_messages)} delete messages."


### PR DESCRIPTION
## What does this change?

This change adds a test for the `update_notifier` and fixes a bug where we were sending too many messages due to an indentation error around a loop.
 
## How to test

- [x] Run the tests, do they pass?
- [x] Run this in production, does it send the expected number of messages?

## How can we measure success?

A functioning adapter sending the expected number of messages.