### PR TITLE
Strip URL prefix from LoC IDs (#2540)

### DIFF
--- a/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcHasRecordControlNumber.scala
+++ b/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcHasRecordControlNumber.scala
@@ -28,14 +28,17 @@ import weco.pipeline.transformer.marc_common.models.MarcField
 
 trait MarcHasRecordControlNumber extends LabelDerivedIdentifiers with Logging {
   protected val defaultSecondIndicator: String = ""
+  private val urlLocPrefix: String = "http://idlocgov/authorities/subjects/"
+
   protected def getLabel(field: MarcField): Option[String] =
     Option(field.subfields.filter(_.tag == "a").map(_.content).mkString(" "))
       .filter(_.isEmpty)
 
   protected def normalise(identifier: String): String = {
-    // Sort out dodgy punctuation and spacing
+    // Sort out dodgy punctuation and spacing and remove a URL prefix which exists on some otherwise valid LCSH IDs
     identifier
       .replaceAll("[,.\\s]", "")
+      .stripPrefix(urlLocPrefix)
   }
 
   private def getIdentifierSubfieldContents(field: MarcField): Seq[String] =

--- a/pipeline/transformer/transformer_marc_common/src/test/scala/weco/pipeline/transformer/marc_common/transformers/MarcHasRecordControlNumberTest.scala
+++ b/pipeline/transformer/transformer_marc_common/src/test/scala/weco/pipeline/transformer/marc_common/transformers/MarcHasRecordControlNumberTest.scala
@@ -60,6 +60,27 @@ class MarcHasRecordControlNumberTest
       actualSourceIdentifier shouldBe expectedSourceIdentifier
     }
 
+    it("finds an identifier with a URL prefix") {
+      val field =
+        create655FieldWith(indicator2 = "0", identifierValue = "http://idlocgov/authorities/subjects/sh92000896")
+
+      val expectedSourceIdentifier = SourceIdentifier(
+        identifierType = IdentifierType.LCSubjects,
+        value = "sh92000896",
+        ontologyType = ontologyType
+      )
+
+      val actualSourceIdentifier = MarcHasRecordControlNumber
+        .apply(
+          field = field,
+          ontologyType = ontologyType
+        )
+        .allSourceIdentifiers
+        .loneElement
+
+      actualSourceIdentifier shouldBe expectedSourceIdentifier
+    }
+
     it("throws an exception on an invalid LoC identifier") {
       forAll(
         Table(


### PR DESCRIPTION
## What does this change?

Fixes https://github.com/wellcomecollection/catalogue-pipeline/issues/2540.

This implements a minor change in `MarcHasRecordControlNumber` to strip a URL prefix from LCSH IDs if present.

## How to test

I included a test case for this.

## How can we measure success?

We should stop getting "Could not determine LoC scheme from ID" errors with url-prefixed IDs. 

## Have we considered potential risks?

This only adds one line of code stripping a specific prefix value from a string if present, so I can't think of any risks. 
