### PR TITLE
Refine subject transform based on feedback from collections information

### DIFF
--- a/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcSubjects.scala
+++ b/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcSubjects.scala
@@ -1,32 +1,87 @@
 package weco.pipeline.transformer.marc_common.transformers
 import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.work.Subject
-import weco.pipeline.transformer.marc_common.models.MarcRecord
+import weco.pipeline.transformer.marc_common.models.{MarcFieldOps, MarcRecord}
 import weco.pipeline.transformer.marc_common.transformers.subjects.{
   MarcConceptSubject,
   MarcMeetingSubject,
   MarcOrganisationSubject,
-  MarcPersonSubject,
-  MarcSubject
+  MarcPersonSubject
 }
 
-object MarcSubjects extends MarcDataTransformer {
+object MarcSubjects extends MarcDataTransformer with MarcFieldOps {
 
   override type Output = Seq[Subject[IdState.Unminted]]
 
-  private val transformers: Map[String, MarcSubject] = (
-    Seq("650", "648", "651").map(marcTag => marcTag -> MarcConceptSubject)
-      ++ Seq(
-        "600" -> MarcPersonSubject,
-        "610" -> MarcOrganisationSubject,
-        "611" -> MarcMeetingSubject
-      )
-  ).toMap
+  /** Our cataloguing practise encodes the following rules with respect to which
+    * headings we choose from the MARC record in 6xx fields, which we ignore and
+    * what concept type they map to.
+    *
+    * See: https://www.loc.gov/marc/bibliographic/bd6xx.html - Subject Access
+    * Fields https://www.loc.gov/marc/bibliographic/bd650.html650 - Subject
+    * Added Entry - Topical Term (MarcConceptSubject)
+    * https://www.loc.gov/marc/bibliographic/bd651.html651 - Subject Added Entry
+    * \- Geographic Name (MarcConceptSubject)
+    * https://www.loc.gov/marc/bibliographic/bd648.html648 - Subject Added Entry
+    * \- Chronological Term (MarcConceptSubject)
+    * https://www.loc.gov/marc/bibliographic/bd600.html600 - Subject Added Entry
+    * \- Personal Name (MarcPersonSubject)
+    * https://www.loc.gov/marc/bibliographic/bd610.html610 - Subject Added Entry
+    * \- Corporate Name (MarcOrganisationSubject)
+    * https://www.loc.gov/marc/bibliographic/bd611.html611 - Subject Added Entry
+    * \- Meeting Name (MarcMeetingSubject)
+    *
+    * We catalogue using LoC (2nd indicator 0) and MeSH (2nd indicator 2) and
+    * other (2nd indicator 7), so for the above Subject Added Entry's we do not
+    * take any headings with 2nd indicators 1, 3-6, there are particular rules
+    * on 2nd indicator 7 headings:
+    *
+    * We currently keep/use the following 650_7 ǂ2: local, homoit, indig, enslv
+    *
+    * See https://www.loc.gov/standards/sourcelist/subject.html for a list of
+    * subject sources.
+    *
+    * Consult the Collections Information Team for further information or when
+    * making changes.
+    */
 
-  private lazy val marcTags = transformers.keys.toSeq
+  val transformMap = Map(
+    "600" -> MarcPersonSubject,
+    "610" -> MarcOrganisationSubject,
+    "611" -> MarcMeetingSubject,
+    "650" -> MarcConceptSubject,
+    "648" -> MarcConceptSubject,
+    "651" -> MarcConceptSubject
+  )
+
+  val validIndicator2Values: Seq[String] = Seq("0", "2")
+  val validSubjectMarcTags: Seq[String] = transformMap.keys.toSeq
+
+  private lazy val marcTags = transformMap.keys.toSeq
   override def apply(record: MarcRecord): Output = {
-    record.fieldsWithTags(marcTags: _*).flatMap {
-      field => transformers(field.marcTag)(field)
-    }
+    record
+      .fieldsWithTags(marcTags: _*)
+      .filter {
+        field =>
+          {
+            (field.marcTag, field.indicator2) match {
+              case (tag, i2)
+                  if validSubjectMarcTags.contains(tag) && validIndicator2Values
+                    .contains(i2) =>
+                true
+              case (tag, "7") if validSubjectMarcTags.contains(tag) =>
+                field
+                  .subfieldsWithTag("2")
+                  .exists(_.content match {
+                    case "local" | "homoit" | "indig" | "enslv" => true
+                    case _                                      => false
+                  })
+              case _ => false
+            }
+          }
+      }
+      .flatMap {
+        field => transformMap(field.marcTag)(field)
+      }
   }
 }

--- a/pipeline/transformer/transformer_marc_common/src/test/scala/weco/pipeline/transformer/marc_common/transformers/MarcSubjectsTest.scala
+++ b/pipeline/transformer/transformer_marc_common/src/test/scala/weco/pipeline/transformer/marc_common/transformers/MarcSubjectsTest.scala
@@ -10,12 +10,15 @@ import weco.catalogue.internal_model.work.{
   Person,
   Place
 }
+import weco.fixtures.RandomGenerators
 import weco.pipeline.transformer.marc_common.generators.MarcTestRecord
 import weco.pipeline.transformer.marc_common.models.{MarcField, MarcSubfield}
+import scala.language.existentials
 
 class MarcSubjectsTest
     extends MarcAbstractAgentBehaviours
     with LoneElement
+    with RandomGenerators
     with TableDrivenPropertyChecks {
   describe("When there are no subjects") {
     it("returns nothing if no relevant fields are present") {
@@ -51,7 +54,66 @@ class MarcSubjectsTest
         )
       ) shouldBe Nil
     }
+  }
 
+  private def subjectPair = chooseFrom(
+    ("600", a[Person[IdState.Identifiable]]),
+    ("610", a[Organisation[IdState.Identifiable]]),
+    ("611", a[Meeting[IdState.Identifiable]]),
+    ("648", a[Period[IdState.Identifiable]]),
+    ("650", a[Concept[IdState.Identifiable]]),
+    ("651", a[Place[IdState.Identifiable]])
+  )
+
+  describe("only extracting subjects that follow our cataloguing practise") {
+    forAll(
+      Table(
+        ("marcSubjectPair", "indicator2", "subfield2", "shouldCreateSubject"),
+        (subjectPair, "0", "", true),
+        (subjectPair, "1", "", false),
+        (subjectPair, "2", "", true),
+        (subjectPair, "3", "", false),
+        (subjectPair, "4", "", false),
+        (subjectPair, "5", "", false),
+        (subjectPair, "6", "", false),
+        (subjectPair, "7", "local", true),
+        (subjectPair, "7", "homoit", true),
+        (subjectPair, "7", "indig", true),
+        (subjectPair, "7", "enslv", true),
+        (subjectPair, "7", "asth", false),
+        (subjectPair, "7", "", false)
+      )
+    ) {
+      (subjectPair, indicator2, subfield2, shouldCreateSubject) =>
+        val (marcTag, subjectType) = subjectPair
+        it(
+          s"creates a Subject containing a ${subjectType.clazzTag.toString().split('.').last} given a $$$marcTag field" +
+            s"with indicator2 $indicator2 and subfield2 $subfield2"
+        ) {
+          val subject = MarcSubjects(
+            MarcTestRecord(fields =
+              Seq(
+                MarcField(
+                  marcTag = marcTag,
+                  subfields = Seq(
+                    MarcSubfield(tag = "a", content = "The Title")
+                  ) ++ (
+                    if (subfield2.isEmpty) Seq.empty
+                    else Seq(MarcSubfield(tag = "2", content = subfield2))
+                  ),
+                  indicator2 = indicator2
+                )
+              )
+            )
+          )
+
+          if (shouldCreateSubject) {
+            subject.loneElement.concepts.loneElement shouldBe subjectType
+          } else {
+            subject shouldBe Nil
+          }
+        }
+    }
   }
   describe("extracting subjects from various fields") {
     forAll(
@@ -75,7 +137,8 @@ class MarcSubjectsTest
                 MarcField(
                   marcTag = marcTag,
                   subfields =
-                    Seq(MarcSubfield(tag = "a", content = "The Title"))
+                    Seq(MarcSubfield(tag = "a", content = "The Title")),
+                  indicator2 = "0"
                 )
               )
             )
@@ -104,7 +167,8 @@ class MarcSubjectsTest
             marcTag =>
               MarcField(
                 marcTag = marcTag,
-                subfields = Seq(MarcSubfield(tag = "a", content = s"$marcTag"))
+                subfields = Seq(MarcSubfield(tag = "a", content = s"$marcTag")),
+                indicator2 = "0"
               )
           )
         )
@@ -130,7 +194,8 @@ class MarcSubjectsTest
               MarcSubfield(tag = "p", content = "P"),
               MarcSubfield(tag = "q", content = "Q"),
               MarcSubfield(tag = "l", content = "L")
-            )
+            ),
+            indicator2 = "0"
           )
         )
       )

--- a/pipeline/transformer/transformer_marc_xml/src/test/scala/weco/pipeline/transformer/marc/xml/transformers/MarcXMLRecordTransformerTest.scala
+++ b/pipeline/transformer/transformer_marc_xml/src/test/scala/weco/pipeline/transformer/marc/xml/transformers/MarcXMLRecordTransformerTest.scala
@@ -97,22 +97,22 @@ class MarcXMLRecordTransformerTest
           <datafield tag="520">
             <subfield code="a">Some of them [sc. physicians] I know are ignorant beyond Description.</subfield>
           </datafield>
-          <datafield tag="600">
+          <datafield tag="600" ind2="0">
             <subfield code="a">William Burroughs</subfield>
           </datafield>
-          <datafield tag="610">
+          <datafield tag="610" ind2="0">
             <subfield code="a">Umbrella Corporation</subfield>
           </datafield>
-          <datafield tag="611">
+          <datafield tag="611" ind2="0">
             <subfield code="a">Derndingle Entmoot 3019</subfield>
           </datafield>
-          <datafield tag="648">
+          <datafield tag="648" ind2="0">
             <subfield code="a">Fourth Millenium of the Third Age</subfield>
           </datafield>
-          <datafield tag="650">
+          <datafield tag="650"  ind2="0">
             <subfield code="a">Effective Homeopathy</subfield>
           </datafield>
-          <datafield tag="651">
+          <datafield tag="651" ind2="0">
             <subfield code="a">Houyhnhnm Land</subfield>
           </datafield>
           <datafield tag="655">


### PR DESCRIPTION
## What does this change?

This change refines the rules for transforming subjects from MARC based on conversations with Collection Information.

> Our cataloguing practise encodes the following rules with respect to which headings we choose from the MARC record in 6xx fields, which we ignore and what concept type they map to.
> 
> See: https://www.loc.gov/marc/bibliographic/bd6xx.html - Subject Access
> Fields:
> - https://www.loc.gov/marc/bibliographic/bd650.html650 - Subject Added Entry - Topical Term (`MarcConceptSubject`)
> - https://www.loc.gov/marc/bibliographic/bd651.html651 - Subject Added Entry - Geographic Name (`MarcConceptSubject`)
> - https://www.loc.gov/marc/bibliographic/bd648.html648 - Subject Added Entry - Chronological Term (`MarcConceptSubject`)
> - https://www.loc.gov/marc/bibliographic/bd600.html600 - Subject Added Entry - Personal Name (`MarcPersonSubject`)
> - https://www.loc.gov/marc/bibliographic/bd610.html610 - Subject Added Entry - Corporate Name (`MarcOrganisationSubject`)
> - https://www.loc.gov/marc/bibliographic/bd611.html611 - Subject Added Entry - Meeting Name (`MarcMeetingSubject`)
> 
> We catalogue using LoC (2nd indicator 0) and MeSH (2nd indicator 2) and other (2nd indicator 7), so for the above Subject Added Entry's we do not take any headings with 2nd indicators 1, 3-6, there are particular rules on 2nd indicator 7 headings: 
> 
> We currently keep/use the following 650_7 ǂ2: local, homoit, indig, enslv

See: https://wellcome.slack.com/archives/C02ANCYL90E/p1716217517115789

## How to test

- [ ] Run the tests
- [ ] Run this in a test pipeline, do the expected changes occur?

## How can we measure success?

Existing records using this transform are unchanged, and we can move closer to a correct EBSCO sourced work transform.

## Have we considered potential risks?

This does change a transform used elsewhere, but the Sierra subject transform overrides `getSubjects`, so those records should not be impacted.

