### PR TITLE
Connect EBSCO transformer to id-minter

### DIFF
--- a/pipeline/terraform/modules/stack/service_transformers.tf
+++ b/pipeline/terraform/modules/stack/service_transformers.tf
@@ -51,14 +51,7 @@ locals {
   }
 
   transformer_output_topic_arns = [
-    # Temporarily remove the Ebsco transformer output topic
-    # In order to experiment with the new transformer
-    module.transformers["mets"].output_topic_arn,
-    module.transformers["calm"].output_topic_arn,
-    module.transformers["sierra"].output_topic_arn,
-    module.transformers["tei"].output_topic_arn,
-    module.transformers["miro"].output_topic_arn,
-    # for k, v in module.transformers : v.output_topic_arn
+    for k, v in module.transformers : v.output_topic_arn
   ]
 }
 


### PR DESCRIPTION
## What does this change?

This change connects the EBSCO transformer to the id-minter, allowing messages to proceed past this point in the pipeline and enable testing. 

Once this is merged, a reindex of the EBSCO source can be performed to merge and redirect currently Sierra sourced records to EBSCO sourced ones.

> [!NOTE]
> This change has been selectively applied to the `2024-04-29` pipeline and should not be merged so it is not accidentally applied to `2024-02-19` until testing is complete.

Follows:
- https://github.com/wellcomecollection/catalogue-pipeline/pull/2624
- https://github.com/wellcomecollection/catalogue-pipeline/pull/2653

Part of https://github.com/wellcomecollection/platform/issues/5738

Required for https://github.com/wellcomecollection/catalogue-pipeline/issues/2618

## How to test

- [ ] Run an EBSCO reindex and observe the pipeline behaving as expected.

## How can we measure success?

We are able to successfully test matching and merging outside of the prod pipeline. 

## Have we considered potential risks?

If applied to the prod pipeline this would allow records for EBSCO resources to be created in a state not yet ready to be consumed.

