### PR TITLE
make test ids a bit more realistic

### DIFF
--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraContributorsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraContributorsTest.scala
@@ -312,7 +312,7 @@ class SierraContributorsTest
 
     it("gets an identifier from subfield ǂ0") {
       val name = "Ivan the ivy"
-      val lcshCode = "lcsh7101607"
+      val lcshCode = "nlcsh7101607"
 
       val varFields = List(
         VarField(
@@ -339,13 +339,13 @@ class SierraContributorsTest
       "combines identifiers with inconsistent spacing/punctuation from subfield ǂ0"
     ) {
       val name = "Wanda the watercress"
-      val lcshCodeCanonical = "lcsh2055034"
-      val lcshCode1 = "lcsh 2055034"
-      val lcshCode2 = "  lcsh2055034 "
-      val lcshCode3 = " lc sh 2055034"
+      val lcshCodeCanonical = "nlcsh2055034"
+      val lcshCode1 = "nlcsh 2055034"
+      val lcshCode2 = "  nlcsh2055034 "
+      val lcshCode3 = " nlc sh 2055034"
 
       // Based on an example from a real record; see Sierra b3017492.
-      val lcshCode4 = "lcsh 2055034.,"
+      val lcshCode4 = "nlcsh 2055034.,"
 
       val varFields = List(
         VarField(
@@ -383,8 +383,8 @@ class SierraContributorsTest
           marcTag = "100",
           subfields = List(
             Subfield(tag = "a", content = name),
-            Subfield(tag = "0", content = "lcsh9069541"),
-            Subfield(tag = "0", content = "lcsh3384149")
+            Subfield(tag = "0", content = "nlcsh9069541"),
+            Subfield(tag = "0", content = "nlcsh3384149")
           )
         )
       )
@@ -537,7 +537,7 @@ class SierraContributorsTest
 
     it("gets an identifier from subfield ǂ0") {
       val name = "Gerry the Garlic"
-      val lcshCode = "lcsh7212"
+      val lcshCode = "nlcsh7212"
 
       val varFields = List(
         VarField(
@@ -565,10 +565,10 @@ class SierraContributorsTest
 
     it("gets an identifier with inconsistent spacing from subfield ǂ0") {
       val name = "Charlie the chive"
-      val lcshCodeCanonical = "lcsh6791210"
-      val lcshCode1 = "lcsh 6791210"
-      val lcshCode2 = "  lcsh6791210 "
-      val lcshCode3 = " lc sh 6791210"
+      val lcshCodeCanonical = "nlcsh6791210"
+      val lcshCode1 = "nlcsh 6791210"
+      val lcshCode2 = "  nlcsh6791210 "
+      val lcshCode3 = " nlc sh 6791210"
 
       val varFields = List(
         VarField(
@@ -729,7 +729,7 @@ class SierraContributorsTest
         marcTag = "111",
         subfields = List(
           Subfield(tag = "a", content = "label"),
-          Subfield(tag = "0", content = "456")
+          Subfield(tag = "0", content = "n456")
         )
       )
       val List(contributor) =
@@ -739,7 +739,7 @@ class SierraContributorsTest
         sourceIdentifier(
           identifierType = IdentifierType.LCNames,
           ontologyType = "Meeting",
-          value = "456"
+          value = "n456"
         )
       )
       contributor.roles shouldBe Nil

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/subjects/SierraMeetingSubjectsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/subjects/SierraMeetingSubjectsTest.scala
@@ -27,7 +27,8 @@ class SierraMeetingSubjectsTest
     createVarFieldWith(
       marcTag = tag,
       subfields = subfields.toList,
-      indicator2 = "0")
+      indicator2 = "0"
+    )
 
   it("returns zero subjects if there are none") {
     SierraMeetingSubjects(bibId, bibData()) shouldBe Nil
@@ -43,7 +44,7 @@ class SierraMeetingSubjectsTest
   it("returns subjects for varfield 611, subfield $$a") {
     val data = bibData(
       varField("600", Subfield(tag = "a", content = "Not content")),
-      varField("611", Subfield(tag = "a", content = "Content")),
+      varField("611", Subfield(tag = "a", content = "Content"))
     )
 
     // It is a happy accident of history that Subjects derived from Meetings have an ontologyType
@@ -52,45 +53,49 @@ class SierraMeetingSubjectsTest
     // simply up to the concepts that define it, but for now, we will ensure that it exists.
     val List(subject) = SierraMeetingSubjects(bibId, data)
     subject should have(
-      'label ("Content"),
+      'label("Content"),
       sourceIdentifier(
         value = "content",
         ontologyType = "Meeting",
-        identifierType = IdentifierType.LabelDerived)
+        identifierType = IdentifierType.LabelDerived
+      )
     )
     val List(concept) = subject.concepts
     concept should have(
-      'label ("Content"),
+      'label("Content"),
       labelDerivedMeetingId("content")
     )
   }
 
   it(
-    "returns subjects with subfields $$a, $$c and $$d concatenated in order they appear") {
+    "returns subjects with subfields $$a, $$c and $$d concatenated in order they appear"
+  ) {
     val data = bibData(
       varField(
         "611",
         Subfield(tag = "c", content = "C"),
         Subfield(tag = "a", content = "A"),
-        Subfield(tag = "d", content = "D"),
+        Subfield(tag = "d", content = "D")
       )
     )
 
     val List(subject) = SierraMeetingSubjects(bibId, data)
     subject should have(
-      'label ("C A D"),
+      'label("C A D"),
       sourceIdentifier(
         value = "c a d",
         ontologyType = "Meeting",
-        identifierType = IdentifierType.LabelDerived)
+        identifierType = IdentifierType.LabelDerived
+      )
     )
     val List(concept) = subject.concepts
     concept should have(
-      'label ("C A D"),
+      'label("C A D"),
       sourceIdentifier(
         value = "c a d",
         ontologyType = "Meeting",
-        identifierType = IdentifierType.LabelDerived)
+        identifierType = IdentifierType.LabelDerived
+      )
     )
   }
 
@@ -98,25 +103,27 @@ class SierraMeetingSubjectsTest
     val data = bibData(
       varField(
         "611",
-        Subfield(tag = "a", content = "Düsseldorf Convention 2097"),
+        Subfield(tag = "a", content = "Düsseldorf Convention 2097")
       )
     )
 
     val List(subject) = SierraMeetingSubjects(bibId, data)
     subject should have(
-      'label ("Düsseldorf Convention 2097"),
+      'label("Düsseldorf Convention 2097"),
       sourceIdentifier(
         value = "dusseldorf convention 2097",
         ontologyType = "Meeting",
-        identifierType = IdentifierType.LabelDerived)
+        identifierType = IdentifierType.LabelDerived
+      )
     )
     val List(concept) = subject.concepts
     concept should have(
-      'label ("Düsseldorf Convention 2097"),
+      'label("Düsseldorf Convention 2097"),
       sourceIdentifier(
         value = "dusseldorf convention 2097",
         ontologyType = "Meeting",
-        identifierType = IdentifierType.LabelDerived)
+        identifierType = IdentifierType.LabelDerived
+      )
     )
   }
 
@@ -125,25 +132,27 @@ class SierraMeetingSubjectsTest
       varField(
         "611",
         Subfield(tag = "a", content = "Content"),
-        Subfield(tag = "0", content = "lcsh7212")
+        Subfield(tag = "0", content = "nlcsh7212")
       )
     )
 
     val List(subject) = SierraMeetingSubjects(bibId, data)
     subject should have(
-      'label ("Content"),
+      'label("Content"),
       sourceIdentifier(
-        value = "lcsh7212",
+        value = "nlcsh7212",
         ontologyType = "Meeting",
-        identifierType = IdentifierType.LCNames)
+        identifierType = IdentifierType.LCNames
+      )
     )
     val List(concept) = subject.concepts
     concept should have(
-      'label ("Content"),
+      'label("Content"),
       sourceIdentifier(
-        value = "lcsh7212",
+        value = "nlcsh7212",
         ontologyType = "Meeting",
-        identifierType = IdentifierType.LCNames)
+        identifierType = IdentifierType.LCNames
+      )
     )
 
   }
@@ -151,7 +160,7 @@ class SierraMeetingSubjectsTest
   it("returns multiple subjects if multiple 611") {
     val data = bibData(
       varField("611", Subfield(tag = "a", content = "First")),
-      varField("611", Subfield(tag = "a", content = "Second")),
+      varField("611", Subfield(tag = "a", content = "Second"))
     )
     val subjects = SierraMeetingSubjects(bibId, data)
     subjects.length shouldBe 2
@@ -161,19 +170,21 @@ class SierraMeetingSubjectsTest
         // only those places that did have them should keep them
         // They should not be introduced anywhere else.
         subject should have(
-          'label (label),
+          'label(label),
           sourceIdentifier(
             value = label.toLowerCase,
             ontologyType = "Meeting",
-            identifierType = IdentifierType.LabelDerived)
+            identifierType = IdentifierType.LabelDerived
+          )
         )
         val List(concept) = subject.concepts
         concept should have(
-          'label (label),
+          'label(label),
           sourceIdentifier(
             value = label.toLowerCase,
             ontologyType = "Meeting",
-            identifierType = IdentifierType.LabelDerived)
+            identifierType = IdentifierType.LabelDerived
+          )
         )
     }
   }

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/subjects/SierraPersonSubjectsTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/subjects/SierraPersonSubjectsTest.scala
@@ -198,7 +198,7 @@ class SierraPersonSubjectsTest
     "creates an identifiable subject with library of congress heading if there is a subfield 0 and the second indicator is 0"
   ) {
     val name = "Gerry the Garlic"
-    val lcshCode = "lcsh7212"
+    val lcshCode = "nlcsh7212"
 
     val bibData = createSierraBibDataWith(
       varFields = List(
@@ -215,7 +215,7 @@ class SierraPersonSubjectsTest
 
     val List(subject) = SierraPersonSubjects(bibId, bibData)
     subject should have(
-      'label ("Gerry the Garlic"),
+      'label("Gerry the Garlic"),
       sourceIdentifier(
         identifierType = IdentifierType.LCNames,
         ontologyType = "Person",
@@ -223,7 +223,7 @@ class SierraPersonSubjectsTest
       )
     )
     subject.onlyConcept should have(
-      'label ("Gerry the Garlic"),
+      'label("Gerry the Garlic"),
       sourceIdentifier(
         identifierType = IdentifierType.LCNames,
         ontologyType = "Person",
@@ -249,11 +249,11 @@ class SierraPersonSubjectsTest
 
     val List(subject) = SierraPersonSubjects(bibId, bibData)
     subject should have(
-      'label ("Gerry the Garlic")
+      'label("Gerry the Garlic")
     )
 
     subject.onlyConcept should have(
-      'label ("Gerry the Garlic"),
+      'label("Gerry the Garlic"),
       labelDerivedPersonId("gerry the garlic")
     )
   }
@@ -313,7 +313,7 @@ class SierraPersonSubjectsTest
     it("in the concepts") {
       subject.onlyConcept shouldBe a[Person[_]]
       subject.onlyConcept should have(
-        'label ("Aristophanes. Birds."),
+        'label("Aristophanes. Birds."),
         labelDerivedPersonId("aristophanes. birds")
       )
     }
@@ -329,7 +329,7 @@ class SierraPersonSubjectsTest
       // of the title as a whole as distinct from
       //  - the unmarked version n80119944, found in b13149143,
       //  - or the French version nr2006002530, found in b2201679x
-      val List(subjectWithLanguage)= SierraPersonSubjects(
+      val List(subjectWithLanguage) = SierraPersonSubjects(
         bibId,
         createSierraBibDataWith(
           varFields = List(
@@ -415,9 +415,8 @@ class SierraPersonSubjectsTest
     subject.id shouldBe IdState.Identifiable(sourceIdentifier)
   }
 
-  /**
-    * Assert that the result of creating subjects with the given bibdata results in a single
-    * subject with a single concept, both bearing the given label.
+  /** Assert that the result of creating subjects with the given bibdata results
+    * in a single subject with a single concept, both bearing the given label.
     */
   private def assertCreatesSubjectWithLabel(
     bibData: SierraBibData,


### PR DESCRIPTION
## What does this change?

Currently, the id scheme for an Agent is to assumed to be LCNames.  This is almost always true, but it not guaranteed.  Sometimes they are LCSH.

As such, it should go through the existing method for determining a LoC scheme from an id, which checks the prefix.  All of these tests would fail if we change that.

This PR only changes the tests, and not the behaviour.  This is to isolate it from a larger piece of work

## How to test
This is a change to some values in the test suite only - just run the tests.

## How can we measure success?

When we make id scheme resolution more consistent across fields, the tests will pass.

## Have we considered potential risks?

The point of this change is to help isolate test changes from behaviour changes so that I do not inadvertently break things, and to make, it easier for a reviewer to reason about.

I may have missed some in this PR.  That should not be a problem.  The goal of reducing the amount of change to the test suite happening alongside changes to the SUT has been achieved anyway.
