### PR TITLE
Send version as iso8601 date converted to int

### DIFF
--- a/ebsco_adapter/ebsco_adapter/src/test_update_notifier.py
+++ b/ebsco_adapter/ebsco_adapter/src/test_update_notifier.py
@@ -8,7 +8,7 @@ def test_update_notifier():
     s3_bucket = "test_bucket"
     xml_s3_prefix = "test_prefix"
     topic_arn = "test_topic_arn"
-    notify_for_batch = "test_batch"
+    notify_for_batch = "2023-01-01"
 
     fake_s3_client = FakeS3Client()
     fake_sns_client = FakeSnsClient()
@@ -37,7 +37,7 @@ def test_update_notifier():
                 "bucket": s3_bucket,
                 "key": f"test_prefix/update-{i}.xml",
             },
-            "version": 1,
+            "version": 20230101,
             "deleted": False,
             "sha256": "test_sha256",
         }
@@ -48,7 +48,7 @@ def test_update_notifier():
         {
             "id": f"delete-{i}",
             "location": None,
-            "version": 1,
+            "version": 20230101,
             "deleted": True,
             "sha256": None,
         }

--- a/ebsco_adapter/ebsco_adapter/src/update_notifier.py
+++ b/ebsco_adapter/ebsco_adapter/src/update_notifier.py
@@ -7,6 +7,8 @@ def update_notifier(
     update_messages = []
     deleted_messages = []
 
+    version = int("".join(filter(str.isdigit, notify_for_batch)))
+
     if updates["updated"] is not None:
         for update_id, update in dict(updates["updated"]).items():
             update_messages.append(
@@ -16,7 +18,7 @@ def update_notifier(
                         "bucket": s3_bucket,
                         "key": update["s3_key"],
                     },
-                    "version": 1,
+                    "version": version,
                     "deleted": False,
                     "sha256": update["sha256"],
                 }
@@ -28,7 +30,7 @@ def update_notifier(
                 {
                     "id": delete_id,
                     "location": None,
-                    "version": 1,
+                    "version": version,
                     "deleted": True,
                     "sha256": None,
                 }


### PR DESCRIPTION
## What does this change?

This changes the version to be the iso8601 date converted to an int, this should meet the requirements of a version identifier required by the pipeline (always incrementing, one per item updated per window) but not require storing any additional state.

## How to test

- [x] Run the tests?
- [ ] Deploy this change, does the transformer parse the version?

## How can we measure success?

We are able to satisfy the pipeline requirement for a version id without more complicated state management.