### PR TITLE
Wire up EBSCO transformer

### DIFF
--- a/common/source_model/src/main/scala/weco/catalogue/source_model/ebsco/EbscoSourceData.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/ebsco/EbscoSourceData.scala
@@ -2,9 +2,7 @@ package weco.catalogue.source_model.ebsco
 
 import weco.storage.providers.s3.S3ObjectLocation
 
-sealed trait EbscoSourceData {
-  val version: Int
-}
-case class EbscoChangedSourceData(s3Location: S3ObjectLocation, version: Int)
+sealed trait EbscoSourceData {}
+case class EbscoUpdatedSourceData(s3Location: S3ObjectLocation)
     extends EbscoSourceData
-case class EbscoDeletedSourceData(version: Int) extends EbscoSourceData
+case object EbscoDeletedSourceData extends EbscoSourceData

--- a/pipeline/terraform/modules/stack/service_transformers.tf
+++ b/pipeline/terraform/modules/stack/service_transformers.tf
@@ -51,7 +51,14 @@ locals {
   }
 
   transformer_output_topic_arns = [
-    for k, v in module.transformers : v.output_topic_arn
+    # Temporarily remove the Ebsco transformer output topic
+    # In order to experiment with the new transformer
+    module.transformers["mets"].output_topic_arn,
+    module.transformers["calm"].output_topic_arn,
+    module.transformers["sierra"].output_topic_arn,
+    module.transformers["tei"].output_topic_arn,
+    module.transformers["miro"].output_topic_arn,
+    # for k, v in module.transformers : v.output_topic_arn
   ]
 }
 

--- a/pipeline/transformer/transformer_ebsco/src/main/scala/weco/pipeline/transformer/ebsco/EbscoTransformer.scala
+++ b/pipeline/transformer/transformer_ebsco/src/main/scala/weco/pipeline/transformer/ebsco/EbscoTransformer.scala
@@ -1,9 +1,16 @@
 package weco.pipeline.transformer.ebsco
 
-import weco.catalogue.internal_model.identifiers.{IdentifierType, SourceIdentifier}
+import weco.catalogue.internal_model.identifiers.{
+  IdentifierType,
+  SourceIdentifier
+}
 import weco.catalogue.internal_model.work.WorkState.Source
 import weco.catalogue.internal_model.work.{DeletedReason, Work, WorkState}
-import weco.catalogue.source_model.ebsco.{EbscoDeletedSourceData, EbscoSourceData, EbscoUpdatedSourceData}
+import weco.catalogue.source_model.ebsco.{
+  EbscoDeletedSourceData,
+  EbscoSourceData,
+  EbscoUpdatedSourceData
+}
 import weco.pipeline.transformer.Transformer
 import weco.pipeline.transformer.marc.xml.data.MarcXMLRecord
 import weco.pipeline.transformer.marc.xml.transformers.MarcXMLRecordTransformer
@@ -15,7 +22,6 @@ import weco.storage.store.Readable
 import java.time.Instant
 import scala.util.Try
 import scala.xml.XML
-
 
 class EbscoTransformer(store: Readable[S3ObjectLocation, String])
     extends Transformer[EbscoSourceData] {
@@ -36,8 +42,12 @@ class EbscoTransformer(store: Readable[S3ObjectLocation, String])
           Work.Deleted[Source](
             version = version,
             // TODO: The adapter should provide the date & time
-            state = Source(SourceIdentifier(IdentifierType.EbscoAltLookup, "Work", id), Instant.now()),
-            deletedReason = DeletedReason.DeletedFromSource("Deleted by EBSCO source")
+            state = Source(
+              SourceIdentifier(IdentifierType.EbscoAltLookup, "Work", id),
+              Instant.now()
+            ),
+            deletedReason =
+              DeletedReason.DeletedFromSource("Deleted by EBSCO source")
           )
         )
     }

--- a/pipeline/transformer/transformer_ebsco/src/main/scala/weco/pipeline/transformer/ebsco/EbscoTransformer.scala
+++ b/pipeline/transformer/transformer_ebsco/src/main/scala/weco/pipeline/transformer/ebsco/EbscoTransformer.scala
@@ -1,11 +1,20 @@
 package weco.pipeline.transformer.ebsco
 
-import weco.catalogue.internal_model.work.{Work, WorkState}
-import weco.catalogue.source_model.ebsco.EbscoSourceData
+import weco.catalogue.internal_model.identifiers.{IdentifierType, SourceIdentifier}
+import weco.catalogue.internal_model.work.WorkState.Source
+import weco.catalogue.internal_model.work.{DeletedReason, Work, WorkState}
+import weco.catalogue.source_model.ebsco.{EbscoDeletedSourceData, EbscoSourceData, EbscoUpdatedSourceData}
 import weco.pipeline.transformer.Transformer
+import weco.pipeline.transformer.marc.xml.data.MarcXMLRecord
+import weco.pipeline.transformer.marc.xml.transformers.MarcXMLRecordTransformer
 import weco.pipeline.transformer.result.Result
 import weco.storage.providers.s3.S3ObjectLocation
 import weco.storage.store.Readable
+
+import java.time.Instant
+import scala.util.Try
+import scala.xml.XML
+
 
 class EbscoTransformer(store: Readable[S3ObjectLocation, String])
     extends Transformer[EbscoSourceData] {
@@ -14,5 +23,21 @@ class EbscoTransformer(store: Readable[S3ObjectLocation, String])
     sourceData: EbscoSourceData,
     version: Int
   ): Result[Work[WorkState.Source]] =
-    Left(new Throwable("Not implemented"))
+    sourceData match {
+      case EbscoUpdatedSourceData(s3Location) =>
+        for {
+          xmlString <- store.get(s3Location).left.map(_.e)
+          xml <- Try(XML.loadString(xmlString.identifiedT)).toEither
+        } yield MarcXMLRecordTransformer(MarcXMLRecord(xml))
+
+      case EbscoDeletedSourceData =>
+        Right(
+          Work.Deleted[Source](
+            version = version,
+            // TODO: The adapter should provide the date & time
+            state = Source(SourceIdentifier(IdentifierType.EbscoAltLookup, "Work", id), Instant.now()),
+            deletedReason = DeletedReason.DeletedFromSource("Deleted by EBSCO source")
+          )
+        )
+    }
 }

--- a/pipeline/transformer/transformer_ebsco/src/main/scala/weco/pipeline/transformer/ebsco/service/EbscoSourceDataRetriever.scala
+++ b/pipeline/transformer/transformer_ebsco/src/main/scala/weco/pipeline/transformer/ebsco/service/EbscoSourceDataRetriever.scala
@@ -1,7 +1,7 @@
 package weco.pipeline.transformer.ebsco.service
 
 import weco.catalogue.source_model.EbscoSourcePayload
-import weco.catalogue.source_model.ebsco.EbscoSourceData
+import weco.catalogue.source_model.ebsco.{EbscoDeletedSourceData, EbscoSourceData, EbscoUpdatedSourceData}
 import weco.pipeline.transformer.SourceDataRetriever
 import weco.storage.{Identified, NoVersionExistsError, ReadError, Version}
 
@@ -10,6 +10,17 @@ class EbscoSourceDataRetriever
 
   override def lookupSourceData(
     payload: EbscoSourcePayload
-  ): Either[ReadError, Identified[Version[String, Int], EbscoSourceData]] =
-    Left(NoVersionExistsError(""))
+  ): Either[ReadError, Identified[Version[String, Int], EbscoSourceData]] = {
+
+    (payload.deleted, payload.location) match {
+      case (true, _) =>
+        Right(Identified(Version(payload.id, payload.version), EbscoDeletedSourceData))
+
+      case (false, Some(location)) =>
+        Right(Identified(Version(payload.id, payload.version), EbscoUpdatedSourceData(location)))
+
+      case (false, None) =>
+        Left(NoVersionExistsError(s"Missing location for EbscoSourcePayload ${payload.id}, version ${payload.version}"))
+    }
+  }
 }

--- a/pipeline/transformer/transformer_ebsco/src/main/scala/weco/pipeline/transformer/ebsco/service/EbscoSourceDataRetriever.scala
+++ b/pipeline/transformer/transformer_ebsco/src/main/scala/weco/pipeline/transformer/ebsco/service/EbscoSourceDataRetriever.scala
@@ -1,7 +1,11 @@
 package weco.pipeline.transformer.ebsco.service
 
 import weco.catalogue.source_model.EbscoSourcePayload
-import weco.catalogue.source_model.ebsco.{EbscoDeletedSourceData, EbscoSourceData, EbscoUpdatedSourceData}
+import weco.catalogue.source_model.ebsco.{
+  EbscoDeletedSourceData,
+  EbscoSourceData,
+  EbscoUpdatedSourceData
+}
 import weco.pipeline.transformer.SourceDataRetriever
 import weco.storage.{Identified, NoVersionExistsError, ReadError, Version}
 
@@ -14,13 +18,27 @@ class EbscoSourceDataRetriever
 
     (payload.deleted, payload.location) match {
       case (true, _) =>
-        Right(Identified(Version(payload.id, payload.version), EbscoDeletedSourceData))
+        Right(
+          Identified(
+            Version(payload.id, payload.version),
+            EbscoDeletedSourceData
+          )
+        )
 
       case (false, Some(location)) =>
-        Right(Identified(Version(payload.id, payload.version), EbscoUpdatedSourceData(location)))
+        Right(
+          Identified(
+            Version(payload.id, payload.version),
+            EbscoUpdatedSourceData(location)
+          )
+        )
 
       case (false, None) =>
-        Left(NoVersionExistsError(s"Missing location for EbscoSourcePayload ${payload.id}, version ${payload.version}"))
+        Left(
+          NoVersionExistsError(
+            s"Missing location for EbscoSourcePayload ${payload.id}, version ${payload.version}"
+          )
+        )
     }
   }
 }

--- a/pipeline/transformer/transformer_ebsco/src/test/scala/weco/pipeline/transformer/ebsco/EbscoTransformerTest.scala
+++ b/pipeline/transformer/transformer_ebsco/src/test/scala/weco/pipeline/transformer/ebsco/EbscoTransformerTest.scala
@@ -1,13 +1,49 @@
 package weco.pipeline.transformer.ebsco
 
+import org.scalatest.EitherValues
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+import weco.catalogue.internal_model.identifiers.DataState
+import weco.catalogue.internal_model.work.WorkData
+import weco.catalogue.source_model.ebsco.EbscoUpdatedSourceData
+import weco.storage.generators.S3ObjectLocationGenerators
+import weco.storage.providers.s3.S3ObjectLocation
+import weco.storage.store.memory.MemoryStore
 
 class EbscoTransformerTest
     extends AnyFunSpec
+    with S3ObjectLocationGenerators
+    with EitherValues
     with Matchers {
 
-  it("runs the tests") {
-    true shouldBe true
+  describe("a minimal XML record") {
+    it("generates a Work with a sourceIdentifier") {
+      info("at minimum, a Work from an XML record needs an id and a title")
+      val location = createS3ObjectLocation
+
+      val record =
+        <record xmlns="http://www.loc.gov/MARC21/slim">
+            <controlfield tag="001">3PaDhRp</controlfield>
+            <datafield tag ="245">
+              <subfield code="a">matacologian</subfield>
+            </datafield>
+          </record>
+
+      val transformer = new EbscoTransformer(
+        new MemoryStore[S3ObjectLocation, String](
+          Map(location -> record.toString())
+        )
+      )
+
+      val result =
+        transformer.apply("3PaDhRp", EbscoUpdatedSourceData(location), 20240401)
+      result shouldBe a[Right[_, _]]
+      val work = result.value
+
+      work.state.sourceIdentifier.value shouldBe "3PaDhRp"
+      work.data should equal(
+        WorkData[DataState.Unidentified](title = Some("matacologian"))
+      )
+    }
   }
 }

--- a/pipeline/transformer/transformer_marc_xml/src/main/scala/weco/pipeline/transformer/marc/xml/transformers/MarcXMLRecordTransformer.scala
+++ b/pipeline/transformer/transformer_marc_xml/src/main/scala/weco/pipeline/transformer/marc/xml/transformers/MarcXMLRecordTransformer.scala
@@ -1,12 +1,7 @@
 package weco.pipeline.transformer.marc.xml.transformers
 
-import weco.catalogue.internal_model.identifiers.{
-  DataState,
-  IdentifierType,
-  SourceIdentifier
-}
-import weco.catalogue.internal_model.work.WorkState.Source
-import weco.catalogue.internal_model.work.{Work, WorkData}
+import weco.catalogue.internal_model.identifiers.DataState
+import weco.catalogue.internal_model.work.WorkData
 import weco.pipeline.transformer.marc.xml.data.MarcXMLRecord
 import weco.pipeline.transformer.marc_common.logging.LoggingContext
 import weco.pipeline.transformer.marc_common.transformers.{
@@ -21,33 +16,8 @@ import weco.pipeline.transformer.marc_common.transformers.{
   MarcTitle
 }
 
-import java.time.Instant
-
 object MarcXMLRecordTransformer {
-
-  def apply(record: MarcXMLRecord): Work.Visible[Source] = {
-    // TODO: The state stuff here is EBSCO-specific.  Move it when the EBSCO transformer is implemented
-    val state = Source(
-      sourceIdentifier = SourceIdentifier(
-        identifierType = IdentifierType.EbscoAltLookup,
-        ontologyType = "Work",
-        value = record.controlField("001").get
-      ),
-      // TODO: I don't think we get sourceModifiedTime in the XML records from EBSCO,
-      //   but we might be able to work something out
-      sourceModifiedTime = Instant.now
-    )
-    implicit val ctx: LoggingContext = LoggingContext(
-      state.sourceIdentifier.value
-    )
-    Work.Visible[Source](
-      version = 0,
-      state = state,
-      data = workDataFromMarcRecord(record)
-    )
-  }
-
-  private def workDataFromMarcRecord(
+  def apply(
     record: MarcXMLRecord
   )(
     implicit ctx: LoggingContext


### PR DESCRIPTION
## What does this change?

This change wires the `EbscoTransformer` to the `MarcXMLRecordTransformer` generating works from EBSCO source data. It should propagate updates and deletions through the pipeline.

> [!NOTE]
> This includes a terraform change which unsubscribes the EBSCO transformer output topic from the id minter, in order to prevent messages getting past this point so we can safely experiment without creating a new pipeline.

## How to test

- [x] Run the tests, do they pass?

## How can we measure success?

We see updates propagate through the pipeline as expected and can use the EBSCO adapter as a source of truth for e-resources.

## Have we considered potential risks?

See above comment about merging this PR.
