### PR TITLE
Forgotten mets

### DIFF
--- a/mets_adapter/populate_mets/populate_mets_from_csv.py
+++ b/mets_adapter/populate_mets/populate_mets_from_csv.py
@@ -1,0 +1,25 @@
+import csv
+import sys
+from populate_mets import specific
+
+
+# Push each Born Digital bag mentioned in a CSV through the adapter.
+# The CSV should have a row corresponding to each Bag (Item) thus:
+# Item, MY/BAG/1/2/3
+# Item, MY/BAG/4/5/6
+# More columns can be added, and rows starting with other values are ignored.
+
+
+def main(csv_path):
+    with open(csv_path, 'r') as csv_file:
+        specific(extract_bag_ids(csv.reader(csv_file)))
+
+
+def extract_bag_ids(csv_reader):
+    for row in csv_reader:
+        if row[0] == "Item":
+            yield f"born-digital/{row[1]}"
+
+
+if __name__ == '__main__':
+    main(sys.argv[1])

--- a/mets_adapter/populate_mets/populate_mets_from_csv.py
+++ b/mets_adapter/populate_mets/populate_mets_from_csv.py
@@ -11,7 +11,7 @@ from populate_mets import specific
 
 
 def main(csv_path):
-    with open(csv_path, 'r') as csv_file:
+    with open(csv_path, "r") as csv_file:
         specific(extract_bag_ids(csv.reader(csv_file)))
 
 
@@ -21,5 +21,5 @@ def extract_bag_ids(csv_reader):
             yield f"born-digital/{row[1]}"
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main(sys.argv[1])

--- a/scripts/es_source_identifier.py
+++ b/scripts/es_source_identifier.py
@@ -1,0 +1,12 @@
+# Given the identifier and source system name, return a GET request that can be
+# used in the Elasticsearch console to fetch the record from the works-source index.
+
+# It's basically just URL Encoding, but it can be a bit of a faff compared to ids in other indices
+import sys
+from urllib.parse import quote_plus
+
+date = sys.argv[1]
+source_system = sys.argv[2]
+work_id = sys.argv[3]
+doc_id = quote_plus(f"Work[{source_system}/{work_id.lower()}]")
+print(f"GET works-source-{date}/_doc/{doc_id}")


### PR DESCRIPTION
## What does this change?
This adds two scripts.

### populate_mets_from_csv.py
This is the script I used to extract and push the identifiers of Born Digital METS records from Ashley's CSV, in order to pick up the [missing METS records](https://github.com/wellcomecollection/catalogue-pipeline/issues/2645)

I have already run this and the files should all have made it through the pipeline. 

### es_source_identifier.py

This script formats a source identifier as an Elasticsearch `_doc` request.  It's always a bit tricky to find things in the `-source` index because it is just a simple JSON store with oddly formatted identifiers.  This just makes it a bit easier to format those ids in order to make a request.

## How can we measure success?

* All those missing records should now be present. 
* It should now be simpler and quicker to find a given record in works-source

