### PR TITLE
Add MarcFormat transformer

### DIFF
--- a/pipeline/transformer/transformer_ebsco/src/main/scala/weco/pipeline/transformer/ebsco/EbscoTransformer.scala
+++ b/pipeline/transformer/transformer_ebsco/src/main/scala/weco/pipeline/transformer/ebsco/EbscoTransformer.scala
@@ -93,6 +93,7 @@ class EbscoTransformer(store: Readable[S3ObjectLocation, String])
         production = MarcProduction(record),
         languages = MarcLanguage(record).toList,
         format = MarcFormat(record)
-    ))
+      )
+    )
   }
 }

--- a/pipeline/transformer/transformer_ebsco/src/main/scala/weco/pipeline/transformer/ebsco/EbscoTransformer.scala
+++ b/pipeline/transformer/transformer_ebsco/src/main/scala/weco/pipeline/transformer/ebsco/EbscoTransformer.scala
@@ -5,7 +5,6 @@ import weco.catalogue.internal_model.identifiers.{
   IdentifierType,
   SourceIdentifier
 }
-import weco.catalogue.internal_model.work.Format.EJournals
 import weco.catalogue.internal_model.work.WorkState.Source
 import weco.catalogue.internal_model.work.{
   DeletedReason,
@@ -91,12 +90,9 @@ class EbscoTransformer(store: Readable[S3ObjectLocation, String])
         subjects = MarcSubjects(record).toList,
         genres = MarcGenres(record).toList,
         holdings = MarcElectronicResources.toHoldings(record).toList,
+        production = MarcProduction(record),
         languages = MarcLanguage(record).toList,
-        // TODO: We should rely on a Marc transformer to extract this information
-        //   but we know that all the records we are transforming from this source
-        //   are EJournals.
-        format = Some(EJournals)
-      )
-    )
+        format = MarcFormat(record)
+    ))
   }
 }

--- a/pipeline/transformer/transformer_ebsco/src/test/scala/weco/pipeline/transformer/ebsco/EbscoTransformerTest.scala
+++ b/pipeline/transformer/transformer_ebsco/src/test/scala/weco/pipeline/transformer/ebsco/EbscoTransformerTest.scala
@@ -27,10 +27,13 @@ class EbscoTransformerTest
 
       val record =
         <record xmlns="http://www.loc.gov/MARC21/slim">
+            <leader>00000cas a2200000 a 4500</leader>
             <controlfield tag="001">3PaDhRp</controlfield>
+            <controlfield tag="006">m\\\\\o\\d\\||||||</controlfield>
             <datafield tag ="245">
               <subfield code="a">matacologian</subfield>
             </datafield>
+
           </record>
 
       val transformer = new EbscoTransformer(

--- a/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcDataTransformer.scala
+++ b/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcDataTransformer.scala
@@ -32,7 +32,7 @@ trait MarcDataTransformerWithLoggingContext {
  * The FieldTransformer can generate a Person, regardless of which it is
  * while the corresponding DataTransformer sets the Subjectness or Contributorness
  * of it.
- *  */
+ * */
 trait MarcFieldTransformer {
   type Output
 

--- a/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcFormat.scala
+++ b/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcFormat.scala
@@ -1,0 +1,173 @@
+package weco.pipeline.transformer.marc_common.transformers
+
+import weco.catalogue.internal_model.work.Format
+import weco.pipeline.transformer.marc_common.models.MarcRecord
+
+/** https://www.loc.gov/marc/bibliographic/bd008s.html "23 - Form of item
+  * (006/06)" The spec for field 008 contains a list of material specific
+  * details including the form of item, the code for which matches the value
+  * found in the 006 field at position 6.
+  */
+sealed trait FormOfItem
+object MarcO08Field {
+  object FormOfItem {
+    case object Online extends FormOfItem
+  }
+}
+
+// Used to transform data from a MARC field where the data is positional
+// e.g. the leader and some control fields
+sealed trait MarcPositionalElement extends MarcDataTransformer {
+  val position: Int
+  val length: Int = 1
+}
+
+/** https://www.loc.gov/marc/bibliographic/bd006.html "Additional Material
+  * Characteristics" Marc 006 field is a control field that contains additional
+  * material characteristics, based on the form of material.
+  *
+  * For example, for continuing resources, the 006 field contains the form of
+  * item at position 6, but for visual materials it's at position 12.
+  *
+  * We infer the form of material based on values in the leader field.
+  *
+  * At present we only care about the form of item for books and continuing
+  * resources, in order to indentify e-books and e-journals (o in position 6).
+  * This could be extended to other forms of material in the future.
+  */
+object MarcO06Field {
+  trait FormOfItemField extends MarcPositionalElement {
+    type Output = Option[FormOfItem]
+
+    val position = 6
+
+    def apply(record: MarcRecord): Option[FormOfItem] = {
+      record
+        .controlField("006")
+        .map(_.content)
+        .map(_.slice(position, position + length))
+        .flatMap {
+          case "o" => Some(MarcO08Field.FormOfItem.Online)
+          case _   => None
+        }
+    }
+  }
+
+  case object Books {
+    case object FormOfItemField extends FormOfItemField
+  }
+
+  case object ContinuingResource {
+    case object FormOfItemField extends FormOfItemField
+  }
+}
+
+/** https://www.loc.gov/marc/bibliographic/bdleader.html "Leader" The leader
+  * field contains information about the record as a whole. We use it to
+  * determine the type of record and the bibliographic level, which is used to
+  * determine the format of the material.
+  *
+  * For example the type of record for a continuing resource is 'a' (language
+  * material) in position 6 (type of record), and 's' (serial) in position 7
+  * (bibliographic level).
+  *
+  * At present we only care about the type of record and bibliographic level for
+  * books and continuing resources, in order to indentify e-books and
+  * e-journals. This could be extended to other types of material in the future.
+  */
+object MarcLeader {
+  // https://www.loc.gov/marc/bibliographic/bdleader.html "06 - Type of record"
+  case object TypeOfRecord extends MarcPositionalElement {
+    sealed trait MarcLeaderTypeOfRecord
+
+    case object LanguageMaterial extends MarcLeaderTypeOfRecord
+
+    type Output = Option[MarcLeaderTypeOfRecord]
+
+    val position = 6
+
+    def apply(record: MarcRecord): Option[MarcLeaderTypeOfRecord] = {
+      val leader = record.leader
+      val typeOfRecord = leader.slice(position, position + length)
+
+      typeOfRecord match {
+        case "a" => Some(LanguageMaterial)
+        case _   => None
+      }
+    }
+  }
+
+  // https://www.loc.gov/marc/bibliographic/bdleader.html "07 - Bibliographic level"
+  case object BibliographicLevel extends MarcPositionalElement {
+    sealed trait MarcLeaderBibliographicLevel
+
+    case object Monograph extends MarcLeaderBibliographicLevel
+    case object Serial extends MarcLeaderBibliographicLevel
+
+    type Output = Option[MarcLeaderBibliographicLevel]
+
+    val position = 7
+
+    def apply(record: MarcRecord): Option[MarcLeaderBibliographicLevel] = {
+      val leader = record.leader
+      val bibliographicLevel = leader.slice(position, position + length)
+
+      bibliographicLevel match {
+        case "m" => Some(Monograph)
+        case "s" => Some(Serial)
+        case _   => None
+      }
+    }
+  }
+}
+
+object MarcFormat extends MarcDataTransformer {
+  type Output = Option[Format]
+
+  /** This function maps a MARC record to a Format, if possible.
+    *
+    * We do this by inspecting the leader field, then the 006 field, and
+    * referring 008 material specific details (though we do not read the 008
+    * field directly).
+    */
+  def apply(record: MarcRecord): Option[Format] = {
+    val (material, leader, form) = (
+      MarcLeader.TypeOfRecord(record),
+      MarcLeader.BibliographicLevel(record)
+    ) match {
+      case (
+            material @ Some(MarcLeader.TypeOfRecord.LanguageMaterial),
+            level @ Some(MarcLeader.BibliographicLevel.Serial)
+          ) =>
+        (
+          material,
+          level,
+          MarcO06Field.ContinuingResource.FormOfItemField(record)
+        )
+
+      case (
+            material @ Some(MarcLeader.TypeOfRecord.LanguageMaterial),
+            level @ Some(MarcLeader.BibliographicLevel.Monograph)
+          ) =>
+        (material, level, MarcO06Field.Books.FormOfItemField(record))
+
+      case _ => (None, None, None)
+    }
+
+    (material, leader, form) match {
+      case (
+            Some(MarcLeader.TypeOfRecord.LanguageMaterial),
+            Some(MarcLeader.BibliographicLevel.Serial),
+            Some(MarcO08Field.FormOfItem.Online)
+          ) =>
+        Some(Format.EJournals)
+      case (
+            Some(MarcLeader.TypeOfRecord.LanguageMaterial),
+            Some(MarcLeader.BibliographicLevel.Monograph),
+            Some(MarcO08Field.FormOfItem.Online)
+          ) =>
+        Some(Format.EBooks)
+      case _ => None
+    }
+  }
+}

--- a/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcFormat.scala
+++ b/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcFormat.scala
@@ -32,7 +32,7 @@ sealed trait MarcPositionalElement extends MarcDataTransformer {
   * We infer the form of material based on values in the leader field.
   *
   * At present we only care about the form of item for books and continuing
-  * resources, in order to indentify e-books and e-journals (o in position 6).
+  * resources, in order to identify e-books and e-journals (o in position 6).
   * This could be extended to other forms of material in the future.
   */
 object Marc006Field {

--- a/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcFormat.scala
+++ b/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcFormat.scala
@@ -9,7 +9,7 @@ import weco.pipeline.transformer.marc_common.models.MarcRecord
   * found in the 006 field at position 6.
   */
 sealed trait FormOfItem
-object MarcO08Field {
+object Marc008Field {
   object FormOfItem {
     case object Online extends FormOfItem
   }
@@ -35,7 +35,7 @@ sealed trait MarcPositionalElement extends MarcDataTransformer {
   * resources, in order to indentify e-books and e-journals (o in position 6).
   * This could be extended to other forms of material in the future.
   */
-object MarcO06Field {
+object Marc006Field {
   trait FormOfItemField extends MarcPositionalElement {
     type Output = Option[FormOfItem]
 
@@ -47,7 +47,7 @@ object MarcO06Field {
         .map(_.content)
         .map(_.slice(position, position + length))
         .flatMap {
-          case "o" => Some(MarcO08Field.FormOfItem.Online)
+          case "o" => Some(Marc008Field.FormOfItem.Online)
           case _   => None
         }
     }
@@ -142,14 +142,14 @@ object MarcFormat extends MarcDataTransformer {
         (
           material,
           level,
-          MarcO06Field.ContinuingResource.FormOfItemField(record)
+          Marc006Field.ContinuingResource.FormOfItemField(record)
         )
 
       case (
             material @ Some(MarcLeader.TypeOfRecord.LanguageMaterial),
             level @ Some(MarcLeader.BibliographicLevel.Monograph)
           ) =>
-        (material, level, MarcO06Field.Books.FormOfItemField(record))
+        (material, level, Marc006Field.Books.FormOfItemField(record))
 
       case _ => (None, None, None)
     }
@@ -158,13 +158,13 @@ object MarcFormat extends MarcDataTransformer {
       case (
             Some(MarcLeader.TypeOfRecord.LanguageMaterial),
             Some(MarcLeader.BibliographicLevel.Serial),
-            Some(MarcO08Field.FormOfItem.Online)
+            Some(Marc008Field.FormOfItem.Online)
           ) =>
         Some(Format.EJournals)
       case (
             Some(MarcLeader.TypeOfRecord.LanguageMaterial),
             Some(MarcLeader.BibliographicLevel.Monograph),
-            Some(MarcO08Field.FormOfItem.Online)
+            Some(Marc008Field.FormOfItem.Online)
           ) =>
         Some(Format.EBooks)
       case _ => None

--- a/pipeline/transformer/transformer_marc_common/src/test/scala/weco/pipeline/transformer/marc_common/generators/MarcTestRecord.scala
+++ b/pipeline/transformer/transformer_marc_common/src/test/scala/weco/pipeline/transformer/marc_common/generators/MarcTestRecord.scala
@@ -11,7 +11,7 @@ import weco.pipeline.transformer.marc_common.models.{
 case class MarcTestRecord(
   fields: Seq[MarcField] = Nil,
   controlFields: Seq[MarcControlField] = Nil,
-  leader: String = "",
+  leader: String = ""
 ) extends MarcRecord
     with LoneElement {
   def fieldsWithTags(tags: String*): Seq[MarcField] =

--- a/pipeline/transformer/transformer_marc_common/src/test/scala/weco/pipeline/transformer/marc_common/generators/MarcTestRecord.scala
+++ b/pipeline/transformer/transformer_marc_common/src/test/scala/weco/pipeline/transformer/marc_common/generators/MarcTestRecord.scala
@@ -10,7 +10,8 @@ import weco.pipeline.transformer.marc_common.models.{
 
 case class MarcTestRecord(
   fields: Seq[MarcField] = Nil,
-  controlFields: Seq[MarcControlField] = Nil
+  controlFields: Seq[MarcControlField] = Nil,
+  leader: String = "",
 ) extends MarcRecord
     with LoneElement {
   def fieldsWithTags(tags: String*): Seq[MarcField] =
@@ -27,7 +28,4 @@ case class MarcTestRecord(
           .filter(_.tag == subfieldTag)
           .toList
     }
-
-  // These are not used in the tests, but we need to implement them to satisfy the interface
-  override val leader: String = ""
 }

--- a/pipeline/transformer/transformer_marc_common/src/test/scala/weco/pipeline/transformer/marc_common/transformers/MarcFormatTest.scala
+++ b/pipeline/transformer/transformer_marc_common/src/test/scala/weco/pipeline/transformer/marc_common/transformers/MarcFormatTest.scala
@@ -1,0 +1,52 @@
+package weco.pipeline.transformer.marc_common.transformers
+
+import org.scalatest.OptionValues
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import weco.catalogue.internal_model.work.Format.{EBooks, EJournals}
+import weco.pipeline.transformer.marc_common.generators.MarcTestRecord
+import weco.pipeline.transformer.marc_common.models.MarcControlField
+
+class MarcFormatTest extends AnyFunSpec with Matchers with OptionValues {
+  describe("Extracting format information from MARC Leader/07, 006/06 & 008 material specific details") {
+    info("https://www.loc.gov/marc/bibliographic/bdleader.html")
+    info("https://www.loc.gov/marc/bibliographic/bd006.html")
+    info("https://www.loc.gov/marc/bibliographic/bd008s.html")
+
+    it("returns an e-journal format when metadata indicates it") {
+      val record = MarcTestRecord(
+        leader = "00000cas a22000003a 4500",
+        controlFields = Seq(
+          MarcControlField("006", "m\\\\\\\\\\o\\\\d\\\\||||||")
+        )
+      )
+
+      MarcFormat(record).value shouldBe EJournals
+    }
+
+    it("returns an e-book format when metadata indicates it") {
+      val record = MarcTestRecord(
+        leader = "00000cam a22000003a 4500",
+        controlFields = Seq(
+          MarcControlField("006", "m\\\\\\\\\\o\\\\d\\\\||||||")
+        )
+      )
+
+      MarcFormat(record).value shouldBe EBooks
+    }
+
+    // We only care about the format ofe-journals and e-books at the moment
+    // so we don't need to test for other formats. As this transformer
+    // is only used in the context of the EBSCO transformer.
+    it("returns no format when metadata indicates neither e-journal nor e-book") {
+      val record = MarcTestRecord(
+        leader = "00000 am  2200289 a 4500",
+        controlFields = Seq(
+          MarcControlField("006", "m\\\\\\\\\\f\\\\d\\\\||||||")
+        )
+      )
+
+      MarcFormat(record) shouldBe None
+    }
+  }
+}

--- a/pipeline/transformer/transformer_marc_common/src/test/scala/weco/pipeline/transformer/marc_common/transformers/MarcFormatTest.scala
+++ b/pipeline/transformer/transformer_marc_common/src/test/scala/weco/pipeline/transformer/marc_common/transformers/MarcFormatTest.scala
@@ -3,11 +3,12 @@ package weco.pipeline.transformer.marc_common.transformers
 import org.scalatest.OptionValues
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks
 import weco.catalogue.internal_model.work.Format.{EBooks, EJournals}
 import weco.pipeline.transformer.marc_common.generators.MarcTestRecord
 import weco.pipeline.transformer.marc_common.models.MarcControlField
 
-class MarcFormatTest extends AnyFunSpec with Matchers with OptionValues {
+class MarcFormatTest extends AnyFunSpec with Matchers with OptionValues with TableDrivenPropertyChecks{
   describe(
     "Extracting format information from MARC Leader/07, 006/06 & 008 material specific details"
   ) {
@@ -15,42 +16,38 @@ class MarcFormatTest extends AnyFunSpec with Matchers with OptionValues {
     info("https://www.loc.gov/marc/bibliographic/bd006.html")
     info("https://www.loc.gov/marc/bibliographic/bd008s.html")
 
-    it("returns an e-journal format when metadata indicates it") {
-      val record = MarcTestRecord(
-        leader = "00000cas a22000003a 4500",
-        controlFields = Seq(
-          MarcControlField("006", "m\\\\\\\\\\o\\\\d\\\\||||||")
+
+    describe("with a MARC leader and 006 control field") {
+      forAll(
+        Table(
+          ("leader", "006", "expectedFormat"),
+          // 'as' in Leader/06 & 07  indicates 'language material' and 'serial'
+          // 'o' in 006/06 indicates 'online'
+          ("00000cas a22000003a 4500", "m\\\\\\\\\\o\\\\d\\\\||||||", Some(EJournals)),
+          // 'am' in Leader/06 & 07  indicates 'language material' and 'monograph'
+          // 'o' in 006/06 indicates 'online'
+          ("00000cam a22000003a 4500", "m\\\\\\\\\\o\\\\d\\\\||||||", Some(EBooks)),
+          // 'am' in Leader/06 & 07  indicates 'language material' and 'monograph'
+          // 'f' in 006/06 indicates 'braille'
+          ("00000cam a22000003a 4500", "m\\\\\\\\\\f\\\\d\\\\||||||", None),
+          // 'ac' in Leader/06 & 07  indicates 'language material' and 'collection'
+          // 'o' in 006/06 is non-sensical without a mapping to material type
+          ("00000cac a22000003a 4500", "m\\\\\\\\\\o\\\\d\\\\||||||", None),
+
         )
-      )
-
-      MarcFormat(record).value shouldBe EJournals
-    }
-
-    it("returns an e-book format when metadata indicates it") {
-      val record = MarcTestRecord(
-        leader = "00000cam a22000003a 4500",
-        controlFields = Seq(
-          MarcControlField("006", "m\\\\\\\\\\o\\\\d\\\\||||||")
-        )
-      )
-
-      MarcFormat(record).value shouldBe EBooks
-    }
-
-    // We only care about the format of e-journals and e-books at the moment
-    // so we don't need to test for other formats. As this transformer
-    // is only used in the context of the EBSCO transformer.
-    it(
-      "returns no format when metadata indicates neither e-journal nor e-book"
-    ) {
-      val record = MarcTestRecord(
-        leader = "00000 am  2200289 a 4500",
-        controlFields = Seq(
-          MarcControlField("006", "m\\\\\\\\\\f\\\\d\\\\||||||")
-        )
-      )
-
-      MarcFormat(record) shouldBe None
+      ) {
+        (leader, controlField006, expectedFormat) =>
+          it(
+            s"returns $expectedFormat when Leader/06 & 07 is '${leader.slice(6, 8)}' and 006/06 is '${controlField006.slice(6, 7)}'"
+          ) {
+            MarcFormat(MarcTestRecord(
+              leader = leader,
+              controlFields = Seq(
+                MarcControlField("006", controlField006)
+              )
+            )) shouldBe expectedFormat
+          }
+      }
     }
   }
 }

--- a/pipeline/transformer/transformer_marc_common/src/test/scala/weco/pipeline/transformer/marc_common/transformers/MarcFormatTest.scala
+++ b/pipeline/transformer/transformer_marc_common/src/test/scala/weco/pipeline/transformer/marc_common/transformers/MarcFormatTest.scala
@@ -37,7 +37,7 @@ class MarcFormatTest extends AnyFunSpec with Matchers with OptionValues {
       MarcFormat(record).value shouldBe EBooks
     }
 
-    // We only care about the format ofe-journals and e-books at the moment
+    // We only care about the format of e-journals and e-books at the moment
     // so we don't need to test for other formats. As this transformer
     // is only used in the context of the EBSCO transformer.
     it(

--- a/pipeline/transformer/transformer_marc_common/src/test/scala/weco/pipeline/transformer/marc_common/transformers/MarcFormatTest.scala
+++ b/pipeline/transformer/transformer_marc_common/src/test/scala/weco/pipeline/transformer/marc_common/transformers/MarcFormatTest.scala
@@ -8,7 +8,9 @@ import weco.pipeline.transformer.marc_common.generators.MarcTestRecord
 import weco.pipeline.transformer.marc_common.models.MarcControlField
 
 class MarcFormatTest extends AnyFunSpec with Matchers with OptionValues {
-  describe("Extracting format information from MARC Leader/07, 006/06 & 008 material specific details") {
+  describe(
+    "Extracting format information from MARC Leader/07, 006/06 & 008 material specific details"
+  ) {
     info("https://www.loc.gov/marc/bibliographic/bdleader.html")
     info("https://www.loc.gov/marc/bibliographic/bd006.html")
     info("https://www.loc.gov/marc/bibliographic/bd008s.html")
@@ -38,7 +40,9 @@ class MarcFormatTest extends AnyFunSpec with Matchers with OptionValues {
     // We only care about the format ofe-journals and e-books at the moment
     // so we don't need to test for other formats. As this transformer
     // is only used in the context of the EBSCO transformer.
-    it("returns no format when metadata indicates neither e-journal nor e-book") {
+    it(
+      "returns no format when metadata indicates neither e-journal nor e-book"
+    ) {
       val record = MarcTestRecord(
         leader = "00000 am  2200289 a 4500",
         controlFields = Seq(

--- a/pipeline/transformer/transformer_marc_common/src/test/scala/weco/pipeline/transformer/marc_common/transformers/MarcParentsTest.scala
+++ b/pipeline/transformer/transformer_marc_common/src/test/scala/weco/pipeline/transformer/marc_common/transformers/MarcParentsTest.scala
@@ -11,7 +11,9 @@ import weco.pipeline.transformer.marc_common.generators.MarcTestRecord
 import weco.pipeline.transformer.marc_common.models.{MarcField, MarcSubfield}
 
 class MarcParentsTest extends AnyFunSpec with Matchers with LoneElement {
-  describe("Extracting relation information from MARC fields 440, 490, 773 & 830") {
+  describe(
+    "Extracting relation information from MARC fields 440, 490, 773 & 830"
+  ) {
     info("https://www.loc.gov/marc/bibliographic/bd4xx.html")
     info("https://www.loc.gov/marc/bibliographic/bd773.html")
     info("https://www.loc.gov/marc/bibliographic/bd830.html")
@@ -22,7 +24,8 @@ class MarcParentsTest extends AnyFunSpec with Matchers with LoneElement {
         List(
           MarcField(
             marcTag = "440",
-            subfields = List(MarcSubfield(tag = "a", content = "A title from 440ǂa"))
+            subfields =
+              List(MarcSubfield(tag = "a", content = "A title from 440ǂa"))
           )
         ),
         List("A title from 440ǂa")
@@ -31,7 +34,8 @@ class MarcParentsTest extends AnyFunSpec with Matchers with LoneElement {
         List(
           MarcField(
             marcTag = "490",
-            subfields = List(MarcSubfield(tag = "a", content = "A title from 490ǂa"))
+            subfields =
+              List(MarcSubfield(tag = "a", content = "A title from 490ǂa"))
           )
         ),
         List("A title from 490ǂa")
@@ -40,7 +44,8 @@ class MarcParentsTest extends AnyFunSpec with Matchers with LoneElement {
         List(
           MarcField(
             marcTag = "773",
-            subfields = List(MarcSubfield(tag = "t", content = "A title from 773ǂt"))
+            subfields =
+              List(MarcSubfield(tag = "t", content = "A title from 773ǂt"))
           )
         ),
         List("A title from 773ǂt")
@@ -49,7 +54,8 @@ class MarcParentsTest extends AnyFunSpec with Matchers with LoneElement {
         List(
           MarcField(
             marcTag = "773",
-            subfields = List(MarcSubfield(tag = "a", content = "A title from 773ǂa"))
+            subfields =
+              List(MarcSubfield(tag = "a", content = "A title from 773ǂa"))
           )
         ),
         List("A title from 773ǂa")
@@ -58,7 +64,8 @@ class MarcParentsTest extends AnyFunSpec with Matchers with LoneElement {
         List(
           MarcField(
             marcTag = "773",
-            subfields = List(MarcSubfield(tag = "s", content = "A title from 773ǂs"))
+            subfields =
+              List(MarcSubfield(tag = "s", content = "A title from 773ǂs"))
           )
         ),
         List("A title from 773ǂs")
@@ -67,7 +74,8 @@ class MarcParentsTest extends AnyFunSpec with Matchers with LoneElement {
         List(
           MarcField(
             marcTag = "830",
-            subfields = List(MarcSubfield(tag = "t", content = "A title from 830ǂt"))
+            subfields =
+              List(MarcSubfield(tag = "t", content = "A title from 830ǂt"))
           )
         ),
         List("A title from 830ǂt")
@@ -76,7 +84,8 @@ class MarcParentsTest extends AnyFunSpec with Matchers with LoneElement {
         List(
           MarcField(
             marcTag = "830",
-            subfields = List(MarcSubfield(tag = "a", content = "A title from 830ǂa"))
+            subfields =
+              List(MarcSubfield(tag = "a", content = "A title from 830ǂa"))
           )
         ),
         List("A title from 830ǂa")
@@ -109,11 +118,13 @@ class MarcParentsTest extends AnyFunSpec with Matchers with LoneElement {
         List(
           MarcField(
             marcTag = "440",
-            subfields = List(MarcSubfield(tag = "a", content = "A title from 440ǂa"))
+            subfields =
+              List(MarcSubfield(tag = "a", content = "A title from 440ǂa"))
           ),
           MarcField(
             marcTag = "490",
-            subfields = List(MarcSubfield(tag = "a", content = "A title from 490ǂa"))
+            subfields =
+              List(MarcSubfield(tag = "a", content = "A title from 490ǂa"))
           )
         ),
         List("A title from 440ǂa", "A title from 490ǂa")
@@ -126,7 +137,7 @@ class MarcParentsTest extends AnyFunSpec with Matchers with LoneElement {
           )
         ),
         List()
-      ),
+      )
     )
 
     def createRelationWithTitle(title: String): Relation =
@@ -140,11 +151,12 @@ class MarcParentsTest extends AnyFunSpec with Matchers with LoneElement {
         numDescendents = 0
       )
 
-    /**
-     * This test uses the same test data as SierraParentsTest, modified to create
-     * MarcField instances instead of VarField instances.
-     */
-    it("constructs relations appropriate for the MARC fields 440, 490, 773, 830") {
+    /** This test uses the same test data as SierraParentsTest, modified to
+      * create MarcField instances instead of VarField instances.
+      */
+    it(
+      "constructs relations appropriate for the MARC fields 440, 490, 773, 830"
+    ) {
       forAll(testCases) {
         case (testMarcFields, expectedTitles) =>
           MarcParents(

--- a/pipeline/transformer/transformer_marc_xml/src/main/scala/weco/pipeline/transformer/marc/xml/transformers/MarcXMLRecordTransformer.scala
+++ b/pipeline/transformer/transformer_marc_xml/src/main/scala/weco/pipeline/transformer/marc/xml/transformers/MarcXMLRecordTransformer.scala
@@ -18,6 +18,7 @@ import weco.pipeline.transformer.marc_common.transformers.{
   MarcDesignation,
   MarcEdition,
   MarcElectronicResources,
+  MarcFormat,
   MarcGenres,
   MarcInternationalStandardIdentifiers,
   MarcLanguage,
@@ -64,7 +65,8 @@ object MarcXMLRecordTransformer {
         genres = MarcGenres(record).toList,
         languages = MarcLanguage(record).toList,
         production = MarcProduction(record),
-        collectionPath = MarcCollectionPath(record)
+        collectionPath = MarcCollectionPath(record),
+        format = MarcFormat(record)
       )
     )
   }

--- a/pipeline/transformer/transformer_marc_xml/src/test/scala/weco/pipeline/transformer/marc/xml/transformers/MarcXMLRecordTransformerTest.scala
+++ b/pipeline/transformer/transformer_marc_xml/src/test/scala/weco/pipeline/transformer/marc/xml/transformers/MarcXMLRecordTransformerTest.scala
@@ -5,7 +5,17 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.catalogue.internal_model.identifiers.IdState.Unidentifiable
 import weco.catalogue.internal_model.locations.DigitalLocation
-import weco.catalogue.internal_model.work.{Agent, CollectionPath, Concept, InstantRange, Period, Place, ProductionEvent, Relations, SeriesRelation}
+import weco.catalogue.internal_model.work.{
+  Agent,
+  CollectionPath,
+  Concept,
+  InstantRange,
+  Period,
+  Place,
+  ProductionEvent,
+  Relations,
+  SeriesRelation
+}
 import weco.pipeline.transformer.marc.xml.data.MarcXMLRecord
 import weco.pipeline.transformer.marc_common.logging.LoggingContext
 
@@ -25,7 +35,9 @@ class MarcXMLRecordTransformerTest
     val work = MarcXMLRecordTransformer(
       record = MarcXMLRecord(
         <record xmlns="http://www.loc.gov/MARC21/slim">
+          <leader>00000cas a22000003a 4500</leader>
           <controlfield tag="001">3PaDhRp</controlfield>
+          <controlfield tag="006">m\\\\\o\\d\\||||||</controlfield>
           <controlfield tag="008">030214c20039999cauar o 0 a0eng c</controlfield>
           <datafield tag="245">
             <subfield code="a">matacologian</subfield>
@@ -206,6 +218,10 @@ class MarcXMLRecordTransformerTest
 
     it("extracts genres") {
       work.data.genres.loneElement.label shouldBe "Lo-Fi Darkwave"
+    }
+
+    it("extracts format") {
+      work.data.format.get.label shouldBe "E-journals"
     }
 
     it("extracts production") {


### PR DESCRIPTION
## What does this change?

This change adds a transformer for MarcFormat, only used by the EBSCO transformer as the Sierra transformer reads material type from the bibdata for this purpose. 

The material types used in format are specific to the Wellcome Collection and do not directly relate to the MARC data in our records and requires some assumptions about how to do that encoded here.

We currently only matches E-book & E-Journal formats as that's all that is required for the EBSCO source data, but the change here tries to make a start a transformer that could be used more widely to identify format from MARC in other sources.

Part of:
- https://github.com/wellcomecollection/platform/issues/5738
- https://github.com/wellcomecollection/catalogue-pipeline/issues/2642

## How to test

- [x] Run the tests
- [ ] Run this in a test pipeline, do the expected changes occur?

## How can we measure success?

Existing records using this transform are unchanged, and we can move closer to a correct EBSCO sourced work transform.

## Have we considered potential risks?

This should only impact EBSCO sourced works.

