### PR TITLE
Add MarcLanguage transformer

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/languages/Language.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/languages/Language.scala
@@ -10,7 +10,7 @@ import grizzled.slf4j.Logging
   *
   * e.g. you might have two languages:
   *
-  * Language(it = "ita", label = "Italian") Language(it = "ita", label =
+  * Language(id = "ita", label = "Italian") Language(it = "ita", label =
   * "Judeo-Italian")
   *
   * This is based on the MARC language code list. A single language might have

--- a/pipeline/transformer/transformer_ebsco/src/main/scala/weco/pipeline/transformer/ebsco/EbscoTransformer.scala
+++ b/pipeline/transformer/transformer_ebsco/src/main/scala/weco/pipeline/transformer/ebsco/EbscoTransformer.scala
@@ -57,7 +57,7 @@ class EbscoTransformer(store: Readable[S3ObjectLocation, String])
       sourceIdentifier = SourceIdentifier(
         identifierType = IdentifierType.EbscoAltLookup,
         ontologyType = "Work",
-        value = record.controlField("001").get
+        value = record.controlField("001").get.content
       ),
       // TODO: The adapter should provide the date & time
       sourceModifiedTime = Instant.now

--- a/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/models/MarcField.scala
+++ b/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/models/MarcField.scala
@@ -14,5 +14,5 @@ case class MarcField(
 
 case class MarcControlField(
   marcTag: String,
-  content: String,
+  content: String
 ) extends MarcTaggedField

--- a/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/models/MarcField.scala
+++ b/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/models/MarcField.scala
@@ -1,10 +1,18 @@
 package weco.pipeline.transformer.marc_common.models
 
+sealed trait MarcTaggedField {
+  val marcTag: String
+}
+
 case class MarcField(
   marcTag: String,
   subfields: Seq[MarcSubfield] = Nil,
-  content: Option[String] = None,
   fieldTag: Option[String] = None,
   indicator1: String = " ",
   indicator2: String = " "
-)
+) extends MarcTaggedField
+
+case class MarcControlField(
+  marcTag: String,
+  content: String,
+) extends MarcTaggedField

--- a/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/models/MarcRecord.scala
+++ b/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/models/MarcRecord.scala
@@ -6,7 +6,14 @@ package weco.pipeline.transformer.marc_common.models
  * */
 trait MarcRecord {
 
+  val leader: String
+
+  val controlFields: Seq[MarcControlField]
+
   val fields: Seq[MarcField]
+
+  def controlField(tag: String): Option[MarcControlField] = controlFields.find(_.marcTag == tag)
+
   def fieldsWithTags(tags: String*): Seq[MarcField]
 
   def subfieldsWithTag(tagPair: (String, String)): List[MarcSubfield]

--- a/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/models/MarcRecord.scala
+++ b/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/models/MarcRecord.scala
@@ -16,9 +16,9 @@ trait MarcRecord {
   // If there are multiple control fields with the same tag, return Noneg
   def controlField(tag: String): Option[MarcControlField] =
     controlFields.filter(_.marcTag == tag) match {
-        case Nil => None
-        case x :: Nil => Some(x)
-        case _ => None
+      case Nil      => None
+      case x :: Nil => Some(x)
+      case _        => None
     }
 
   def fieldsWithTags(tags: String*): Seq[MarcField]

--- a/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/models/MarcRecord.scala
+++ b/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/models/MarcRecord.scala
@@ -12,7 +12,8 @@ trait MarcRecord {
 
   val fields: Seq[MarcField]
 
-  def controlField(tag: String): Option[MarcControlField] = controlFields.find(_.marcTag == tag)
+  def controlField(tag: String): Option[MarcControlField] =
+    controlFields.find(_.marcTag == tag)
 
   def fieldsWithTags(tags: String*): Seq[MarcField]
 

--- a/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/models/MarcRecord.scala
+++ b/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/models/MarcRecord.scala
@@ -12,8 +12,14 @@ trait MarcRecord {
 
   val fields: Seq[MarcField]
 
+  // Only return a control field if there is exactly one with the given tag
+  // If there are multiple control fields with the same tag, return Noneg
   def controlField(tag: String): Option[MarcControlField] =
-    controlFields.find(_.marcTag == tag)
+    controlFields.filter(_.marcTag == tag) match {
+        case Nil => None
+        case x :: Nil => Some(x)
+        case _ => None
+    }
 
   def fieldsWithTags(tags: String*): Seq[MarcField]
 

--- a/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcDataTransformer.scala
+++ b/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcDataTransformer.scala
@@ -2,13 +2,11 @@ package weco.pipeline.transformer.marc_common.transformers
 
 import weco.pipeline.transformer.marc_common.logging.LoggingContext
 import weco.pipeline.transformer.marc_common.models.{MarcField, MarcRecord}
-import weco.pipeline.transformer.marc_common.models.MarcRecord
 
 /*
  * A MarcDataTransformer finds the appropriate field(s) within a
  * MarcRecord, and transforms them into the target output.
- *
- *  */
+ */
 trait MarcDataTransformer {
   type Output
 

--- a/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcLanguage.scala
+++ b/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcLanguage.scala
@@ -1,0 +1,29 @@
+package weco.pipeline.transformer.marc_common.transformers
+
+import weco.catalogue.internal_model.languages.{Language, MarcLanguageCodeList}
+import weco.pipeline.transformer.marc_common.models.MarcRecord
+
+/*
+ * Extracts the language from control field 008 of a MARC record
+ *
+ * Field 008 is a fixed-length data element that provides information
+ * about the record as a whole. The language code is located at positions 35-37.
+ *
+ * See: https://www.loc.gov/marc/bibliographic/bd008a.html
+ */
+object MarcLanguage extends MarcDataTransformer {
+  type Output = Option[Language]
+
+  override def apply(record: MarcRecord): Option[Language] = {
+    record.controlField("008").flatMap { controlField =>
+      val fieldLength = controlField.content.length
+      // Assume missing material specific coded elements between 18-34,
+      // it seems common for this field to be omit positions in this range
+      // so read from end of field backwards.
+      MarcLanguageCodeList.fromCode(code = controlField.content.slice(
+        from = fieldLength - 5,
+        until = fieldLength - 2
+      ))
+    }
+  }
+}

--- a/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcLanguage.scala
+++ b/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcLanguage.scala
@@ -15,15 +15,18 @@ object MarcLanguage extends MarcDataTransformer {
   type Output = Option[Language]
 
   override def apply(record: MarcRecord): Option[Language] = {
-    record.controlField("008").flatMap { controlField =>
-      val fieldLength = controlField.content.length
-      // Assume missing material specific coded elements between 18-34,
-      // it seems common for this field to be omit positions in this range
-      // so read from end of field backwards.
-      MarcLanguageCodeList.fromCode(code = controlField.content.slice(
-        from = fieldLength - 5,
-        until = fieldLength - 2
-      ))
+    record.controlField("008").flatMap {
+      controlField =>
+        val fieldLength = controlField.content.length
+        // Assume missing material specific coded elements between 18-34,
+        // it seems common for this field to be omit positions in this range
+        // so read from end of field backwards.
+        MarcLanguageCodeList.fromCode(code =
+          controlField.content.slice(
+            from = fieldLength - 5,
+            until = fieldLength - 2
+          )
+        )
     }
   }
 }

--- a/pipeline/transformer/transformer_marc_common/src/test/scala/weco/pipeline/transformer/marc_common/generators/MarcTestRecord.scala
+++ b/pipeline/transformer/transformer_marc_common/src/test/scala/weco/pipeline/transformer/marc_common/generators/MarcTestRecord.scala
@@ -1,14 +1,11 @@
 package weco.pipeline.transformer.marc_common.generators
 
 import org.scalatest.LoneElement
-import weco.pipeline.transformer.marc_common.models.{
-  MarcField,
-  MarcRecord,
-  MarcSubfield
-}
+import weco.pipeline.transformer.marc_common.models.{MarcControlField, MarcField, MarcRecord, MarcSubfield}
 
 case class MarcTestRecord(
-  fields: Seq[MarcField]
+  fields: Seq[MarcField] = Nil,
+  controlFields: Seq[MarcControlField] = Nil,
 ) extends MarcRecord
     with LoneElement {
   def fieldsWithTags(tags: String*): Seq[MarcField] =
@@ -26,4 +23,6 @@ case class MarcTestRecord(
           .toList
     }
 
+  // These are not used in the tests, but we need to implement them to satisfy the interface
+  override val leader: String = ""
 }

--- a/pipeline/transformer/transformer_marc_common/src/test/scala/weco/pipeline/transformer/marc_common/transformers/MarcLanguageTest.scala
+++ b/pipeline/transformer/transformer_marc_common/src/test/scala/weco/pipeline/transformer/marc_common/transformers/MarcLanguageTest.scala
@@ -1,0 +1,33 @@
+package weco.pipeline.transformer.marc_common.transformers
+
+import org.scalatest.LoneElement
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import weco.catalogue.internal_model.languages.Language
+import weco.pipeline.transformer.marc_common.generators.MarcTestRecord
+import weco.pipeline.transformer.marc_common.models.MarcControlField
+
+class MarcLanguageTest extends AnyFunSpec with Matchers with LoneElement {
+  describe("Extracting edition information from MARC 008") {
+    info("https://www.loc.gov/marc/bibliographic/bd008a.html")
+    val englishLanguage = Language("eng", "English")
+
+    it("returns the language from 008") {
+      val record = MarcTestRecord(controlFields =
+        Seq(
+          MarcControlField("008", "961009c19339999ilubr pso 0 a0eng c")
+        )
+      )
+      MarcLanguage(record) shouldBe Some(englishLanguage)
+    }
+
+    it("returns None, where the language is missing") {
+      val record = MarcTestRecord(controlFields =
+        Seq(
+          MarcControlField("008", "240424nuuuuuuuuxx |||| o|||||||||||||||d")
+        )
+      )
+      MarcLanguage(record) shouldBe None
+    }
+  }
+}

--- a/pipeline/transformer/transformer_marc_xml/src/main/scala/weco/pipeline/transformer/marc/xml/data/MarcXMLRecord.scala
+++ b/pipeline/transformer/transformer_marc_xml/src/main/scala/weco/pipeline/transformer/marc/xml/data/MarcXMLRecord.scala
@@ -1,12 +1,16 @@
 package weco.pipeline.transformer.marc.xml.data
 
-import weco.pipeline.transformer.marc_common.models.{
-  MarcField,
-  MarcRecord,
-  MarcSubfield
-}
+import weco.pipeline.transformer.marc_common.models.{MarcControlField, MarcField, MarcRecord, MarcSubfield}
 
-import scala.xml.{Node, NodeSeq}
+import scala.xml.Node
+
+object MarcXMLControlField {
+  def apply(elem: Node): MarcControlField =
+    MarcControlField(
+      marcTag = elem \@ "tag",
+      content = elem.text
+    )
+}
 
 /*
  * Represents a MARC XML Record as sent by EBSCO
@@ -17,13 +21,9 @@ import scala.xml.{Node, NodeSeq}
 case class MarcXMLRecord(recordElement: Node) extends MarcRecord {
 
   lazy val leader: String = recordElement \ "leader" text
-  def controlField(tag: String): Option[String] =
-    recordElement \ "controlfield" filter hasTag(tag) match {
-      case NodeSeq.Empty => None
-      case Seq(node)     => Some(node.text)
-      case _ =>
-        None // TODO: warn that there are multiple matches and return (head.text)?
-    }
+
+  override val controlFields: Seq[MarcControlField] =
+    recordElement \ "controlfield" map (node => MarcXMLControlField(node))
 
   def fieldsWithTags(tags: String*): Seq[MarcField] =
     recordElement \ "datafield" filter hasTag(tags: _*) map (MarcXMLDataField(

--- a/pipeline/transformer/transformer_marc_xml/src/main/scala/weco/pipeline/transformer/marc/xml/data/MarcXMLRecord.scala
+++ b/pipeline/transformer/transformer_marc_xml/src/main/scala/weco/pipeline/transformer/marc/xml/data/MarcXMLRecord.scala
@@ -1,6 +1,11 @@
 package weco.pipeline.transformer.marc.xml.data
 
-import weco.pipeline.transformer.marc_common.models.{MarcControlField, MarcField, MarcRecord, MarcSubfield}
+import weco.pipeline.transformer.marc_common.models.{
+  MarcControlField,
+  MarcField,
+  MarcRecord,
+  MarcSubfield
+}
 
 import scala.xml.Node
 

--- a/pipeline/transformer/transformer_marc_xml/src/main/scala/weco/pipeline/transformer/marc/xml/transformers/MarcXMLRecordTransformer.scala
+++ b/pipeline/transformer/transformer_marc_xml/src/main/scala/weco/pipeline/transformer/marc/xml/transformers/MarcXMLRecordTransformer.scala
@@ -4,19 +4,7 @@ import weco.catalogue.internal_model.identifiers.DataState
 import weco.catalogue.internal_model.work.WorkData
 import weco.pipeline.transformer.marc.xml.data.MarcXMLRecord
 import weco.pipeline.transformer.marc_common.logging.LoggingContext
-import weco.pipeline.transformer.marc_common.transformers.{
-  MarcAlternativeTitles,
-  MarcContributors,
-  MarcCurrentFrequency,
-  MarcDescription,
-  MarcDesignation,
-  MarcEdition,
-  MarcElectronicResources,
-  MarcGenres,
-  MarcInternationalStandardIdentifiers,
-  MarcSubjects,
-  MarcTitle
-}
+import weco.pipeline.transformer.marc_common.transformers.{MarcAlternativeTitles, MarcContributors, MarcCurrentFrequency, MarcDescription, MarcDesignation, MarcEdition, MarcElectronicResources, MarcGenres, MarcInternationalStandardIdentifiers, MarcLanguage, MarcSubjects, MarcTitle}
 
 object MarcXMLRecordTransformer {
   def apply(
@@ -35,7 +23,8 @@ object MarcXMLRecordTransformer {
       items = MarcElectronicResources(record).toList,
       contributors = MarcContributors(record).toList,
       subjects = MarcSubjects(record).toList,
-      genres = MarcGenres(record).toList
+      genres = MarcGenres(record).toList,
+      languages = MarcLanguage(record).toList
     )
   }
 }

--- a/pipeline/transformer/transformer_marc_xml/src/main/scala/weco/pipeline/transformer/marc/xml/transformers/MarcXMLRecordTransformer.scala
+++ b/pipeline/transformer/transformer_marc_xml/src/main/scala/weco/pipeline/transformer/marc/xml/transformers/MarcXMLRecordTransformer.scala
@@ -4,7 +4,20 @@ import weco.catalogue.internal_model.identifiers.DataState
 import weco.catalogue.internal_model.work.WorkData
 import weco.pipeline.transformer.marc.xml.data.MarcXMLRecord
 import weco.pipeline.transformer.marc_common.logging.LoggingContext
-import weco.pipeline.transformer.marc_common.transformers.{MarcAlternativeTitles, MarcContributors, MarcCurrentFrequency, MarcDescription, MarcDesignation, MarcEdition, MarcElectronicResources, MarcGenres, MarcInternationalStandardIdentifiers, MarcLanguage, MarcSubjects, MarcTitle}
+import weco.pipeline.transformer.marc_common.transformers.{
+  MarcAlternativeTitles,
+  MarcContributors,
+  MarcCurrentFrequency,
+  MarcDescription,
+  MarcDesignation,
+  MarcEdition,
+  MarcElectronicResources,
+  MarcGenres,
+  MarcInternationalStandardIdentifiers,
+  MarcLanguage,
+  MarcSubjects,
+  MarcTitle
+}
 
 object MarcXMLRecordTransformer {
   def apply(

--- a/pipeline/transformer/transformer_marc_xml/src/test/scala/weco/pipeline/transformer/marc/xml/data/MarcXMLRecordTest.scala
+++ b/pipeline/transformer/transformer_marc_xml/src/test/scala/weco/pipeline/transformer/marc/xml/data/MarcXMLRecordTest.scala
@@ -3,6 +3,7 @@ package weco.pipeline.transformer.marc.xml.data
 import org.scalatest.LoneElement
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+import weco.pipeline.transformer.marc_common.models.MarcControlField
 
 class MarcXMLRecordTest extends AnyFunSpec with Matchers with LoneElement {
   describe("extracting the leader") {
@@ -23,7 +24,7 @@ class MarcXMLRecordTest extends AnyFunSpec with Matchers with LoneElement {
           <controlfield tag="001">ebs1234567890e</controlfield>
           <controlfield tag="003">EBZ</controlfield>
         </record>
-      ).controlField("003").get shouldBe "EBZ"
+      ).controlField("003").get shouldBe MarcControlField("003","EBZ")
     }
 
     it("returns None if the requested field does not exist") {

--- a/pipeline/transformer/transformer_marc_xml/src/test/scala/weco/pipeline/transformer/marc/xml/transformers/MarcXMLRecordTransformerTest.scala
+++ b/pipeline/transformer/transformer_marc_xml/src/test/scala/weco/pipeline/transformer/marc/xml/transformers/MarcXMLRecordTransformerTest.scala
@@ -20,6 +20,7 @@ class MarcXMLRecordTransformerTest
       MarcXMLRecord(
         <record xmlns="http://www.loc.gov/MARC21/slim">
           <controlfield tag="001">3PaDhRp</controlfield>
+          <controlfield tag="008">030214c20039999cauar o 0 a0eng c</controlfield>
           <datafield tag ="245">
             <subfield code="a">matacologian</subfield>
           </datafield>
@@ -111,6 +112,12 @@ class MarcXMLRecordTransformerTest
       workData.otherIdentifiers.map(
         _.value
       ) should contain theSameElementsAs Seq("8601416781396", "1477-4615")
+    }
+
+    it("extracts language") {
+      workData.languages.map(
+        _.id
+      ) should contain theSameElementsAs Seq("eng")
     }
 
     it("extracts the current frequency") {

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/data/BibDataAsMarcRecord.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/data/BibDataAsMarcRecord.scala
@@ -1,10 +1,6 @@
 package weco.pipeline.transformer.sierra.data
 
-import weco.pipeline.transformer.marc_common.models.{
-  MarcField,
-  MarcRecord,
-  MarcSubfield
-}
+import weco.pipeline.transformer.marc_common.models.{MarcControlField, MarcField, MarcRecord, MarcSubfield}
 import weco.sierra.models.SierraQueryOps
 import weco.sierra.models.data.SierraBibData
 import weco.sierra.models.marc.{Subfield, VarField}
@@ -25,7 +21,6 @@ trait SierraMarcDataConversions {
     MarcField(
       marcTag = varField.marcTag.get,
       subfields = varField.subfields.map(sierraSubfieldToMarcSubField),
-      content = None,
       fieldTag = varField.fieldTag,
       indicator1 = varField.indicator1.getOrElse(" "),
       indicator2 = varField.indicator2.getOrElse(" ")
@@ -41,6 +36,11 @@ object SierraMarcDataConversions extends SierraMarcDataConversions {}
 class BibDataAsMarcRecord(bibData: SierraBibData)
     extends MarcRecord
     with SierraQueryOps {
+
+  // BibData doesn't have a leader or control fields, so we provide empty values
+  override val leader: String = ""
+  override val controlFields: Seq[MarcControlField] = Nil
+
   lazy val fields: Seq[MarcField] =
     bibData.varFields
       // Only actual MARC varfields, with an actual MARC tag, are exercised

--- a/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/data/BibDataAsMarcRecord.scala
+++ b/pipeline/transformer/transformer_sierra/src/main/scala/weco/pipeline/transformer/sierra/data/BibDataAsMarcRecord.scala
@@ -1,6 +1,11 @@
 package weco.pipeline.transformer.sierra.data
 
-import weco.pipeline.transformer.marc_common.models.{MarcControlField, MarcField, MarcRecord, MarcSubfield}
+import weco.pipeline.transformer.marc_common.models.{
+  MarcControlField,
+  MarcField,
+  MarcRecord,
+  MarcSubfield
+}
 import weco.sierra.models.SierraQueryOps
 import weco.sierra.models.data.SierraBibData
 import weco.sierra.models.marc.{Subfield, VarField}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -264,6 +264,10 @@ object CatalogueDependencies {
   val calmTransformerDependencies: Seq[ModuleID] =
     ExternalDependencies.jsoupDependencies ++
       ExternalDependencies.parseDependencies
+
+  val ebscoTransformerDependencies: Seq[ModuleID] =
+    WellcomeDependencies.storageTypesafeLibrary
+
   // METS adapter
 
   val metsAdapterDependencies: Seq[ModuleID] =


### PR DESCRIPTION
## What does this change?

This change adds a transformer for the MARC language as extracted from control field 008 as per https://www.loc.gov/marc/bibliographic/bd008a.html. We need to implement this transform in order to get the language for EBSCO sourced records.

This does not need to be extended to BibData from Sierra as the control fields are not available and have already been extracted on some form to fields on the bib record.

This will need to be implemented to the EBSCO transform in https://github.com/wellcomecollection/catalogue-pipeline/issues/2618

Part of https://github.com/wellcomecollection/platform/issues/5738

## How to test

- [x] Run the tests

## How can we measure success?

We're able to produce EBSCO sourced works that have the correct language associated with them.

## Have we considered potential risks?

This change should only impact EBSCO records.

