### PR TITLE
Do not show reserve notes

### DIFF
--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -367,11 +367,11 @@ object SierraItemAccess extends SierraQueryOps with Logging {
       // the contents of this field under the "a" subfield of the "MARC 999" field.
       case (_, _, _, _, Some(LocationType.OnExhibition))
           if itemData.varFields.exists(_.marcTag.exists(_ == "999")) =>
-        // Get all subfields inside of all "MARC 999" fields
+        // Get all "a" subfields inside of all "MARC 999" fields
         val marcTag999SubfieldContent =
           itemData.varFields
             .filter(_.marcTag.exists(_ == "999"))
-            .flatMap(varField => varField.subfields.map(sub => sub.content))
+            .flatMap(varField => varField.subfields.filter(_.tag == "a").map(sub => sub.content))
 
         // Concatenate all of them together and separate them with "<br />"
         AccessCondition(

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -364,10 +364,10 @@ object SierraItemAccess extends SierraQueryOps with Logging {
       // When an item is on display in an exhibition, it is not available for request.
       // In this case, the 999 MARC tag field should give some more detail.
       case (_, _, _, _, Some(LocationType.OnExhibition))
-          if itemData.varFields.exists(_.marcTag.exists(tag => tag == "999")) =>
+          if itemData.varFields.exists(_.marcTag.exists(_ == "999")) =>
         val marcTag999SubfieldContent =
           itemData.varFields
-            .filter(_.marcTag.exists(tag => tag == "999"))
+            .filter(_.marcTag.exists(_ == "999"))
             .flatMap(varField => varField.subfields.map(sub => sub.content))
 
         AccessCondition(

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -362,14 +362,18 @@ object SierraItemAccess extends SierraQueryOps with Logging {
         )
 
       // When an item is on display in an exhibition, it is not available for request.
-      // In this case, the 999 MARC tag field should give some more detail.
+      // The exhibition team uses the "Shelfmark 999" field in the Sierra client to provide more
+      // information on items which are on loan or on an exhibition. The Sierra API then exposes
+      // the contents of this field under the "a" subfield of the "MARC 999" field.
       case (_, _, _, _, Some(LocationType.OnExhibition))
           if itemData.varFields.exists(_.marcTag.exists(_ == "999")) =>
+        // Get all subfields inside of all "MARC 999" fields
         val marcTag999SubfieldContent =
           itemData.varFields
             .filter(_.marcTag.exists(_ == "999"))
             .flatMap(varField => varField.subfields.map(sub => sub.content))
 
+        // Concatenate all of them together and separate them with "<br />"
         AccessCondition(
           method = AccessMethod.NotRequestable,
           note = Some(marcTag999SubfieldContent.mkString("<br />"))

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -366,9 +366,9 @@ object SierraItemAccess extends SierraQueryOps with Logging {
       case (_, _, _, _, Some(LocationType.OnExhibition))
           if itemData.varFields.exists(_.marcTag.exists(tag => tag == "999")) =>
         val marcTag999SubfieldContent =
-           itemData.varFields
-             .filter(_.marcTag.exists(tag => tag == "999"))
-             .flatMap(varField => varField.subfields.map(sub => sub.content))
+          itemData.varFields
+            .filter(_.marcTag.exists(tag => tag == "999"))
+            .flatMap(varField => varField.subfields.map(sub => sub.content))
 
         AccessCondition(
           method = AccessMethod.NotRequestable,

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -371,7 +371,10 @@ object SierraItemAccess extends SierraQueryOps with Logging {
         val marcTag999SubfieldContent =
           itemData.varFields
             .filter(_.marcTag.exists(_ == "999"))
-            .flatMap(varField => varField.subfields.filter(_.tag == "a").map(sub => sub.content))
+            .flatMap(
+              varField =>
+                varField.subfields.filter(_.tag == "a").map(sub => sub.content)
+            )
 
         // Concatenate all of them together and separate them with "<br />"
         AccessCondition(

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -362,26 +362,17 @@ object SierraItemAccess extends SierraQueryOps with Logging {
         )
 
       // When an item is on display in an exhibition, it is not available for request.
-      // In this case, the Reserves Note(s) should give some more detail.
+      // In this case, the 999 MARC tag field should give some more detail.
       case (_, _, _, _, Some(LocationType.OnExhibition))
-          if itemData.varFields.withFieldTag("r").nonEmpty =>
-        // Reserves Notes normally contain text at either end that is not
-        // relevant for end users wishing to understand how to access the item.
-        // (https://documentation.iii.com/sierrahelp/Content/sgcir/sgcir_course_updaterecs.html)
-        // These include the date it went on/off reserve, and the number of times it circulated
-        // Remove that text before storing the remainder as an access condition note.
-        val sanitisedReservesNotes =
-          for (source_str <- itemData.varFields.withFieldTag("r").contents)
-            yield source_str
-              .replaceFirst(
-                "^\\d\\d-\\d\\d-\\d\\d (ON|OFF) RESERVE FOR ",
-                ""
-              )
-              .replaceAll(" CIRCED \\d+ TIMES", "")
+          if itemData.varFields.exists(_.marcTag.exists(tag => tag == "999")) =>
+        val marcTag999SubfieldContent =
+           itemData.varFields
+             .filter(_.marcTag.exists(tag => tag == "999"))
+             .flatMap(varField => varField.subfields.map(sub => sub.content))
 
         AccessCondition(
           method = AccessMethod.NotRequestable,
-          note = Some(sanitisedReservesNotes.mkString("<br />"))
+          note = Some(marcTag999SubfieldContent.mkString("<br />"))
         )
 
       case (_, _, _, _, _) if itemData.hasDueDate =>

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -836,7 +836,7 @@ class SierraItemAccessTest
       )
     }
     it(
-      "has the default 'contact the library' note if there are no Reserves Notes"
+      "has the default 'contact the library' note if there are MARC 999 fields"
     ) {
       val itemData = createSierraItemDataWith(
         fixedFields = Map(

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -782,7 +782,7 @@ class SierraItemAccessTest
         note(displayreservation)
       )
     }
-    it("can show multiple 999 MARC tag notes") {
+    it("can show multiple 999 MARC tag subfields tagged with 'a' and ignores other subfield tags") {
       val itemData = createSierraItemDataWith(
         fixedFields = Map(
           "79" -> createLocationWith("exres", "On Exhibition")
@@ -790,7 +790,8 @@ class SierraItemAccessTest
         varFields = List(
           VarField(marcTag = "999", subfields=List(Subfield(tag="a", content="in the bottom of a locked filing cabinet"))),
           VarField(marcTag = "999", subfields=List(Subfield(tag="a", content="stuck in a disused lavatory"))),
-          VarField(marcTag = "999", subfields=List(Subfield(tag="a", content="with a sign on the door saying 'Beware of The Leopard'")))
+          VarField(marcTag = "999", subfields=List(Subfield(tag="b", content="ignore me"))),
+          VarField(marcTag = "999", subfields=List(Subfield(tag="a", content="with a sign on the door saying 'Beware of The Leopard'"))),
         )
       )
 


### PR DESCRIPTION
## What does this change?

Fixes #2584 

This modifies the content of the `note` field (stored under `accessConditions`) on Sierra items. Instead of using the reserve note field(s), it now uses the 999 MARC field.

I also removed the sanitisation code because the text it removes (e.g. `RESERVE FOR`) doesn't seem to be present in the 999 MARC field.

I based the code on the following Sierra item (only relevant fields included):

```json
{
  "id": "1607327",
  "varFields": [
    {
      "fieldTag": "c",
      "marcTag": "999",
      "ind1": " ",
      "ind2": " ",
      "subfields": [
        {
          "tag": "a",
          "content": "Pre-Raphaelites, Musei di San Domenico, Forli, Italy, 23 February - 30 June 2024"
        }
      ]
    }
  ]
}
```

Additionally, the implementation should be able to handle the following two cases (though I'm not sure there are any items where either of these two edge cases applies):
1) Multiple var fields with the `999` MARC tag
2) A var field with the `999` MARC tag with multiple subfields

In both of these cases the contents of individual var fields/sub fields are concatenated and separated with `<br />`.

## How to test

I modified the existing unit tests.

## How can we measure success?

The `note` section under `Where to find it` should stop showing reservation notes and instead show the contents of the 999 MARC field  on Sierra items (e.g. https://wellcomecollection.org/works/uxrgqnek). 

## Have we considered potential risks?

The logic I implemented uses the contents of _all_ subfields on all MARC 999 fields but I wonder if we should only filter for subfields with a specific tag (e.g. `a`).
