### PR TITLE
Add reindex functionality to EBSCO adapter

### DIFF
--- a/ebsco_adapter/ebsco_adapter/src/compare_uploads.py
+++ b/ebsco_adapter/ebsco_adapter/src/compare_uploads.py
@@ -36,7 +36,6 @@ def find_uploads_to_compare(available_files, xml_s3_prefix, s3_store):
     date_list_with_notified_flag = find_notified_and_completed_flag(
         available_files, xml_s3_prefix, s3_store
     )
-
     # The current date is the most recent if it has not been notified
     current_date = None
     if (

--- a/ebsco_adapter/ebsco_adapter/src/compare_uploads.py
+++ b/ebsco_adapter/ebsco_adapter/src/compare_uploads.py
@@ -27,7 +27,8 @@ def find_notified_and_completed_flag(available_files, xml_s3_prefix, s3_store):
             "date": date,
             "notified_completed": _is_notified(date),
             "unpacking_completed": _is_completed(date),
-        } for date in dates_list
+        }
+        for date in dates_list
     ]
 
 

--- a/ebsco_adapter/ebsco_adapter/src/extract_marc.py
+++ b/ebsco_adapter/ebsco_adapter/src/extract_marc.py
@@ -56,7 +56,11 @@ def extract_marc_records(
                 already_uploaded = []
                 for control_number, record in batch.items():
                     s3_key = os.path.join(upload_prefix, f"{control_number}.xml")
-                    uploaded_file = s3_store.create_file(s3_key, record)
+                    uploaded_file = s3_store.create_file(
+                        s3_key,
+                        record,
+                        "application/xml"
+                    )
                     files_uploaded[control_number] = {
                         "s3_key": s3_key,
                         "sha256": uploaded_file["sha256"],
@@ -69,7 +73,9 @@ def extract_marc_records(
 
             json_encoded_files_uploaded = json.dumps(files_uploaded)
             s3_store.create_file(
-                batch_completion_flag_path, json_encoded_files_uploaded.encode("utf-8")
+                batch_completion_flag_path,
+                json_encoded_files_uploaded.encode("utf-8"),
+                "application/json"
             )
 
             unpacked_files[batch_name] = files_uploaded

--- a/ebsco_adapter/ebsco_adapter/src/extract_marc.py
+++ b/ebsco_adapter/ebsco_adapter/src/extract_marc.py
@@ -57,9 +57,7 @@ def extract_marc_records(
                 for control_number, record in batch.items():
                     s3_key = os.path.join(upload_prefix, f"{control_number}.xml")
                     uploaded_file = s3_store.create_file(
-                        s3_key,
-                        record,
-                        "application/xml"
+                        s3_key, record, "application/xml"
                     )
                     files_uploaded[control_number] = {
                         "s3_key": s3_key,
@@ -75,7 +73,7 @@ def extract_marc_records(
             s3_store.create_file(
                 batch_completion_flag_path,
                 json_encoded_files_uploaded.encode("utf-8"),
-                "application/json"
+                "application/json",
             )
 
             unpacked_files[batch_name] = files_uploaded

--- a/ebsco_adapter/ebsco_adapter/src/main.py
+++ b/ebsco_adapter/ebsco_adapter/src/main.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import argparse
 import tempfile
 import os
 
@@ -7,9 +8,9 @@ from types import SimpleNamespace
 from ebsco_ftp import EbscoFtp
 from s3_store import S3Store
 from sns_publisher import SnsPublisher
-from sync_files import sync_and_list_files
+from sync_files import sync_and_list_files, list_files
 from extract_marc import extract_marc_records
-from compare_uploads import compare_uploads
+from compare_uploads import compare_uploads, find_notified_and_completed_flag
 from update_notifier import update_notifier
 
 ftp_server = os.environ.get("FTP_SERVER")
@@ -25,34 +26,110 @@ ftp_s3_prefix = os.path.join(s3_prefix, "ftp")
 xml_s3_prefix = os.path.join(s3_prefix, "xml")
 
 
+def run_process(temp_dir, ebsco_ftp, s3_store, sns_publisher):
+    print("Running regular process ...")
+    available_files = sync_and_list_files(
+        temp_dir, ftp_s3_prefix, ebsco_ftp, s3_store
+    )
+    updates = compare_uploads(
+        available_files, extract_marc_records, xml_s3_prefix, temp_dir, s3_store
+    )
+    if updates is not None:
+        update_notifier(
+            updates,
+            updates["notify_for_batch"],
+            s3_store,
+            s3_bucket,
+            xml_s3_prefix,
+            sns_publisher,
+        )
+
+    return {}
+
+def run_reindex(s3_store, sns_publisher, reindex_type, ids=None):
+    assert reindex_type in ["full", "partial"], "Invalid reindex type"
+    assert ids is not None or reindex_type == "full", "You must provide IDs for partial reindexing"
+
+    print(f"Running reindex with type {reindex_type} and ids {ids} ...")
+    files = list_files(ftp_s3_prefix, s3_store)
+    batches = find_notified_and_completed_flag(files, xml_s3_prefix, s3_store)
+    notified_and_completed_batches = [
+        batch["date"] for batch in batches if batch["notified_completed"] and batch["unpacking_completed"]
+    ]
+
+    print(f"Found {notified_and_completed_batches} notified and completed batches.")
+
+    if not notified_and_completed_batches:
+        print("No valid batch to reindex, stopping!")
+        return {}
+
+    most_recent_batch = max(notified_and_completed_batches)
+    print(f"Attempting reindex for most recent batch: {most_recent_batch}")
+
+    print("Loading completed flag file ...")
+    completed_flag_path = os.path.join(xml_s3_prefix, most_recent_batch, "completed.flag")
+    completed_flag = s3_store.load_file(completed_flag_path)
+    print(f"Completed flag loaded, found {len(completed_flag)} records.")
+
+    if ids is not None:
+        # Filter out records that are not in the provided list of IDs
+        completed_flag = {id: record for id, record in completed_flag.items() if id in ids}
+        print(f"Finding matches for {len(ids)} IDs, found {len(completed_flag)} matches.")
+        print(f"IDs not found: {set(ids) - set(completed_flag.keys())}")
+
+    update_notifier(
+        {"updated": completed_flag, "deleted": None},
+        most_recent_batch,
+        s3_store,
+        s3_bucket,
+        xml_s3_prefix,
+        sns_publisher,
+    )
+
+
 def lambda_handler(event, context):
+    print("Starting lambda_handler, got event: ", event)
     with tempfile.TemporaryDirectory() as temp_dir:
         with EbscoFtp(
-            ftp_server, ftp_username, ftp_password, ftp_remote_dir
+                ftp_server, ftp_username, ftp_password, ftp_remote_dir
         ) as ebsco_ftp:
             s3_store = S3Store(s3_bucket)
             sns_publisher = SnsPublisher(sns_topic_arn)
 
-            available_files = sync_and_list_files(
-                temp_dir, ftp_s3_prefix, ebsco_ftp, s3_store
-            )
-            updates = compare_uploads(
-                available_files, extract_marc_records, xml_s3_prefix, temp_dir, s3_store
-            )
-            if updates is not None:
-                update_notifier(
-                    updates,
-                    updates["notify_for_batch"],
-                    s3_store,
-                    s3_bucket,
-                    xml_s3_prefix,
-                    sns_publisher,
-                )
-
-    return {}
+            if event is not None and "reindex_type" in event:
+                return run_reindex(s3_store, sns_publisher, event["reindex_type"], event.get("reindex_ids"))
+            else:
+                return run_process(temp_dir, ebsco_ftp, s3_store, sns_publisher)
 
 
 if __name__ == "__main__":
-    event = []
+    event = None
     context = SimpleNamespace(invoked_function_arn=None)
-    lambda_handler(event, context)
+
+    # Parse command line arguments for running locally
+    parser = argparse.ArgumentParser(description="Perform reindexing operations")
+    parser.add_argument(
+        "--reindex-type",
+        type=str,
+        choices=["full", "partial"],
+        help="Type of reindexing (full or partial)"
+    )
+    parser.add_argument(
+        "--reindex-ids",
+        type=str,
+        help="Comma-separated list of IDs to reindex (for partial)"
+    )
+
+    args = parser.parse_args()
+    if args.reindex_type:
+        reindex_ids = None
+        if args.reindex_ids:
+            reindex_ids = args.reindex_ids.split(",")
+            reindex_ids = [rid.strip() for rid in reindex_ids]
+
+        event = {
+            "reindex_type": args.reindex_type,
+            "reindex_ids": reindex_ids
+        }
+
+    lambda_handler(event, None)

--- a/ebsco_adapter/ebsco_adapter/src/main.py
+++ b/ebsco_adapter/ebsco_adapter/src/main.py
@@ -28,9 +28,7 @@ xml_s3_prefix = os.path.join(s3_prefix, "xml")
 
 def run_process(temp_dir, ebsco_ftp, s3_store, sns_publisher):
     print("Running regular process ...")
-    available_files = sync_and_list_files(
-        temp_dir, ftp_s3_prefix, ebsco_ftp, s3_store
-    )
+    available_files = sync_and_list_files(temp_dir, ftp_s3_prefix, ebsco_ftp, s3_store)
     updates = compare_uploads(
         available_files, extract_marc_records, xml_s3_prefix, temp_dir, s3_store
     )
@@ -49,13 +47,17 @@ def run_process(temp_dir, ebsco_ftp, s3_store, sns_publisher):
 
 def run_reindex(s3_store, sns_publisher, reindex_type, ids=None):
     assert reindex_type in ["full", "partial"], "Invalid reindex type"
-    assert ids is not None or reindex_type == "full", "You must provide IDs for partial reindexing"
+    assert (
+        ids is not None or reindex_type == "full"
+    ), "You must provide IDs for partial reindexing"
 
     print(f"Running reindex with type {reindex_type} and ids {ids} ...")
     files = list_files(ftp_s3_prefix, s3_store)
     batches = find_notified_and_completed_flag(files, xml_s3_prefix, s3_store)
     notified_and_completed_batches = [
-        batch["date"] for batch in batches if batch["notified_completed"] and batch["unpacking_completed"]
+        batch["date"]
+        for batch in batches
+        if batch["notified_completed"] and batch["unpacking_completed"]
     ]
 
     print(f"Found {notified_and_completed_batches} notified and completed batches.")
@@ -67,15 +69,21 @@ def run_reindex(s3_store, sns_publisher, reindex_type, ids=None):
     most_recent_batch = max(notified_and_completed_batches)
     print(f"Attempting reindex for most recent batch: {most_recent_batch}")
 
-    completed_flag_path = os.path.join(xml_s3_prefix, most_recent_batch, "completed.flag")
+    completed_flag_path = os.path.join(
+        xml_s3_prefix, most_recent_batch, "completed.flag"
+    )
     print(f"Loading completed flag file ({completed_flag_path}) ...")
     completed_flag = s3_store.load_file(completed_flag_path)
     print(f"Completed flag loaded, found {len(completed_flag)} records.")
 
     if ids is not None:
         # Include only the IDs that are in the list provided if any
-        completed_flag = {id: record for id, record in completed_flag.items() if id in ids}
-        print(f"Finding matches for {len(ids)} IDs, found {len(completed_flag)} matches.")
+        completed_flag = {
+            id: record for id, record in completed_flag.items() if id in ids
+        }
+        print(
+            f"Finding matches for {len(ids)} IDs, found {len(completed_flag)} matches."
+        )
         print(f"IDs not found: {set(ids) - set(completed_flag.keys())}")
 
     update_notifier(
@@ -92,13 +100,18 @@ def lambda_handler(event, context):
     print("Starting lambda_handler, got event: ", event)
     with tempfile.TemporaryDirectory() as temp_dir:
         with EbscoFtp(
-                ftp_server, ftp_username, ftp_password, ftp_remote_dir
+            ftp_server, ftp_username, ftp_password, ftp_remote_dir
         ) as ebsco_ftp:
             s3_store = S3Store(s3_bucket)
             sns_publisher = SnsPublisher(sns_topic_arn)
 
             if event is not None and "reindex_type" in event:
-                return run_reindex(s3_store, sns_publisher, event["reindex_type"], event.get("reindex_ids"))
+                return run_reindex(
+                    s3_store,
+                    sns_publisher,
+                    event["reindex_type"],
+                    event.get("reindex_ids"),
+                )
             else:
                 return run_process(temp_dir, ebsco_ftp, s3_store, sns_publisher)
 
@@ -113,12 +126,12 @@ if __name__ == "__main__":
         "--reindex-type",
         type=str,
         choices=["full", "partial"],
-        help="Type of reindexing (full or partial)"
+        help="Type of reindexing (full or partial)",
     )
     parser.add_argument(
         "--reindex-ids",
         type=str,
-        help="Comma-separated list of IDs to reindex (for partial)"
+        help="Comma-separated list of IDs to reindex (for partial)",
     )
 
     args = parser.parse_args()
@@ -128,9 +141,6 @@ if __name__ == "__main__":
             reindex_ids = args.reindex_ids.split(",")
             reindex_ids = [rid.strip() for rid in reindex_ids]
 
-        event = {
-            "reindex_type": args.reindex_type,
-            "reindex_ids": reindex_ids
-        }
+        event = {"reindex_type": args.reindex_type, "reindex_ids": reindex_ids}
 
     lambda_handler(event, None)

--- a/ebsco_adapter/ebsco_adapter/src/main.py
+++ b/ebsco_adapter/ebsco_adapter/src/main.py
@@ -67,9 +67,8 @@ def run_reindex(s3_store, sns_publisher, reindex_type, ids=None):
     most_recent_batch = max(notified_and_completed_batches)
     print(f"Attempting reindex for most recent batch: {most_recent_batch}")
 
-    print("Loading completed flag file ...")
     completed_flag_path = os.path.join(xml_s3_prefix, most_recent_batch, "completed.flag")
-    print(completed_flag_path)
+    print(f"Loading completed flag file ({completed_flag_path}) ...")
     completed_flag = s3_store.load_file(completed_flag_path)
     print(f"Completed flag loaded, found {len(completed_flag)} records.")
 

--- a/ebsco_adapter/ebsco_adapter/src/main.py
+++ b/ebsco_adapter/ebsco_adapter/src/main.py
@@ -141,6 +141,8 @@ if __name__ == "__main__":
             reindex_ids = args.reindex_ids.split(",")
             reindex_ids = [rid.strip() for rid in reindex_ids]
 
-        event = {"reindex_type": args.reindex_type, "reindex_ids": reindex_ids}
+    # This is the event that will be passed to the lambda handler.
+    # When invoking the function, use this structure to trigger reindexing.
+    event = {"reindex_type": args.reindex_type, "reindex_ids": reindex_ids}
 
     lambda_handler(event, None)

--- a/ebsco_adapter/ebsco_adapter/src/main.py
+++ b/ebsco_adapter/ebsco_adapter/src/main.py
@@ -19,8 +19,8 @@ ftp_password = os.environ.get("FTP_PASSWORD")
 ftp_remote_dir = os.environ.get("FTP_REMOTE_DIR")
 sns_topic_arn = os.environ.get("OUTPUT_TOPIC_ARN")
 
-s3_bucket = os.environ.get("S3_BUCKET")
-s3_prefix = os.environ.get("S3_PREFIX")
+s3_bucket = os.environ.get("S3_BUCKET", "wellcomecollection-platform-ebsco-adapter")
+s3_prefix = os.environ.get("S3_PREFIX", "dev")
 
 ftp_s3_prefix = os.path.join(s3_prefix, "ftp")
 xml_s3_prefix = os.path.join(s3_prefix, "xml")
@@ -46,6 +46,7 @@ def run_process(temp_dir, ebsco_ftp, s3_store, sns_publisher):
 
     return {}
 
+
 def run_reindex(s3_store, sns_publisher, reindex_type, ids=None):
     assert reindex_type in ["full", "partial"], "Invalid reindex type"
     assert ids is not None or reindex_type == "full", "You must provide IDs for partial reindexing"
@@ -68,11 +69,12 @@ def run_reindex(s3_store, sns_publisher, reindex_type, ids=None):
 
     print("Loading completed flag file ...")
     completed_flag_path = os.path.join(xml_s3_prefix, most_recent_batch, "completed.flag")
+    print(completed_flag_path)
     completed_flag = s3_store.load_file(completed_flag_path)
     print(f"Completed flag loaded, found {len(completed_flag)} records.")
 
     if ids is not None:
-        # Filter out records that are not in the provided list of IDs
+        # Include only the IDs that are in the list provided if any
         completed_flag = {id: record for id, record in completed_flag.items() if id in ids}
         print(f"Finding matches for {len(ids)} IDs, found {len(completed_flag)} matches.")
         print(f"IDs not found: {set(ids) - set(completed_flag.keys())}")

--- a/ebsco_adapter/ebsco_adapter/src/s3_store.py
+++ b/ebsco_adapter/ebsco_adapter/src/s3_store.py
@@ -1,6 +1,8 @@
-import boto3
+import json
 import os
 import hashlib
+
+import boto3
 
 
 class S3Store:
@@ -42,6 +44,14 @@ class S3Store:
 
         return target_location
 
+    def load_file(self, s3_key):
+        s3 = self.s3_client
+
+        response = s3.get_object(Bucket=self.s3_bucket, Key=s3_key)
+        return json.loads(
+            response["Body"].read()
+        )
+
     def upload_file(self, s3_prefix, file):
         s3 = self.s3_client
 
@@ -50,7 +60,7 @@ class S3Store:
 
         return s3_key
 
-    def create_file(self, s3_key, file_contents_as_bytes):
+    def create_file(self, s3_key, file_contents_as_bytes, content_type):
         # generate sha256 checksum of the file contents
         sha256_hash = hashlib.sha256(file_contents_as_bytes).hexdigest()
 
@@ -63,7 +73,7 @@ class S3Store:
                 Key=s3_key,
                 Body=file_contents_as_bytes,
                 Metadata={"sha256": sha256_hash},
-                ContentType="application/xml",
+                ContentType=content_type,
             )
             synced = True
 

--- a/ebsco_adapter/ebsco_adapter/src/s3_store.py
+++ b/ebsco_adapter/ebsco_adapter/src/s3_store.py
@@ -48,9 +48,7 @@ class S3Store:
         s3 = self.s3_client
 
         response = s3.get_object(Bucket=self.s3_bucket, Key=s3_key)
-        return json.loads(
-            response["Body"].read()
-        )
+        return json.loads(response["Body"].read())
 
     def upload_file(self, s3_prefix, file):
         s3 = self.s3_client

--- a/ebsco_adapter/ebsco_adapter/src/sync_files.py
+++ b/ebsco_adapter/ebsco_adapter/src/sync_files.py
@@ -52,7 +52,11 @@ def list_files(s3_prefix, s3_store):
             file_details["batch_name"] = get_batch_name(file_details)
             available_files.append(file_details)
 
-    return available_files
+    file_list = {}
+    for file in available_files:
+        file_list[file["batch_name"]] = file
+
+    return file_list
 
 
 def sync_files(target_directory, s3_prefix, ebsco_ftp, s3_store):
@@ -106,12 +110,13 @@ def sync_and_list_files(target_directory, s3_prefix, ebsco_ftp, s3_store):
     for file in uploaded_files_list:
         uploaded_files[file["batch_name"]] = file
 
-    file_list = {}
-    for file in available_files_list:
+    def _add_download_location(file):
         if file["batch_name"] in uploaded_files:
             file["download_location"] = uploaded_files[file["batch_name"]][
                 "download_location"
             ]
-        file_list[file["batch_name"]] = file
+        return file
 
-    return file_list
+    return {
+        k: _add_download_location(file) for k, file in available_files_list.items()
+    }

--- a/ebsco_adapter/ebsco_adapter/src/sync_files.py
+++ b/ebsco_adapter/ebsco_adapter/src/sync_files.py
@@ -117,6 +117,4 @@ def sync_and_list_files(target_directory, s3_prefix, ebsco_ftp, s3_store):
             ]
         return file
 
-    return {
-        k: _add_download_location(file) for k, file in available_files_list.items()
-    }
+    return {k: _add_download_location(file) for k, file in available_files_list.items()}

--- a/ebsco_adapter/ebsco_adapter/src/test_compare_uploads.py
+++ b/ebsco_adapter/ebsco_adapter/src/test_compare_uploads.py
@@ -83,7 +83,7 @@ def test_compare_uploads_with_one_file():
 
 
 def test_compare_uploads_with_two_files_first_notified():
-    batch_name_1 = "2024-03-22"
+    batch_name_1 = "2024-03-28"
     batch_name_2 = "2024-04-05"
     fixture_file_name_1 = "ebz-s7451719-20240328-1.xml"
     fixture_file_name_2 = "ebz-s7451719-20240405-1.xml"

--- a/ebsco_adapter/ebsco_adapter/src/test_fixtures.py
+++ b/ebsco_adapter/ebsco_adapter/src/test_fixtures.py
@@ -6,6 +6,9 @@ class FakeSnsClient:
     def __init__(self):
         self.published_messages = []
 
+    def test_reset(self):
+        self.published_messages = []
+
     def test_get_published_messages(self):
         return self.published_messages
 
@@ -47,6 +50,15 @@ class FakeEbscoFtp:
         pass
 
 
+# This class is used to simulate the body of a streaming response from S3.
+class FakeStreamingBody:
+    def __init__(self, body):
+        self.body = body
+
+    def read(self):
+        return self.body
+
+
 class FakeS3Client:
     def __init__(self, objects=None):
         if objects is None:
@@ -66,6 +78,10 @@ class FakeS3Client:
     def download_file(self, Bucket, Key, target_location):
         with open(target_location, "wb") as f:
             f.write(self.objects[Key]["Body"])
+
+    def get_object(self, Bucket, Key):
+        streaming_body = FakeStreamingBody(self.objects[Key]["Body"])
+        return {"Body": streaming_body}
 
     def upload_file(self, file, Bucket, Key):
         with open(file, "rb") as f:

--- a/ebsco_adapter/ebsco_adapter/src/test_main.py
+++ b/ebsco_adapter/ebsco_adapter/src/test_main.py
@@ -1,0 +1,204 @@
+import json
+import os
+import tempfile
+
+from test_fixtures import FakeS3Client, FakeSnsClient, FakeEbscoFtp
+from s3_store import S3Store
+from sns_publisher import SnsPublisher
+
+from main import run_reindex, run_process
+
+xml_s3_prefix = "xml"
+ftp_s3_prefix = "ftp"
+topic_arn = "test_topic_arn"
+test_bucket = "test_bucket"
+
+ebs9579e = {
+    'id': 'ebs9579e',
+    'location': {
+        'bucket': 'wellcomecollection-platform-ebsco-adapter',
+        'key': 'dev/xml/2024-03-22/ebs9579e.xml'
+    },
+    'version': 20240322,
+    'deleted': False,
+    'sha256': '4c4a7fb13bf8b7beda96bbe75358eb882a6130592b29f6149a308d82e0356d22'
+}
+
+ebs29555e = {
+    'id': 'ebs29555e',
+    'location': {
+        'bucket': 'wellcomecollection-platform-ebsco-adapter',
+        'key': 'dev/xml/2024-03-22/ebs29555e.xml'
+    },
+    'version': 20240322,
+    'deleted': False,
+    'sha256': 'cb719218d3435395a2fa948088bf2c0fe86748dddfb5a2e8e2bbb199f6cf48dd'
+}
+
+ebs9579e_20240405 = {
+    'id': 'ebs9579e',
+    'location': {
+        'bucket': 'wellcomecollection-platform-ebsco-adapter',
+        'key': 'dev/xml/2024-04-05/ebs9579e.xml'
+    }, 'version': 20240405,
+    'deleted': False,
+    'sha256': 'b166aa8eb3c4f85dc95602fbdd920b444dfb6e08f6bc59881ad737878ed04822'
+}
+
+ebs29555e_20240405_deleted = {
+    'id': 'ebs29555e',
+    'location': None,
+    'version': 20240405,
+    'deleted': True,
+    'sha256': None
+}
+
+
+def test_run_process():
+    batch_name_1 = "2024-03-28"
+    batch_name_2 = "2024-04-05"
+
+    fixture_file_name_1 = "ebz-s7451719-20240328-1.xml"
+    fixture_file_name_2 = "ebz-s7451719-20240405-2.xml"
+
+    current_dir = os.path.dirname(os.path.realpath(__file__))
+    fixtures_file_1 = os.path.join(current_dir, "fixtures", fixture_file_name_1)
+    fixtures_file_2 = os.path.join(current_dir, "fixtures", fixture_file_name_2)
+
+    with open(fixtures_file_1, "rb") as f:
+        file_contents_1 = f.read()
+
+    with open(fixtures_file_2, "rb") as f:
+        file_contents_2 = f.read()
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        s3_objects = {
+            f"dev/{ftp_s3_prefix}/{fixture_file_name_1}": {
+                "Body": file_contents_1,
+            },
+            f"dev/{xml_s3_prefix}/{batch_name_1}/completed.flag": {
+                "Body": json.dumps(
+                    {
+                        "ebs9579e": {
+                            "s3_key": f"xml/{batch_name_1}/ebs9579e.xml",
+                            "sha256": "4c4a7fb13bf8b7beda96bbe75358eb882a6130592b29f6149a308d82e0356d22",
+                        },
+                        "ebs29555e": {
+                            "s3_key": f"xml/{batch_name_1}/ebs29555e.xml",
+                            "sha256": "cb719218d3435395a2fa948088bf2c0fe86748dddfb5a2e8e2bbb199f6cf48dd",
+                        },
+                    }
+                ).encode()
+            },
+            f"dev/{xml_s3_prefix}/{batch_name_1}/notified.flag": {
+                "Body": "",
+            },
+        }
+
+        fake_s3_client = FakeS3Client(s3_objects)
+        s3_store = S3Store(test_bucket, fake_s3_client)
+
+        fake_sns_client = FakeSnsClient()
+        sns_publisher = SnsPublisher(topic_arn, fake_sns_client)
+
+        fake_ebsco_ftp = FakeEbscoFtp(
+            {
+                "ebz-s7451719-20240328-1.xml": file_contents_1,
+                "ebz-s7451719-20240405-1.xml": file_contents_2,
+            }
+        )
+
+        print("\n--- Running test ingest process ---")
+        run_process(temp_dir, fake_ebsco_ftp, s3_store, sns_publisher)
+
+        files_ftp = s3_store.list_files(f"dev/{ftp_s3_prefix}")
+        assert files_ftp == [
+            "ebz-s7451719-20240328-1.xml",
+            "ebz-s7451719-20240405-1.xml",
+        ]
+
+        # get the number of files in the s3 bucket under the xml prefix
+        files_xml_batch_2 = s3_store.list_files(f"dev/{xml_s3_prefix}/{batch_name_2}")
+        assert files_xml_batch_2 == [
+            "ebs9579e.xml",
+            "completed.flag",
+            "notified.flag",
+        ]
+
+        published_messages = fake_sns_client.test_get_published_messages()
+
+        for msg in published_messages:
+            print(msg)
+
+        expected_messages = [
+            ebs9579e_20240405,
+            ebs29555e_20240405_deleted
+        ]
+
+        for msg in expected_messages:
+            print(msg)
+
+        assert published_messages == expected_messages
+
+
+def test_run_reindex():
+    fixture_file_name = "ebz-s7451719-20240328-1.xml"
+    current_dir = os.path.dirname(os.path.realpath(__file__))
+    fixtures_file = os.path.join(current_dir, "fixtures", fixture_file_name)
+
+    with open(fixtures_file, "rb") as f:
+        file_contents = f.read()
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        s3_objects = {
+            f"{ftp_s3_prefix}/{fixture_file_name}": {
+                "Body": file_contents,
+            }
+        }
+
+        fake_s3_client = FakeS3Client(s3_objects)
+        s3_store = S3Store(test_bucket, fake_s3_client)
+
+        fake_sns_client = FakeSnsClient()
+        sns_publisher = SnsPublisher(topic_arn, fake_sns_client)
+
+        fake_ebsco_ftp = FakeEbscoFtp(
+            {
+                "ebz-s7451719-20240322-1.xml": file_contents,
+            }
+        )
+        print("\n--- Running test ingest process ---")
+        run_process(temp_dir, fake_ebsco_ftp, s3_store, sns_publisher)
+
+        # get the number of files in the s3 bucket under the xml prefix
+        files = s3_store.list_files(f"dev/{xml_s3_prefix}")
+
+        assert files == [
+            "ebs9579e.xml",
+            "ebs29555e.xml",
+            "completed.flag",
+            "notified.flag",
+        ]
+
+        published_messages = fake_sns_client.test_get_published_messages()
+        assert published_messages == [ebs9579e, ebs29555e]
+
+        fake_sns_client.test_reset()
+        assert fake_sns_client.test_get_published_messages() == []
+
+        print("\n--- Running test reindex with type full ---")
+        run_reindex(s3_store, sns_publisher, "full")
+
+        reindex_published_messages = fake_sns_client.test_get_published_messages()
+        assert reindex_published_messages == [ebs9579e, ebs29555e]
+
+        fake_sns_client.test_reset()
+        assert fake_sns_client.test_get_published_messages() == []
+
+        print("\n--- Running test reindex with type partial ---")
+        run_reindex(s3_store, sns_publisher, "partial", ["ebs9579e"])
+
+        reindex_published_messages = fake_sns_client.test_get_published_messages()
+        assert reindex_published_messages == [ebs9579e]
+
+

--- a/ebsco_adapter/ebsco_adapter/src/test_main.py
+++ b/ebsco_adapter/ebsco_adapter/src/test_main.py
@@ -14,43 +14,44 @@ topic_arn = "test_topic_arn"
 test_bucket = "test_bucket"
 
 ebs9579e = {
-    'id': 'ebs9579e',
-    'location': {
-        'bucket': 'wellcomecollection-platform-ebsco-adapter',
-        'key': 'dev/xml/2024-03-22/ebs9579e.xml'
+    "id": "ebs9579e",
+    "location": {
+        "bucket": "wellcomecollection-platform-ebsco-adapter",
+        "key": "dev/xml/2024-03-22/ebs9579e.xml",
     },
-    'version': 20240322,
-    'deleted': False,
-    'sha256': '4c4a7fb13bf8b7beda96bbe75358eb882a6130592b29f6149a308d82e0356d22'
+    "version": 20240322,
+    "deleted": False,
+    "sha256": "4c4a7fb13bf8b7beda96bbe75358eb882a6130592b29f6149a308d82e0356d22",
 }
 
 ebs29555e = {
-    'id': 'ebs29555e',
-    'location': {
-        'bucket': 'wellcomecollection-platform-ebsco-adapter',
-        'key': 'dev/xml/2024-03-22/ebs29555e.xml'
+    "id": "ebs29555e",
+    "location": {
+        "bucket": "wellcomecollection-platform-ebsco-adapter",
+        "key": "dev/xml/2024-03-22/ebs29555e.xml",
     },
-    'version': 20240322,
-    'deleted': False,
-    'sha256': 'cb719218d3435395a2fa948088bf2c0fe86748dddfb5a2e8e2bbb199f6cf48dd'
+    "version": 20240322,
+    "deleted": False,
+    "sha256": "cb719218d3435395a2fa948088bf2c0fe86748dddfb5a2e8e2bbb199f6cf48dd",
 }
 
 ebs9579e_20240405 = {
-    'id': 'ebs9579e',
-    'location': {
-        'bucket': 'wellcomecollection-platform-ebsco-adapter',
-        'key': 'dev/xml/2024-04-05/ebs9579e.xml'
-    }, 'version': 20240405,
-    'deleted': False,
-    'sha256': 'b166aa8eb3c4f85dc95602fbdd920b444dfb6e08f6bc59881ad737878ed04822'
+    "id": "ebs9579e",
+    "location": {
+        "bucket": "wellcomecollection-platform-ebsco-adapter",
+        "key": "dev/xml/2024-04-05/ebs9579e.xml",
+    },
+    "version": 20240405,
+    "deleted": False,
+    "sha256": "b166aa8eb3c4f85dc95602fbdd920b444dfb6e08f6bc59881ad737878ed04822",
 }
 
 ebs29555e_20240405_deleted = {
-    'id': 'ebs29555e',
-    'location': None,
-    'version': 20240405,
-    'deleted': True,
-    'sha256': None
+    "id": "ebs29555e",
+    "location": None,
+    "version": 20240405,
+    "deleted": True,
+    "sha256": None,
 }
 
 
@@ -130,10 +131,7 @@ def test_run_process():
         for msg in published_messages:
             print(msg)
 
-        expected_messages = [
-            ebs9579e_20240405,
-            ebs29555e_20240405_deleted
-        ]
+        expected_messages = [ebs9579e_20240405, ebs29555e_20240405_deleted]
 
         for msg in expected_messages:
             print(msg)
@@ -200,5 +198,3 @@ def test_run_reindex():
 
         reindex_published_messages = fake_sns_client.test_get_published_messages()
         assert reindex_published_messages == [ebs9579e]
-
-

--- a/ebsco_adapter/ebsco_adapter/src/update_notifier.py
+++ b/ebsco_adapter/ebsco_adapter/src/update_notifier.py
@@ -49,8 +49,4 @@ def update_notifier(
     notified_completion_flag_path = os.path.join(
         xml_s3_prefix, notify_for_batch, notified_completion_flag
     )
-    s3_store.create_file(
-        notified_completion_flag_path,
-        b"",
-        "application/txt"
-    )
+    s3_store.create_file(notified_completion_flag_path, b"", "application/txt")

--- a/ebsco_adapter/ebsco_adapter/src/update_notifier.py
+++ b/ebsco_adapter/ebsco_adapter/src/update_notifier.py
@@ -49,4 +49,8 @@ def update_notifier(
     notified_completion_flag_path = os.path.join(
         xml_s3_prefix, notify_for_batch, notified_completion_flag
     )
-    s3_store.create_file(notified_completion_flag_path, b"")
+    s3_store.create_file(
+        notified_completion_flag_path,
+        b"",
+        "application/txt"
+    )


### PR DESCRIPTION
## What does this change?

This changes add the ability to reindex items from the EBSCO adapter by invoking the lambda directly with a JSON payload.

It can be invoked locally using the CLI, directly or by invoking the lambda directly using a payload like:

# Partial reindex
```json
{
  "reindex_type": "partial",
  "reindex_ids": "ebz123e"
}
```

# Full reindex
```json
{
  "reindex_type": "full",
}
```

The intention is to modify the reindex script to invoke this lambda alongside the usual re-index service in a future PR.

## How to test

- [x] Run the tests
- [x] Test this locally against prod, does it behave as expected?

## How can we measure success?

We can run a full re-index of the pipeline including EBSCO data.

## Have we considered potential risks?

This changes the previously untested `main.py`. We've added end to end tests here in an attempt to provide better end to end test coverage. We should also test in production with a manually deployed lambda to be sure this behaves as expected (as well as invoking the deployed lambda).
