### PR TITLE
Link by refno

### DIFF
--- a/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/transformers/CalmMergeCandidates.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/transformers/CalmMergeCandidates.scala
@@ -41,7 +41,7 @@ object CalmMergeCandidates extends CalmRecordOps {
       .flatMap {
         id =>
           SourceIdentifier(
-            identifierType = IdentifierType.METS,
+            identifierType = IdentifierType.CalmRefNo,
             ontologyType = "Work",
             value = id
           ).validatedWithWarning

--- a/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/transformers/CalmMergeCandidates.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/transformers/CalmMergeCandidates.scala
@@ -37,7 +37,7 @@ object CalmMergeCandidates extends CalmRecordOps {
       }
   private def metsMergeCandidate(record: CalmRecord) =
     record
-      .get("SDB_URL")
+      .get("RefNo")
       .flatMap {
         id =>
           SourceIdentifier(

--- a/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/CalmTransformerTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/CalmTransformerTest.scala
@@ -48,7 +48,7 @@ class CalmTransformerTest
           mergeCandidates = List(
             MergeCandidate(
               identifier =
-                SourceIdentifier(IdentifierType.METS, "Work", "a/b/c"),
+                SourceIdentifier(IdentifierType.CalmRefNo, "Work", "a/b/c"),
               reason = "Archivematica work"
             )
           )
@@ -159,7 +159,7 @@ class CalmTransformerTest
         MergeCandidate(
           identifier = SourceIdentifier(
             value = "a/b/c",
-            identifierType = IdentifierType.METS,
+            identifierType = IdentifierType.CalmRefNo,
             ontologyType = "Work"
           ),
           reason = "Archivematica work"

--- a/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/CalmTransformerTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/CalmTransformerTest.scala
@@ -44,7 +44,14 @@ class CalmTransformerTest
             identifierType = IdentifierType.CalmRecordIdentifier,
             ontologyType = "Work"
           ),
-          record.retrievedAt
+          record.retrievedAt,
+          mergeCandidates = List(
+            MergeCandidate(
+              identifier =
+                SourceIdentifier(IdentifierType.METS, "Work", "a/b/c"),
+              reason = "Archivematica work"
+            )
+          )
         ),
         data = WorkData[DataState.Unidentified](
           title = Some("abc"),
@@ -149,6 +156,14 @@ class CalmTransformerTest
           ),
           reason = "CALM/Sierra harvest work"
         ),
+        MergeCandidate(
+          identifier = SourceIdentifier(
+            value = "a/b/c",
+            identifierType = IdentifierType.METS,
+            ontologyType = "Work"
+          ),
+          reason = "Archivematica work"
+        )
       )
   }
 
@@ -237,7 +252,10 @@ class CalmTransformerTest
       "Subject" -> "<i>anatomy</i>",
       "CatalogueStatus" -> "Catalogued"
     )
-    CalmTransformer(record, version).right.get.data.subjects should contain theSameElementsAs List(
+    CalmTransformer(
+      record,
+      version
+    ).right.get.data.subjects should contain theSameElementsAs List(
       Subject("anatomy", List(Concept("anatomy"))),
       Subject("botany", List(Concept("botany")))
     )
@@ -347,7 +365,10 @@ class CalmTransformerTest
       "CreatorName" -> "Rocksteady",
       "CatalogueStatus" -> "Catalogued"
     )
-    CalmTransformer(record, version).right.get.data.contributors should contain theSameElementsAs List(
+    CalmTransformer(
+      record,
+      version
+    ).right.get.data.contributors should contain theSameElementsAs List(
       Contributor(
         agent =
           Agent(id = labelDerivedAgentIdentifier("bebop"), label = "Bebop"),
@@ -356,7 +377,8 @@ class CalmTransformerTest
       Contributor(
         agent = Agent(
           id = labelDerivedAgentIdentifier("rocksteady"),
-          label = "Rocksteady"),
+          label = "Rocksteady"
+        ),
         roles = Nil
       )
     )
@@ -373,7 +395,10 @@ class CalmTransformerTest
       "Arrangement" -> "meet at midnight",
       "CatalogueStatus" -> "Catalogued"
     )
-    CalmTransformer(record, version).right.get.data.notes should contain theSameElementsAs List(
+    CalmTransformer(
+      record,
+      version
+    ).right.get.data.notes should contain theSameElementsAs List(
       Note(contents = "no copyright", noteType = NoteType.CopyrightNote),
       Note(contents = "meet at midnight", noteType = NoteType.ArrangementNote)
     )
@@ -388,7 +413,10 @@ class CalmTransformerTest
       "Alternative_Title" -> "Original title: Disk 2",
       "CatalogueStatus" -> "Catalogued"
     )
-    CalmTransformer(record, version).right.get.data.alternativeTitles shouldBe List("Original title: Disk 2")
+    CalmTransformer(
+      record,
+      version
+    ).right.get.data.alternativeTitles shouldBe List("Original title: Disk 2")
   }
 
   it("ignores case when transforming workType") {
@@ -485,11 +513,12 @@ class CalmTransformerTest
       (suppressibleRecordB, true)
     )
 
-    forAll(examples) { (record, suppressed) =>
-      CalmTransformer(record, version).right.get match {
-        case _: Work.Deleted[Source] => suppressed shouldBe true
-        case _                       => suppressed shouldBe false
-      }
+    forAll(examples) {
+      (record, suppressed) =>
+        CalmTransformer(record, version).right.get match {
+          case _: Work.Deleted[Source] => suppressed shouldBe true
+          case _                       => suppressed shouldBe false
+        }
     }
   }
 
@@ -510,8 +539,9 @@ class CalmTransformerTest
       "CatalogueStatus" -> "Catalogued"
     )
 
-    List(noTitle, noLevel, noRefNo) map { record =>
-      CalmTransformer(record, version).right.get shouldBe a[Work.Invisible[_]]
+    List(noTitle, noLevel, noRefNo) map {
+      record =>
+        CalmTransformer(record, version).right.get shouldBe a[Work.Invisible[_]]
     }
   }
 

--- a/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/transformers/CalmMergeCandidatesTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/transformers/CalmMergeCandidatesTest.scala
@@ -78,7 +78,7 @@ class CalmMergeCandidatesTest
 
         mergeCandidates.loneElement shouldBe MergeCandidate(
           identifier = SourceIdentifier(
-            identifierType = IdentifierType.METS,
+            identifierType = IdentifierType.CalmRefNo,
             ontologyType = "Work",
             value = refno
           ),
@@ -94,7 +94,7 @@ class CalmMergeCandidatesTest
 
         mergeCandidates.loneElement shouldBe MergeCandidate(
           identifier = SourceIdentifier(
-            identifierType = IdentifierType.METS,
+            identifierType = IdentifierType.CalmRefNo,
             ontologyType = "Work",
             value = uuid
           ),
@@ -156,7 +156,7 @@ class CalmMergeCandidatesTest
       mergeCandidates should contain theSameElementsAs Seq(
         MergeCandidate(
           identifier = SourceIdentifier(
-            identifierType = IdentifierType.METS,
+            identifierType = IdentifierType.CalmRefNo,
             ontologyType = "Work",
             value = refno
           ),
@@ -184,7 +184,7 @@ class CalmMergeCandidatesTest
       mergeCandidates.loneElement shouldBe
         MergeCandidate(
           identifier = SourceIdentifier(
-            identifierType = IdentifierType.METS,
+            identifierType = IdentifierType.CalmRefNo,
             ontologyType = "Work",
             value = refno
           ),

--- a/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/transformers/CalmMergeCandidatesTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/transformers/CalmMergeCandidatesTest.scala
@@ -53,16 +53,26 @@ class CalmMergeCandidatesTest
     }
   }
 
-  describe("creating a METS mergeCandidate from the SDB_URL") {
+  describe("creating a METS mergeCandidate from the RefNo") {
+    info(
+      "Although SDB_URL has been repurposed to record the Archivematica UUID"
+    )
+    info(
+      "(See: https://app.gitbook.com/o/-LumfFcEMKx4gYXKAZTQ/s/HcPN6OwpaxdCucwfmiAz/metadata-fields/superseded-fields#sdb_ref-sdb_type-sdb_url)"
+    )
+    info("Archivematica UUIDs are not stable, and change with every ingest.")
+    info(
+      "Therefore, the most stable identifier that is common to the two records is the RefNo."
+    )
+    info("Following the same pattern as Sierra bnumbers,")
+    info(
+      "the Refno serves as the identifier for the METS document, in its own namespace"
+    )
     describe("successful creation") {
-      info("SDB_URL has been repurposed to record the Archivematica UUID")
-      info(
-        "See: https://app.gitbook.com/o/-LumfFcEMKx4gYXKAZTQ/s/HcPN6OwpaxdCucwfmiAz/metadata-fields/superseded-fields#sdb_ref-sdb_type-sdb_url"
-      )
-      it("creates a mergeCandidate from a UUID") {
-        val uuid = "d00df00d-beef-cafe-f00d-beefcafef00d"
+      it("creates a mergeCandidate from the RefNo") {
+        val refno = "CAFE/FO/OD"
         val record = createCalmRecordWith(
-          "SDB_URL" -> uuid
+          "RefNo" -> refno
         )
         val mergeCandidates = CalmMergeCandidates(record)
 
@@ -70,15 +80,15 @@ class CalmMergeCandidatesTest
           identifier = SourceIdentifier(
             identifierType = IdentifierType.METS,
             ontologyType = "Work",
-            value = uuid
+            value = refno
           ),
           reason = "Archivematica work"
         )
       }
       it("ignores leading and trailing whitespace") {
-        val uuid = "d00df00d-beef-cafe-f00d-beefcafef00d"
+        val uuid = "CAFE/FO/OD"
         val record = createCalmRecordWith(
-          "SDB_URL" -> s" \n $uuid \t\r   "
+          "RefNo" -> s" \n $uuid \t\r   "
         )
         val mergeCandidates = CalmMergeCandidates(record)
 
@@ -134,10 +144,10 @@ class CalmMergeCandidatesTest
 
   describe("creating merge candidates of both types") {
     it("can merge with both a Sierra and a METS candidate") {
-      val uuid = "d00df00d-beef-cafe-f00d-beefcafef00d"
+      val refno = "DOO/DF/OOD"
       val bnumber = "b12345672"
       val record = createCalmRecordWith(
-        "SDB_URL" -> uuid,
+        "RefNo" -> refno,
         "BNumber" -> bnumber
       )
 
@@ -148,7 +158,7 @@ class CalmMergeCandidatesTest
           identifier = SourceIdentifier(
             identifierType = IdentifierType.METS,
             ontologyType = "Work",
-            value = uuid
+            value = refno
           ),
           reason = "Archivematica work"
         ),
@@ -163,9 +173,9 @@ class CalmMergeCandidatesTest
       )
     }
     it("can successfully create a METS candidate when faced with bad BNumber") {
-      val uuid = "d00df00d-beef-cafe-f00d-beefcafef00d"
+      val refno = "GOOD/FO/OD"
       val record = createCalmRecordWith(
-        "SDB_URL" -> uuid,
+        "RefNo" -> refno,
         "BNumber" -> "AAAAAAAAAAAAAAA!"
       )
 
@@ -176,7 +186,7 @@ class CalmMergeCandidatesTest
           identifier = SourceIdentifier(
             identifierType = IdentifierType.METS,
             ontologyType = "Work",
-            value = uuid
+            value = refno
           ),
           reason = "Archivematica work"
         )

--- a/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/transformers/CalmMergeCandidatesTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/transformers/CalmMergeCandidatesTest.scala
@@ -64,10 +64,11 @@ class CalmMergeCandidatesTest
     info(
       "Therefore, the most stable identifier that is common to the two records is the RefNo."
     )
-    info("Following the same pattern as Sierra bnumbers,")
+    info("The Works derived from both the METS record and the CALM record")
     info(
-      "the Refno serves as the identifier for the METS document, in its own namespace"
+      "are expected to contain a merge candidate pointing to the CALM RefNo"
     )
+    info("This allows them to merge transitively across that identifier")
     describe("successful creation") {
       it("creates a mergeCandidate from the RefNo") {
         val refno = "CAFE/FO/OD"

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/identifiers/SourceIdentifierValidation.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/identifiers/SourceIdentifierValidation.scala
@@ -63,14 +63,14 @@ object SourceIdentifierValidation {
      * There are two options for a METS id, depending on the source of the file.
      *  - b number
      *      - A Goobi METS file is identified using the b number of the corresponding Sierra record
-     *  - UUID
-     *      - An Archivematica METS file is identified using a UUID.
+     *  - CALM RefNo
+     *      - An Archivematica METS file is identified using the RefNo from the corresponding CALM record.
      *
      * From the perspective of anything wanting to validate a possible METS ID, this distinction is
      * irrelevant.  All a caller needs to know is whether the string in question looks like METS.
      */
     private def isValidMetsId(str: String): Boolean =
-      sierraSystemNumber.toPredicate(str) || tryParseUUID(str).isSuccess
+      sierraSystemNumber.toPredicate(str) || calmRefNo.toPredicate(str)
     private implicit class RegexOps(regex: Regex) {
       def toPredicate: String => Boolean = regex.findFirstIn(_).isDefined
     }

--- a/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/MetsXml.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/MetsXml.scala
@@ -65,7 +65,7 @@ case class ArchivematicaMetsXML(root: Elem) extends MetsXml {
           new RuntimeException("multiple candidate record identifiers found")
         )
     }
-  
+
   def metsIdentifier: Either[Exception, String] = recordIdentifier
   def accessConditions: Either[Throwable, MetsAccessConditions] =
     (root \ "amdSec" \ "rightsMD").headOption

--- a/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/MetsXml.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformer/MetsXml.scala
@@ -65,32 +65,8 @@ case class ArchivematicaMetsXML(root: Elem) extends MetsXml {
           new RuntimeException("multiple candidate record identifiers found")
         )
     }
-  /*
-   *   <mets:dmdSec ID="dmdSec_1">
-      <mets:mdWrap MDTYPE="PREMIS:OBJECT">
-        <mets:xmlData>
-          <premis:object xmlns:premis="http://www.loc.gov/premis/v3" xsi:type="premis:intellectualEntity" xsi:schemaLocation="http://www.loc.gov/premis/v3 http://www.loc.gov/standards/premis/v3/premis.xsd" version="3.0">
-            <premis:objectIdentifier>
-              <premis:objectIdentifierType>UUID</premis:objectIdentifierType>
-              <premis:objectIdentifierValue>a765b7de-d8dd-45fe-94c9-8c4632e02178</premis:objectIdentifierValue>
-            </premis:objectIdentifier>
-            <premis:originalName>GC253_A_34_9-a765b7de-d8dd-45fe-94c9-8c4632e02178</premis:originalName>
-          </premis:object>
-        </mets:xmlData>
-      </mets:mdWrap>
-    </mets:dmdSec>
-   * */
-  def metsIdentifier: Either[Exception, String] = {
-    root \ "dmdSec" \ "mdWrap" \ "xmlData" \ "object" \ "objectIdentifier" \ "objectIdentifierValue" match {
-      case NodeSeq.Empty =>
-        Left(new RuntimeException("could not find mets identifier"))
-      case nodeseq if nodeseq.length == 1 => Right(nodeseq.head.text.trim)
-      case _ =>
-        Left(
-          new RuntimeException("multiple candidate mets identifiers found")
-        )
-    }
-  }
+  
+  def metsIdentifier: Either[Exception, String] = recordIdentifier
   def accessConditions: Either[Throwable, MetsAccessConditions] =
     (root \ "amdSec" \ "rightsMD").headOption
       .map(PremisAccessConditions(_)) match {

--- a/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformer/ArchivematicaMetsXMLTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformer/ArchivematicaMetsXMLTest.scala
@@ -35,13 +35,11 @@ class ArchivematicaMetsXMLTest
           "BA/AD/FO/OD"
       }
 
-      it("extracts the metsIdentifier from a premis objectIdentifier element") {
+      it("extracts the metsIdentifier from a dublincore identifier element") {
         ArchivematicaMetsXML(
-          archivematicaMetsWith(metsIdentifier =
-            "baadf00d-beef-cafe-f00d-beefcafef00d"
-          )
+          archivematicaMetsWith(recordIdentifier = "GO/OD/CA/FE")
         ).metsIdentifier.right.get shouldBe
-          "baadf00d-beef-cafe-f00d-beefcafef00d"
+          "GO/OD/CA/FE"
       }
 
     }


### PR DESCRIPTION
## What does this change?

This links Archivematica METS files to CALM records via the CALM id.  It also changes the source of the identifier for Archivematica METS files to use the CALM Refno instead of the unstable UUID that gets regenerated by Archivematica on each ingest.

Should fix https://github.com/wellcomecollection/catalogue-pipeline/issues/2623 after a reindex
## How to test

In a new pipeline (this change requires a reindex), push through a CALM record and corresponding Archivematica METS record (e.g. ARTCOO/A/3/1).

The records should merge

## How can we measure success?

We should get Born Digital content on the website (for those records with the appropriate access)

## Have we considered potential risks?

Because I am changing the identifier for these Archivematica-sourced records, their URLs will change.  However, they would not have been reachable anyway as METS files only result in a record at the end of the pipeline in consort with whatever they merge into, and never on their own.

The ID I have chosen is (I think) guaranteed to be unique in our context. I don't believe it is possible for two records to come through the pipeline with the same RefNo, because it corresponds to a position in a directory tree (I suppose it may be possible to put a record in the "wrong" position in the tree, but I think that would be a different problem). 

This ID is not guaranteed to be stable.  It is a value managed by humans which is meaningful - it governs the position of a record in a hierarchy - and as such _may_ change if someone decides it belongs in a different position.  However, it is considerably more stable than the UUID, and only ever changed deliberately, so if someone changes it on one side, it is not unreasonable to expect them to change it on the other.