### PR TITLE
Create EBSCO holdings and perform merge

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/languages/Language.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/languages/Language.scala
@@ -10,7 +10,7 @@ import grizzled.slf4j.Logging
   *
   * e.g. you might have two languages:
   *
-  * Language(it = "ita", label = "Italian") Language(it = "ita", label =
+  * Language(id = "ita", label = "Italian") Language(it = "ita", label =
   * "Judeo-Italian")
   *
   * This is based on the MARC language code list. A single language might have

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/generators/IdentifiersGenerators.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/generators/IdentifiersGenerators.scala
@@ -2,11 +2,7 @@ package weco.catalogue.internal_model.generators
 
 import org.scalacheck.Arbitrary
 import weco.fixtures.RandomGenerators
-import weco.catalogue.internal_model.identifiers.{
-  CanonicalId,
-  IdentifierType,
-  SourceIdentifier
-}
+import weco.catalogue.internal_model.identifiers.{CanonicalId, IdentifierType, SourceIdentifier}
 
 trait IdentifiersGenerators extends RandomGenerators {
   implicit val arbitraryCanonicalId: Arbitrary[CanonicalId] =
@@ -35,7 +31,8 @@ trait IdentifiersGenerators extends RandomGenerators {
     identifierType: IdentifierType = chooseFrom(
       IdentifierType.MiroImageNumber,
       IdentifierType.SierraSystemNumber,
-      IdentifierType.CalmRecordIdentifier
+      IdentifierType.CalmRecordIdentifier,
+      IdentifierType.EbscoAltLookup,
     ),
     value: String = randomAlphanumeric(length = 10),
     ontologyType: String = "Work"

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/generators/IdentifiersGenerators.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/generators/IdentifiersGenerators.scala
@@ -32,8 +32,10 @@ trait IdentifiersGenerators extends RandomGenerators {
       IdentifierType.MiroImageNumber,
       IdentifierType.SierraSystemNumber,
       IdentifierType.CalmRecordIdentifier,
-      // We do not include IdentifierType.EbscoAltLookup here
-      // because it always redirects Sierra works to Ebsco works.
+      // We deliberately omit Tei & Ebsco identifiers here so that we
+      // have predictable merge behaviour in tests. Miro & Calm records
+      // are always merged to to Sierra, and this is the relationship
+      // we assume in tests that use this generator.
     ),
     value: String = randomAlphanumeric(length = 10),
     ontologyType: String = "Work"

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/generators/IdentifiersGenerators.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/generators/IdentifiersGenerators.scala
@@ -32,7 +32,8 @@ trait IdentifiersGenerators extends RandomGenerators {
       IdentifierType.MiroImageNumber,
       IdentifierType.SierraSystemNumber,
       IdentifierType.CalmRecordIdentifier,
-      IdentifierType.EbscoAltLookup,
+      // We do not include IdentifierType.EbscoAltLookup here
+      // because it always redirects Sierra works to Ebsco works.
     ),
     value: String = randomAlphanumeric(length = 10),
     ontologyType: String = "Work"

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/generators/SierraWorkGenerators.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/generators/SierraWorkGenerators.scala
@@ -1,6 +1,6 @@
 package weco.catalogue.internal_model.work.generators
 
-import weco.catalogue.internal_model.identifiers.IdState
+import weco.catalogue.internal_model.identifiers.{IdState, IdentifierType}
 import weco.catalogue.internal_model.work.{MergeCandidate, Work, WorkState}
 
 trait SierraWorkGenerators extends WorkGenerators with ItemsGenerators {
@@ -13,6 +13,27 @@ trait SierraWorkGenerators extends WorkGenerators with ItemsGenerators {
           createSierraIdentifierSourceIdentifier
         )
       )
+
+  def sierraEbscoIdentifiedWorkPair(): (
+    Work.Visible[WorkState.Identified],
+      Work.Visible[WorkState.Identified]
+    ) = {
+    val ebscoWork = ebscoIdentifiedWork()
+    val sierraDigitalWork = sierraDigitalIdentifiedWork()
+      .mergeCandidates(
+        List(
+          MergeCandidate(
+            id = IdState.Identified(
+              canonicalId = ebscoWork.state.canonicalId,
+              sourceIdentifier = ebscoWork.sourceIdentifier
+            ),
+            reason = "Ebsco/Sierra work"
+          )
+        )
+      )
+
+    (sierraDigitalWork, ebscoWork)
+  }
 
   def sierraIdentifiedWorkPair(): (
     Work.Visible[WorkState.Identified],
@@ -34,6 +55,9 @@ trait SierraWorkGenerators extends WorkGenerators with ItemsGenerators {
 
     (digitisedWork, physicalWork)
   }
+
+  def ebscoIdentifiedWork(): Work.Visible[WorkState.Identified] =
+    identifiedWork(sourceIdentifier = createSourceIdentifierWith(IdentifierType.EbscoAltLookup))
 
   def sierraPhysicalIdentifiedWork(): Work.Visible[WorkState.Identified] =
     sierraIdentifiedWork().items(List(createIdentifiedPhysicalItem))

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/SourcePayload.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/SourcePayload.scala
@@ -5,6 +5,8 @@ import weco.catalogue.source_model.mets.MetsSourceData
 import weco.catalogue.source_model.miro.{MiroSourceOverrides, MiroUpdateEvent}
 import weco.catalogue.source_model.tei.TeiMetadata
 
+import java.time.Instant
+
 sealed trait SourcePayload {
   val id: String
   val version: Int
@@ -15,7 +17,8 @@ case class EbscoSourcePayload(
   location: Option[S3ObjectLocation],
   version: Int,
   sha256: Option[String],
-  deleted: Boolean = false
+  deleted: Boolean = false,
+  time: Instant
 ) extends SourcePayload
 
 case class CalmSourcePayload(

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/ebsco/EbscoSourceData.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/ebsco/EbscoSourceData.scala
@@ -2,7 +2,14 @@ package weco.catalogue.source_model.ebsco
 
 import weco.storage.providers.s3.S3ObjectLocation
 
-sealed trait EbscoSourceData {}
-case class EbscoUpdatedSourceData(s3Location: S3ObjectLocation)
+import java.time.Instant
+
+sealed trait EbscoSourceData {
+  val modifiedTime: Instant
+}
+case class EbscoUpdatedSourceData(
+                                   s3Location: S3ObjectLocation,
+                                   modifiedTime: Instant
+                                 )
     extends EbscoSourceData
-case object EbscoDeletedSourceData extends EbscoSourceData
+case class EbscoDeletedSourceData(modifiedTime: Instant) extends EbscoSourceData

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/ebsco/EbscoSourceData.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/ebsco/EbscoSourceData.scala
@@ -8,8 +8,7 @@ sealed trait EbscoSourceData {
   val modifiedTime: Instant
 }
 case class EbscoUpdatedSourceData(
-                                   s3Location: S3ObjectLocation,
-                                   modifiedTime: Instant
-                                 )
-    extends EbscoSourceData
+  s3Location: S3ObjectLocation,
+  modifiedTime: Instant
+) extends EbscoSourceData
 case class EbscoDeletedSourceData(modifiedTime: Instant) extends EbscoSourceData

--- a/ebsco_adapter/ebsco_adapter/src/main.py
+++ b/ebsco_adapter/ebsco_adapter/src/main.py
@@ -132,7 +132,9 @@ def lambda_handler(event, context):
                     event.get("reindex_ids"),
                 )
             else:
-                return run_process(temp_dir, ebsco_ftp, s3_store, sns_publisher, invoked_at)
+                return run_process(
+                    temp_dir, ebsco_ftp, s3_store, sns_publisher, invoked_at
+                )
 
 
 if __name__ == "__main__":

--- a/ebsco_adapter/ebsco_adapter/src/test_main.py
+++ b/ebsco_adapter/ebsco_adapter/src/test_main.py
@@ -12,6 +12,7 @@ xml_s3_prefix = "xml"
 ftp_s3_prefix = "ftp"
 topic_arn = "test_topic_arn"
 test_bucket = "test_bucket"
+invoked_at = "2023-01-01T00:00:00Z"
 
 ebs9579e = {
     "id": "ebs9579e",
@@ -22,6 +23,7 @@ ebs9579e = {
     "version": 20240322,
     "deleted": False,
     "sha256": "4c4a7fb13bf8b7beda96bbe75358eb882a6130592b29f6149a308d82e0356d22",
+    "time": invoked_at,
 }
 
 ebs29555e = {
@@ -33,6 +35,7 @@ ebs29555e = {
     "version": 20240322,
     "deleted": False,
     "sha256": "cb719218d3435395a2fa948088bf2c0fe86748dddfb5a2e8e2bbb199f6cf48dd",
+    "time": invoked_at,
 }
 
 ebs9579e_20240405 = {
@@ -44,6 +47,7 @@ ebs9579e_20240405 = {
     "version": 20240405,
     "deleted": False,
     "sha256": "b166aa8eb3c4f85dc95602fbdd920b444dfb6e08f6bc59881ad737878ed04822",
+    "time": invoked_at,
 }
 
 ebs29555e_20240405_deleted = {
@@ -52,6 +56,7 @@ ebs29555e_20240405_deleted = {
     "version": 20240405,
     "deleted": True,
     "sha256": None,
+    "time": invoked_at,
 }
 
 
@@ -110,7 +115,7 @@ def test_run_process():
         )
 
         print("\n--- Running test ingest process ---")
-        run_process(temp_dir, fake_ebsco_ftp, s3_store, sns_publisher)
+        run_process(temp_dir, fake_ebsco_ftp, s3_store, sns_publisher, invoked_at)
 
         files_ftp = s3_store.list_files(f"dev/{ftp_s3_prefix}")
         assert files_ftp == [
@@ -166,7 +171,7 @@ def test_run_reindex():
             }
         )
         print("\n--- Running test ingest process ---")
-        run_process(temp_dir, fake_ebsco_ftp, s3_store, sns_publisher)
+        run_process(temp_dir, fake_ebsco_ftp, s3_store, sns_publisher, invoked_at)
 
         # get the number of files in the s3 bucket under the xml prefix
         files = s3_store.list_files(f"dev/{xml_s3_prefix}")
@@ -185,7 +190,7 @@ def test_run_reindex():
         assert fake_sns_client.test_get_published_messages() == []
 
         print("\n--- Running test reindex with type full ---")
-        run_reindex(s3_store, sns_publisher, "full")
+        run_reindex(s3_store, sns_publisher, invoked_at, "full")
 
         reindex_published_messages = fake_sns_client.test_get_published_messages()
         assert reindex_published_messages == [ebs9579e, ebs29555e]
@@ -194,7 +199,7 @@ def test_run_reindex():
         assert fake_sns_client.test_get_published_messages() == []
 
         print("\n--- Running test reindex with type partial ---")
-        run_reindex(s3_store, sns_publisher, "partial", ["ebs9579e"])
+        run_reindex(s3_store, sns_publisher, invoked_at, "partial", ["ebs9579e"])
 
         reindex_published_messages = fake_sns_client.test_get_published_messages()
         assert reindex_published_messages == [ebs9579e]

--- a/ebsco_adapter/ebsco_adapter/src/test_update_notifier.py
+++ b/ebsco_adapter/ebsco_adapter/src/test_update_notifier.py
@@ -61,7 +61,13 @@ def test_update_notifier():
     expected_messages = expected_update_messages + expected_deleted_messages
 
     update_notifier(
-        updates, notify_for_batch, s3_store, s3_bucket, xml_s3_prefix, sns_publisher, invoked_at
+        updates,
+        notify_for_batch,
+        s3_store,
+        s3_bucket,
+        xml_s3_prefix,
+        sns_publisher,
+        invoked_at,
     )
     published_messages = fake_sns_client.test_get_published_messages()
 

--- a/ebsco_adapter/ebsco_adapter/src/test_update_notifier.py
+++ b/ebsco_adapter/ebsco_adapter/src/test_update_notifier.py
@@ -18,6 +18,7 @@ def test_update_notifier():
 
     number_of_updates = 100
     number_of_deleted = 50
+    invoked_at = "2023-01-01T00:00:00Z"
 
     updates = {
         "updated": {
@@ -40,6 +41,7 @@ def test_update_notifier():
             "version": 20230101,
             "deleted": False,
             "sha256": "test_sha256",
+            "time": "2023-01-01T00:00:00Z",
         }
         for i in range(number_of_updates)
     ]
@@ -51,6 +53,7 @@ def test_update_notifier():
             "version": 20230101,
             "deleted": True,
             "sha256": None,
+            "time": "2023-01-01T00:00:00Z",
         }
         for i in range(number_of_deleted)
     ]
@@ -58,7 +61,7 @@ def test_update_notifier():
     expected_messages = expected_update_messages + expected_deleted_messages
 
     update_notifier(
-        updates, notify_for_batch, s3_store, s3_bucket, xml_s3_prefix, sns_publisher
+        updates, notify_for_batch, s3_store, s3_bucket, xml_s3_prefix, sns_publisher, invoked_at
     )
     published_messages = fake_sns_client.test_get_published_messages()
 

--- a/ebsco_adapter/ebsco_adapter/src/update_notifier.py
+++ b/ebsco_adapter/ebsco_adapter/src/update_notifier.py
@@ -2,7 +2,7 @@ import os
 
 
 def update_notifier(
-    updates, notify_for_batch, s3_store, s3_bucket, xml_s3_prefix, sns_publisher
+    updates, notify_for_batch, s3_store, s3_bucket, xml_s3_prefix, sns_publisher, invoked_at
 ):
     update_messages = []
     deleted_messages = []
@@ -21,6 +21,7 @@ def update_notifier(
                     "version": version,
                     "deleted": False,
                     "sha256": update["sha256"],
+                    "time": invoked_at
                 }
             )
 
@@ -33,6 +34,7 @@ def update_notifier(
                     "version": version,
                     "deleted": True,
                     "sha256": None,
+                    "time": invoked_at
                 }
             )
 

--- a/ebsco_adapter/ebsco_adapter/src/update_notifier.py
+++ b/ebsco_adapter/ebsco_adapter/src/update_notifier.py
@@ -2,7 +2,13 @@ import os
 
 
 def update_notifier(
-    updates, notify_for_batch, s3_store, s3_bucket, xml_s3_prefix, sns_publisher, invoked_at
+    updates,
+    notify_for_batch,
+    s3_store,
+    s3_bucket,
+    xml_s3_prefix,
+    sns_publisher,
+    invoked_at,
 ):
     update_messages = []
     deleted_messages = []
@@ -21,7 +27,7 @@ def update_notifier(
                     "version": version,
                     "deleted": False,
                     "sha256": update["sha256"],
-                    "time": invoked_at
+                    "time": invoked_at,
                 }
             )
 
@@ -34,7 +40,7 @@ def update_notifier(
                     "version": version,
                     "deleted": True,
                     "sha256": None,
-                    "time": invoked_at
+                    "time": invoked_at,
                 }
             )
 

--- a/pipeline/ingestor/test_documents/work-production.1098.json
+++ b/pipeline/ingestor/test_documents/work-production.1098.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 1098",
-  "createdAt" : "2024-02-16T15:36:44.229565Z",
+  "createdAt" : "2024-05-13T10:22:00.812626Z",
   "id" : "guav7chy",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "guav7chy",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "W9fptfa5Xn"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "W9fptfa5Xn",

--- a/pipeline/ingestor/test_documents/work-production.1098.json
+++ b/pipeline/ingestor/test_documents/work-production.1098.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 1098",
-  "createdAt" : "2024-05-13T10:22:00.812626Z",
+  "createdAt" : "2024-05-15T08:17:25.275272Z",
   "id" : "guav7chy",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "guav7chy",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "W9fptfa5Xn"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "W9fptfa5Xn",

--- a/pipeline/ingestor/test_documents/work-production.1900.json
+++ b/pipeline/ingestor/test_documents/work-production.1900.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 1900",
-  "createdAt" : "2024-05-13T10:22:00.800552Z",
+  "createdAt" : "2024-05-15T08:17:25.267552Z",
   "id" : "rbnro6wx",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "rbnro6wx",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "akaUmx5H3i"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "akaUmx5H3i",

--- a/pipeline/ingestor/test_documents/work-production.1900.json
+++ b/pipeline/ingestor/test_documents/work-production.1900.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 1900",
-  "createdAt" : "2024-02-16T15:36:44.190107Z",
+  "createdAt" : "2024-05-13T10:22:00.800552Z",
   "id" : "rbnro6wx",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "rbnro6wx",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "akaUmx5H3i"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "akaUmx5H3i",

--- a/pipeline/ingestor/test_documents/work-production.1904.json
+++ b/pipeline/ingestor/test_documents/work-production.1904.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 1904",
-  "createdAt" : "2024-02-16T15:36:44.209947Z",
+  "createdAt" : "2024-05-13T10:22:00.808103Z",
   "id" : "aiv95swj",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "aiv95swj",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "h0QyLvGt20"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "h0QyLvGt20",

--- a/pipeline/ingestor/test_documents/work-production.1904.json
+++ b/pipeline/ingestor/test_documents/work-production.1904.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 1904",
-  "createdAt" : "2024-05-13T10:22:00.808103Z",
+  "createdAt" : "2024-05-15T08:17:25.271712Z",
   "id" : "aiv95swj",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "aiv95swj",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "h0QyLvGt20"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "h0QyLvGt20",

--- a/pipeline/ingestor/test_documents/work-production.1976.json
+++ b/pipeline/ingestor/test_documents/work-production.1976.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 1976",
-  "createdAt" : "2024-05-13T10:22:00.805267Z",
+  "createdAt" : "2024-05-15T08:17:25.269638Z",
   "id" : "5vjghupy",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "5vjghupy",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "xrdlOL8J49"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "xrdlOL8J49",

--- a/pipeline/ingestor/test_documents/work-production.1976.json
+++ b/pipeline/ingestor/test_documents/work-production.1976.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 1976",
-  "createdAt" : "2024-02-16T15:36:44.199498Z",
+  "createdAt" : "2024-05-13T10:22:00.805267Z",
   "id" : "5vjghupy",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "5vjghupy",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "xrdlOL8J49"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "xrdlOL8J49",

--- a/pipeline/ingestor/test_documents/work-production.2020.json
+++ b/pipeline/ingestor/test_documents/work-production.2020.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 2020",
-  "createdAt" : "2024-02-16T15:36:44.223193Z",
+  "createdAt" : "2024-05-13T10:22:00.810677Z",
   "id" : "0fucriyr",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "0fucriyr",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "KgSH5dUX0Z"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "KgSH5dUX0Z",

--- a/pipeline/ingestor/test_documents/work-production.2020.json
+++ b/pipeline/ingestor/test_documents/work-production.2020.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 2020",
-  "createdAt" : "2024-05-13T10:22:00.810677Z",
+  "createdAt" : "2024-05-15T08:17:25.273533Z",
   "id" : "0fucriyr",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "0fucriyr",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "KgSH5dUX0Z"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "KgSH5dUX0Z",

--- a/pipeline/ingestor/test_documents/work-thumbnail.json
+++ b/pipeline/ingestor/test_documents/work-thumbnail.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a thumbnail",
-  "createdAt" : "2024-02-16T15:36:44.151896Z",
+  "createdAt" : "2024-05-13T10:22:00.752214Z",
   "id" : "sahqcluh",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "sahqcluh",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "rRRYGQYiF7"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "rRRYGQYiF7",

--- a/pipeline/ingestor/test_documents/work-thumbnail.json
+++ b/pipeline/ingestor/test_documents/work-thumbnail.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a thumbnail",
-  "createdAt" : "2024-05-13T10:22:00.752214Z",
+  "createdAt" : "2024-05-15T08:17:25.253981Z",
   "id" : "sahqcluh",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "sahqcluh",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "rRRYGQYiF7"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "rRRYGQYiF7",

--- a/pipeline/ingestor/test_documents/work-title-dodo.json
+++ b/pipeline/ingestor/test_documents/work-title-dodo.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with 'dodo' in the title",
-  "createdAt" : "2024-05-13T10:22:00.757481Z",
+  "createdAt" : "2024-05-15T08:17:25.256890Z",
   "id" : "ezagik4b",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "ezagik4b",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "xg9OuzGali"
@@ -34,8 +34,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "xg9OuzGali",

--- a/pipeline/ingestor/test_documents/work-title-dodo.json
+++ b/pipeline/ingestor/test_documents/work-title-dodo.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with 'dodo' in the title",
-  "createdAt" : "2024-02-16T15:36:44.167559Z",
+  "createdAt" : "2024-05-13T10:22:00.757481Z",
   "id" : "ezagik4b",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "ezagik4b",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "xg9OuzGali"
@@ -34,8 +34,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "xg9OuzGali",

--- a/pipeline/ingestor/test_documents/work-title-mouse.json
+++ b/pipeline/ingestor/test_documents/work-title-mouse.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with 'mouse' in the title",
-  "createdAt" : "2024-05-13T10:22:00.760047Z",
+  "createdAt" : "2024-05-15T08:17:25.258939Z",
   "id" : "lnn17cwk",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "lnn17cwk",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "EhPpSB8mq7"
@@ -34,8 +34,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "EhPpSB8mq7",

--- a/pipeline/ingestor/test_documents/work-title-mouse.json
+++ b/pipeline/ingestor/test_documents/work-title-mouse.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with 'mouse' in the title",
-  "createdAt" : "2024-02-16T15:36:44.172159Z",
+  "createdAt" : "2024-05-13T10:22:00.760047Z",
   "id" : "lnn17cwk",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "lnn17cwk",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "EhPpSB8mq7"
@@ -34,8 +34,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "EhPpSB8mq7",

--- a/pipeline/ingestor/test_documents/work-with-edition-and-duration.json
+++ b/pipeline/ingestor/test_documents/work-with-edition-and-duration.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with optional top-level fields",
-  "createdAt" : "2024-05-13T10:22:00.741484Z",
+  "createdAt" : "2024-05-15T08:17:25.244884Z",
   "id" : "gsruvqwf",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "gsruvqwf",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "7YNi35xO0f"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "7YNi35xO0f",

--- a/pipeline/ingestor/test_documents/work-with-edition-and-duration.json
+++ b/pipeline/ingestor/test_documents/work-with-edition-and-duration.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with optional top-level fields",
-  "createdAt" : "2024-02-16T15:36:44.133193Z",
+  "createdAt" : "2024-05-13T10:22:00.741484Z",
   "id" : "gsruvqwf",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "gsruvqwf",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "7YNi35xO0f"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "7YNi35xO0f",

--- a/pipeline/ingestor/test_documents/work.items-with-location-types.0.json
+++ b/pipeline/ingestor/test_documents/work.items-with-location-types.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "items with different location types",
-  "createdAt" : "2024-05-13T10:22:01.146785Z",
+  "createdAt" : "2024-05-15T08:17:25.530111Z",
   "id" : "tnnwysoe",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "tnnwysoe",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "JC6PIObmiP"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "JC6PIObmiP",
@@ -51,8 +51,8 @@
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "miro-image-number",
-                "label" : "Miro image number",
+                "id" : "calm-record-id",
+                "label" : "Calm RecordIdentifier",
                 "type" : "IdentifierType"
               },
               "value" : "0FUCKKVOQZ",

--- a/pipeline/ingestor/test_documents/work.items-with-location-types.0.json
+++ b/pipeline/ingestor/test_documents/work.items-with-location-types.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "items with different location types",
-  "createdAt" : "2024-02-16T15:36:44.948303Z",
+  "createdAt" : "2024-05-13T10:22:01.146785Z",
   "id" : "tnnwysoe",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "tnnwysoe",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "JC6PIObmiP"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "JC6PIObmiP",
@@ -51,8 +51,8 @@
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "calm-record-id",
-                "label" : "Calm RecordIdentifier",
+                "id" : "miro-image-number",
+                "label" : "Miro image number",
                 "type" : "IdentifierType"
               },
               "value" : "0FUCKKVOQZ",

--- a/pipeline/ingestor/test_documents/work.items-with-location-types.1.json
+++ b/pipeline/ingestor/test_documents/work.items-with-location-types.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "items with different location types",
-  "createdAt" : "2024-02-16T15:36:44.949159Z",
+  "createdAt" : "2024-05-13T10:22:01.147313Z",
   "id" : "feri8p7w",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "feri8p7w",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "MM8GfuD4za"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "MM8GfuD4za",
@@ -51,8 +51,8 @@
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "calm-record-id",
-                "label" : "Calm RecordIdentifier",
+                "id" : "ebsco-alt-lookup",
+                "label" : "EBSCO lookup identifier",
                 "type" : "IdentifierType"
               },
               "value" : "XaTo6WyiCa",

--- a/pipeline/ingestor/test_documents/work.items-with-location-types.1.json
+++ b/pipeline/ingestor/test_documents/work.items-with-location-types.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "items with different location types",
-  "createdAt" : "2024-05-13T10:22:01.147313Z",
+  "createdAt" : "2024-05-15T08:17:25.530744Z",
   "id" : "feri8p7w",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "feri8p7w",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "MM8GfuD4za"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "MM8GfuD4za",
@@ -51,8 +51,8 @@
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "ebsco-alt-lookup",
-                "label" : "EBSCO lookup identifier",
+                "id" : "calm-record-id",
+                "label" : "Calm RecordIdentifier",
                 "type" : "IdentifierType"
               },
               "value" : "XaTo6WyiCa",

--- a/pipeline/ingestor/test_documents/work.items-with-location-types.2.json
+++ b/pipeline/ingestor/test_documents/work.items-with-location-types.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "items with different location types",
-  "createdAt" : "2024-05-13T10:22:01.147788Z",
+  "createdAt" : "2024-05-15T08:17:25.531459Z",
   "id" : "xzwsggki",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "xzwsggki",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "G6KR1DmPfn"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "G6KR1DmPfn",
@@ -51,8 +51,8 @@
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "calm-record-id",
-                "label" : "Calm RecordIdentifier",
+                "id" : "sierra-system-number",
+                "label" : "Sierra system number",
                 "type" : "IdentifierType"
               },
               "value" : "k2sxFZY9hd",

--- a/pipeline/ingestor/test_documents/work.items-with-location-types.2.json
+++ b/pipeline/ingestor/test_documents/work.items-with-location-types.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "items with different location types",
-  "createdAt" : "2024-02-16T15:36:44.949861Z",
+  "createdAt" : "2024-05-13T10:22:01.147788Z",
   "id" : "xzwsggki",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "xzwsggki",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "G6KR1DmPfn"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "G6KR1DmPfn",
@@ -51,8 +51,8 @@
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "sierra-system-number",
-                "label" : "Sierra system number",
+                "id" : "calm-record-id",
+                "label" : "Calm RecordIdentifier",
                 "type" : "IdentifierType"
               },
               "value" : "k2sxFZY9hd",

--- a/pipeline/ingestor/test_documents/work.visible.everything.0.json
+++ b/pipeline/ingestor/test_documents/work.visible.everything.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "a list of work with all the include-able fields",
-  "createdAt" : "2024-05-13T10:22:00.991946Z",
+  "createdAt" : "2024-05-15T08:17:25.421484Z",
   "id" : "tmdfbk5k",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "tmdfbk5k",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "Aic5qOhRoS"
@@ -53,8 +53,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "Aic5qOhRoS",
@@ -62,8 +62,8 @@
         },
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "UfcQYSxE7g",
@@ -117,8 +117,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "ebsco-alt-lookup",
-                    "label" : "EBSCO lookup identifier",
+                    "id" : "calm-record-id",
+                    "label" : "Calm RecordIdentifier",
                     "type" : "IdentifierType"
                   },
                   "value" : "4fR1f4tFlV",
@@ -149,8 +149,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "calm-record-id",
-                    "label" : "Calm RecordIdentifier",
+                    "id" : "sierra-system-number",
+                    "label" : "Sierra system number",
                     "type" : "IdentifierType"
                   },
                   "value" : "MLX8biK5UW",
@@ -171,8 +171,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "sierra-system-number",
-                    "label" : "Sierra system number",
+                    "id" : "calm-record-id",
+                    "label" : "Calm RecordIdentifier",
                     "type" : "IdentifierType"
                   },
                   "value" : "8xazsI6am8",
@@ -187,8 +187,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "calm-record-id",
-                    "label" : "Calm RecordIdentifier",
+                    "id" : "miro-image-number",
+                    "label" : "Miro image number",
                     "type" : "IdentifierType"
                   },
                   "value" : "aEhJ0QNRzQ",
@@ -203,8 +203,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "ebsco-alt-lookup",
-                    "label" : "EBSCO lookup identifier",
+                    "id" : "calm-record-id",
+                    "label" : "Calm RecordIdentifier",
                     "type" : "IdentifierType"
                   },
                   "value" : "4g2k9frr0x",
@@ -224,8 +224,8 @@
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "calm-record-id",
-                "label" : "Calm RecordIdentifier",
+                "id" : "miro-image-number",
+                "label" : "Miro image number",
                 "type" : "IdentifierType"
               },
               "value" : "GWWFxlGgZX",
@@ -258,8 +258,8 @@
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "sierra-system-number",
-                "label" : "Sierra system number",
+                "id" : "calm-record-id",
+                "label" : "Calm RecordIdentifier",
                 "type" : "IdentifierType"
               },
               "value" : "dG0mvvCJtU",

--- a/pipeline/ingestor/test_documents/work.visible.everything.0.json
+++ b/pipeline/ingestor/test_documents/work.visible.everything.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "a list of work with all the include-able fields",
-  "createdAt" : "2024-02-16T15:36:44.682166Z",
+  "createdAt" : "2024-05-13T10:22:00.991946Z",
   "id" : "tmdfbk5k",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "tmdfbk5k",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "Aic5qOhRoS"
@@ -53,8 +53,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "Aic5qOhRoS",
@@ -62,8 +62,8 @@
         },
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "UfcQYSxE7g",
@@ -117,8 +117,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "calm-record-id",
-                    "label" : "Calm RecordIdentifier",
+                    "id" : "ebsco-alt-lookup",
+                    "label" : "EBSCO lookup identifier",
                     "type" : "IdentifierType"
                   },
                   "value" : "4fR1f4tFlV",
@@ -149,8 +149,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "sierra-system-number",
-                    "label" : "Sierra system number",
+                    "id" : "calm-record-id",
+                    "label" : "Calm RecordIdentifier",
                     "type" : "IdentifierType"
                   },
                   "value" : "MLX8biK5UW",
@@ -171,8 +171,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "calm-record-id",
-                    "label" : "Calm RecordIdentifier",
+                    "id" : "sierra-system-number",
+                    "label" : "Sierra system number",
                     "type" : "IdentifierType"
                   },
                   "value" : "8xazsI6am8",
@@ -187,8 +187,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "miro-image-number",
-                    "label" : "Miro image number",
+                    "id" : "calm-record-id",
+                    "label" : "Calm RecordIdentifier",
                     "type" : "IdentifierType"
                   },
                   "value" : "aEhJ0QNRzQ",
@@ -203,8 +203,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "calm-record-id",
-                    "label" : "Calm RecordIdentifier",
+                    "id" : "ebsco-alt-lookup",
+                    "label" : "EBSCO lookup identifier",
                     "type" : "IdentifierType"
                   },
                   "value" : "4g2k9frr0x",
@@ -224,8 +224,8 @@
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "miro-image-number",
-                "label" : "Miro image number",
+                "id" : "calm-record-id",
+                "label" : "Calm RecordIdentifier",
                 "type" : "IdentifierType"
               },
               "value" : "GWWFxlGgZX",
@@ -258,8 +258,8 @@
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "calm-record-id",
-                "label" : "Calm RecordIdentifier",
+                "id" : "sierra-system-number",
+                "label" : "Sierra system number",
                 "type" : "IdentifierType"
               },
               "value" : "dG0mvvCJtU",

--- a/pipeline/ingestor/test_documents/work.visible.everything.1.json
+++ b/pipeline/ingestor/test_documents/work.visible.everything.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "a list of work with all the include-able fields",
-  "createdAt" : "2024-05-13T10:22:00.997317Z",
+  "createdAt" : "2024-05-15T08:17:25.424426Z",
   "id" : "dhzcyeul",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "dhzcyeul",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "LMVvWxgXRS"
@@ -53,8 +53,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "LMVvWxgXRS",
@@ -62,8 +62,8 @@
         },
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "mD7jxioppl",
@@ -117,8 +117,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "calm-record-id",
-                    "label" : "Calm RecordIdentifier",
+                    "id" : "sierra-system-number",
+                    "label" : "Sierra system number",
                     "type" : "IdentifierType"
                   },
                   "value" : "ZvMlY5yFST",
@@ -149,8 +149,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "sierra-system-number",
-                    "label" : "Sierra system number",
+                    "id" : "miro-image-number",
+                    "label" : "Miro image number",
                     "type" : "IdentifierType"
                   },
                   "value" : "f8JXFRL51H",
@@ -187,8 +187,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "miro-image-number",
-                    "label" : "Miro image number",
+                    "id" : "sierra-system-number",
+                    "label" : "Sierra system number",
                     "type" : "IdentifierType"
                   },
                   "value" : "PAydChzshi",
@@ -203,8 +203,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "ebsco-alt-lookup",
-                    "label" : "EBSCO lookup identifier",
+                    "id" : "calm-record-id",
+                    "label" : "Calm RecordIdentifier",
                     "type" : "IdentifierType"
                   },
                   "value" : "Pv8CsB8YxC",
@@ -224,8 +224,8 @@
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "ebsco-alt-lookup",
-                "label" : "EBSCO lookup identifier",
+                "id" : "sierra-system-number",
+                "label" : "Sierra system number",
                 "type" : "IdentifierType"
               },
               "value" : "HYZ1N6BwQR",
@@ -260,8 +260,8 @@
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "miro-image-number",
-                "label" : "Miro image number",
+                "id" : "calm-record-id",
+                "label" : "Calm RecordIdentifier",
                 "type" : "IdentifierType"
               },
               "value" : "fYVwu7Y7Y7",

--- a/pipeline/ingestor/test_documents/work.visible.everything.1.json
+++ b/pipeline/ingestor/test_documents/work.visible.everything.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "a list of work with all the include-able fields",
-  "createdAt" : "2024-02-16T15:36:44.697471Z",
+  "createdAt" : "2024-05-13T10:22:00.997317Z",
   "id" : "dhzcyeul",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "dhzcyeul",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "LMVvWxgXRS"
@@ -53,8 +53,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "LMVvWxgXRS",
@@ -62,8 +62,8 @@
         },
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "mD7jxioppl",
@@ -117,8 +117,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "sierra-system-number",
-                    "label" : "Sierra system number",
+                    "id" : "calm-record-id",
+                    "label" : "Calm RecordIdentifier",
                     "type" : "IdentifierType"
                   },
                   "value" : "ZvMlY5yFST",
@@ -149,8 +149,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "miro-image-number",
-                    "label" : "Miro image number",
+                    "id" : "sierra-system-number",
+                    "label" : "Sierra system number",
                     "type" : "IdentifierType"
                   },
                   "value" : "f8JXFRL51H",
@@ -187,8 +187,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "sierra-system-number",
-                    "label" : "Sierra system number",
+                    "id" : "miro-image-number",
+                    "label" : "Miro image number",
                     "type" : "IdentifierType"
                   },
                   "value" : "PAydChzshi",
@@ -203,8 +203,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "calm-record-id",
-                    "label" : "Calm RecordIdentifier",
+                    "id" : "ebsco-alt-lookup",
+                    "label" : "EBSCO lookup identifier",
                     "type" : "IdentifierType"
                   },
                   "value" : "Pv8CsB8YxC",
@@ -224,8 +224,8 @@
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "sierra-system-number",
-                "label" : "Sierra system number",
+                "id" : "ebsco-alt-lookup",
+                "label" : "EBSCO lookup identifier",
                 "type" : "IdentifierType"
               },
               "value" : "HYZ1N6BwQR",
@@ -260,8 +260,8 @@
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "calm-record-id",
-                "label" : "Calm RecordIdentifier",
+                "id" : "miro-image-number",
+                "label" : "Miro image number",
                 "type" : "IdentifierType"
               },
               "value" : "fYVwu7Y7Y7",

--- a/pipeline/ingestor/test_documents/work.visible.everything.2.json
+++ b/pipeline/ingestor/test_documents/work.visible.everything.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "a list of work with all the include-able fields",
-  "createdAt" : "2024-02-16T15:36:44.706563Z",
+  "createdAt" : "2024-05-13T10:22:01.000767Z",
   "id" : "kspmagtl",
   "document" : {
     "debug" : {
@@ -62,8 +62,8 @@
         },
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "ebsco-alt-lookup",
+            "label" : "EBSCO lookup identifier",
             "type" : "IdentifierType"
           },
           "value" : "Hq3k05Fqag",
@@ -117,8 +117,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "calm-record-id",
-                    "label" : "Calm RecordIdentifier",
+                    "id" : "miro-image-number",
+                    "label" : "Miro image number",
                     "type" : "IdentifierType"
                   },
                   "value" : "KLw3A3d2Sg",
@@ -133,8 +133,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "sierra-system-number",
-                    "label" : "Sierra system number",
+                    "id" : "miro-image-number",
+                    "label" : "Miro image number",
                     "type" : "IdentifierType"
                   },
                   "value" : "9vtTXh5eC6",
@@ -149,8 +149,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "sierra-system-number",
-                    "label" : "Sierra system number",
+                    "id" : "calm-record-id",
+                    "label" : "Calm RecordIdentifier",
                     "type" : "IdentifierType"
                   },
                   "value" : "Jxv9xrQ6Lp",
@@ -187,8 +187,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "miro-image-number",
-                    "label" : "Miro image number",
+                    "id" : "sierra-system-number",
+                    "label" : "Sierra system number",
                     "type" : "IdentifierType"
                   },
                   "value" : "Qgjny3fstP",
@@ -259,8 +259,8 @@
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "sierra-system-number",
-                "label" : "Sierra system number",
+                "id" : "calm-record-id",
+                "label" : "Calm RecordIdentifier",
                 "type" : "IdentifierType"
               },
               "value" : "da6nNHPpdW",

--- a/pipeline/ingestor/test_documents/work.visible.everything.2.json
+++ b/pipeline/ingestor/test_documents/work.visible.everything.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "a list of work with all the include-able fields",
-  "createdAt" : "2024-05-13T10:22:01.000767Z",
+  "createdAt" : "2024-05-15T08:17:25.426470Z",
   "id" : "kspmagtl",
   "document" : {
     "debug" : {
@@ -62,8 +62,8 @@
         },
         {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup",
-            "label" : "EBSCO lookup identifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "Hq3k05Fqag",
@@ -117,8 +117,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "miro-image-number",
-                    "label" : "Miro image number",
+                    "id" : "calm-record-id",
+                    "label" : "Calm RecordIdentifier",
                     "type" : "IdentifierType"
                   },
                   "value" : "KLw3A3d2Sg",
@@ -133,8 +133,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "miro-image-number",
-                    "label" : "Miro image number",
+                    "id" : "sierra-system-number",
+                    "label" : "Sierra system number",
                     "type" : "IdentifierType"
                   },
                   "value" : "9vtTXh5eC6",
@@ -149,8 +149,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "calm-record-id",
-                    "label" : "Calm RecordIdentifier",
+                    "id" : "sierra-system-number",
+                    "label" : "Sierra system number",
                     "type" : "IdentifierType"
                   },
                   "value" : "Jxv9xrQ6Lp",
@@ -187,8 +187,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "sierra-system-number",
-                    "label" : "Sierra system number",
+                    "id" : "miro-image-number",
+                    "label" : "Miro image number",
                     "type" : "IdentifierType"
                   },
                   "value" : "Qgjny3fstP",
@@ -259,8 +259,8 @@
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "calm-record-id",
-                "label" : "Calm RecordIdentifier",
+                "id" : "sierra-system-number",
+                "label" : "Sierra system number",
                 "type" : "IdentifierType"
               },
               "value" : "da6nNHPpdW",

--- a/pipeline/ingestor/test_documents/works.contributor.0.json
+++ b/pipeline/ingestor/test_documents/works.contributor.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different contributor",
-  "createdAt" : "2024-05-13T10:22:01.085613Z",
+  "createdAt" : "2024-05-15T08:17:25.482999Z",
   "id" : "5qgfzto1",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "5qgfzto1",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "x4HrV5FXFI"
@@ -43,8 +43,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "x4HrV5FXFI",

--- a/pipeline/ingestor/test_documents/works.contributor.0.json
+++ b/pipeline/ingestor/test_documents/works.contributor.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different contributor",
-  "createdAt" : "2024-02-16T15:36:44.852063Z",
+  "createdAt" : "2024-05-13T10:22:01.085613Z",
   "id" : "5qgfzto1",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "5qgfzto1",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "x4HrV5FXFI"
@@ -43,8 +43,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "x4HrV5FXFI",

--- a/pipeline/ingestor/test_documents/works.contributor.1.json
+++ b/pipeline/ingestor/test_documents/works.contributor.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different contributor",
-  "createdAt" : "2024-05-13T10:22:01.086130Z",
+  "createdAt" : "2024-05-15T08:17:25.483411Z",
   "id" : "a8uyvixy",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "a8uyvixy",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "HfSgzBeJhd"
@@ -43,8 +43,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "HfSgzBeJhd",

--- a/pipeline/ingestor/test_documents/works.contributor.1.json
+++ b/pipeline/ingestor/test_documents/works.contributor.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different contributor",
-  "createdAt" : "2024-02-16T15:36:44.853574Z",
+  "createdAt" : "2024-05-13T10:22:01.086130Z",
   "id" : "a8uyvixy",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "a8uyvixy",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "HfSgzBeJhd"
@@ -43,8 +43,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "HfSgzBeJhd",

--- a/pipeline/ingestor/test_documents/works.contributor.2.json
+++ b/pipeline/ingestor/test_documents/works.contributor.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different contributor",
-  "createdAt" : "2024-02-16T15:36:44.857789Z",
+  "createdAt" : "2024-05-13T10:22:01.090694Z",
   "id" : "toypx23i",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "toypx23i",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "MhQvVMFf3I"
@@ -53,8 +53,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "MhQvVMFf3I",

--- a/pipeline/ingestor/test_documents/works.contributor.2.json
+++ b/pipeline/ingestor/test_documents/works.contributor.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different contributor",
-  "createdAt" : "2024-05-13T10:22:01.090694Z",
+  "createdAt" : "2024-05-15T08:17:25.485853Z",
   "id" : "toypx23i",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "toypx23i",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "MhQvVMFf3I"
@@ -53,8 +53,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "MhQvVMFf3I",

--- a/pipeline/ingestor/test_documents/works.contributor.3.json
+++ b/pipeline/ingestor/test_documents/works.contributor.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different contributor",
-  "createdAt" : "2024-02-16T15:36:44.858500Z",
+  "createdAt" : "2024-05-13T10:22:01.091210Z",
   "id" : "mudchggm",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "mudchggm",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "XCPwwavyjz"
@@ -53,8 +53,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "XCPwwavyjz",

--- a/pipeline/ingestor/test_documents/works.contributor.3.json
+++ b/pipeline/ingestor/test_documents/works.contributor.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different contributor",
-  "createdAt" : "2024-05-13T10:22:01.091210Z",
+  "createdAt" : "2024-05-15T08:17:25.486303Z",
   "id" : "mudchggm",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "mudchggm",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "XCPwwavyjz"
@@ -53,8 +53,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "XCPwwavyjz",

--- a/pipeline/ingestor/test_documents/works.deleted.0.json
+++ b/pipeline/ingestor/test_documents/works.deleted.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of deleted works",
-  "createdAt" : "2024-02-16T15:36:44.110356Z",
+  "createdAt" : "2024-05-13T10:22:00.729210Z",
   "id" : "pnwuzuig",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "pnwuzuig",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "ebsco-alt-lookup"
           },
           "ontologyType" : "Work",
           "value" : "h0Og1ZYVOG"

--- a/pipeline/ingestor/test_documents/works.deleted.0.json
+++ b/pipeline/ingestor/test_documents/works.deleted.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of deleted works",
-  "createdAt" : "2024-05-13T10:22:00.729210Z",
+  "createdAt" : "2024-05-15T08:17:25.230175Z",
   "id" : "pnwuzuig",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "pnwuzuig",
         "identifier" : {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "h0Og1ZYVOG"

--- a/pipeline/ingestor/test_documents/works.deleted.1.json
+++ b/pipeline/ingestor/test_documents/works.deleted.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of deleted works",
-  "createdAt" : "2024-05-13T10:22:00.729483Z",
+  "createdAt" : "2024-05-15T08:17:25.230436Z",
   "id" : "drwubxen",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "drwubxen",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "id6G7vla4o"

--- a/pipeline/ingestor/test_documents/works.deleted.1.json
+++ b/pipeline/ingestor/test_documents/works.deleted.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of deleted works",
-  "createdAt" : "2024-02-16T15:36:44.110947Z",
+  "createdAt" : "2024-05-13T10:22:00.729483Z",
   "id" : "drwubxen",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "drwubxen",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "id6G7vla4o"

--- a/pipeline/ingestor/test_documents/works.every-format.0.json
+++ b/pipeline/ingestor/test_documents/works.every-format.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-02-16T15:36:44.887738Z",
+  "createdAt" : "2024-05-13T10:22:01.111Z",
   "id" : "w2ap82cs",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "w2ap82cs",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "ebsco-alt-lookup"
           },
           "ontologyType" : "Work",
           "value" : "UZlr85jkfd"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "ebsco-alt-lookup",
+            "label" : "EBSCO lookup identifier",
             "type" : "IdentifierType"
           },
           "value" : "UZlr85jkfd",

--- a/pipeline/ingestor/test_documents/works.every-format.0.json
+++ b/pipeline/ingestor/test_documents/works.every-format.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-05-13T10:22:01.111Z",
+  "createdAt" : "2024-05-15T08:17:25.500813Z",
   "id" : "w2ap82cs",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "w2ap82cs",
         "identifier" : {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "UZlr85jkfd"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup",
-            "label" : "EBSCO lookup identifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "UZlr85jkfd",

--- a/pipeline/ingestor/test_documents/works.every-format.10.json
+++ b/pipeline/ingestor/test_documents/works.every-format.10.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-05-13T10:22:01.115409Z",
+  "createdAt" : "2024-05-15T08:17:25.504087Z",
   "id" : "5lq8kfis",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "5lq8kfis",
         "identifier" : {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "ajAY87vuuJ"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup",
-            "label" : "EBSCO lookup identifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "ajAY87vuuJ",

--- a/pipeline/ingestor/test_documents/works.every-format.10.json
+++ b/pipeline/ingestor/test_documents/works.every-format.10.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-02-16T15:36:44.894946Z",
+  "createdAt" : "2024-05-13T10:22:01.115409Z",
   "id" : "5lq8kfis",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "5lq8kfis",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "ebsco-alt-lookup"
           },
           "ontologyType" : "Work",
           "value" : "ajAY87vuuJ"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "ebsco-alt-lookup",
+            "label" : "EBSCO lookup identifier",
             "type" : "IdentifierType"
           },
           "value" : "ajAY87vuuJ",

--- a/pipeline/ingestor/test_documents/works.every-format.11.json
+++ b/pipeline/ingestor/test_documents/works.every-format.11.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-02-16T15:36:44.895813Z",
+  "createdAt" : "2024-05-13T10:22:01.115757Z",
   "id" : "kkzdnfal",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "kkzdnfal",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "J1fupAzsfb"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "J1fupAzsfb",

--- a/pipeline/ingestor/test_documents/works.every-format.11.json
+++ b/pipeline/ingestor/test_documents/works.every-format.11.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-05-13T10:22:01.115757Z",
+  "createdAt" : "2024-05-15T08:17:25.504402Z",
   "id" : "kkzdnfal",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "kkzdnfal",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "J1fupAzsfb"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "J1fupAzsfb",

--- a/pipeline/ingestor/test_documents/works.every-format.12.json
+++ b/pipeline/ingestor/test_documents/works.every-format.12.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-05-13T10:22:01.116069Z",
+  "createdAt" : "2024-05-15T08:17:25.504717Z",
   "id" : "02pauy4p",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "02pauy4p",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "mZeIhkjzt3"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "mZeIhkjzt3",

--- a/pipeline/ingestor/test_documents/works.every-format.12.json
+++ b/pipeline/ingestor/test_documents/works.every-format.12.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-02-16T15:36:44.896529Z",
+  "createdAt" : "2024-05-13T10:22:01.116069Z",
   "id" : "02pauy4p",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "02pauy4p",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "mZeIhkjzt3"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "mZeIhkjzt3",

--- a/pipeline/ingestor/test_documents/works.every-format.13.json
+++ b/pipeline/ingestor/test_documents/works.every-format.13.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-02-16T15:36:44.897106Z",
+  "createdAt" : "2024-05-13T10:22:01.116386Z",
   "id" : "83tyy1gh",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "83tyy1gh",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "qt38YgNxOY"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "qt38YgNxOY",

--- a/pipeline/ingestor/test_documents/works.every-format.13.json
+++ b/pipeline/ingestor/test_documents/works.every-format.13.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-05-13T10:22:01.116386Z",
+  "createdAt" : "2024-05-15T08:17:25.505036Z",
   "id" : "83tyy1gh",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "83tyy1gh",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "qt38YgNxOY"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "qt38YgNxOY",

--- a/pipeline/ingestor/test_documents/works.every-format.14.json
+++ b/pipeline/ingestor/test_documents/works.every-format.14.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-02-16T15:36:44.897549Z",
+  "createdAt" : "2024-05-13T10:22:01.116748Z",
   "id" : "vwzsza7o",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "vwzsza7o",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "DHZ5kGsC2N"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "DHZ5kGsC2N",

--- a/pipeline/ingestor/test_documents/works.every-format.14.json
+++ b/pipeline/ingestor/test_documents/works.every-format.14.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-05-13T10:22:01.116748Z",
+  "createdAt" : "2024-05-15T08:17:25.505354Z",
   "id" : "vwzsza7o",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "vwzsza7o",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "DHZ5kGsC2N"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "DHZ5kGsC2N",

--- a/pipeline/ingestor/test_documents/works.every-format.15.json
+++ b/pipeline/ingestor/test_documents/works.every-format.15.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-05-13T10:22:01.117060Z",
+  "createdAt" : "2024-05-15T08:17:25.505666Z",
   "id" : "9vihnjwg",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "9vihnjwg",
         "identifier" : {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "oeggPvgjRA"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup",
-            "label" : "EBSCO lookup identifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "oeggPvgjRA",

--- a/pipeline/ingestor/test_documents/works.every-format.15.json
+++ b/pipeline/ingestor/test_documents/works.every-format.15.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-02-16T15:36:44.898016Z",
+  "createdAt" : "2024-05-13T10:22:01.117060Z",
   "id" : "9vihnjwg",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "9vihnjwg",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "ebsco-alt-lookup"
           },
           "ontologyType" : "Work",
           "value" : "oeggPvgjRA"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "ebsco-alt-lookup",
+            "label" : "EBSCO lookup identifier",
             "type" : "IdentifierType"
           },
           "value" : "oeggPvgjRA",

--- a/pipeline/ingestor/test_documents/works.every-format.16.json
+++ b/pipeline/ingestor/test_documents/works.every-format.16.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-05-13T10:22:01.117369Z",
+  "createdAt" : "2024-05-15T08:17:25.506034Z",
   "id" : "4blsy3iy",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "4blsy3iy",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "CwPK521Yf5"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "CwPK521Yf5",

--- a/pipeline/ingestor/test_documents/works.every-format.16.json
+++ b/pipeline/ingestor/test_documents/works.every-format.16.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-02-16T15:36:44.898454Z",
+  "createdAt" : "2024-05-13T10:22:01.117369Z",
   "id" : "4blsy3iy",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "4blsy3iy",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "CwPK521Yf5"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "CwPK521Yf5",

--- a/pipeline/ingestor/test_documents/works.every-format.17.json
+++ b/pipeline/ingestor/test_documents/works.every-format.17.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-02-16T15:36:44.898929Z",
+  "createdAt" : "2024-05-13T10:22:01.117676Z",
   "id" : "9is9e3tz",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "9is9e3tz",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "ZVe3xG7r6V"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "ZVe3xG7r6V",

--- a/pipeline/ingestor/test_documents/works.every-format.17.json
+++ b/pipeline/ingestor/test_documents/works.every-format.17.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-05-13T10:22:01.117676Z",
+  "createdAt" : "2024-05-15T08:17:25.506336Z",
   "id" : "9is9e3tz",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "9is9e3tz",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "ZVe3xG7r6V"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "ZVe3xG7r6V",

--- a/pipeline/ingestor/test_documents/works.every-format.2.json
+++ b/pipeline/ingestor/test_documents/works.every-format.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-02-16T15:36:44.889455Z",
+  "createdAt" : "2024-05-13T10:22:01.111725Z",
   "id" : "cinepzd4",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "cinepzd4",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "ALANM5eCQQ"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "ALANM5eCQQ",

--- a/pipeline/ingestor/test_documents/works.every-format.2.json
+++ b/pipeline/ingestor/test_documents/works.every-format.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-05-13T10:22:01.111725Z",
+  "createdAt" : "2024-05-15T08:17:25.501546Z",
   "id" : "cinepzd4",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "cinepzd4",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "ALANM5eCQQ"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "ALANM5eCQQ",

--- a/pipeline/ingestor/test_documents/works.every-format.21.json
+++ b/pipeline/ingestor/test_documents/works.every-format.21.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-05-13T10:22:01.118943Z",
+  "createdAt" : "2024-05-15T08:17:25.507529Z",
   "id" : "3ygkb1yd",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "3ygkb1yd",
         "identifier" : {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "mTs82bfnk2"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup",
-            "label" : "EBSCO lookup identifier",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "mTs82bfnk2",

--- a/pipeline/ingestor/test_documents/works.every-format.21.json
+++ b/pipeline/ingestor/test_documents/works.every-format.21.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-02-16T15:36:44.901048Z",
+  "createdAt" : "2024-05-13T10:22:01.118943Z",
   "id" : "3ygkb1yd",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "3ygkb1yd",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "ebsco-alt-lookup"
           },
           "ontologyType" : "Work",
           "value" : "mTs82bfnk2"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "ebsco-alt-lookup",
+            "label" : "EBSCO lookup identifier",
             "type" : "IdentifierType"
           },
           "value" : "mTs82bfnk2",

--- a/pipeline/ingestor/test_documents/works.every-format.22.json
+++ b/pipeline/ingestor/test_documents/works.every-format.22.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-05-13T10:22:01.119240Z",
+  "createdAt" : "2024-05-15T08:17:25.507841Z",
   "id" : "ccfchgq4",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "ccfchgq4",
         "identifier" : {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "a62zjJ09dk"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup",
-            "label" : "EBSCO lookup identifier",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "a62zjJ09dk",

--- a/pipeline/ingestor/test_documents/works.every-format.22.json
+++ b/pipeline/ingestor/test_documents/works.every-format.22.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-02-16T15:36:44.901570Z",
+  "createdAt" : "2024-05-13T10:22:01.119240Z",
   "id" : "ccfchgq4",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "ccfchgq4",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "ebsco-alt-lookup"
           },
           "ontologyType" : "Work",
           "value" : "a62zjJ09dk"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "ebsco-alt-lookup",
+            "label" : "EBSCO lookup identifier",
             "type" : "IdentifierType"
           },
           "value" : "a62zjJ09dk",

--- a/pipeline/ingestor/test_documents/works.every-format.3.json
+++ b/pipeline/ingestor/test_documents/works.every-format.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-05-13T10:22:01.112057Z",
+  "createdAt" : "2024-05-15T08:17:25.501905Z",
   "id" : "btrlxjc4",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "btrlxjc4",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "oZVNybADYL"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "oZVNybADYL",

--- a/pipeline/ingestor/test_documents/works.every-format.3.json
+++ b/pipeline/ingestor/test_documents/works.every-format.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-02-16T15:36:44.890037Z",
+  "createdAt" : "2024-05-13T10:22:01.112057Z",
   "id" : "btrlxjc4",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "btrlxjc4",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "oZVNybADYL"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "oZVNybADYL",

--- a/pipeline/ingestor/test_documents/works.every-format.4.json
+++ b/pipeline/ingestor/test_documents/works.every-format.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-02-16T15:36:44.890452Z",
+  "createdAt" : "2024-05-13T10:22:01.112366Z",
   "id" : "ifz9zadf",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "ifz9zadf",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "MZkkqME2t4"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "MZkkqME2t4",

--- a/pipeline/ingestor/test_documents/works.every-format.4.json
+++ b/pipeline/ingestor/test_documents/works.every-format.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-05-13T10:22:01.112366Z",
+  "createdAt" : "2024-05-15T08:17:25.502222Z",
   "id" : "ifz9zadf",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "ifz9zadf",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "MZkkqME2t4"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "MZkkqME2t4",

--- a/pipeline/ingestor/test_documents/works.every-format.5.json
+++ b/pipeline/ingestor/test_documents/works.every-format.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-05-13T10:22:01.112688Z",
+  "createdAt" : "2024-05-15T08:17:25.502539Z",
   "id" : "xlcpwdx8",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "xlcpwdx8",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "QBSkLFL8Cz"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "QBSkLFL8Cz",

--- a/pipeline/ingestor/test_documents/works.every-format.5.json
+++ b/pipeline/ingestor/test_documents/works.every-format.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-02-16T15:36:44.890899Z",
+  "createdAt" : "2024-05-13T10:22:01.112688Z",
   "id" : "xlcpwdx8",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "xlcpwdx8",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "QBSkLFL8Cz"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "QBSkLFL8Cz",

--- a/pipeline/ingestor/test_documents/works.every-format.6.json
+++ b/pipeline/ingestor/test_documents/works.every-format.6.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-05-13T10:22:01.113245Z",
+  "createdAt" : "2024-05-15T08:17:25.502854Z",
   "id" : "cmz25207",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "cmz25207",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "pmMJGY9dht"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "pmMJGY9dht",

--- a/pipeline/ingestor/test_documents/works.every-format.6.json
+++ b/pipeline/ingestor/test_documents/works.every-format.6.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-02-16T15:36:44.891661Z",
+  "createdAt" : "2024-05-13T10:22:01.113245Z",
   "id" : "cmz25207",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "cmz25207",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "pmMJGY9dht"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "pmMJGY9dht",

--- a/pipeline/ingestor/test_documents/works.every-format.7.json
+++ b/pipeline/ingestor/test_documents/works.every-format.7.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-02-16T15:36:44.892202Z",
+  "createdAt" : "2024-05-13T10:22:01.113648Z",
   "id" : "6qjgnqbc",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "6qjgnqbc",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "Nr737MdPwA"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "Nr737MdPwA",

--- a/pipeline/ingestor/test_documents/works.every-format.7.json
+++ b/pipeline/ingestor/test_documents/works.every-format.7.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-05-13T10:22:01.113648Z",
+  "createdAt" : "2024-05-15T08:17:25.503179Z",
   "id" : "6qjgnqbc",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "6qjgnqbc",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "Nr737MdPwA"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "Nr737MdPwA",

--- a/pipeline/ingestor/test_documents/works.every-format.8.json
+++ b/pipeline/ingestor/test_documents/works.every-format.8.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-02-16T15:36:44.893353Z",
+  "createdAt" : "2024-05-13T10:22:01.114011Z",
   "id" : "cwpfpixj",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "cwpfpixj",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "D1YQhdjF03"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "D1YQhdjF03",

--- a/pipeline/ingestor/test_documents/works.every-format.8.json
+++ b/pipeline/ingestor/test_documents/works.every-format.8.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-05-13T10:22:01.114011Z",
+  "createdAt" : "2024-05-15T08:17:25.503486Z",
   "id" : "cwpfpixj",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "cwpfpixj",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "D1YQhdjF03"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "D1YQhdjF03",

--- a/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.0.json
+++ b/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2024-02-16T15:36:45.088363Z",
+  "createdAt" : "2024-05-13T10:22:01.232628Z",
   "id" : "i2iqani2",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "i2iqani2",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "w5jYpuBxun"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "w5jYpuBxun",
@@ -51,8 +51,8 @@
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "calm-record-id",
-                "label" : "Calm RecordIdentifier",
+                "id" : "ebsco-alt-lookup",
+                "label" : "EBSCO lookup identifier",
                 "type" : "IdentifierType"
               },
               "value" : "Gazclr9E9a",

--- a/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.0.json
+++ b/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2024-05-13T10:22:01.232628Z",
+  "createdAt" : "2024-05-15T08:17:25.600488Z",
   "id" : "i2iqani2",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "i2iqani2",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "w5jYpuBxun"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "w5jYpuBxun",
@@ -51,8 +51,8 @@
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "ebsco-alt-lookup",
-                "label" : "EBSCO lookup identifier",
+                "id" : "calm-record-id",
+                "label" : "Calm RecordIdentifier",
                 "type" : "IdentifierType"
               },
               "value" : "Gazclr9E9a",

--- a/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.1.json
+++ b/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2024-02-16T15:36:45.088997Z",
+  "createdAt" : "2024-05-13T10:22:01.233114Z",
   "id" : "lqwyh6sk",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "lqwyh6sk",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "fxX5tbPGXa"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "fxX5tbPGXa",
@@ -51,8 +51,8 @@
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "miro-image-number",
-                "label" : "Miro image number",
+                "id" : "sierra-system-number",
+                "label" : "Sierra system number",
                 "type" : "IdentifierType"
               },
               "value" : "hWM7iXmYa3",

--- a/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.1.json
+++ b/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2024-05-13T10:22:01.233114Z",
+  "createdAt" : "2024-05-15T08:17:25.600906Z",
   "id" : "lqwyh6sk",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "lqwyh6sk",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "fxX5tbPGXa"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "fxX5tbPGXa",
@@ -51,8 +51,8 @@
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "sierra-system-number",
-                "label" : "Sierra system number",
+                "id" : "miro-image-number",
+                "label" : "Miro image number",
                 "type" : "IdentifierType"
               },
               "value" : "hWM7iXmYa3",

--- a/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.2.json
+++ b/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2024-02-16T15:36:45.090347Z",
+  "createdAt" : "2024-05-13T10:22:01.233502Z",
   "id" : "vcuqhxox",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "vcuqhxox",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "coEy1hoMJJ"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "coEy1hoMJJ",
@@ -51,8 +51,8 @@
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "calm-record-id",
-                "label" : "Calm RecordIdentifier",
+                "id" : "ebsco-alt-lookup",
+                "label" : "EBSCO lookup identifier",
                 "type" : "IdentifierType"
               },
               "value" : "y8mU1pknKH",

--- a/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.2.json
+++ b/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2024-05-13T10:22:01.233502Z",
+  "createdAt" : "2024-05-15T08:17:25.601305Z",
   "id" : "vcuqhxox",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "vcuqhxox",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "coEy1hoMJJ"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "coEy1hoMJJ",
@@ -51,8 +51,8 @@
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "ebsco-alt-lookup",
-                "label" : "EBSCO lookup identifier",
+                "id" : "calm-record-id",
+                "label" : "Calm RecordIdentifier",
                 "type" : "IdentifierType"
               },
               "value" : "y8mU1pknKH",

--- a/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.3.json
+++ b/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2024-02-16T15:36:45.090952Z",
+  "createdAt" : "2024-05-13T10:22:01.233892Z",
   "id" : "phodmv5g",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "phodmv5g",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "kSl7z2IaIy"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "kSl7z2IaIy",
@@ -51,8 +51,8 @@
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "sierra-system-number",
-                "label" : "Sierra system number",
+                "id" : "ebsco-alt-lookup",
+                "label" : "EBSCO lookup identifier",
                 "type" : "IdentifierType"
               },
               "value" : "F1p8IUjfnY",

--- a/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.3.json
+++ b/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2024-05-13T10:22:01.233892Z",
+  "createdAt" : "2024-05-15T08:17:25.601756Z",
   "id" : "phodmv5g",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "phodmv5g",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "kSl7z2IaIy"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "kSl7z2IaIy",
@@ -51,8 +51,8 @@
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "ebsco-alt-lookup",
-                "label" : "EBSCO lookup identifier",
+                "id" : "sierra-system-number",
+                "label" : "Sierra system number",
                 "type" : "IdentifierType"
               },
               "value" : "F1p8IUjfnY",

--- a/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.4.json
+++ b/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2024-02-16T15:36:45.091476Z",
+  "createdAt" : "2024-05-13T10:22:01.234253Z",
   "id" : "tq4mfefg",
   "document" : {
     "debug" : {
@@ -51,8 +51,8 @@
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "sierra-system-number",
-                "label" : "Sierra system number",
+                "id" : "ebsco-alt-lookup",
+                "label" : "EBSCO lookup identifier",
                 "type" : "IdentifierType"
               },
               "value" : "2u7aRU7LCi",

--- a/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.4.json
+++ b/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2024-05-13T10:22:01.234253Z",
+  "createdAt" : "2024-05-15T08:17:25.602142Z",
   "id" : "tq4mfefg",
   "document" : {
     "debug" : {
@@ -51,8 +51,8 @@
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "ebsco-alt-lookup",
-                "label" : "EBSCO lookup identifier",
+                "id" : "sierra-system-number",
+                "label" : "Sierra system number",
                 "type" : "IdentifierType"
               },
               "value" : "2u7aRU7LCi",

--- a/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.5.json
+++ b/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2024-02-16T15:36:45.091973Z",
+  "createdAt" : "2024-05-13T10:22:01.234643Z",
   "id" : "phdnojlc",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "phdnojlc",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "s5auwvXuSK"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "s5auwvXuSK",
@@ -51,8 +51,8 @@
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "miro-image-number",
-                "label" : "Miro image number",
+                "id" : "ebsco-alt-lookup",
+                "label" : "EBSCO lookup identifier",
                 "type" : "IdentifierType"
               },
               "value" : "c8ezCyfQlB",

--- a/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.5.json
+++ b/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2024-05-13T10:22:01.234643Z",
+  "createdAt" : "2024-05-15T08:17:25.602538Z",
   "id" : "phdnojlc",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "phdnojlc",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "s5auwvXuSK"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "s5auwvXuSK",
@@ -51,8 +51,8 @@
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "ebsco-alt-lookup",
-                "label" : "EBSCO lookup identifier",
+                "id" : "miro-image-number",
+                "label" : "Miro image number",
                 "type" : "IdentifierType"
               },
               "value" : "c8ezCyfQlB",

--- a/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.6.json
+++ b/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.6.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2024-05-13T10:22:01.235015Z",
+  "createdAt" : "2024-05-15T08:17:25.603058Z",
   "id" : "vh87ts9v",
   "document" : {
     "debug" : {
@@ -51,8 +51,8 @@
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "miro-image-number",
-                "label" : "Miro image number",
+                "id" : "sierra-system-number",
+                "label" : "Sierra system number",
                 "type" : "IdentifierType"
               },
               "value" : "Bhh45MMdul",

--- a/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.6.json
+++ b/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.6.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2024-02-16T15:36:45.092595Z",
+  "createdAt" : "2024-05-13T10:22:01.235015Z",
   "id" : "vh87ts9v",
   "document" : {
     "debug" : {
@@ -51,8 +51,8 @@
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "sierra-system-number",
-                "label" : "Sierra system number",
+                "id" : "miro-image-number",
+                "label" : "Miro image number",
                 "type" : "IdentifierType"
               },
               "value" : "Bhh45MMdul",

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.1.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-02-16T15:36:44.959790Z",
+  "createdAt" : "2024-05-13T10:22:01.154414Z",
   "id" : "ulwn0n8f",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "ulwn0n8f",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "ZRqzugpVU0"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "ZRqzugpVU0",

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.1.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-05-13T10:22:01.154414Z",
+  "createdAt" : "2024-05-15T08:17:25.536447Z",
   "id" : "ulwn0n8f",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "ulwn0n8f",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "ZRqzugpVU0"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "ZRqzugpVU0",

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.10.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.10.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-05-13T10:22:01.158333Z",
+  "createdAt" : "2024-05-15T08:17:25.540993Z",
   "id" : "uoi8tp8u",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "uoi8tp8u",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "Y14qUDXX1m"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "Y14qUDXX1m",

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.10.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.10.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-02-16T15:36:44.967342Z",
+  "createdAt" : "2024-05-13T10:22:01.158333Z",
   "id" : "uoi8tp8u",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "uoi8tp8u",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "Y14qUDXX1m"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "Y14qUDXX1m",

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.11.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.11.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-02-16T15:36:44.968441Z",
+  "createdAt" : "2024-05-13T10:22:01.158770Z",
   "id" : "xgqiid3b",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "xgqiid3b",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "3x3CaelluS"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "3x3CaelluS",

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.11.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.11.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-05-13T10:22:01.158770Z",
+  "createdAt" : "2024-05-15T08:17:25.541489Z",
   "id" : "xgqiid3b",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "xgqiid3b",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "3x3CaelluS"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "3x3CaelluS",

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.12.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.12.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-02-16T15:36:44.970024Z",
+  "createdAt" : "2024-05-13T10:22:01.159196Z",
   "id" : "tqemj6yt",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "tqemj6yt",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "ebsco-alt-lookup"
           },
           "ontologyType" : "Work",
           "value" : "FJUZazquWo"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "ebsco-alt-lookup",
+            "label" : "EBSCO lookup identifier",
             "type" : "IdentifierType"
           },
           "value" : "FJUZazquWo",

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.12.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.12.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-05-13T10:22:01.159196Z",
+  "createdAt" : "2024-05-15T08:17:25.541943Z",
   "id" : "tqemj6yt",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "tqemj6yt",
         "identifier" : {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "FJUZazquWo"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup",
-            "label" : "EBSCO lookup identifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "FJUZazquWo",

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.15.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.15.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-05-13T10:22:01.160608Z",
+  "createdAt" : "2024-05-15T08:17:25.543166Z",
   "id" : "fzrzebxx",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "fzrzebxx",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "fNUyylf5KL"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "fNUyylf5KL",

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.15.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.15.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-02-16T15:36:44.972630Z",
+  "createdAt" : "2024-05-13T10:22:01.160608Z",
   "id" : "fzrzebxx",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "fzrzebxx",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "fNUyylf5KL"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "fNUyylf5KL",

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.16.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.16.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-02-16T15:36:44.973723Z",
+  "createdAt" : "2024-05-13T10:22:01.161085Z",
   "id" : "iautlnkw",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "iautlnkw",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "ebsco-alt-lookup"
           },
           "ontologyType" : "Work",
           "value" : "CcLh1PJlWp"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "ebsco-alt-lookup",
+            "label" : "EBSCO lookup identifier",
             "type" : "IdentifierType"
           },
           "value" : "CcLh1PJlWp",

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.16.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.16.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-05-13T10:22:01.161085Z",
+  "createdAt" : "2024-05-15T08:17:25.543585Z",
   "id" : "iautlnkw",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "iautlnkw",
         "identifier" : {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "CcLh1PJlWp"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup",
-            "label" : "EBSCO lookup identifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "CcLh1PJlWp",

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.17.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.17.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-02-16T15:36:44.974663Z",
+  "createdAt" : "2024-05-13T10:22:01.161515Z",
   "id" : "3tm3cnoq",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "3tm3cnoq",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "KxMxs7kIOR"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "KxMxs7kIOR",

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.17.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.17.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-05-13T10:22:01.161515Z",
+  "createdAt" : "2024-05-15T08:17:25.544011Z",
   "id" : "3tm3cnoq",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "3tm3cnoq",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "KxMxs7kIOR"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "KxMxs7kIOR",

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.18.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.18.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-02-16T15:36:44.975362Z",
+  "createdAt" : "2024-05-13T10:22:01.161924Z",
   "id" : "sihntejb",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "sihntejb",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "lxE0qlBbPi"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "lxE0qlBbPi",

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.18.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.18.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-05-13T10:22:01.161924Z",
+  "createdAt" : "2024-05-15T08:17:25.544443Z",
   "id" : "sihntejb",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "sihntejb",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "lxE0qlBbPi"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "lxE0qlBbPi",

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.19.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.19.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-02-16T15:36:44.977010Z",
+  "createdAt" : "2024-05-13T10:22:01.162323Z",
   "id" : "4hdjmnto",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "4hdjmnto",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "7ZYKrzxgMS"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "7ZYKrzxgMS",

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.19.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.19.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-05-13T10:22:01.162323Z",
+  "createdAt" : "2024-05-15T08:17:25.544863Z",
   "id" : "4hdjmnto",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "4hdjmnto",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "7ZYKrzxgMS"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "7ZYKrzxgMS",

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.2.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-02-16T15:36:44.960883Z",
+  "createdAt" : "2024-05-13T10:22:01.154844Z",
   "id" : "msgkyj11",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "msgkyj11",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "fZgItN5K9R"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "fZgItN5K9R",

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.2.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-05-13T10:22:01.154844Z",
+  "createdAt" : "2024-05-15T08:17:25.536896Z",
   "id" : "msgkyj11",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "msgkyj11",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "fZgItN5K9R"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "fZgItN5K9R",

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.20.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.20.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-05-13T10:22:01.162738Z",
+  "createdAt" : "2024-05-15T08:17:25.545284Z",
   "id" : "kldauk4g",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "kldauk4g",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "fNgtG1SKw3"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "fNgtG1SKw3",

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.20.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.20.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-02-16T15:36:44.977595Z",
+  "createdAt" : "2024-05-13T10:22:01.162738Z",
   "id" : "kldauk4g",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "kldauk4g",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "fNgtG1SKw3"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "fNgtG1SKw3",

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.21.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.21.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-05-13T10:22:01.163145Z",
+  "createdAt" : "2024-05-15T08:17:25.545714Z",
   "id" : "tr1wn4ml",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "tr1wn4ml",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "FVccBcFLmx"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "FVccBcFLmx",

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.21.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.21.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-02-16T15:36:44.978357Z",
+  "createdAt" : "2024-05-13T10:22:01.163145Z",
   "id" : "tr1wn4ml",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "tr1wn4ml",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "FVccBcFLmx"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "FVccBcFLmx",

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.3.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-05-13T10:22:01.155280Z",
+  "createdAt" : "2024-05-15T08:17:25.537351Z",
   "id" : "5axbzov3",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "5axbzov3",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "QJncU8pZH7"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "QJncU8pZH7",

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.3.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-02-16T15:36:44.962044Z",
+  "createdAt" : "2024-05-13T10:22:01.155280Z",
   "id" : "5axbzov3",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "5axbzov3",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "QJncU8pZH7"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "QJncU8pZH7",

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.4.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-05-13T10:22:01.155698Z",
+  "createdAt" : "2024-05-15T08:17:25.537776Z",
   "id" : "kvukzd4h",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "kvukzd4h",
         "identifier" : {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "tYtyWP3z92"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup",
-            "label" : "EBSCO lookup identifier",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "tYtyWP3z92",

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.4.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-02-16T15:36:44.962814Z",
+  "createdAt" : "2024-05-13T10:22:01.155698Z",
   "id" : "kvukzd4h",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "kvukzd4h",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "ebsco-alt-lookup"
           },
           "ontologyType" : "Work",
           "value" : "tYtyWP3z92"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "ebsco-alt-lookup",
+            "label" : "EBSCO lookup identifier",
             "type" : "IdentifierType"
           },
           "value" : "tYtyWP3z92",

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.5.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-02-16T15:36:44.963850Z",
+  "createdAt" : "2024-05-13T10:22:01.156164Z",
   "id" : "vkukqiog",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "vkukqiog",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "wUadwA2M9C"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "wUadwA2M9C",

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.5.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-05-13T10:22:01.156164Z",
+  "createdAt" : "2024-05-15T08:17:25.538492Z",
   "id" : "vkukqiog",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "vkukqiog",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "wUadwA2M9C"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "wUadwA2M9C",

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.6.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.6.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-02-16T15:36:44.964704Z",
+  "createdAt" : "2024-05-13T10:22:01.156588Z",
   "id" : "q7ypgqb2",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "q7ypgqb2",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "RzqlD5LN4d"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "RzqlD5LN4d",

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.6.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.6.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-05-13T10:22:01.156588Z",
+  "createdAt" : "2024-05-15T08:17:25.539138Z",
   "id" : "q7ypgqb2",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "q7ypgqb2",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "RzqlD5LN4d"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "RzqlD5LN4d",

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.7.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.7.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-05-13T10:22:01.157036Z",
+  "createdAt" : "2024-05-15T08:17:25.539638Z",
   "id" : "cdqpxiaz",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "cdqpxiaz",
         "identifier" : {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "kYbman54cI"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup",
-            "label" : "EBSCO lookup identifier",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "kYbman54cI",

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.7.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.7.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-02-16T15:36:44.965373Z",
+  "createdAt" : "2024-05-13T10:22:01.157036Z",
   "id" : "cdqpxiaz",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "cdqpxiaz",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "ebsco-alt-lookup"
           },
           "ontologyType" : "Work",
           "value" : "kYbman54cI"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "ebsco-alt-lookup",
+            "label" : "EBSCO lookup identifier",
             "type" : "IdentifierType"
           },
           "value" : "kYbman54cI",

--- a/pipeline/ingestor/test_documents/works.examples.availabilities.closed-only.json
+++ b/pipeline/ingestor/test_documents/works.examples.availabilities.closed-only.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for availabilities tests",
-  "createdAt" : "2024-02-16T15:36:45.121848Z",
+  "createdAt" : "2024-05-13T10:22:01.256193Z",
   "id" : "bb4tv6zd",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "bb4tv6zd",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "rXrfr8eL5R"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "rXrfr8eL5R",
@@ -51,8 +51,8 @@
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "miro-image-number",
-                "label" : "Miro image number",
+                "id" : "ebsco-alt-lookup",
+                "label" : "EBSCO lookup identifier",
                 "type" : "IdentifierType"
               },
               "value" : "JJ01MHKXQ3",

--- a/pipeline/ingestor/test_documents/works.examples.availabilities.closed-only.json
+++ b/pipeline/ingestor/test_documents/works.examples.availabilities.closed-only.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for availabilities tests",
-  "createdAt" : "2024-05-13T10:22:01.256193Z",
+  "createdAt" : "2024-05-15T08:17:25.619978Z",
   "id" : "bb4tv6zd",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "bb4tv6zd",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "rXrfr8eL5R"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "rXrfr8eL5R",
@@ -51,8 +51,8 @@
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "ebsco-alt-lookup",
-                "label" : "EBSCO lookup identifier",
+                "id" : "miro-image-number",
+                "label" : "Miro image number",
                 "type" : "IdentifierType"
               },
               "value" : "JJ01MHKXQ3",

--- a/pipeline/ingestor/test_documents/works.examples.availabilities.everywhere.json
+++ b/pipeline/ingestor/test_documents/works.examples.availabilities.everywhere.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for availabilities tests",
-  "createdAt" : "2024-02-16T15:36:45.131921Z",
+  "createdAt" : "2024-05-13T10:22:01.262601Z",
   "id" : "ntlrk7nw",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "ntlrk7nw",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "9pCp7jd9rF"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "9pCp7jd9rF",
@@ -51,8 +51,8 @@
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "calm-record-id",
-                "label" : "Calm RecordIdentifier",
+                "id" : "miro-image-number",
+                "label" : "Miro image number",
                 "type" : "IdentifierType"
               },
               "value" : "S97qOpHViO",
@@ -79,8 +79,8 @@
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "miro-image-number",
-                "label" : "Miro image number",
+                "id" : "sierra-system-number",
+                "label" : "Sierra system number",
                 "type" : "IdentifierType"
               },
               "value" : "BZp7GTBM7U",

--- a/pipeline/ingestor/test_documents/works.examples.availabilities.everywhere.json
+++ b/pipeline/ingestor/test_documents/works.examples.availabilities.everywhere.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for availabilities tests",
-  "createdAt" : "2024-05-13T10:22:01.262601Z",
+  "createdAt" : "2024-05-15T08:17:25.623181Z",
   "id" : "ntlrk7nw",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "ntlrk7nw",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "9pCp7jd9rF"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "9pCp7jd9rF",
@@ -51,8 +51,8 @@
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "miro-image-number",
-                "label" : "Miro image number",
+                "id" : "calm-record-id",
+                "label" : "Calm RecordIdentifier",
                 "type" : "IdentifierType"
               },
               "value" : "S97qOpHViO",
@@ -79,8 +79,8 @@
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "sierra-system-number",
-                "label" : "Sierra system number",
+                "id" : "miro-image-number",
+                "label" : "Miro image number",
                 "type" : "IdentifierType"
               },
               "value" : "BZp7GTBM7U",

--- a/pipeline/ingestor/test_documents/works.examples.availabilities.nowhere.json
+++ b/pipeline/ingestor/test_documents/works.examples.availabilities.nowhere.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for availabilities tests",
-  "createdAt" : "2024-02-16T15:36:45.129878Z",
+  "createdAt" : "2024-05-13T10:22:01.260932Z",
   "id" : "cc2ql7v8",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "cc2ql7v8",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "ebsco-alt-lookup"
           },
           "ontologyType" : "Work",
           "value" : "I3pLB8wFUc"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "ebsco-alt-lookup",
+            "label" : "EBSCO lookup identifier",
             "type" : "IdentifierType"
           },
           "value" : "I3pLB8wFUc",

--- a/pipeline/ingestor/test_documents/works.examples.availabilities.nowhere.json
+++ b/pipeline/ingestor/test_documents/works.examples.availabilities.nowhere.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for availabilities tests",
-  "createdAt" : "2024-05-13T10:22:01.260932Z",
+  "createdAt" : "2024-05-15T08:17:25.621915Z",
   "id" : "cc2ql7v8",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "cc2ql7v8",
         "identifier" : {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "I3pLB8wFUc"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup",
-            "label" : "EBSCO lookup identifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "I3pLB8wFUc",

--- a/pipeline/ingestor/test_documents/works.examples.availabilities.online-only.json
+++ b/pipeline/ingestor/test_documents/works.examples.availabilities.online-only.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for availabilities tests",
-  "createdAt" : "2024-05-13T10:22:01.257904Z",
+  "createdAt" : "2024-05-15T08:17:25.620995Z",
   "id" : "pgf0nj3t",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "pgf0nj3t",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "lZntXsvtio"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "lZntXsvtio",

--- a/pipeline/ingestor/test_documents/works.examples.availabilities.online-only.json
+++ b/pipeline/ingestor/test_documents/works.examples.availabilities.online-only.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for availabilities tests",
-  "createdAt" : "2024-02-16T15:36:45.128092Z",
+  "createdAt" : "2024-05-13T10:22:01.257904Z",
   "id" : "pgf0nj3t",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "pgf0nj3t",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "lZntXsvtio"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "lZntXsvtio",

--- a/pipeline/ingestor/test_documents/works.examples.availabilities.open-only.json
+++ b/pipeline/ingestor/test_documents/works.examples.availabilities.open-only.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for availabilities tests",
-  "createdAt" : "2024-02-16T15:36:45.115828Z",
+  "createdAt" : "2024-05-13T10:22:01.254620Z",
   "id" : "jwvjyz6g",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "jwvjyz6g",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "TXyrDnY4M5"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "TXyrDnY4M5",
@@ -51,8 +51,8 @@
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "miro-image-number",
-                "label" : "Miro image number",
+                "id" : "calm-record-id",
+                "label" : "Calm RecordIdentifier",
                 "type" : "IdentifierType"
               },
               "value" : "gjgNk1LNtP",

--- a/pipeline/ingestor/test_documents/works.examples.availabilities.open-only.json
+++ b/pipeline/ingestor/test_documents/works.examples.availabilities.open-only.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for availabilities tests",
-  "createdAt" : "2024-05-13T10:22:01.254620Z",
+  "createdAt" : "2024-05-15T08:17:25.618844Z",
   "id" : "jwvjyz6g",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "jwvjyz6g",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "TXyrDnY4M5"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "TXyrDnY4M5",
@@ -51,8 +51,8 @@
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "calm-record-id",
-                "label" : "Calm RecordIdentifier",
+                "id" : "miro-image-number",
+                "label" : "Miro image number",
                 "type" : "IdentifierType"
               },
               "value" : "gjgNk1LNtP",

--- a/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.1.json
+++ b/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2024-05-13T10:22:01.216326Z",
+  "createdAt" : "2024-05-15T08:17:25.583261Z",
   "id" : "r7wachux",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "r7wachux",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "GY2AKxyW0l"
@@ -43,8 +43,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "GY2AKxyW0l",

--- a/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.1.json
+++ b/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2024-02-16T15:36:45.063531Z",
+  "createdAt" : "2024-05-13T10:22:01.216326Z",
   "id" : "r7wachux",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "r7wachux",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "GY2AKxyW0l"
@@ -43,8 +43,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "GY2AKxyW0l",

--- a/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.2.json
+++ b/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2024-05-13T10:22:01.216686Z",
+  "createdAt" : "2024-05-15T08:17:25.583599Z",
   "id" : "wmvuppum",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "wmvuppum",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "KzPZAnMiJN"
@@ -43,8 +43,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "KzPZAnMiJN",

--- a/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.2.json
+++ b/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2024-02-16T15:36:45.064224Z",
+  "createdAt" : "2024-05-13T10:22:01.216686Z",
   "id" : "wmvuppum",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "wmvuppum",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "KzPZAnMiJN"
@@ -43,8 +43,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "KzPZAnMiJN",

--- a/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.3.json
+++ b/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2024-02-16T15:36:45.064708Z",
+  "createdAt" : "2024-05-13T10:22:01.217027Z",
   "id" : "vcba0kh0",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "vcba0kh0",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "ebsco-alt-lookup"
           },
           "ontologyType" : "Work",
           "value" : "SiI3pPIMZv"
@@ -43,8 +43,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "ebsco-alt-lookup",
+            "label" : "EBSCO lookup identifier",
             "type" : "IdentifierType"
           },
           "value" : "SiI3pPIMZv",

--- a/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.3.json
+++ b/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2024-05-13T10:22:01.217027Z",
+  "createdAt" : "2024-05-15T08:17:25.583925Z",
   "id" : "vcba0kh0",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "vcba0kh0",
         "identifier" : {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "SiI3pPIMZv"
@@ -43,8 +43,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup",
-            "label" : "EBSCO lookup identifier",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "SiI3pPIMZv",

--- a/pipeline/ingestor/test_documents/works.examples.different-work-types.Section.json
+++ b/pipeline/ingestor/test_documents/works.examples.different-work-types.Section.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples of works with different types",
-  "createdAt" : "2024-02-16T15:36:45.013530Z",
+  "createdAt" : "2024-05-13T10:22:01.184308Z",
   "id" : "pflggfra",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "pflggfra",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "4QwQTlrFnQ"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "4QwQTlrFnQ",

--- a/pipeline/ingestor/test_documents/works.examples.different-work-types.Section.json
+++ b/pipeline/ingestor/test_documents/works.examples.different-work-types.Section.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples of works with different types",
-  "createdAt" : "2024-05-13T10:22:01.184308Z",
+  "createdAt" : "2024-05-15T08:17:25.560405Z",
   "id" : "pflggfra",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "pflggfra",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "4QwQTlrFnQ"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "4QwQTlrFnQ",

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.0.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2024-05-13T10:22:01.242361Z",
+  "createdAt" : "2024-05-15T08:17:25.609178Z",
   "id" : "o0u9h1wt",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "o0u9h1wt",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "Q8nyGjzx3m"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "Q8nyGjzx3m",

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.0.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2024-02-16T15:36:45.101384Z",
+  "createdAt" : "2024-05-13T10:22:01.242361Z",
   "id" : "o0u9h1wt",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "o0u9h1wt",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "Q8nyGjzx3m"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "Q8nyGjzx3m",

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.1.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2024-05-13T10:22:01.242684Z",
+  "createdAt" : "2024-05-15T08:17:25.609517Z",
   "id" : "1ndk3ton",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "1ndk3ton",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "HgjmZ1Psfx"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "HgjmZ1Psfx",

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.1.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2024-02-16T15:36:45.101879Z",
+  "createdAt" : "2024-05-13T10:22:01.242684Z",
   "id" : "1ndk3ton",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "1ndk3ton",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "HgjmZ1Psfx"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "HgjmZ1Psfx",

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.3.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2024-02-16T15:36:45.102644Z",
+  "createdAt" : "2024-05-13T10:22:01.243339Z",
   "id" : "vguputez",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "vguputez",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "ebsco-alt-lookup"
           },
           "ontologyType" : "Work",
           "value" : "6Fz9KprYAw"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "ebsco-alt-lookup",
+            "label" : "EBSCO lookup identifier",
             "type" : "IdentifierType"
           },
           "value" : "6Fz9KprYAw",

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.3.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2024-05-13T10:22:01.243339Z",
+  "createdAt" : "2024-05-15T08:17:25.610122Z",
   "id" : "vguputez",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "vguputez",
         "identifier" : {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "6Fz9KprYAw"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup",
-            "label" : "EBSCO lookup identifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "6Fz9KprYAw",

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.4.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2024-02-16T15:36:45.103067Z",
+  "createdAt" : "2024-05-13T10:22:01.243634Z",
   "id" : "xsbqgayk",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "xsbqgayk",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "zZmCliZ5OR"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "zZmCliZ5OR",

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.4.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2024-05-13T10:22:01.243634Z",
+  "createdAt" : "2024-05-15T08:17:25.610416Z",
   "id" : "xsbqgayk",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "xsbqgayk",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "zZmCliZ5OR"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "zZmCliZ5OR",

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.6.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.6.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2024-02-16T15:36:45.103865Z",
+  "createdAt" : "2024-05-13T10:22:01.244222Z",
   "id" : "cpyuhtp8",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "cpyuhtp8",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "KSqlcVurSf"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "KSqlcVurSf",

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.6.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.6.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2024-05-13T10:22:01.244222Z",
+  "createdAt" : "2024-05-15T08:17:25.611067Z",
   "id" : "cpyuhtp8",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "cpyuhtp8",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "KSqlcVurSf"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "KSqlcVurSf",

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.8.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.8.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2024-05-13T10:22:01.244808Z",
+  "createdAt" : "2024-05-15T08:17:25.611669Z",
   "id" : "u1amc1nv",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "u1amc1nv",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "rB0Sw27DZl"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "rB0Sw27DZl",

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.8.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.8.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2024-02-16T15:36:45.104627Z",
+  "createdAt" : "2024-05-13T10:22:01.244808Z",
   "id" : "u1amc1nv",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "u1amc1nv",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "rB0Sw27DZl"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "rB0Sw27DZl",

--- a/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.0.json
+++ b/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2024-05-13T10:22:01.189875Z",
+  "createdAt" : "2024-05-15T08:17:25.564538Z",
   "id" : "oxbsq4ck",
   "document" : {
     "debug" : {
@@ -52,8 +52,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "ebsco-alt-lookup",
-                    "label" : "EBSCO lookup identifier",
+                    "id" : "sierra-system-number",
+                    "label" : "Sierra system number",
                     "type" : "IdentifierType"
                   },
                   "value" : "hmRoJyr1Mq",
@@ -68,8 +68,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "sierra-system-number",
-                    "label" : "Sierra system number",
+                    "id" : "miro-image-number",
+                    "label" : "Miro image number",
                     "type" : "IdentifierType"
                   },
                   "value" : "aNC7XCeymD",

--- a/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.0.json
+++ b/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2024-02-16T15:36:45.019745Z",
+  "createdAt" : "2024-05-13T10:22:01.189875Z",
   "id" : "oxbsq4ck",
   "document" : {
     "debug" : {
@@ -52,8 +52,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "sierra-system-number",
-                    "label" : "Sierra system number",
+                    "id" : "ebsco-alt-lookup",
+                    "label" : "EBSCO lookup identifier",
                     "type" : "IdentifierType"
                   },
                   "value" : "hmRoJyr1Mq",
@@ -68,8 +68,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "miro-image-number",
-                    "label" : "Miro image number",
+                    "id" : "sierra-system-number",
+                    "label" : "Sierra system number",
                     "type" : "IdentifierType"
                   },
                   "value" : "aNC7XCeymD",

--- a/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.1.json
+++ b/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2024-02-16T15:36:45.020567Z",
+  "createdAt" : "2024-05-13T10:22:01.195385Z",
   "id" : "wdnn2etp",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "wdnn2etp",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "hx40zJbSlL"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "hx40zJbSlL",
@@ -52,8 +52,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "calm-record-id",
-                    "label" : "Calm RecordIdentifier",
+                    "id" : "sierra-system-number",
+                    "label" : "Sierra system number",
                     "type" : "IdentifierType"
                   },
                   "value" : "85YYFFvT9f",

--- a/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.1.json
+++ b/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2024-05-13T10:22:01.195385Z",
+  "createdAt" : "2024-05-15T08:17:25.565005Z",
   "id" : "wdnn2etp",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "wdnn2etp",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "hx40zJbSlL"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "hx40zJbSlL",
@@ -52,8 +52,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "sierra-system-number",
-                    "label" : "Sierra system number",
+                    "id" : "calm-record-id",
+                    "label" : "Calm RecordIdentifier",
                     "type" : "IdentifierType"
                   },
                   "value" : "85YYFFvT9f",

--- a/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.2.json
+++ b/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2024-02-16T15:36:45.022420Z",
+  "createdAt" : "2024-05-13T10:22:01.196172Z",
   "id" : "d5kj1fx3",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "d5kj1fx3",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "ebsco-alt-lookup"
           },
           "ontologyType" : "Work",
           "value" : "1KOlZmZXOW"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "ebsco-alt-lookup",
+            "label" : "EBSCO lookup identifier",
             "type" : "IdentifierType"
           },
           "value" : "1KOlZmZXOW",
@@ -52,8 +52,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "calm-record-id",
-                    "label" : "Calm RecordIdentifier",
+                    "id" : "ebsco-alt-lookup",
+                    "label" : "EBSCO lookup identifier",
                     "type" : "IdentifierType"
                   },
                   "value" : "odercwIWKJ",

--- a/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.2.json
+++ b/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2024-05-13T10:22:01.196172Z",
+  "createdAt" : "2024-05-15T08:17:25.565376Z",
   "id" : "d5kj1fx3",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "d5kj1fx3",
         "identifier" : {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "1KOlZmZXOW"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup",
-            "label" : "EBSCO lookup identifier",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "1KOlZmZXOW",
@@ -52,8 +52,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "ebsco-alt-lookup",
-                    "label" : "EBSCO lookup identifier",
+                    "id" : "calm-record-id",
+                    "label" : "Calm RecordIdentifier",
                     "type" : "IdentifierType"
                   },
                   "value" : "odercwIWKJ",

--- a/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.3.json
+++ b/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2024-05-13T10:22:01.197032Z",
+  "createdAt" : "2024-05-15T08:17:25.565802Z",
   "id" : "9dwdlo2r",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "9dwdlo2r",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "s6jP7JiYzJ"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "s6jP7JiYzJ",
@@ -52,8 +52,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "miro-image-number",
-                    "label" : "Miro image number",
+                    "id" : "calm-record-id",
+                    "label" : "Calm RecordIdentifier",
                     "type" : "IdentifierType"
                   },
                   "value" : "mKTFidDlsq",
@@ -68,8 +68,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "ebsco-alt-lookup",
-                    "label" : "EBSCO lookup identifier",
+                    "id" : "miro-image-number",
+                    "label" : "Miro image number",
                     "type" : "IdentifierType"
                   },
                   "value" : "glMPaKQZ55",
@@ -84,8 +84,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "ebsco-alt-lookup",
-                    "label" : "EBSCO lookup identifier",
+                    "id" : "calm-record-id",
+                    "label" : "Calm RecordIdentifier",
                     "type" : "IdentifierType"
                   },
                   "value" : "2nMuMcZq1J",

--- a/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.3.json
+++ b/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2024-02-16T15:36:45.028118Z",
+  "createdAt" : "2024-05-13T10:22:01.197032Z",
   "id" : "9dwdlo2r",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "9dwdlo2r",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "s6jP7JiYzJ"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "s6jP7JiYzJ",
@@ -52,8 +52,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "calm-record-id",
-                    "label" : "Calm RecordIdentifier",
+                    "id" : "miro-image-number",
+                    "label" : "Miro image number",
                     "type" : "IdentifierType"
                   },
                   "value" : "mKTFidDlsq",
@@ -68,8 +68,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "miro-image-number",
-                    "label" : "Miro image number",
+                    "id" : "ebsco-alt-lookup",
+                    "label" : "EBSCO lookup identifier",
                     "type" : "IdentifierType"
                   },
                   "value" : "glMPaKQZ55",
@@ -84,8 +84,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "calm-record-id",
-                    "label" : "Calm RecordIdentifier",
+                    "id" : "ebsco-alt-lookup",
+                    "label" : "EBSCO lookup identifier",
                     "type" : "IdentifierType"
                   },
                   "value" : "2nMuMcZq1J",

--- a/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.4.json
+++ b/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2024-02-16T15:36:45.029540Z",
+  "createdAt" : "2024-05-13T10:22:01.198363Z",
   "id" : "gqd3shrq",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "gqd3shrq",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "aiNvMk5aVu"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "aiNvMk5aVu",
@@ -52,8 +52,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "calm-record-id",
-                    "label" : "Calm RecordIdentifier",
+                    "id" : "sierra-system-number",
+                    "label" : "Sierra system number",
                     "type" : "IdentifierType"
                   },
                   "value" : "85YYFFvT9f",
@@ -74,8 +74,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "calm-record-id",
-                    "label" : "Calm RecordIdentifier",
+                    "id" : "ebsco-alt-lookup",
+                    "label" : "EBSCO lookup identifier",
                     "type" : "IdentifierType"
                   },
                   "value" : "odercwIWKJ",
@@ -96,8 +96,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "calm-record-id",
-                    "label" : "Calm RecordIdentifier",
+                    "id" : "miro-image-number",
+                    "label" : "Miro image number",
                     "type" : "IdentifierType"
                   },
                   "value" : "mKTFidDlsq",
@@ -112,8 +112,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "miro-image-number",
-                    "label" : "Miro image number",
+                    "id" : "ebsco-alt-lookup",
+                    "label" : "EBSCO lookup identifier",
                     "type" : "IdentifierType"
                   },
                   "value" : "glMPaKQZ55",
@@ -128,8 +128,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "calm-record-id",
-                    "label" : "Calm RecordIdentifier",
+                    "id" : "ebsco-alt-lookup",
+                    "label" : "EBSCO lookup identifier",
                     "type" : "IdentifierType"
                   },
                   "value" : "2nMuMcZq1J",

--- a/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.4.json
+++ b/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2024-05-13T10:22:01.198363Z",
+  "createdAt" : "2024-05-15T08:17:25.566560Z",
   "id" : "gqd3shrq",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "gqd3shrq",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "aiNvMk5aVu"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "aiNvMk5aVu",
@@ -52,8 +52,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "sierra-system-number",
-                    "label" : "Sierra system number",
+                    "id" : "calm-record-id",
+                    "label" : "Calm RecordIdentifier",
                     "type" : "IdentifierType"
                   },
                   "value" : "85YYFFvT9f",
@@ -74,8 +74,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "ebsco-alt-lookup",
-                    "label" : "EBSCO lookup identifier",
+                    "id" : "calm-record-id",
+                    "label" : "Calm RecordIdentifier",
                     "type" : "IdentifierType"
                   },
                   "value" : "odercwIWKJ",
@@ -96,8 +96,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "miro-image-number",
-                    "label" : "Miro image number",
+                    "id" : "calm-record-id",
+                    "label" : "Calm RecordIdentifier",
                     "type" : "IdentifierType"
                   },
                   "value" : "mKTFidDlsq",
@@ -112,8 +112,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "ebsco-alt-lookup",
-                    "label" : "EBSCO lookup identifier",
+                    "id" : "miro-image-number",
+                    "label" : "Miro image number",
                     "type" : "IdentifierType"
                   },
                   "value" : "glMPaKQZ55",
@@ -128,8 +128,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "ebsco-alt-lookup",
-                    "label" : "EBSCO lookup identifier",
+                    "id" : "calm-record-id",
+                    "label" : "Calm RecordIdentifier",
                     "type" : "IdentifierType"
                   },
                   "value" : "2nMuMcZq1J",

--- a/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.5.json
+++ b/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2024-02-16T15:36:45.030091Z",
+  "createdAt" : "2024-05-13T10:22:01.198991Z",
   "id" : "90vab5q4",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "90vab5q4",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "iZFAZvTVR4"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "iZFAZvTVR4",

--- a/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.5.json
+++ b/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2024-05-13T10:22:01.198991Z",
+  "createdAt" : "2024-05-15T08:17:25.566950Z",
   "id" : "90vab5q4",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "90vab5q4",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "iZFAZvTVR4"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "iZFAZvTVR4",

--- a/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.2.json
+++ b/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2024-02-16T15:36:45.050554Z",
+  "createdAt" : "2024-05-13T10:22:01.207646Z",
   "id" : "cerujhar",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "cerujhar",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "xzBExh6kx6"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "xzBExh6kx6",

--- a/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.2.json
+++ b/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2024-05-13T10:22:01.207646Z",
+  "createdAt" : "2024-05-15T08:17:25.576574Z",
   "id" : "cerujhar",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "cerujhar",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "xzBExh6kx6"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "xzBExh6kx6",

--- a/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.3.json
+++ b/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2024-02-16T15:36:45.051501Z",
+  "createdAt" : "2024-05-13T10:22:01.208199Z",
   "id" : "igluyxyl",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "igluyxyl",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "ebsco-alt-lookup"
           },
           "ontologyType" : "Work",
           "value" : "R5Stsp385V"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "ebsco-alt-lookup",
+            "label" : "EBSCO lookup identifier",
             "type" : "IdentifierType"
           },
           "value" : "R5Stsp385V",

--- a/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.3.json
+++ b/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2024-05-13T10:22:01.208199Z",
+  "createdAt" : "2024-05-15T08:17:25.577010Z",
   "id" : "igluyxyl",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "igluyxyl",
         "identifier" : {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "R5Stsp385V"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup",
-            "label" : "EBSCO lookup identifier",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "R5Stsp385V",

--- a/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.4.json
+++ b/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2024-05-13T10:22:01.209497Z",
+  "createdAt" : "2024-05-15T08:17:25.577611Z",
   "id" : "t8hhmnzs",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "t8hhmnzs",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "7erLcgxEad"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "7erLcgxEad",

--- a/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.4.json
+++ b/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2024-02-16T15:36:45.052824Z",
+  "createdAt" : "2024-05-13T10:22:01.209497Z",
   "id" : "t8hhmnzs",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "t8hhmnzs",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "7erLcgxEad"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "7erLcgxEad",

--- a/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.5.json
+++ b/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2024-02-16T15:36:45.053499Z",
+  "createdAt" : "2024-05-13T10:22:01.210961Z",
   "id" : "peojwvfe",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "peojwvfe",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "7qcFvAY3kD"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "7qcFvAY3kD",

--- a/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.5.json
+++ b/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2024-05-13T10:22:01.210961Z",
+  "createdAt" : "2024-05-15T08:17:25.578138Z",
   "id" : "peojwvfe",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "peojwvfe",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "7qcFvAY3kD"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "7qcFvAY3kD",

--- a/pipeline/ingestor/test_documents/works.formats.5.Journals.json
+++ b/pipeline/ingestor/test_documents/works.formats.5.Journals.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2024-05-13T10:22:01.022105Z",
+  "createdAt" : "2024-05-15T08:17:25.443063Z",
   "id" : "ftxlgr2v",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "ftxlgr2v",
         "identifier" : {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "RLx5N8CTsZ"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup",
-            "label" : "EBSCO lookup identifier",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "RLx5N8CTsZ",

--- a/pipeline/ingestor/test_documents/works.formats.5.Journals.json
+++ b/pipeline/ingestor/test_documents/works.formats.5.Journals.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2024-02-16T15:36:44.769242Z",
+  "createdAt" : "2024-05-13T10:22:01.022105Z",
   "id" : "ftxlgr2v",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "ftxlgr2v",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "ebsco-alt-lookup"
           },
           "ontologyType" : "Work",
           "value" : "RLx5N8CTsZ"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "ebsco-alt-lookup",
+            "label" : "EBSCO lookup identifier",
             "type" : "IdentifierType"
           },
           "value" : "RLx5N8CTsZ",

--- a/pipeline/ingestor/test_documents/works.formats.6.Journals.json
+++ b/pipeline/ingestor/test_documents/works.formats.6.Journals.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2024-05-13T10:22:01.024578Z",
+  "createdAt" : "2024-05-15T08:17:25.444151Z",
   "id" : "o5wujppw",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "o5wujppw",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "3jkbPOk92T"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "3jkbPOk92T",

--- a/pipeline/ingestor/test_documents/works.formats.6.Journals.json
+++ b/pipeline/ingestor/test_documents/works.formats.6.Journals.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2024-02-16T15:36:44.770933Z",
+  "createdAt" : "2024-05-13T10:22:01.024578Z",
   "id" : "o5wujppw",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "o5wujppw",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "3jkbPOk92T"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "3jkbPOk92T",

--- a/pipeline/ingestor/test_documents/works.formats.9.Pictures.json
+++ b/pipeline/ingestor/test_documents/works.formats.9.Pictures.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2024-02-16T15:36:44.781028Z",
+  "createdAt" : "2024-05-13T10:22:01.028582Z",
   "id" : "wvcw0lp9",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "wvcw0lp9",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "h2CF3B2FRN"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "h2CF3B2FRN",

--- a/pipeline/ingestor/test_documents/works.formats.9.Pictures.json
+++ b/pipeline/ingestor/test_documents/works.formats.9.Pictures.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2024-05-13T10:22:01.028582Z",
+  "createdAt" : "2024-05-15T08:17:25.447571Z",
   "id" : "wvcw0lp9",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "wvcw0lp9",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "h2CF3B2FRN"
@@ -38,8 +38,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "h2CF3B2FRN",

--- a/pipeline/ingestor/test_documents/works.genres.json
+++ b/pipeline/ingestor/test_documents/works.genres.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with different concepts in the genre",
-  "createdAt" : "2024-02-16T15:36:44.831608Z",
+  "createdAt" : "2024-05-13T10:22:01.066935Z",
   "id" : "jlp05mgl",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "jlp05mgl",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "ebsco-alt-lookup"
           },
           "ontologyType" : "Work",
           "value" : "iIjgaHUI5C"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "ebsco-alt-lookup",
+            "label" : "EBSCO lookup identifier",
             "type" : "IdentifierType"
           },
           "value" : "iIjgaHUI5C",
@@ -60,8 +60,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "miro-image-number",
-                    "label" : "Miro image number",
+                    "id" : "calm-record-id",
+                    "label" : "Calm RecordIdentifier",
                     "type" : "IdentifierType"
                   },
                   "value" : "nJ8zsEX9al",

--- a/pipeline/ingestor/test_documents/works.genres.json
+++ b/pipeline/ingestor/test_documents/works.genres.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with different concepts in the genre",
-  "createdAt" : "2024-05-13T10:22:01.066935Z",
+  "createdAt" : "2024-05-15T08:17:25.470317Z",
   "id" : "jlp05mgl",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "jlp05mgl",
         "identifier" : {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "iIjgaHUI5C"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup",
-            "label" : "EBSCO lookup identifier",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "iIjgaHUI5C",
@@ -60,8 +60,8 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "calm-record-id",
-                    "label" : "Calm RecordIdentifier",
+                    "id" : "miro-image-number",
+                    "label" : "Miro image number",
                     "type" : "IdentifierType"
                   },
                   "value" : "nJ8zsEX9al",

--- a/pipeline/ingestor/test_documents/works.invisible.0.json
+++ b/pipeline/ingestor/test_documents/works.invisible.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of invisible works",
-  "createdAt" : "2024-05-13T10:22:00.712340Z",
+  "createdAt" : "2024-05-15T08:17:25.214583Z",
   "id" : "rczekocx",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "rczekocx",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "Y4unjFIXxl"

--- a/pipeline/ingestor/test_documents/works.invisible.0.json
+++ b/pipeline/ingestor/test_documents/works.invisible.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of invisible works",
-  "createdAt" : "2024-02-16T15:36:44.079633Z",
+  "createdAt" : "2024-05-13T10:22:00.712340Z",
   "id" : "rczekocx",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "rczekocx",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "Y4unjFIXxl"

--- a/pipeline/ingestor/test_documents/works.invisible.1.json
+++ b/pipeline/ingestor/test_documents/works.invisible.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of invisible works",
-  "createdAt" : "2024-05-13T10:22:00.712557Z",
+  "createdAt" : "2024-05-15T08:17:25.214801Z",
   "id" : "60edujsq",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "60edujsq",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "m0zER7Z50Y"

--- a/pipeline/ingestor/test_documents/works.invisible.1.json
+++ b/pipeline/ingestor/test_documents/works.invisible.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of invisible works",
-  "createdAt" : "2024-02-16T15:36:44.080467Z",
+  "createdAt" : "2024-05-13T10:22:00.712557Z",
   "id" : "60edujsq",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "60edujsq",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "m0zER7Z50Y"

--- a/pipeline/ingestor/test_documents/works.invisible.2.json
+++ b/pipeline/ingestor/test_documents/works.invisible.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of invisible works",
-  "createdAt" : "2024-02-16T15:36:44.081589Z",
+  "createdAt" : "2024-05-13T10:22:00.712748Z",
   "id" : "0uk2wzxd",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "0uk2wzxd",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "x2TEreIkut"

--- a/pipeline/ingestor/test_documents/works.invisible.2.json
+++ b/pipeline/ingestor/test_documents/works.invisible.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of invisible works",
-  "createdAt" : "2024-05-13T10:22:00.712748Z",
+  "createdAt" : "2024-05-15T08:17:25.214981Z",
   "id" : "0uk2wzxd",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "0uk2wzxd",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "x2TEreIkut"

--- a/pipeline/ingestor/test_documents/works.items-with-licenses.1.json
+++ b/pipeline/ingestor/test_documents/works.items-with-licenses.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with licensed digital items",
-  "createdAt" : "2024-05-13T10:22:01.055538Z",
+  "createdAt" : "2024-05-15T08:17:25.462552Z",
   "id" : "sojyedta",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "sojyedta",
         "identifier" : {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "xSR5EK6UWY"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup",
-            "label" : "EBSCO lookup identifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "xSR5EK6UWY",

--- a/pipeline/ingestor/test_documents/works.items-with-licenses.1.json
+++ b/pipeline/ingestor/test_documents/works.items-with-licenses.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with licensed digital items",
-  "createdAt" : "2024-02-16T15:36:44.814531Z",
+  "createdAt" : "2024-05-13T10:22:01.055538Z",
   "id" : "sojyedta",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "sojyedta",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "ebsco-alt-lookup"
           },
           "ontologyType" : "Work",
           "value" : "xSR5EK6UWY"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "ebsco-alt-lookup",
+            "label" : "EBSCO lookup identifier",
             "type" : "IdentifierType"
           },
           "value" : "xSR5EK6UWY",

--- a/pipeline/ingestor/test_documents/works.items-with-licenses.2.json
+++ b/pipeline/ingestor/test_documents/works.items-with-licenses.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with licensed digital items",
-  "createdAt" : "2024-02-16T15:36:44.815039Z",
+  "createdAt" : "2024-05-13T10:22:01.056164Z",
   "id" : "fxryjmiz",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "fxryjmiz",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "D9r1zHmiHw"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "D9r1zHmiHw",

--- a/pipeline/ingestor/test_documents/works.items-with-licenses.2.json
+++ b/pipeline/ingestor/test_documents/works.items-with-licenses.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with licensed digital items",
-  "createdAt" : "2024-05-13T10:22:01.056164Z",
+  "createdAt" : "2024-05-15T08:17:25.462915Z",
   "id" : "fxryjmiz",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "fxryjmiz",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "D9r1zHmiHw"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "D9r1zHmiHw",

--- a/pipeline/ingestor/test_documents/works.items-with-licenses.3.json
+++ b/pipeline/ingestor/test_documents/works.items-with-licenses.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with licensed digital items",
-  "createdAt" : "2024-02-16T15:36:44.815616Z",
+  "createdAt" : "2024-05-13T10:22:01.057086Z",
   "id" : "ub2i8snt",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "ub2i8snt",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "by26w1evrA"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "by26w1evrA",

--- a/pipeline/ingestor/test_documents/works.items-with-licenses.3.json
+++ b/pipeline/ingestor/test_documents/works.items-with-licenses.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with licensed digital items",
-  "createdAt" : "2024-05-13T10:22:01.057086Z",
+  "createdAt" : "2024-05-15T08:17:25.463336Z",
   "id" : "ub2i8snt",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "ub2i8snt",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "by26w1evrA"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "by26w1evrA",

--- a/pipeline/ingestor/test_documents/works.items-with-licenses.4.json
+++ b/pipeline/ingestor/test_documents/works.items-with-licenses.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with licensed digital items",
-  "createdAt" : "2024-02-16T15:36:44.816062Z",
+  "createdAt" : "2024-05-13T10:22:01.058116Z",
   "id" : "abt11p2s",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "abt11p2s",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "Jxv45oXcss"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "Jxv45oXcss",

--- a/pipeline/ingestor/test_documents/works.items-with-licenses.4.json
+++ b/pipeline/ingestor/test_documents/works.items-with-licenses.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with licensed digital items",
-  "createdAt" : "2024-05-13T10:22:01.058116Z",
+  "createdAt" : "2024-05-15T08:17:25.463639Z",
   "id" : "abt11p2s",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "abt11p2s",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "Jxv45oXcss"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "Jxv45oXcss",

--- a/pipeline/ingestor/test_documents/works.items-with-other-identifiers.0.json
+++ b/pipeline/ingestor/test_documents/works.items-with-other-identifiers.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2024-05-13T10:22:01.097860Z",
+  "createdAt" : "2024-05-15T08:17:25.490704Z",
   "id" : "hdjyypp6",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "hdjyypp6",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "voGpMYI3LU"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "voGpMYI3LU",
@@ -60,8 +60,8 @@
             },
             {
               "identifierType" : {
-                "id" : "miro-image-number",
-                "label" : "Miro image number",
+                "id" : "calm-record-id",
+                "label" : "Calm RecordIdentifier",
                 "type" : "IdentifierType"
               },
               "value" : "MKDvFJ5itR",

--- a/pipeline/ingestor/test_documents/works.items-with-other-identifiers.0.json
+++ b/pipeline/ingestor/test_documents/works.items-with-other-identifiers.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2024-02-16T15:36:44.866711Z",
+  "createdAt" : "2024-05-13T10:22:01.097860Z",
   "id" : "hdjyypp6",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "hdjyypp6",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "voGpMYI3LU"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "voGpMYI3LU",
@@ -60,8 +60,8 @@
             },
             {
               "identifierType" : {
-                "id" : "calm-record-id",
-                "label" : "Calm RecordIdentifier",
+                "id" : "miro-image-number",
+                "label" : "Miro image number",
                 "type" : "IdentifierType"
               },
               "value" : "MKDvFJ5itR",

--- a/pipeline/ingestor/test_documents/works.items-with-other-identifiers.1.json
+++ b/pipeline/ingestor/test_documents/works.items-with-other-identifiers.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2024-05-13T10:22:01.098674Z",
+  "createdAt" : "2024-05-15T08:17:25.491088Z",
   "id" : "jemj47jb",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "jemj47jb",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "W2xfjSjI6E"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "W2xfjSjI6E",

--- a/pipeline/ingestor/test_documents/works.items-with-other-identifiers.1.json
+++ b/pipeline/ingestor/test_documents/works.items-with-other-identifiers.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2024-02-16T15:36:44.867879Z",
+  "createdAt" : "2024-05-13T10:22:01.098674Z",
   "id" : "jemj47jb",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "jemj47jb",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "W2xfjSjI6E"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "W2xfjSjI6E",

--- a/pipeline/ingestor/test_documents/works.items-with-other-identifiers.2.json
+++ b/pipeline/ingestor/test_documents/works.items-with-other-identifiers.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2024-02-16T15:36:44.870332Z",
+  "createdAt" : "2024-05-13T10:22:01.099425Z",
   "id" : "si1cs1lq",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "si1cs1lq",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "QBdAX1EiWS"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "QBdAX1EiWS",
@@ -51,8 +51,8 @@
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "sierra-system-number",
-                "label" : "Sierra system number",
+                "id" : "miro-image-number",
+                "label" : "Miro image number",
                 "type" : "IdentifierType"
               },
               "value" : "NW5yJ4Q4nj",

--- a/pipeline/ingestor/test_documents/works.items-with-other-identifiers.2.json
+++ b/pipeline/ingestor/test_documents/works.items-with-other-identifiers.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2024-05-13T10:22:01.099425Z",
+  "createdAt" : "2024-05-15T08:17:25.491454Z",
   "id" : "si1cs1lq",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "si1cs1lq",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "QBdAX1EiWS"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "QBdAX1EiWS",
@@ -51,8 +51,8 @@
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "miro-image-number",
-                "label" : "Miro image number",
+                "id" : "sierra-system-number",
+                "label" : "Sierra system number",
                 "type" : "IdentifierType"
               },
               "value" : "NW5yJ4Q4nj",

--- a/pipeline/ingestor/test_documents/works.items-with-other-identifiers.3.json
+++ b/pipeline/ingestor/test_documents/works.items-with-other-identifiers.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2024-02-16T15:36:44.871148Z",
+  "createdAt" : "2024-05-13T10:22:01.099914Z",
   "id" : "pdufpdhz",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "pdufpdhz",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "ebsco-alt-lookup"
           },
           "ontologyType" : "Work",
           "value" : "TJPbhBJugC"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "ebsco-alt-lookup",
+            "label" : "EBSCO lookup identifier",
             "type" : "IdentifierType"
           },
           "value" : "TJPbhBJugC",
@@ -60,8 +60,8 @@
             },
             {
               "identifierType" : {
-                "id" : "calm-record-id",
-                "label" : "Calm RecordIdentifier",
+                "id" : "miro-image-number",
+                "label" : "Miro image number",
                 "type" : "IdentifierType"
               },
               "value" : "Ib4rPRFUwV",

--- a/pipeline/ingestor/test_documents/works.items-with-other-identifiers.3.json
+++ b/pipeline/ingestor/test_documents/works.items-with-other-identifiers.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2024-05-13T10:22:01.099914Z",
+  "createdAt" : "2024-05-15T08:17:25.491823Z",
   "id" : "pdufpdhz",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "pdufpdhz",
         "identifier" : {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "TJPbhBJugC"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup",
-            "label" : "EBSCO lookup identifier",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "TJPbhBJugC",
@@ -60,8 +60,8 @@
             },
             {
               "identifierType" : {
-                "id" : "miro-image-number",
-                "label" : "Miro image number",
+                "id" : "calm-record-id",
+                "label" : "Calm RecordIdentifier",
                 "type" : "IdentifierType"
               },
               "value" : "Ib4rPRFUwV",

--- a/pipeline/ingestor/test_documents/works.items-with-other-identifiers.4.json
+++ b/pipeline/ingestor/test_documents/works.items-with-other-identifiers.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2024-02-16T15:36:44.872360Z",
+  "createdAt" : "2024-05-13T10:22:01.100387Z",
   "id" : "rzcvxgso",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "rzcvxgso",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "8CwvL5s2ax"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "8CwvL5s2ax",
@@ -51,8 +51,8 @@
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "sierra-system-number",
-                "label" : "Sierra system number",
+                "id" : "calm-record-id",
+                "label" : "Calm RecordIdentifier",
                 "type" : "IdentifierType"
               },
               "value" : "yqR7eWPnru",
@@ -60,8 +60,8 @@
             },
             {
               "identifierType" : {
-                "id" : "sierra-system-number",
-                "label" : "Sierra system number",
+                "id" : "ebsco-alt-lookup",
+                "label" : "EBSCO lookup identifier",
                 "type" : "IdentifierType"
               },
               "value" : "wmEBLIOVK6",

--- a/pipeline/ingestor/test_documents/works.items-with-other-identifiers.4.json
+++ b/pipeline/ingestor/test_documents/works.items-with-other-identifiers.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2024-05-13T10:22:01.100387Z",
+  "createdAt" : "2024-05-15T08:17:25.492173Z",
   "id" : "rzcvxgso",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "rzcvxgso",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "8CwvL5s2ax"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "8CwvL5s2ax",
@@ -51,8 +51,8 @@
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "calm-record-id",
-                "label" : "Calm RecordIdentifier",
+                "id" : "sierra-system-number",
+                "label" : "Sierra system number",
                 "type" : "IdentifierType"
               },
               "value" : "yqR7eWPnru",
@@ -60,8 +60,8 @@
             },
             {
               "identifierType" : {
-                "id" : "ebsco-alt-lookup",
-                "label" : "EBSCO lookup identifier",
+                "id" : "sierra-system-number",
+                "label" : "Sierra system number",
                 "type" : "IdentifierType"
               },
               "value" : "wmEBLIOVK6",

--- a/pipeline/ingestor/test_documents/works.languages.0.eng.json
+++ b/pipeline/ingestor/test_documents/works.languages.0.eng.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2024-05-13T10:22:01.035248Z",
+  "createdAt" : "2024-05-15T08:17:25.451896Z",
   "id" : "9pon81hb",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "9pon81hb",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "mVHoe2r6sk"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "mVHoe2r6sk",

--- a/pipeline/ingestor/test_documents/works.languages.0.eng.json
+++ b/pipeline/ingestor/test_documents/works.languages.0.eng.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2024-02-16T15:36:44.789216Z",
+  "createdAt" : "2024-05-13T10:22:01.035248Z",
   "id" : "9pon81hb",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "9pon81hb",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "mVHoe2r6sk"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "mVHoe2r6sk",

--- a/pipeline/ingestor/test_documents/works.languages.1.eng.json
+++ b/pipeline/ingestor/test_documents/works.languages.1.eng.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2024-02-16T15:36:44.791139Z",
+  "createdAt" : "2024-05-13T10:22:01.036773Z",
   "id" : "mye6nsw6",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "mye6nsw6",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "jswjHR3oqS"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "jswjHR3oqS",

--- a/pipeline/ingestor/test_documents/works.languages.1.eng.json
+++ b/pipeline/ingestor/test_documents/works.languages.1.eng.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2024-05-13T10:22:01.036773Z",
+  "createdAt" : "2024-05-15T08:17:25.452942Z",
   "id" : "mye6nsw6",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "mye6nsw6",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "jswjHR3oqS"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "jswjHR3oqS",

--- a/pipeline/ingestor/test_documents/works.languages.2.eng.json
+++ b/pipeline/ingestor/test_documents/works.languages.2.eng.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2024-05-13T10:22:01.038947Z",
+  "createdAt" : "2024-05-15T08:17:25.454214Z",
   "id" : "giiyodfc",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "giiyodfc",
         "identifier" : {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "9x0HfU454v"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup",
-            "label" : "EBSCO lookup identifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "9x0HfU454v",

--- a/pipeline/ingestor/test_documents/works.languages.2.eng.json
+++ b/pipeline/ingestor/test_documents/works.languages.2.eng.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2024-02-16T15:36:44.793553Z",
+  "createdAt" : "2024-05-13T10:22:01.038947Z",
   "id" : "giiyodfc",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "giiyodfc",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "ebsco-alt-lookup"
           },
           "ontologyType" : "Work",
           "value" : "9x0HfU454v"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "ebsco-alt-lookup",
+            "label" : "EBSCO lookup identifier",
             "type" : "IdentifierType"
           },
           "value" : "9x0HfU454v",

--- a/pipeline/ingestor/test_documents/works.languages.4.eng+swe+tur.json
+++ b/pipeline/ingestor/test_documents/works.languages.4.eng+swe+tur.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2024-05-13T10:22:01.044522Z",
+  "createdAt" : "2024-05-15T08:17:25.456668Z",
   "id" : "oagougti",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "oagougti",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "c67fbITZO5"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "c67fbITZO5",

--- a/pipeline/ingestor/test_documents/works.languages.4.eng+swe+tur.json
+++ b/pipeline/ingestor/test_documents/works.languages.4.eng+swe+tur.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2024-02-16T15:36:44.798157Z",
+  "createdAt" : "2024-05-13T10:22:01.044522Z",
   "id" : "oagougti",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "oagougti",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "c67fbITZO5"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "c67fbITZO5",

--- a/pipeline/ingestor/test_documents/works.languages.5.swe.json
+++ b/pipeline/ingestor/test_documents/works.languages.5.swe.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2024-05-13T10:22:01.047872Z",
+  "createdAt" : "2024-05-15T08:17:25.458099Z",
   "id" : "olhrstrz",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "olhrstrz",
         "identifier" : {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "UagAbkJTEE"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup",
-            "label" : "EBSCO lookup identifier",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "UagAbkJTEE",

--- a/pipeline/ingestor/test_documents/works.languages.5.swe.json
+++ b/pipeline/ingestor/test_documents/works.languages.5.swe.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2024-02-16T15:36:44.800935Z",
+  "createdAt" : "2024-05-13T10:22:01.047872Z",
   "id" : "olhrstrz",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "olhrstrz",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "ebsco-alt-lookup"
           },
           "ontologyType" : "Work",
           "value" : "UagAbkJTEE"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "ebsco-alt-lookup",
+            "label" : "EBSCO lookup identifier",
             "type" : "IdentifierType"
           },
           "value" : "UagAbkJTEE",

--- a/pipeline/ingestor/test_documents/works.languages.6.tur.json
+++ b/pipeline/ingestor/test_documents/works.languages.6.tur.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2024-02-16T15:36:44.803590Z",
+  "createdAt" : "2024-05-13T10:22:01.049884Z",
   "id" : "6navwg1c",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "6navwg1c",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "ebsco-alt-lookup"
           },
           "ontologyType" : "Work",
           "value" : "Ra2FIC2DNd"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "ebsco-alt-lookup",
+            "label" : "EBSCO lookup identifier",
             "type" : "IdentifierType"
           },
           "value" : "Ra2FIC2DNd",

--- a/pipeline/ingestor/test_documents/works.languages.6.tur.json
+++ b/pipeline/ingestor/test_documents/works.languages.6.tur.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2024-05-13T10:22:01.049884Z",
+  "createdAt" : "2024-05-15T08:17:25.459537Z",
   "id" : "6navwg1c",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "6navwg1c",
         "identifier" : {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "Ra2FIC2DNd"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup",
-            "label" : "EBSCO lookup identifier",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "Ra2FIC2DNd",

--- a/pipeline/ingestor/test_documents/works.production.multi-year.0.json
+++ b/pipeline/ingestor/test_documents/works.production.multi-year.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2024-05-13T10:22:01.136213Z",
+  "createdAt" : "2024-05-15T08:17:25.522569Z",
   "id" : "cgfghm8m",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "cgfghm8m",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "mh0pYazvpR"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "mh0pYazvpR",

--- a/pipeline/ingestor/test_documents/works.production.multi-year.0.json
+++ b/pipeline/ingestor/test_documents/works.production.multi-year.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2024-02-16T15:36:44.928327Z",
+  "createdAt" : "2024-05-13T10:22:01.136213Z",
   "id" : "cgfghm8m",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "cgfghm8m",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "mh0pYazvpR"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "mh0pYazvpR",

--- a/pipeline/ingestor/test_documents/works.production.multi-year.1.json
+++ b/pipeline/ingestor/test_documents/works.production.multi-year.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2024-02-16T15:36:44.929055Z",
+  "createdAt" : "2024-05-13T10:22:01.136586Z",
   "id" : "bjh2wrdd",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "bjh2wrdd",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "ebsco-alt-lookup"
           },
           "ontologyType" : "Work",
           "value" : "8IL7DS24A3"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "ebsco-alt-lookup",
+            "label" : "EBSCO lookup identifier",
             "type" : "IdentifierType"
           },
           "value" : "8IL7DS24A3",

--- a/pipeline/ingestor/test_documents/works.production.multi-year.1.json
+++ b/pipeline/ingestor/test_documents/works.production.multi-year.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2024-05-13T10:22:01.136586Z",
+  "createdAt" : "2024-05-15T08:17:25.522937Z",
   "id" : "bjh2wrdd",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "bjh2wrdd",
         "identifier" : {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "8IL7DS24A3"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup",
-            "label" : "EBSCO lookup identifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "8IL7DS24A3",

--- a/pipeline/ingestor/test_documents/works.production.multi-year.2.json
+++ b/pipeline/ingestor/test_documents/works.production.multi-year.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2024-02-16T15:36:44.930504Z",
+  "createdAt" : "2024-05-13T10:22:01.136972Z",
   "id" : "mse28reu",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "mse28reu",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "R5aFhbmGJs"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "R5aFhbmGJs",

--- a/pipeline/ingestor/test_documents/works.production.multi-year.2.json
+++ b/pipeline/ingestor/test_documents/works.production.multi-year.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2024-05-13T10:22:01.136972Z",
+  "createdAt" : "2024-05-15T08:17:25.523444Z",
   "id" : "mse28reu",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "mse28reu",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "R5aFhbmGJs"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "R5aFhbmGJs",

--- a/pipeline/ingestor/test_documents/works.production.multi-year.4.json
+++ b/pipeline/ingestor/test_documents/works.production.multi-year.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2024-05-13T10:22:01.137714Z",
+  "createdAt" : "2024-05-15T08:17:25.524311Z",
   "id" : "56tujbhy",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "56tujbhy",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "nFl9elPj6a"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "nFl9elPj6a",

--- a/pipeline/ingestor/test_documents/works.production.multi-year.4.json
+++ b/pipeline/ingestor/test_documents/works.production.multi-year.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2024-02-16T15:36:44.931948Z",
+  "createdAt" : "2024-05-13T10:22:01.137714Z",
   "id" : "56tujbhy",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "56tujbhy",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "nFl9elPj6a"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "nFl9elPj6a",

--- a/pipeline/ingestor/test_documents/works.production.multi-year.5.json
+++ b/pipeline/ingestor/test_documents/works.production.multi-year.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2024-02-16T15:36:44.932459Z",
+  "createdAt" : "2024-05-13T10:22:01.138969Z",
   "id" : "wn4ahfd3",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "wn4ahfd3",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "ebsco-alt-lookup"
           },
           "ontologyType" : "Work",
           "value" : "hRApGkJTZW"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "ebsco-alt-lookup",
+            "label" : "EBSCO lookup identifier",
             "type" : "IdentifierType"
           },
           "value" : "hRApGkJTZW",

--- a/pipeline/ingestor/test_documents/works.production.multi-year.5.json
+++ b/pipeline/ingestor/test_documents/works.production.multi-year.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2024-05-13T10:22:01.138969Z",
+  "createdAt" : "2024-05-15T08:17:25.524738Z",
   "id" : "wn4ahfd3",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "wn4ahfd3",
         "identifier" : {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "hRApGkJTZW"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup",
-            "label" : "EBSCO lookup identifier",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "hRApGkJTZW",

--- a/pipeline/ingestor/test_documents/works.redirected.0.json
+++ b/pipeline/ingestor/test_documents/works.redirected.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of redirected works",
-  "createdAt" : "2024-05-13T10:22:00.719575Z",
+  "createdAt" : "2024-05-15T08:17:25.220502Z",
   "id" : "4nwkprdt",
   "document" : {
     "debug" : {
@@ -25,7 +25,7 @@
       "canonicalId" : "mv6kix0n",
       "sourceIdentifier" : {
         "identifierType" : {
-          "id" : "calm-record-id"
+          "id" : "sierra-system-number"
         },
         "ontologyType" : "Work",
         "value" : "qklbwm3uF6"

--- a/pipeline/ingestor/test_documents/works.redirected.0.json
+++ b/pipeline/ingestor/test_documents/works.redirected.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of redirected works",
-  "createdAt" : "2024-02-16T15:36:44.094272Z",
+  "createdAt" : "2024-05-13T10:22:00.719575Z",
   "id" : "4nwkprdt",
   "document" : {
     "debug" : {
@@ -25,7 +25,7 @@
       "canonicalId" : "mv6kix0n",
       "sourceIdentifier" : {
         "identifierType" : {
-          "id" : "sierra-system-number"
+          "id" : "calm-record-id"
         },
         "ontologyType" : "Work",
         "value" : "qklbwm3uF6"

--- a/pipeline/ingestor/test_documents/works.redirected.1.json
+++ b/pipeline/ingestor/test_documents/works.redirected.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of redirected works",
-  "createdAt" : "2024-05-13T10:22:00.719846Z",
+  "createdAt" : "2024-05-15T08:17:25.220873Z",
   "id" : "6yu7udsf",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "6yu7udsf",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "WDU051A4vR"
@@ -25,7 +25,7 @@
       "canonicalId" : "7wax09hv",
       "sourceIdentifier" : {
         "identifierType" : {
-          "id" : "ebsco-alt-lookup"
+          "id" : "sierra-system-number"
         },
         "ontologyType" : "Work",
         "value" : "qK07HsFHaW"

--- a/pipeline/ingestor/test_documents/works.redirected.1.json
+++ b/pipeline/ingestor/test_documents/works.redirected.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of redirected works",
-  "createdAt" : "2024-02-16T15:36:44.094660Z",
+  "createdAt" : "2024-05-13T10:22:00.719846Z",
   "id" : "6yu7udsf",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "6yu7udsf",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "WDU051A4vR"
@@ -25,7 +25,7 @@
       "canonicalId" : "7wax09hv",
       "sourceIdentifier" : {
         "identifierType" : {
-          "id" : "sierra-system-number"
+          "id" : "ebsco-alt-lookup"
         },
         "ontologyType" : "Work",
         "value" : "qK07HsFHaW"

--- a/pipeline/ingestor/test_documents/works.subjects.0.json
+++ b/pipeline/ingestor/test_documents/works.subjects.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different subjects",
-  "createdAt" : "2024-02-16T15:36:44.835880Z",
+  "createdAt" : "2024-05-13T10:22:01.070276Z",
   "id" : "njj1gugw",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "njj1gugw",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "JeGRUgE73g"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "JeGRUgE73g",

--- a/pipeline/ingestor/test_documents/works.subjects.0.json
+++ b/pipeline/ingestor/test_documents/works.subjects.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different subjects",
-  "createdAt" : "2024-05-13T10:22:01.070276Z",
+  "createdAt" : "2024-05-15T08:17:25.472147Z",
   "id" : "njj1gugw",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "njj1gugw",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "JeGRUgE73g"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "JeGRUgE73g",

--- a/pipeline/ingestor/test_documents/works.subjects.3.json
+++ b/pipeline/ingestor/test_documents/works.subjects.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different subjects",
-  "createdAt" : "2024-02-16T15:36:44.838390Z",
+  "createdAt" : "2024-05-13T10:22:01.073044Z",
   "id" : "opaupm4b",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "opaupm4b",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "ebsco-alt-lookup"
           },
           "ontologyType" : "Work",
           "value" : "spewkKE1s2"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "ebsco-alt-lookup",
+            "label" : "EBSCO lookup identifier",
             "type" : "IdentifierType"
           },
           "value" : "spewkKE1s2",

--- a/pipeline/ingestor/test_documents/works.subjects.3.json
+++ b/pipeline/ingestor/test_documents/works.subjects.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different subjects",
-  "createdAt" : "2024-05-13T10:22:01.073044Z",
+  "createdAt" : "2024-05-15T08:17:25.473884Z",
   "id" : "opaupm4b",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "opaupm4b",
         "identifier" : {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "spewkKE1s2"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "ebsco-alt-lookup",
-            "label" : "EBSCO lookup identifier",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "spewkKE1s2",

--- a/pipeline/ingestor/test_documents/works.subjects.4.json
+++ b/pipeline/ingestor/test_documents/works.subjects.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different subjects",
-  "createdAt" : "2024-05-13T10:22:01.073699Z",
+  "createdAt" : "2024-05-15T08:17:25.474180Z",
   "id" : "el28gega",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "el28gega",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "9qDYGFYXAa"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "9qDYGFYXAa",

--- a/pipeline/ingestor/test_documents/works.subjects.4.json
+++ b/pipeline/ingestor/test_documents/works.subjects.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different subjects",
-  "createdAt" : "2024-02-16T15:36:44.838807Z",
+  "createdAt" : "2024-05-13T10:22:01.073699Z",
   "id" : "el28gega",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "el28gega",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "9qDYGFYXAa"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "9qDYGFYXAa",

--- a/pipeline/ingestor/test_documents/works.title-query-parens.json
+++ b/pipeline/ingestor/test_documents/works.title-query-parens.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work whose title has parens meant to trip up ES",
-  "createdAt" : "2024-05-13T10:22:01.032536Z",
+  "createdAt" : "2024-05-15T08:17:25.450186Z",
   "id" : "1sxjupdc",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "1sxjupdc",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "weuV0WsLiG"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "weuV0WsLiG",

--- a/pipeline/ingestor/test_documents/works.title-query-parens.json
+++ b/pipeline/ingestor/test_documents/works.title-query-parens.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work whose title has parens meant to trip up ES",
-  "createdAt" : "2024-02-16T15:36:44.786561Z",
+  "createdAt" : "2024-05-13T10:22:01.032536Z",
   "id" : "1sxjupdc",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "1sxjupdc",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "weuV0WsLiG"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "weuV0WsLiG",

--- a/pipeline/ingestor/test_documents/works.title-query-syntax.json
+++ b/pipeline/ingestor/test_documents/works.title-query-syntax.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work whose title has lots of ES query syntax operators",
-  "createdAt" : "2024-05-13T10:22:01.030810Z",
+  "createdAt" : "2024-05-15T08:17:25.448771Z",
   "id" : "mdg1yvuv",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "mdg1yvuv",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "9P6mnsoyfd"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "9P6mnsoyfd",

--- a/pipeline/ingestor/test_documents/works.title-query-syntax.json
+++ b/pipeline/ingestor/test_documents/works.title-query-syntax.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work whose title has lots of ES query syntax operators",
-  "createdAt" : "2024-02-16T15:36:44.782951Z",
+  "createdAt" : "2024-05-13T10:22:01.030810Z",
   "id" : "mdg1yvuv",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "mdg1yvuv",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "9P6mnsoyfd"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "9P6mnsoyfd",

--- a/pipeline/ingestor/test_documents/works.visible.0.json
+++ b/pipeline/ingestor/test_documents/works.visible.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of visible works",
-  "createdAt" : "2024-05-13T10:22:00.655455Z",
+  "createdAt" : "2024-05-15T08:17:25.173155Z",
   "id" : "2twopft1",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "2twopft1",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "Uaequ81tpB"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "Uaequ81tpB",

--- a/pipeline/ingestor/test_documents/works.visible.0.json
+++ b/pipeline/ingestor/test_documents/works.visible.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of visible works",
-  "createdAt" : "2024-02-16T15:36:43.992275Z",
+  "createdAt" : "2024-05-13T10:22:00.655455Z",
   "id" : "2twopft1",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "2twopft1",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "Uaequ81tpB"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "Uaequ81tpB",

--- a/pipeline/ingestor/test_documents/works.visible.1.json
+++ b/pipeline/ingestor/test_documents/works.visible.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of visible works",
-  "createdAt" : "2024-05-13T10:22:00.658634Z",
+  "createdAt" : "2024-05-15T08:17:25.174877Z",
   "id" : "dph7sjip",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "dph7sjip",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "WpBejTwv1N"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "WpBejTwv1N",

--- a/pipeline/ingestor/test_documents/works.visible.1.json
+++ b/pipeline/ingestor/test_documents/works.visible.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of visible works",
-  "createdAt" : "2024-02-16T15:36:44.001281Z",
+  "createdAt" : "2024-05-13T10:22:00.658634Z",
   "id" : "dph7sjip",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "dph7sjip",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "WpBejTwv1N"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "WpBejTwv1N",

--- a/pipeline/ingestor/test_documents/works.visible.3.json
+++ b/pipeline/ingestor/test_documents/works.visible.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of visible works",
-  "createdAt" : "2024-02-16T15:36:44.008952Z",
+  "createdAt" : "2024-05-13T10:22:00.660944Z",
   "id" : "raob2ruv",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "raob2ruv",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "wyJzS2SuiH"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "wyJzS2SuiH",

--- a/pipeline/ingestor/test_documents/works.visible.3.json
+++ b/pipeline/ingestor/test_documents/works.visible.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of visible works",
-  "createdAt" : "2024-05-13T10:22:00.660944Z",
+  "createdAt" : "2024-05-15T08:17:25.176805Z",
   "id" : "raob2ruv",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "raob2ruv",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
           "value" : "wyJzS2SuiH"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
           "value" : "wyJzS2SuiH",

--- a/pipeline/ingestor/test_documents/works.visible.4.json
+++ b/pipeline/ingestor/test_documents/works.visible.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of visible works",
-  "createdAt" : "2024-05-13T10:22:00.661990Z",
+  "createdAt" : "2024-05-15T08:17:25.177618Z",
   "id" : "vbi1ii19",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "vbi1ii19",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
           "value" : "CzLNHBFHuR"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
           "value" : "CzLNHBFHuR",

--- a/pipeline/ingestor/test_documents/works.visible.4.json
+++ b/pipeline/ingestor/test_documents/works.visible.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of visible works",
-  "createdAt" : "2024-02-16T15:36:44.014158Z",
+  "createdAt" : "2024-05-13T10:22:00.661990Z",
   "id" : "vbi1ii19",
   "document" : {
     "debug" : {
@@ -8,7 +8,7 @@
         "id" : "vbi1ii19",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
           "value" : "CzLNHBFHuR"
@@ -33,8 +33,8 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
           "value" : "CzLNHBFHuR",

--- a/pipeline/merger/src/main/scala/weco/pipeline/merger/rules/OtherIdentifiersRule.scala
+++ b/pipeline/merger/src/main/scala/weco/pipeline/merger/rules/OtherIdentifiersRule.scala
@@ -99,9 +99,9 @@ object OtherIdentifiersRule extends FieldMergeRule with MergerLogging {
     val isDefinedForSource: WorkPredicate = sierraWork
 
     def rule(
-              target: Work.Visible[Identified],
-              sources: NonEmptyList[Work[Identified]]
-            ): FieldData =
+      target: Work.Visible[Identified],
+      sources: NonEmptyList[Work[Identified]]
+    ): FieldData =
       target.data.otherIdentifiers ++ sources.toList.flatMap(
         getAllowedIdentifiersFromSource
       )

--- a/pipeline/merger/src/main/scala/weco/pipeline/merger/rules/OtherIdentifiersRule.scala
+++ b/pipeline/merger/src/main/scala/weco/pipeline/merger/rules/OtherIdentifiersRule.scala
@@ -52,6 +52,7 @@ object OtherIdentifiersRule extends FieldMergeRule with MergerLogging {
 
     val mergedSources = (
       List(
+        mergeIntoEbscoTarget,
         mergeIntoTeiTarget,
         mergeIntoCalmTarget,
         mergeSingleMiroIntoSingleOrZeroItemSierraTarget
@@ -92,6 +93,19 @@ object OtherIdentifiersRule extends FieldMergeRule with MergerLogging {
           getAllowedIdentifiersFromSource
         )
     }
+
+  private val mergeIntoEbscoTarget = new PartialRule {
+    val isDefinedForTarget: WorkPredicate = ebscoWork
+    val isDefinedForSource: WorkPredicate = sierraWork
+
+    def rule(
+              target: Work.Visible[Identified],
+              sources: NonEmptyList[Work[Identified]]
+            ): FieldData =
+      target.data.otherIdentifiers ++ sources.toList.flatMap(
+        getAllowedIdentifiersFromSource
+      )
+  }
 
   private val mergeIntoTeiTarget = new PartialRule {
     val isDefinedForTarget: WorkPredicate = teiWork

--- a/pipeline/merger/src/main/scala/weco/pipeline/merger/rules/TargetPrecedence.scala
+++ b/pipeline/merger/src/main/scala/weco/pipeline/merger/rules/TargetPrecedence.scala
@@ -8,12 +8,12 @@ object TargetPrecedence {
 
   // This is the canonical list of the order in which we try to select target works
   private val targetPrecedence = Seq(
-    teiWork,
     ebscoWork,
+    teiWork,
     singlePhysicalItemCalmWork,
     sierraDigitisedAv,
     physicalSierra,
-    sierraWork
+    sierraWork,
   )
 
   def targetSatisfying(

--- a/pipeline/merger/src/main/scala/weco/pipeline/merger/rules/TargetPrecedence.scala
+++ b/pipeline/merger/src/main/scala/weco/pipeline/merger/rules/TargetPrecedence.scala
@@ -13,7 +13,7 @@ object TargetPrecedence {
     singlePhysicalItemCalmWork,
     sierraDigitisedAv,
     physicalSierra,
-    sierraWork,
+    sierraWork
   )
 
   def targetSatisfying(

--- a/pipeline/merger/src/main/scala/weco/pipeline/merger/rules/TargetPrecedence.scala
+++ b/pipeline/merger/src/main/scala/weco/pipeline/merger/rules/TargetPrecedence.scala
@@ -9,6 +9,7 @@ object TargetPrecedence {
   // This is the canonical list of the order in which we try to select target works
   private val targetPrecedence = Seq(
     teiWork,
+    ebscoWork,
     singlePhysicalItemCalmWork,
     sierraDigitisedAv,
     physicalSierra,

--- a/pipeline/merger/src/main/scala/weco/pipeline/merger/rules/WorkPredicates.scala
+++ b/pipeline/merger/src/main/scala/weco/pipeline/merger/rules/WorkPredicates.scala
@@ -34,7 +34,11 @@ object WorkPredicates {
   private val miroIdentified: WorkPredicate = identifierTypeId(
     IdentifierType.MiroImageNumber
   )
+  private val ebscoIdentified: WorkPredicate = identifierTypeId(
+    IdentifierType.EbscoAltLookup
+  )
 
+  val ebscoWork: WorkPredicate = ebscoIdentified
   val sierraWork: WorkPredicate = sierraIdentified
   val zeroItem: WorkPredicate = work => work.data.items.isEmpty
   val singleItem: WorkPredicate = work => work.data.items.size == 1

--- a/pipeline/merger/src/test/scala/weco/pipeline/merger/MergerIntegrationTest.scala
+++ b/pipeline/merger/src/test/scala/weco/pipeline/merger/MergerIntegrationTest.scala
@@ -112,6 +112,23 @@ class MergerIntegrationTest
     }
   }
 
+  Scenario("One Sierra and one Ebsco work are matched") {
+    withContext {
+      implicit context =>
+        Given("a Sierra work and a Miro work")
+        val (sierra, ebsco) = sierraEbscoIdentifiedWorkPair()
+
+        When("the works are processed by the matcher/merger")
+        processWorks(sierra, ebsco)
+
+        Then("the Sierra work is redirected to the Ebsco work")
+        context.getMerged(sierra) should beRedirectedTo(ebsco)
+
+        And("the Ebsco work should be unmodified")
+        context.getMerged(ebsco).data shouldBe ebsco.data
+    }
+  }
+
   Scenario("A Sierra picture and METS work are matched") {
     withContext {
       implicit context =>

--- a/pipeline/merger/src/test/scala/weco/pipeline/merger/rules/OtherIdentifiersRuleTest.scala
+++ b/pipeline/merger/src/test/scala/weco/pipeline/merger/rules/OtherIdentifiersRuleTest.scala
@@ -150,6 +150,16 @@ class OtherIdentifiersRuleTest
     }
   }
 
+  it("merges a Sierra work into an Ebsco work with no identifiers added") {
+    val (sierraWork, ebscoWork) = sierraEbscoIdentifiedWorkPair()
+
+    inside(OtherIdentifiersRule.merge(ebscoWork, List(sierraWork))) {
+      case FieldMergeResult(otherIdentifiers, mergedSources) =>
+        otherIdentifiers shouldBe empty
+        mergedSources should contain theSameElementsAs List(sierraWork)
+    }
+  }
+
   it(
     "does not merge any Miro source IDs into Sierra works with format != picture/digital image/3D object") {
     inside(

--- a/pipeline/merger/src/test/scala/weco/pipeline/merger/rules/OtherIdentifiersRuleTest.scala
+++ b/pipeline/merger/src/test/scala/weco/pipeline/merger/rules/OtherIdentifiersRuleTest.scala
@@ -2,11 +2,8 @@ package weco.pipeline.merger.rules
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.{Inside, Inspectors}
-import weco.catalogue.internal_model.identifiers.{
-  IdentifierType,
-  SourceIdentifier
-}
+import org.scalatest.{Inside, Inspectors, LoneElement}
+import weco.catalogue.internal_model.identifiers.{IdentifierType, SourceIdentifier}
 import weco.catalogue.internal_model.work.generators.SourceWorkGenerators
 import weco.catalogue.internal_model.work.{Format, Work, WorkState}
 import weco.pipeline.matcher.generators.MergeCandidateGenerators
@@ -14,11 +11,12 @@ import weco.pipeline.merger.models.FieldMergeResult
 
 class OtherIdentifiersRuleTest
     extends AnyFunSpec
-    with Matchers
-    with SourceWorkGenerators
-    with MergeCandidateGenerators
-    with Inside
-    with Inspectors {
+      with Matchers
+      with SourceWorkGenerators
+      with MergeCandidateGenerators
+      with Inside
+      with LoneElement
+      with Inspectors {
   val nothingWork: Work.Visible[WorkState.Identified] = identifiedWork(
     sourceIdentifier = SourceIdentifier(
       identifierType = IdentifierType.MESH,
@@ -125,7 +123,7 @@ class OtherIdentifiersRuleTest
         otherIdentifiers should contain theSameElementsAs
           miroWork.sourceIdentifier :: physicalSierraWork.data.otherIdentifiers
 
-        mergedSources should contain only miroWork
+        mergedSources.loneElement shouldBe miroWork
     }
   }
 
@@ -146,7 +144,7 @@ class OtherIdentifiersRuleTest
         otherIdentifiers should contain theSameElementsAs
           miroWork.sourceIdentifier :: zeroItemPhysicalSierra.data.otherIdentifiers
 
-        mergedSources should contain theSameElementsAs List(miroWork)
+        mergedSources.loneElement shouldBe miroWork
     }
   }
 
@@ -156,7 +154,7 @@ class OtherIdentifiersRuleTest
     inside(OtherIdentifiersRule.merge(ebscoWork, List(sierraWork))) {
       case FieldMergeResult(otherIdentifiers, mergedSources) =>
         otherIdentifiers shouldBe empty
-        mergedSources should contain theSameElementsAs List(sierraWork)
+        mergedSources.loneElement shouldBe sierraWork
     }
   }
 
@@ -220,8 +218,7 @@ class OtherIdentifiersRuleTest
         otherIdentifiers should contain theSameElementsAs
           (miroWork.sourceIdentifier :: physicalSierraWork.data.otherIdentifiers)
 
-        mergeCandidates should contain theSameElementsAs List(
-          miroWorkWithOtherSources)
+        mergeCandidates.loneElement shouldBe miroWorkWithOtherSources
     }
   }
 

--- a/pipeline/merger/src/test/scala/weco/pipeline/merger/services/PlatformMergerTest.scala
+++ b/pipeline/merger/src/test/scala/weco/pipeline/merger/services/PlatformMergerTest.scala
@@ -1061,6 +1061,26 @@ class PlatformMergerTest
     )
   }
 
+  describe("merging EBSCO & Sierra works") {
+    it("merges a Sierra digital work with an EBSCO work") {
+      val merger = PlatformMerger
+      val (sierraDigitalWork, ebscoWork) = sierraEbscoIdentifiedWorkPair()
+
+      val result = merger
+        .merge(works = Seq(sierraDigitalWork, ebscoWork))
+        .mergedWorksWithTime(now)
+      val redirectedWorks = result.collect {
+        case w: Work.Redirected[Merged] => w
+      }
+      val visibleWorks = result.collect { case w: Work.Visible[Merged] => w }
+
+      redirectedWorks should have size 1
+      visibleWorks should have size 1
+
+      visibleWorks.head.state.canonicalId shouldBe ebscoWork.state.canonicalId
+    }
+  }
+
   describe("merging TEI works") {
     it("merges a physical sierra with a tei") {
       val merger = PlatformMerger

--- a/pipeline/merger/src/test/scala/weco/pipeline/merger/services/PlatformMergerTest.scala
+++ b/pipeline/merger/src/test/scala/weco/pipeline/merger/services/PlatformMergerTest.scala
@@ -1,5 +1,6 @@
 package weco.pipeline.merger.services
 
+import org.scalatest.LoneElement
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks._
@@ -9,21 +10,15 @@ import weco.catalogue.internal_model.locations._
 import weco.catalogue.internal_model.work.WorkFsm._
 import weco.catalogue.internal_model.work.WorkState.{Identified, Merged}
 import weco.catalogue.internal_model.work.generators.SourceWorkGenerators
-import weco.catalogue.internal_model.work.{
-  Format,
-  InternalWork,
-  InvisibilityReason,
-  Item,
-  Work,
-  WorkData
-}
+import weco.catalogue.internal_model.work.{Format, InternalWork, InvisibilityReason, Item, Work, WorkData}
 import weco.pipeline.matcher.generators.MergeCandidateGenerators
 
 class PlatformMergerTest
     extends AnyFunSpec
-    with SourceWorkGenerators
-    with MergeCandidateGenerators
-    with Matchers {
+      with SourceWorkGenerators
+      with MergeCandidateGenerators 
+      with LoneElement
+      with Matchers {
 
   val digitalLocationCCBYNC = createDigitalLocationWith(
     license = Some(License.CCBYNC)
@@ -1077,7 +1072,7 @@ class PlatformMergerTest
       redirectedWorks should have size 1
       visibleWorks should have size 1
 
-      visibleWorks.head.state.canonicalId shouldBe ebscoWork.state.canonicalId
+      visibleWorks.loneElement.state.canonicalId shouldBe ebscoWork.state.canonicalId
     }
   }
 
@@ -1101,7 +1096,7 @@ class PlatformMergerTest
       redirectedWorks should have size 1
       visibleWorks should have size 1
 
-      visibleWorks.head.state.canonicalId shouldBe teiWork.state.canonicalId
+      visibleWorks.loneElement.state.canonicalId shouldBe teiWork.state.canonicalId
     }
 
     it("copies the thumbnail to the inner works") {

--- a/pipeline/transformer/transformer_ebsco/src/main/scala/weco/pipeline/transformer/ebsco/EbscoTransformer.scala
+++ b/pipeline/transformer/transformer_ebsco/src/main/scala/weco/pipeline/transformer/ebsco/EbscoTransformer.scala
@@ -1,22 +1,10 @@
 package weco.pipeline.transformer.ebsco
 
-import weco.catalogue.internal_model.identifiers.{
-  DataState,
-  IdentifierType,
-  SourceIdentifier
-}
+import weco.catalogue.internal_model.identifiers.{DataState, IdentifierType, SourceIdentifier}
+import weco.catalogue.internal_model.work.Format.EJournals
 import weco.catalogue.internal_model.work.WorkState.Source
-import weco.catalogue.internal_model.work.{
-  DeletedReason,
-  Work,
-  WorkData,
-  WorkState
-}
-import weco.catalogue.source_model.ebsco.{
-  EbscoDeletedSourceData,
-  EbscoSourceData,
-  EbscoUpdatedSourceData
-}
+import weco.catalogue.internal_model.work.{DeletedReason, Work, WorkData, WorkState}
+import weco.catalogue.source_model.ebsco.{EbscoDeletedSourceData, EbscoSourceData, EbscoUpdatedSourceData}
 import weco.pipeline.transformer.Transformer
 import weco.pipeline.transformer.marc.xml.data.MarcXMLRecord
 import weco.pipeline.transformer.marc_common.logging.LoggingContext
@@ -83,7 +71,12 @@ class EbscoTransformer(store: Readable[S3ObjectLocation, String])
         contributors = MarcContributors(record).toList,
         subjects = MarcSubjects(record).toList,
         genres = MarcGenres(record).toList,
-        holdings = MarcElectronicResources.toHoldings(record).toList
+        holdings = MarcElectronicResources.toHoldings(record).toList,
+        languages = MarcLanguage(record).toList,
+        // TODO: We should rely on a Marc transformer to extract this information
+        //   but we know that all the records we are transforming from this source
+        //   are EJournals.
+        format = Some(EJournals)
       )
     )
   }

--- a/pipeline/transformer/transformer_ebsco/src/main/scala/weco/pipeline/transformer/ebsco/EbscoTransformer.scala
+++ b/pipeline/transformer/transformer_ebsco/src/main/scala/weco/pipeline/transformer/ebsco/EbscoTransformer.scala
@@ -57,7 +57,7 @@ class EbscoTransformer(store: Readable[S3ObjectLocation, String])
       sourceIdentifier = SourceIdentifier(
         identifierType = IdentifierType.EbscoAltLookup,
         ontologyType = "Work",
-        value = record.controlField("001").get
+        value = record.controlField("001").get.content
       ),
       // TODO: The adapter should provide the date & time
       sourceModifiedTime = Instant.now

--- a/pipeline/transformer/transformer_ebsco/src/main/scala/weco/pipeline/transformer/ebsco/EbscoTransformer.scala
+++ b/pipeline/transformer/transformer_ebsco/src/main/scala/weco/pipeline/transformer/ebsco/EbscoTransformer.scala
@@ -1,10 +1,23 @@
 package weco.pipeline.transformer.ebsco
 
-import weco.catalogue.internal_model.identifiers.{DataState, IdentifierType, SourceIdentifier}
+import weco.catalogue.internal_model.identifiers.{
+  DataState,
+  IdentifierType,
+  SourceIdentifier
+}
 import weco.catalogue.internal_model.work.Format.EJournals
 import weco.catalogue.internal_model.work.WorkState.Source
-import weco.catalogue.internal_model.work.{DeletedReason, Work, WorkData, WorkState}
-import weco.catalogue.source_model.ebsco.{EbscoDeletedSourceData, EbscoSourceData, EbscoUpdatedSourceData}
+import weco.catalogue.internal_model.work.{
+  DeletedReason,
+  Work,
+  WorkData,
+  WorkState
+}
+import weco.catalogue.source_model.ebsco.{
+  EbscoDeletedSourceData,
+  EbscoSourceData,
+  EbscoUpdatedSourceData
+}
 import weco.pipeline.transformer.Transformer
 import weco.pipeline.transformer.marc.xml.data.MarcXMLRecord
 import weco.pipeline.transformer.marc_common.logging.LoggingContext
@@ -45,7 +58,11 @@ class EbscoTransformer(store: Readable[S3ObjectLocation, String])
         )
     }
 
-  private def createWork(record: MarcXMLRecord, version: Int, modifiedTime: Instant): Work.Visible[Source] = {
+  private def createWork(
+    record: MarcXMLRecord,
+    version: Int,
+    modifiedTime: Instant
+  ): Work.Visible[Source] = {
     val state = Source(
       sourceIdentifier = SourceIdentifier(
         identifierType = IdentifierType.EbscoAltLookup,

--- a/pipeline/transformer/transformer_ebsco/src/main/scala/weco/pipeline/transformer/ebsco/EbscoTransformer.scala
+++ b/pipeline/transformer/transformer_ebsco/src/main/scala/weco/pipeline/transformer/ebsco/EbscoTransformer.scala
@@ -1,9 +1,22 @@
 package weco.pipeline.transformer.ebsco
 
-import weco.catalogue.internal_model.identifiers.{DataState, IdentifierType, SourceIdentifier}
+import weco.catalogue.internal_model.identifiers.{
+  DataState,
+  IdentifierType,
+  SourceIdentifier
+}
 import weco.catalogue.internal_model.work.WorkState.Source
-import weco.catalogue.internal_model.work.{DeletedReason, Work, WorkData, WorkState}
-import weco.catalogue.source_model.ebsco.{EbscoDeletedSourceData, EbscoSourceData, EbscoUpdatedSourceData}
+import weco.catalogue.internal_model.work.{
+  DeletedReason,
+  Work,
+  WorkData,
+  WorkState
+}
+import weco.catalogue.source_model.ebsco.{
+  EbscoDeletedSourceData,
+  EbscoSourceData,
+  EbscoUpdatedSourceData
+}
 import weco.pipeline.transformer.Transformer
 import weco.pipeline.transformer.marc.xml.data.MarcXMLRecord
 import weco.pipeline.transformer.marc_common.logging.LoggingContext
@@ -63,18 +76,18 @@ class EbscoTransformer(store: Readable[S3ObjectLocation, String])
       version = 0,
       state = state,
       data = WorkData[DataState.Unidentified](
-          title = MarcTitle(record),
-          alternativeTitles = MarcAlternativeTitles(record).toList,
-          otherIdentifiers = MarcInternationalStandardIdentifiers(record).toList,
-          designation = MarcDesignation(record).toList,
-          description = MarcDescription(record),
-          currentFrequency = MarcCurrentFrequency(record),
-          edition = MarcEdition(record),
-          contributors = MarcContributors(record).toList,
-          subjects = MarcSubjects(record).toList,
-          genres = MarcGenres(record).toList,
-          holdings = MarcElectronicResources.toHoldings(record).toList
-        )
+        title = MarcTitle(record),
+        alternativeTitles = MarcAlternativeTitles(record).toList,
+        otherIdentifiers = MarcInternationalStandardIdentifiers(record).toList,
+        designation = MarcDesignation(record).toList,
+        description = MarcDescription(record),
+        currentFrequency = MarcCurrentFrequency(record),
+        edition = MarcEdition(record),
+        contributors = MarcContributors(record).toList,
+        subjects = MarcSubjects(record).toList,
+        genres = MarcGenres(record).toList,
+        holdings = MarcElectronicResources.toHoldings(record).toList
+      )
     )
   }
 }

--- a/pipeline/transformer/transformer_ebsco/src/main/scala/weco/pipeline/transformer/ebsco/EbscoTransformer.scala
+++ b/pipeline/transformer/transformer_ebsco/src/main/scala/weco/pipeline/transformer/ebsco/EbscoTransformer.scala
@@ -41,7 +41,7 @@ class EbscoTransformer(store: Readable[S3ObjectLocation, String])
         for {
           xmlString <- store.get(s3Location).left.map(_.e)
           xml <- Try(XML.loadString(xmlString.identifiedT)).toEither
-        } yield createWork(MarcXMLRecord(xml))
+        } yield createWork(MarcXMLRecord(xml), version)
 
       case EbscoDeletedSourceData =>
         Right(
@@ -58,7 +58,7 @@ class EbscoTransformer(store: Readable[S3ObjectLocation, String])
         )
     }
 
-  private def createWork(record: MarcXMLRecord): Work.Visible[Source] = {
+  private def createWork(record: MarcXMLRecord, version: Int): Work.Visible[Source] = {
     val state = Source(
       sourceIdentifier = SourceIdentifier(
         identifierType = IdentifierType.EbscoAltLookup,
@@ -72,8 +72,7 @@ class EbscoTransformer(store: Readable[S3ObjectLocation, String])
       state.sourceIdentifier.value
     )
     Work.Visible[Source](
-      // TODO: Get version from the adapter
-      version = 0,
+      version = version,
       state = state,
       data = WorkData[DataState.Unidentified](
         title = MarcTitle(record),

--- a/pipeline/transformer/transformer_ebsco/src/main/scala/weco/pipeline/transformer/ebsco/service/EbscoSourceDataRetriever.scala
+++ b/pipeline/transformer/transformer_ebsco/src/main/scala/weco/pipeline/transformer/ebsco/service/EbscoSourceDataRetriever.scala
@@ -21,7 +21,9 @@ class EbscoSourceDataRetriever
         Right(
           Identified(
             Version(payload.id, payload.version),
-            EbscoDeletedSourceData
+            EbscoDeletedSourceData(
+              modifiedTime = payload.time
+            )
           )
         )
 
@@ -29,7 +31,10 @@ class EbscoSourceDataRetriever
         Right(
           Identified(
             Version(payload.id, payload.version),
-            EbscoUpdatedSourceData(location)
+            EbscoUpdatedSourceData(
+              s3Location = location,
+              modifiedTime = payload.time
+            )
           )
         )
 

--- a/pipeline/transformer/transformer_ebsco/src/test/scala/weco/pipeline/transformer/ebsco/EbscoTransformerTest.scala
+++ b/pipeline/transformer/transformer_ebsco/src/test/scala/weco/pipeline/transformer/ebsco/EbscoTransformerTest.scala
@@ -4,6 +4,7 @@ import org.scalatest.EitherValues
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.catalogue.internal_model.identifiers.DataState
+import weco.catalogue.internal_model.work.Format.EJournals
 import weco.catalogue.internal_model.work.WorkData
 import weco.catalogue.source_model.ebsco.EbscoUpdatedSourceData
 import weco.storage.generators.S3ObjectLocationGenerators
@@ -45,7 +46,10 @@ class EbscoTransformerTest
 
       work.state.sourceIdentifier.value shouldBe "3PaDhRp"
       work.data should equal(
-        WorkData[DataState.Unidentified](title = Some("matacologian"))
+        WorkData[DataState.Unidentified](
+          title = Some("matacologian"),
+          format = Some(EJournals)
+        )
       )
     }
   }

--- a/pipeline/transformer/transformer_ebsco/src/test/scala/weco/pipeline/transformer/ebsco/EbscoTransformerTest.scala
+++ b/pipeline/transformer/transformer_ebsco/src/test/scala/weco/pipeline/transformer/ebsco/EbscoTransformerTest.scala
@@ -10,6 +10,8 @@ import weco.storage.generators.S3ObjectLocationGenerators
 import weco.storage.providers.s3.S3ObjectLocation
 import weco.storage.store.memory.MemoryStore
 
+import java.time.Instant
+
 class EbscoTransformerTest
     extends AnyFunSpec
     with S3ObjectLocationGenerators
@@ -20,6 +22,7 @@ class EbscoTransformerTest
     it("generates a Work with a sourceIdentifier") {
       info("at minimum, a Work from an XML record needs an id and a title")
       val location = createS3ObjectLocation
+      val modifiedTime = Instant.parse("2021-04-01T12:00:00Z")
 
       val record =
         <record xmlns="http://www.loc.gov/MARC21/slim">
@@ -36,7 +39,7 @@ class EbscoTransformerTest
       )
 
       val result =
-        transformer.apply("3PaDhRp", EbscoUpdatedSourceData(location), 20240401)
+        transformer.apply("3PaDhRp", EbscoUpdatedSourceData(location, modifiedTime), 20240401)
       result shouldBe a[Right[_, _]]
       val work = result.value
 

--- a/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/models/MarcField.scala
+++ b/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/models/MarcField.scala
@@ -14,5 +14,5 @@ case class MarcField(
 
 case class MarcControlField(
   marcTag: String,
-  content: String,
+  content: String
 ) extends MarcTaggedField

--- a/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/models/MarcField.scala
+++ b/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/models/MarcField.scala
@@ -1,10 +1,18 @@
 package weco.pipeline.transformer.marc_common.models
 
+sealed trait MarcTaggedField {
+  val marcTag: String
+}
+
 case class MarcField(
   marcTag: String,
   subfields: Seq[MarcSubfield] = Nil,
-  content: Option[String] = None,
   fieldTag: Option[String] = None,
   indicator1: String = " ",
   indicator2: String = " "
-)
+) extends MarcTaggedField
+
+case class MarcControlField(
+  marcTag: String,
+  content: String,
+) extends MarcTaggedField

--- a/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/models/MarcRecord.scala
+++ b/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/models/MarcRecord.scala
@@ -6,7 +6,14 @@ package weco.pipeline.transformer.marc_common.models
  * */
 trait MarcRecord {
 
+  val leader: String
+
+  val controlFields: Seq[MarcControlField]
+
   val fields: Seq[MarcField]
+
+  def controlField(tag: String): Option[MarcControlField] = controlFields.find(_.marcTag == tag)
+
   def fieldsWithTags(tags: String*): Seq[MarcField]
 
   def subfieldsWithTag(tagPair: (String, String)): List[MarcSubfield]

--- a/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/models/MarcRecord.scala
+++ b/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/models/MarcRecord.scala
@@ -16,9 +16,9 @@ trait MarcRecord {
   // If there are multiple control fields with the same tag, return Noneg
   def controlField(tag: String): Option[MarcControlField] =
     controlFields.filter(_.marcTag == tag) match {
-        case Nil => None
-        case x :: Nil => Some(x)
-        case _ => None
+      case Nil      => None
+      case x :: Nil => Some(x)
+      case _        => None
     }
 
   def fieldsWithTags(tags: String*): Seq[MarcField]

--- a/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/models/MarcRecord.scala
+++ b/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/models/MarcRecord.scala
@@ -12,7 +12,8 @@ trait MarcRecord {
 
   val fields: Seq[MarcField]
 
-  def controlField(tag: String): Option[MarcControlField] = controlFields.find(_.marcTag == tag)
+  def controlField(tag: String): Option[MarcControlField] =
+    controlFields.find(_.marcTag == tag)
 
   def fieldsWithTags(tags: String*): Seq[MarcField]
 

--- a/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/models/MarcRecord.scala
+++ b/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/models/MarcRecord.scala
@@ -12,8 +12,14 @@ trait MarcRecord {
 
   val fields: Seq[MarcField]
 
+  // Only return a control field if there is exactly one with the given tag
+  // If there are multiple control fields with the same tag, return Noneg
   def controlField(tag: String): Option[MarcControlField] =
-    controlFields.find(_.marcTag == tag)
+    controlFields.filter(_.marcTag == tag) match {
+        case Nil => None
+        case x :: Nil => Some(x)
+        case _ => None
+    }
 
   def fieldsWithTags(tags: String*): Seq[MarcField]
 

--- a/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcDataTransformer.scala
+++ b/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcDataTransformer.scala
@@ -2,13 +2,11 @@ package weco.pipeline.transformer.marc_common.transformers
 
 import weco.pipeline.transformer.marc_common.logging.LoggingContext
 import weco.pipeline.transformer.marc_common.models.{MarcField, MarcRecord}
-import weco.pipeline.transformer.marc_common.models.MarcRecord
 
 /*
  * A MarcDataTransformer finds the appropriate field(s) within a
  * MarcRecord, and transforms them into the target output.
- *
- *  */
+ */
 trait MarcDataTransformer {
   type Output
 

--- a/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcElectronicResources.scala
+++ b/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcElectronicResources.scala
@@ -3,11 +3,20 @@ package weco.pipeline.transformer.marc_common.transformers
 import grizzled.slf4j.Logging
 import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.locations.AccessStatus.LicensedResources
-import weco.catalogue.internal_model.locations.{AccessCondition, AccessMethod, AccessStatus, DigitalLocation}
+import weco.catalogue.internal_model.locations.{
+  AccessCondition,
+  AccessMethod,
+  AccessStatus,
+  DigitalLocation
+}
 import weco.catalogue.internal_model.locations.LocationType.OnlineResource
 import weco.catalogue.internal_model.work.{Holdings, Item}
 import weco.pipeline.transformer.marc_common.logging.LoggingContext
-import weco.pipeline.transformer.marc_common.models.{MarcField, MarcRecord, MarcSubfield}
+import weco.pipeline.transformer.marc_common.models.{
+  MarcField,
+  MarcRecord,
+  MarcSubfield
+}
 
 import java.net.URL
 import scala.util.{Failure, Success, Try}
@@ -15,30 +24,34 @@ import scala.util.{Failure, Success, Try}
 trait MarcElectronicResources extends Logging {
 
   def toHoldings(
-                         record: MarcRecord
-                       )(implicit ctx: LoggingContext): Seq[Holdings] = {
-    record.fieldsWithTags("856").flatMap { field =>
-      for {
-        url <- getUrl(field).toOption
-        linkText <- field.subfields.find(_.tag == "z").map(_.content)
-        enumeration <- field.subfields.filter(_.tag == "3").map(_.content).headOption
-      } yield Holdings(
-        note = None,
-        enumeration = List(enumeration),
-        location = Some(
-          DigitalLocation(
-            url = url,
-            linkText = Some(linkText),
-            locationType = OnlineResource,
-            accessConditions = List(
-              AccessCondition(
-                method = AccessMethod.ViewOnline,
-                status = status(field)
+    record: MarcRecord
+  )(implicit ctx: LoggingContext): Seq[Holdings] = {
+    record.fieldsWithTags("856").flatMap {
+      field =>
+        for {
+          url <- getUrl(field).toOption
+          linkText <- field.subfields.find(_.tag == "z").map(_.content)
+          enumeration <- field.subfields
+            .filter(_.tag == "3")
+            .map(_.content)
+            .headOption
+        } yield Holdings(
+          note = None,
+          enumeration = List(enumeration),
+          location = Some(
+            DigitalLocation(
+              url = url,
+              linkText = Some(linkText),
+              locationType = OnlineResource,
+              accessConditions = List(
+                AccessCondition(
+                  method = AccessMethod.ViewOnline,
+                  status = status(field)
+                )
               )
             )
           )
         )
-      )
     }
   }
 

--- a/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcElectronicResources.scala
+++ b/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcElectronicResources.scala
@@ -25,7 +25,7 @@ trait MarcElectronicResources extends Logging {
 
   def toHoldings(
     record: MarcRecord
-  )(implicit ctx: LoggingContext): Seq[Holdings] = {
+  ): Seq[Holdings] = {
     record.fieldsWithTags("856").flatMap {
       field =>
         for {

--- a/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcElectronicResources.scala
+++ b/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcElectronicResources.scala
@@ -179,22 +179,6 @@ trait MarcElectronicResources extends Logging {
       )
     )
   )
-
-  private def createDigitalLocation(
-    url: String,
-    status: LicensedResources,
-    linkText: Option[String]
-  ): DigitalLocation = DigitalLocation(
-    url = url,
-    linkText = linkText,
-    locationType = OnlineResource,
-    accessConditions = List(
-      AccessCondition(
-        method = AccessMethod.ViewOnline,
-        status = status
-      )
-    )
-  )
 }
 
 object MarcElectronicResources extends MarcElectronicResources {

--- a/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcLanguage.scala
+++ b/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcLanguage.scala
@@ -1,0 +1,29 @@
+package weco.pipeline.transformer.marc_common.transformers
+
+import weco.catalogue.internal_model.languages.{Language, MarcLanguageCodeList}
+import weco.pipeline.transformer.marc_common.models.MarcRecord
+
+/*
+ * Extracts the language from control field 008 of a MARC record
+ *
+ * Field 008 is a fixed-length data element that provides information
+ * about the record as a whole. The language code is located at positions 35-37.
+ *
+ * See: https://www.loc.gov/marc/bibliographic/bd008a.html
+ */
+object MarcLanguage extends MarcDataTransformer {
+  type Output = Option[Language]
+
+  override def apply(record: MarcRecord): Option[Language] = {
+    record.controlField("008").flatMap { controlField =>
+      val fieldLength = controlField.content.length
+      // Assume missing material specific coded elements between 18-34,
+      // it seems common for this field to be omit positions in this range
+      // so read from end of field backwards.
+      MarcLanguageCodeList.fromCode(code = controlField.content.slice(
+        from = fieldLength - 5,
+        until = fieldLength - 2
+      ))
+    }
+  }
+}

--- a/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcLanguage.scala
+++ b/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcLanguage.scala
@@ -15,15 +15,18 @@ object MarcLanguage extends MarcDataTransformer {
   type Output = Option[Language]
 
   override def apply(record: MarcRecord): Option[Language] = {
-    record.controlField("008").flatMap { controlField =>
-      val fieldLength = controlField.content.length
-      // Assume missing material specific coded elements between 18-34,
-      // it seems common for this field to be omit positions in this range
-      // so read from end of field backwards.
-      MarcLanguageCodeList.fromCode(code = controlField.content.slice(
-        from = fieldLength - 5,
-        until = fieldLength - 2
-      ))
+    record.controlField("008").flatMap {
+      controlField =>
+        val fieldLength = controlField.content.length
+        // Assume missing material specific coded elements between 18-34,
+        // it seems common for this field to be omit positions in this range
+        // so read from end of field backwards.
+        MarcLanguageCodeList.fromCode(code =
+          controlField.content.slice(
+            from = fieldLength - 5,
+            until = fieldLength - 2
+          )
+        )
     }
   }
 }

--- a/pipeline/transformer/transformer_marc_common/src/test/scala/weco/pipeline/transformer/marc_common/generators/MarcTestRecord.scala
+++ b/pipeline/transformer/transformer_marc_common/src/test/scala/weco/pipeline/transformer/marc_common/generators/MarcTestRecord.scala
@@ -1,14 +1,11 @@
 package weco.pipeline.transformer.marc_common.generators
 
 import org.scalatest.LoneElement
-import weco.pipeline.transformer.marc_common.models.{
-  MarcField,
-  MarcRecord,
-  MarcSubfield
-}
+import weco.pipeline.transformer.marc_common.models.{MarcControlField, MarcField, MarcRecord, MarcSubfield}
 
 case class MarcTestRecord(
-  fields: Seq[MarcField]
+  fields: Seq[MarcField] = Nil,
+  controlFields: Seq[MarcControlField] = Nil,
 ) extends MarcRecord
     with LoneElement {
   def fieldsWithTags(tags: String*): Seq[MarcField] =
@@ -26,4 +23,6 @@ case class MarcTestRecord(
           .toList
     }
 
+  // These are not used in the tests, but we need to implement them to satisfy the interface
+  override val leader: String = ""
 }

--- a/pipeline/transformer/transformer_marc_common/src/test/scala/weco/pipeline/transformer/marc_common/transformers/MarcLanguageTest.scala
+++ b/pipeline/transformer/transformer_marc_common/src/test/scala/weco/pipeline/transformer/marc_common/transformers/MarcLanguageTest.scala
@@ -1,0 +1,33 @@
+package weco.pipeline.transformer.marc_common.transformers
+
+import org.scalatest.LoneElement
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import weco.catalogue.internal_model.languages.Language
+import weco.pipeline.transformer.marc_common.generators.MarcTestRecord
+import weco.pipeline.transformer.marc_common.models.MarcControlField
+
+class MarcLanguageTest extends AnyFunSpec with Matchers with LoneElement {
+  describe("Extracting edition information from MARC 008") {
+    info("https://www.loc.gov/marc/bibliographic/bd008a.html")
+    val englishLanguage = Language("eng", "English")
+
+    it("returns the language from 008") {
+      val record = MarcTestRecord(controlFields =
+        Seq(
+          MarcControlField("008", "961009c19339999ilubr pso 0 a0eng c")
+        )
+      )
+      MarcLanguage(record) shouldBe Some(englishLanguage)
+    }
+
+    it("returns None, where the language is missing") {
+      val record = MarcTestRecord(controlFields =
+        Seq(
+          MarcControlField("008", "240424nuuuuuuuuxx |||| o|||||||||||||||d")
+        )
+      )
+      MarcLanguage(record) shouldBe None
+    }
+  }
+}

--- a/pipeline/transformer/transformer_marc_xml/src/main/scala/weco/pipeline/transformer/marc/xml/data/MarcXMLRecord.scala
+++ b/pipeline/transformer/transformer_marc_xml/src/main/scala/weco/pipeline/transformer/marc/xml/data/MarcXMLRecord.scala
@@ -1,12 +1,16 @@
 package weco.pipeline.transformer.marc.xml.data
 
-import weco.pipeline.transformer.marc_common.models.{
-  MarcField,
-  MarcRecord,
-  MarcSubfield
-}
+import weco.pipeline.transformer.marc_common.models.{MarcControlField, MarcField, MarcRecord, MarcSubfield}
 
-import scala.xml.{Node, NodeSeq}
+import scala.xml.Node
+
+object MarcXMLControlField {
+  def apply(elem: Node): MarcControlField =
+    MarcControlField(
+      marcTag = elem \@ "tag",
+      content = elem.text
+    )
+}
 
 /*
  * Represents a MARC XML Record as sent by EBSCO
@@ -17,13 +21,9 @@ import scala.xml.{Node, NodeSeq}
 case class MarcXMLRecord(recordElement: Node) extends MarcRecord {
 
   lazy val leader: String = recordElement \ "leader" text
-  def controlField(tag: String): Option[String] =
-    recordElement \ "controlfield" filter hasTag(tag) match {
-      case NodeSeq.Empty => None
-      case Seq(node)     => Some(node.text)
-      case _ =>
-        None // TODO: warn that there are multiple matches and return (head.text)?
-    }
+
+  override val controlFields: Seq[MarcControlField] =
+    recordElement \ "controlfield" map (node => MarcXMLControlField(node))
 
   def fieldsWithTags(tags: String*): Seq[MarcField] =
     recordElement \ "datafield" filter hasTag(tags: _*) map (MarcXMLDataField(

--- a/pipeline/transformer/transformer_marc_xml/src/main/scala/weco/pipeline/transformer/marc/xml/data/MarcXMLRecord.scala
+++ b/pipeline/transformer/transformer_marc_xml/src/main/scala/weco/pipeline/transformer/marc/xml/data/MarcXMLRecord.scala
@@ -1,6 +1,11 @@
 package weco.pipeline.transformer.marc.xml.data
 
-import weco.pipeline.transformer.marc_common.models.{MarcControlField, MarcField, MarcRecord, MarcSubfield}
+import weco.pipeline.transformer.marc_common.models.{
+  MarcControlField,
+  MarcField,
+  MarcRecord,
+  MarcSubfield
+}
 
 import scala.xml.Node
 

--- a/pipeline/transformer/transformer_marc_xml/src/main/scala/weco/pipeline/transformer/marc/xml/transformers/MarcXMLRecordTransformer.scala
+++ b/pipeline/transformer/transformer_marc_xml/src/main/scala/weco/pipeline/transformer/marc/xml/transformers/MarcXMLRecordTransformer.scala
@@ -4,19 +4,7 @@ import weco.catalogue.internal_model.identifiers.DataState
 import weco.catalogue.internal_model.work.WorkData
 import weco.pipeline.transformer.marc.xml.data.MarcXMLRecord
 import weco.pipeline.transformer.marc_common.logging.LoggingContext
-import weco.pipeline.transformer.marc_common.transformers.{
-  MarcAlternativeTitles,
-  MarcContributors,
-  MarcCurrentFrequency,
-  MarcDescription,
-  MarcDesignation,
-  MarcEdition,
-  MarcElectronicResources,
-  MarcGenres,
-  MarcInternationalStandardIdentifiers,
-  MarcSubjects,
-  MarcTitle
-}
+import weco.pipeline.transformer.marc_common.transformers.{MarcAlternativeTitles, MarcContributors, MarcCurrentFrequency, MarcDescription, MarcDesignation, MarcEdition, MarcElectronicResources, MarcGenres, MarcInternationalStandardIdentifiers, MarcLanguage, MarcSubjects, MarcTitle}
 
 object MarcXMLRecordTransformer {
   def apply(
@@ -35,7 +23,8 @@ object MarcXMLRecordTransformer {
       items = MarcElectronicResources(record).toList,
       contributors = MarcContributors(record).toList,
       subjects = MarcSubjects(record).toList,
-      genres = MarcGenres(record).toList
+      genres = MarcGenres(record).toList,
+      languages = MarcLanguage(record).toList
     )
   }
 }

--- a/pipeline/transformer/transformer_marc_xml/src/main/scala/weco/pipeline/transformer/marc/xml/transformers/MarcXMLRecordTransformer.scala
+++ b/pipeline/transformer/transformer_marc_xml/src/main/scala/weco/pipeline/transformer/marc/xml/transformers/MarcXMLRecordTransformer.scala
@@ -4,7 +4,20 @@ import weco.catalogue.internal_model.identifiers.DataState
 import weco.catalogue.internal_model.work.WorkData
 import weco.pipeline.transformer.marc.xml.data.MarcXMLRecord
 import weco.pipeline.transformer.marc_common.logging.LoggingContext
-import weco.pipeline.transformer.marc_common.transformers.{MarcAlternativeTitles, MarcContributors, MarcCurrentFrequency, MarcDescription, MarcDesignation, MarcEdition, MarcElectronicResources, MarcGenres, MarcInternationalStandardIdentifiers, MarcLanguage, MarcSubjects, MarcTitle}
+import weco.pipeline.transformer.marc_common.transformers.{
+  MarcAlternativeTitles,
+  MarcContributors,
+  MarcCurrentFrequency,
+  MarcDescription,
+  MarcDesignation,
+  MarcEdition,
+  MarcElectronicResources,
+  MarcGenres,
+  MarcInternationalStandardIdentifiers,
+  MarcLanguage,
+  MarcSubjects,
+  MarcTitle
+}
 
 object MarcXMLRecordTransformer {
   def apply(

--- a/pipeline/transformer/transformer_marc_xml/src/test/scala/weco/pipeline/transformer/marc/xml/data/MarcXMLRecordTest.scala
+++ b/pipeline/transformer/transformer_marc_xml/src/test/scala/weco/pipeline/transformer/marc/xml/data/MarcXMLRecordTest.scala
@@ -3,6 +3,7 @@ package weco.pipeline.transformer.marc.xml.data
 import org.scalatest.LoneElement
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+import weco.pipeline.transformer.marc_common.models.MarcControlField
 
 class MarcXMLRecordTest extends AnyFunSpec with Matchers with LoneElement {
   describe("extracting the leader") {
@@ -23,7 +24,7 @@ class MarcXMLRecordTest extends AnyFunSpec with Matchers with LoneElement {
           <controlfield tag="001">ebs1234567890e</controlfield>
           <controlfield tag="003">EBZ</controlfield>
         </record>
-      ).controlField("003").get shouldBe "EBZ"
+      ).controlField("003").get shouldBe MarcControlField("003","EBZ")
     }
 
     it("returns None if the requested field does not exist") {

--- a/pipeline/transformer/transformer_marc_xml/src/test/scala/weco/pipeline/transformer/marc/xml/transformers/MarcXMLRecordTransformerTest.scala
+++ b/pipeline/transformer/transformer_marc_xml/src/test/scala/weco/pipeline/transformer/marc/xml/transformers/MarcXMLRecordTransformerTest.scala
@@ -20,6 +20,7 @@ class MarcXMLRecordTransformerTest
       MarcXMLRecord(
         <record xmlns="http://www.loc.gov/MARC21/slim">
           <controlfield tag="001">3PaDhRp</controlfield>
+          <controlfield tag="008">030214c20039999cauar o 0 a0eng c</controlfield>
           <datafield tag ="245">
             <subfield code="a">matacologian</subfield>
           </datafield>
@@ -111,6 +112,12 @@ class MarcXMLRecordTransformerTest
       workData.otherIdentifiers.map(
         _.value
       ) should contain theSameElementsAs Seq("8601416781396", "1477-4615")
+    }
+
+    it("extracts language") {
+      workData.languages.map(
+        _.id
+      ) should contain theSameElementsAs Seq("eng")
     }
 
     it("extracts the current frequency") {

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/data/BibDataAsMarcRecord.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/data/BibDataAsMarcRecord.scala
@@ -1,10 +1,6 @@
 package weco.pipeline.transformer.sierra.data
 
-import weco.pipeline.transformer.marc_common.models.{
-  MarcField,
-  MarcRecord,
-  MarcSubfield
-}
+import weco.pipeline.transformer.marc_common.models.{MarcControlField, MarcField, MarcRecord, MarcSubfield}
 import weco.sierra.models.SierraQueryOps
 import weco.sierra.models.data.SierraBibData
 import weco.sierra.models.marc.{Subfield, VarField}
@@ -25,7 +21,6 @@ trait SierraMarcDataConversions {
     MarcField(
       marcTag = varField.marcTag.get,
       subfields = varField.subfields.map(sierraSubfieldToMarcSubField),
-      content = None,
       fieldTag = varField.fieldTag,
       indicator1 = varField.indicator1.getOrElse(" "),
       indicator2 = varField.indicator2.getOrElse(" ")
@@ -41,6 +36,11 @@ object SierraMarcDataConversions extends SierraMarcDataConversions {}
 class BibDataAsMarcRecord(bibData: SierraBibData)
     extends MarcRecord
     with SierraQueryOps {
+
+  // BibData doesn't have a leader or control fields, so we provide empty values
+  override val leader: String = ""
+  override val controlFields: Seq[MarcControlField] = Nil
+
   lazy val fields: Seq[MarcField] =
     bibData.varFields
       // Only actual MARC varfields, with an actual MARC tag, are exercised

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/data/BibDataAsMarcRecord.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/data/BibDataAsMarcRecord.scala
@@ -1,6 +1,11 @@
 package weco.pipeline.transformer.sierra.data
 
-import weco.pipeline.transformer.marc_common.models.{MarcControlField, MarcField, MarcRecord, MarcSubfield}
+import weco.pipeline.transformer.marc_common.models.{
+  MarcControlField,
+  MarcField,
+  MarcRecord,
+  MarcSubfield
+}
 import weco.sierra.models.SierraQueryOps
 import weco.sierra.models.data.SierraBibData
 import weco.sierra.models.marc.{Subfield, VarField}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -265,9 +265,8 @@ object CatalogueDependencies {
     ExternalDependencies.jsoupDependencies ++
       ExternalDependencies.parseDependencies
 
-  val ebscoTransformerDependencies: Seq[ModuleID] = {
+  val ebscoTransformerDependencies: Seq[ModuleID] =
     WellcomeDependencies.storageTypesafeLibrary
-  }
 
   // METS adapter
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -264,6 +264,10 @@ object CatalogueDependencies {
   val calmTransformerDependencies: Seq[ModuleID] =
     ExternalDependencies.jsoupDependencies ++
       ExternalDependencies.parseDependencies
+
+  val ebscoTransformerDependencies: Seq[ModuleID] =
+    WellcomeDependencies.storageTypesafeLibrary
+
   // METS adapter
 
   val metsAdapterDependencies: Seq[ModuleID] =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -265,8 +265,9 @@ object CatalogueDependencies {
     ExternalDependencies.jsoupDependencies ++
       ExternalDependencies.parseDependencies
 
-  val ebscoTransformerDependencies: Seq[ModuleID] =
+  val ebscoTransformerDependencies: Seq[ModuleID] = {
     WellcomeDependencies.storageTypesafeLibrary
+  }
 
   // METS adapter
 

--- a/reindexer/scripts/lambda_reindexers.py
+++ b/reindexer/scripts/lambda_reindexers.py
@@ -12,7 +12,7 @@ def invoke_lambda_reindexers(session):
     # There is currently only one Lambda re-indexer, the intention is
     # to add more in the future allowing the adapter to hold the logic
     # for performing re-indexes.
-    function_names = ["ebsco-adapter-ftp"]å
+    function_names = ["ebsco-adapter-ftp"]
     payload = {
         "reindex_type": "full"
     }

--- a/reindexer/scripts/lambda_reindexers.py
+++ b/reindexer/scripts/lambda_reindexers.py
@@ -1,0 +1,27 @@
+import json
+
+
+def invoke_lambda_reindexers(session):
+    """
+    Invoke all Lambda re-indexers.
+
+    The Lambda re-indexers are invoked asynchronously, so this function
+    will return immediately after invoking them.
+    """
+
+    # There is currently only one Lambda re-indexer, the intention is
+    # to add more in the future allowing the adapter to hold the logic
+    # for performing re-indexes.
+    function_names = ["ebsco-adapter-ftp"]å
+    payload = {
+        "reindex_type": "full"
+    }
+
+    lambda_client = session.client("lambda")
+
+    for function_name in function_names:
+        lambda_client.invoke(
+            FunctionName=function_name,
+            InvocationType='Event',
+            Payload=json.dumps(payload).encode('utf-8')
+        )

--- a/reindexer/scripts/lambda_reindexers.py
+++ b/reindexer/scripts/lambda_reindexers.py
@@ -13,15 +13,13 @@ def invoke_lambda_reindexers(session):
     # to add more in the future allowing the adapter to hold the logic
     # for performing re-indexes.
     function_names = ["ebsco-adapter-ftp"]
-    payload = {
-        "reindex_type": "full"
-    }
+    payload = {"reindex_type": "full"}
 
     lambda_client = session.client("lambda")
 
     for function_name in function_names:
         lambda_client.invoke(
             FunctionName=function_name,
-            InvocationType='Event',
-            Payload=json.dumps(payload).encode('utf-8')
+            InvocationType="Event",
+            Payload=json.dumps(payload).encode("utf-8"),
         )

--- a/reindexer/scripts/start_reindex.py
+++ b/reindexer/scripts/start_reindex.py
@@ -9,6 +9,8 @@ import boto3
 import click
 import tqdm
 
+from lambda_reindexers import invoke_lambda_reindexers
+
 SOURCES = {
     "miro": "vhs-sourcedata-miro",
     "sierra": "vhs-sierra-sierra-adapter-20200604",
@@ -281,6 +283,11 @@ def start_reindex(ctx, src, dst, mode, input_file):
         topic_arn=reindexer_topic_arn,
         parameters=parameters,
     )
+
+    # Lambda adapters implement their own reindexing logic,
+    # so we need to invoke them separately. Currently, we run
+    # a full reindex for all lambda adapters (only one at present).
+    invoke_lambda_reindexers(session)
 
     start_reindexer_tasks(session)
 


### PR DESCRIPTION
## What does this change?

This change creates holdings instead of items on an EBSCO sourced work and adds the EBSCO identified works to the target precedence in the merger so that matched Sierra and EBSCO works will get merged.

> [!NOTE]
> This change does not transform the `CollectionPath`, which is needed for Ebsco sourced records to have parity with Sierra source e-resource records. That should be the next change that's worked on before connecting the Ebsco transformer to the id minter in a prod pipeline.

Part of https://github.com/wellcomecollection/catalogue-pipeline/issues/2618

## How to test

- [x] Run the tests
- [ ] Can we test this in non-prod pipeline before deploying?

## How can we measure success?

EBSCO sourced e-resource work pages look more similar to their current Sierra counterparts and where sierra and EBSCO works are matched, Sierra sourced works are redirected to EBSCO works.

## Have we considered potential risks?

If run in an pipeline that a production catalogue API is using this will change results for works in unexpected ways. We should test this before exposing it to public view.

