### PR TITLE
Always prefer MARC 260 if 260 & 264 are present transforming ProductionEvent

### DIFF
--- a/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcProduction.scala
+++ b/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcProduction.scala
@@ -2,11 +2,24 @@ package weco.pipeline.transformer.marc_common.transformers
 
 import grizzled.slf4j.Logging
 import weco.catalogue.internal_model.identifiers.IdState
-import weco.catalogue.internal_model.work.{Agent, Concept, Period, Place, ProductionEvent}
+import weco.catalogue.internal_model.work.{
+  Agent,
+  Concept,
+  Period,
+  Place,
+  ProductionEvent
+}
 import weco.pipeline.transformer.marc_common.exceptions.CataloguingException
-import weco.pipeline.transformer.marc_common.models.{MarcField, MarcFieldOps, MarcRecord}
+import weco.pipeline.transformer.marc_common.models.{
+  MarcField,
+  MarcFieldOps,
+  MarcRecord
+}
 import weco.pipeline.transformer.marc_common.transformers.parsers.MarcProductionEventParser
-import weco.pipeline.transformer.transformers.{ConceptsTransformer, ParsedPeriod}
+import weco.pipeline.transformer.transformers.{
+  ConceptsTransformer,
+  ParsedPeriod
+}
 
 object MarcProduction
     extends MarcDataTransformer
@@ -26,7 +39,9 @@ object MarcProduction
 
       // If both 260 and 264 are present we prefer the 260 fields
       case (from260, _) => {
-        warn(s"Record ${record.controlField("001")} has both 260 and 264 fields. Using 260 fields.")
+        warn(
+          s"Record ${record.controlField("001")} has both 260 and 264 fields. Using 260 fields."
+        )
         from260
       }
     }

--- a/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcProduction.scala
+++ b/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/MarcProduction.scala
@@ -1,30 +1,18 @@
 package weco.pipeline.transformer.marc_common.transformers
 
+import grizzled.slf4j.Logging
 import weco.catalogue.internal_model.identifiers.IdState
-import weco.catalogue.internal_model.work.{
-  Agent,
-  Concept,
-  Period,
-  Place,
-  ProductionEvent
-}
+import weco.catalogue.internal_model.work.{Agent, Concept, Period, Place, ProductionEvent}
 import weco.pipeline.transformer.marc_common.exceptions.CataloguingException
-import weco.pipeline.transformer.marc_common.models.{
-  MarcField,
-  MarcFieldOps,
-  MarcRecord,
-  MarcSubfield
-}
+import weco.pipeline.transformer.marc_common.models.{MarcField, MarcFieldOps, MarcRecord}
 import weco.pipeline.transformer.marc_common.transformers.parsers.MarcProductionEventParser
-import weco.pipeline.transformer.transformers.{
-  ConceptsTransformer,
-  ParsedPeriod
-}
+import weco.pipeline.transformer.transformers.{ConceptsTransformer, ParsedPeriod}
 
 object MarcProduction
     extends MarcDataTransformer
     with MarcFieldOps
-    with ConceptsTransformer {
+    with ConceptsTransformer
+    with Logging {
   type Output = List[ProductionEvent[IdState.Unminted]]
 
   def apply(record: MarcRecord): List[ProductionEvent[IdState.Unminted]] = {
@@ -35,16 +23,12 @@ object MarcProduction
       case (Nil, Nil)     => Nil
       case (from260, Nil) => from260
       case (Nil, from264) => from264
-      // If both 260 and 264 are present we prefer the 260 fields, see if we can safely ignore the 264 content
-      case (from260, _) =>
-        if (shouldDiscard264(record)) from260
-        else
-          // Otherwise this is some sort of cataloguing error.  This is fairly
-          // rare, so let it bubble on to a DLQ.
-          throw CataloguingException(
-            record,
-            message = "Record has both 260 and 264 fields."
-          )
+
+      // If both 260 and 264 are present we prefer the 260 fields
+      case (from260, _) => {
+        warn(s"Record ${record.controlField("001")} has both 260 and 264 fields. Using 260 fields.")
+        from260
+      }
     }
 
     val marc008productionEvents = getProductionFrom008(record)
@@ -193,50 +177,6 @@ object MarcProduction
             function = productionFunction
           )
       }
-
-  /** Populate the production data if both 260 and 264 are present.
-    *
-    * In general, this is a cataloguing error, but sometimes we can do something
-    * more sensible depending on if/how they're duplicated.
-    */
-  private def shouldDiscard264(record: MarcRecord) = {
-    val marc260fields = record.fieldsWithTags("260").toList
-    val marc264fields = record.fieldsWithTags("264").toList
-
-    // We've seen cases where the 264 field only has the following subfields:
-    //
-    //      [('tag', 'c'), ('content', '©2012')]
-    //
-    // or similar, and the 260 field is populated.  In that case, we can
-    // discard the 264 and just use the 260 fields.
-    val marc264OnlyContainsCopyright = marc264fields match {
-      case List(
-            MarcField("264", Seq(MarcSubfield("c", content)), _, _, _)
-          ) =>
-        content.matches("^©\\d{4}$")
-      case _ => false
-    }
-
-    // We've also seen cases where the 260 and 264 field are both present,
-    // and they have matching subfields!  We use the 260 field as it's not
-    // going to throw an exception about unrecognised second indicator.
-    val marc260fieldsMatch264fields =
-      marc260fields.map { _.subfields } == marc264fields.map { _.subfields }
-
-    // We've seen cases where the 264 field only contains punctuation,
-    // for example (MARC record 3150001, retrieved 28 March 2019):
-    //
-    //      260    2019
-    //      264  1 :|b,|c
-    //
-    // If these subfields are entirely punctuation, we discard 264 and
-    // just use 260.
-    val marc264IsOnlyPunctuation = marc264fields
-      .map { _.subfields.map(_.content).mkString("") }
-      .forall { _ matches "^[:,]*$" }
-
-    marc264OnlyContainsCopyright || marc260fieldsMatch264fields || marc264IsOnlyPunctuation
-  }
 
   private def getProductionFrom008(
     record: MarcRecord

--- a/pipeline/transformer/transformer_marc_common/src/test/scala/weco/pipeline/transformer/marc_common/transformers/MarcProductionTest.scala
+++ b/pipeline/transformer/transformer_marc_common/src/test/scala/weco/pipeline/transformer/marc_common/transformers/MarcProductionTest.scala
@@ -3,13 +3,11 @@ package weco.pipeline.transformer.marc_common.transformers
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.catalogue.internal_model.work.{
-  Agent,
   Concept,
   Place,
   ProductionEvent
 }
 import weco.fixtures.RandomGenerators
-import weco.pipeline.transformer.marc_common.exceptions.CataloguingException
 import weco.pipeline.transformer.marc_common.generators.MarcTestRecord
 import weco.pipeline.transformer.marc_common.models.{
   MarcControlField,
@@ -29,136 +27,38 @@ class MarcProductionTest
 
   describe("Both MARC field 260 and 264") {
     it(
-      "throws a cataloguing error if both 260 and 264 are present, and 264 has a 2nd indicator"
+      "if both 260 and 264 are present, accept 260"
     ) {
-      val bibId = randomAlphanumeric(length = 9)
-      val caught = intercept[CataloguingException] {
-        MarcProduction(
-          MarcTestRecord(
-            controlFields = List(
-              MarcControlField(
-                marcTag = "001",
-                content = bibId
-              )
-            ),
-            fields = List(
-              MarcField(
-                marcTag = "260",
-                subfields = List(
-                  MarcSubfield(tag = "a", content = "Paris")
-                )
-              ),
-              MarcField(
-                marcTag = "264",
-                indicator2 = "0",
-                subfields = List(
-                  MarcSubfield(tag = "a", content = "London")
-                )
-              )
-            )
-          )
-        )
-      }
-
-      caught.getMessage should startWith("Problem in the data")
-      caught.getMessage should include(bibId)
-      caught.getMessage should include("Record has both 260 and 264 fields")
-    }
-
-    it("uses 260 if 264 only contains a copyright statement in subfield c") {
       MarcProduction(
         MarcTestRecord(
-          fields = List(
-            MarcField(
-              marcTag = "260",
-              subfields = List(
-                MarcSubfield(tag = "a", content = "San Francisco :"),
-                MarcSubfield(
-                  tag = "b",
-                  content = "Morgan Kaufmann Publishers,"
-                ),
-                MarcSubfield(tag = "c", content = "2004")
-              )
-            ),
-            MarcField(
-              marcTag = "264",
-              subfields = List(
-                MarcSubfield(tag = "c", content = "©2004")
-              )
+          controlFields = List(
+            MarcControlField(
+              marcTag = "001",
+              content = randomAlphanumeric(length = 9)
             )
-          )
-        )
-      ) shouldBe List(
-        ProductionEvent(
-          label = "San Francisco : Morgan Kaufmann Publishers, 2004",
-          places = List(Place("San Francisco")),
-          agents = List(
-            Agent("Morgan Kaufmann Publishers")
           ),
-          dates = List(ParsedPeriod("2004")),
-          function = None
-        )
-      )
-    }
-
-    it("returns correctly if 260 and 264 contain the same subfields") {
-      val matchingSubfields = List(
-        MarcSubfield(tag = "a", content = "London :"),
-        MarcSubfield(tag = "b", content = "Wellcome Trust,"),
-        MarcSubfield(tag = "c", content = "1992")
-      )
-
-      MarcProduction(
-        MarcTestRecord(
-          fields = List(
-            MarcField(
-              marcTag = "260",
-              subfields = matchingSubfields
-            ),
-            MarcField(
-              marcTag = "264",
-              subfields = matchingSubfields
-            )
-          )
-        )
-      ) shouldBe List(
-        ProductionEvent(
-          label = "London : Wellcome Trust, 1992",
-          places = List(Place("London")),
-          agents = List(Agent("Wellcome Trust")),
-          dates = List(ParsedPeriod("1992")),
-          function = None
-        )
-      )
-    }
-
-    // Based on b31500018, as retrieved on 28 March 2019
-    it("returns correctly if the 264 subfields only contain punctuation") {
-      MarcProduction(
-        MarcTestRecord(
           fields = List(
             MarcField(
               marcTag = "260",
               subfields = List(
-                MarcSubfield(tag = "c", content = "2019")
+                MarcSubfield(tag = "a", content = "Paris")
               )
             ),
             MarcField(
               marcTag = "264",
+              indicator2 = "0",
               subfields = List(
-                MarcSubfield(tag = "a", content = ":"),
-                MarcSubfield(tag = "b", content = ","),
-                MarcSubfield(tag = "c", content = "")
+                MarcSubfield(tag = "a", content = "London")
               )
             )
           )
         )
       ) shouldBe List(
         ProductionEvent(
-          label = "2019",
-          places = List(),
+          label = "Paris",
+          places = List(Place("Paris")),
           agents = List(),
-          dates = List(ParsedPeriod("2019")),
+          dates = List(),
           function = None
         )
       )

--- a/pipeline/transformer/transformer_sierra/docker-compose.yml
+++ b/pipeline/transformer/transformer_sierra/docker-compose.yml
@@ -6,3 +6,15 @@ services:
       - SERVICES=sqs
     ports:
       - "4566:4566"
+  elasticsearch:
+    image: "docker.elastic.co/elasticsearch/elasticsearch:8.4.0"
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    environment:
+      - "http.host=0.0.0.0"
+      - "transport.host=0.0.0.0"
+      - "cluster.name=wellcome"
+      - "discovery.type=single-node"
+      - "xpack.security.enabled=false"
+      - "action.auto_create_index=false"

--- a/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraProductionTest.scala
+++ b/pipeline/transformer/transformer_sierra/src/test/scala/weco/pipeline/transformer/sierra/transformers/SierraProductionTest.scala
@@ -466,7 +466,7 @@ class SierraProductionTest
 
   describe("Both MARC field 260 and 264") {
     it(
-      "throws a cataloguing error if both 260 and 264 are present, and 264 has a 2nd indicator"
+      "if both 260 and 264 are present, accept 260"
     ) {
       val bibId = createSierraBibNumber
 
@@ -492,13 +492,15 @@ class SierraProductionTest
 
       val bibData = createSierraBibDataWith(varFields = varFields)
 
-      val caught = intercept[CataloguingException] {
-        SierraProduction(bibId, bibData)
-      }
-
-      caught.getMessage should startWith("Problem in the data")
-      caught.getMessage should include(bibId.withoutCheckDigit)
-      caught.getMessage should include("Record has both 260 and 264 fields")
+      SierraProduction(bibId, bibData) shouldBe List(
+        ProductionEvent(
+          label = "Paris",
+          places = List(Place("Paris")),
+          agents = List(),
+          dates = List(),
+          function = None
+        )
+      )
     }
 
     it("uses 260 if 264 only contains a copyright statement in subfield c") {


### PR DESCRIPTION
## What does this change?

This change removes the logic for throwing a `CataloguingException` in the case that a record contains valid MARC 260 & 264 fields when attempting to transform a `ProductionEvent`. Tracing back the [origin of this logic to 2018, when this code was in the platform monorepo](https://github.com/wellcomecollection/platform/pull/2205) it seems like this change was made as expected correct behaviour, but there's no link to a justification for it.

Removing this logic considerably simplifies the transformer, enables MARC records from EBSCO to be transformed without error.

> [!NOTE]
> We should verify that this behaviour is acceptable with the Collections Information team before merging. See https://wellcome.slack.com/archives/C02ANCYL90E/p1716555606347529

Following this we can [perform an EBSCO re-index](https://github.com/wellcomecollection/catalogue-pipeline/pull/2631) to bring the Sierra sourced records into the new model.

Part of:
- https://github.com/wellcomecollection/platform/issues/5738
- https://github.com/wellcomecollection/catalogue-pipeline/issues/2642

Future work should address where we source production events from for Sierra records (see the conversation linked above).

## How to test

- [ ] Run the tests!

## How can we measure success?

Simpler codebase & the EBSCO transformer can process all records without error.

## Have we considered potential risks?

There may be Sierra records that will now be accepted that were not before, however it is likely we would have noticed these during re-indexes and there is a good chance this does not impact any records.
