### PR TITLE
Trigger EBSCO lambda on a schedule

### DIFF
--- a/ebsco_adapter/terraform/lambda_trigger.tf
+++ b/ebsco_adapter/terraform/lambda_trigger.tf
@@ -1,0 +1,19 @@
+# The lambda source is updated much less frequently than once a day (every 7 days)
+# but it's still a good idea to trigger the lambda to run at least once a day to ensure
+# that it's always up to date.
+resource "aws_cloudwatch_event_rule" "every_day_at_6am" {
+  name                = "trigger_ftp_lambda"
+  schedule_expression = "cron(0 6 * * ? *)"
+}
+
+resource "aws_lambda_permission" "allow_reporter_cloudwatch_trigger" {
+  action        = "lambda:InvokeFunction"
+  function_name = module.ftp_lambda.lambda.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.every_day_at_6am.arn
+}
+
+resource "aws_cloudwatch_event_target" "event_trigger" {
+  rule = aws_cloudwatch_event_rule.every_day_at_6am.name
+  arn  = module.ftp_lambda.lambda.arn
+}


### PR DESCRIPTION
## What does this change?

This change runs the EBSCO adapter lambda daily at 6am to ensure we catch any updates from the EBSCO FTP server. At present updates occur only once every 7 days, but it costs very little to run them daily and this is the fastest cadence the adapter logic will tolerate.

### `terraform plan`
```
Terraform will perform the following actions:

  # aws_cloudwatch_event_rule.every_day_at_6am will be created
  + resource "aws_cloudwatch_event_rule" "every_day_at_6am" {
      + arn                 = (known after apply)
      + event_bus_name      = "default"
      + id                  = (known after apply)
      + name                = "trigger_ftp_lambda"
      + name_prefix         = (known after apply)
      + schedule_expression = "cron(0 6 * * ? *)"
      + tags_all            = {
          + "Department"                = "Digital Platform"
          + "TerraformConfigurationURL" = "https://github.com/wellcomecollection/catalogue-pipeline/tree/main/infrastructure"
        }
    }

  # aws_cloudwatch_event_target.event_trigger will be created
  + resource "aws_cloudwatch_event_target" "event_trigger" {
      + arn            = "arn:aws:lambda:eu-west-1:760097843905:function:ebsco-adapter-ftp"
      + event_bus_name = "default"
      + id             = (known after apply)
      + rule           = "trigger_ftp_lambda"
      + target_id      = (known after apply)
    }

  # aws_lambda_permission.allow_reporter_cloudwatch_trigger will be created
  + resource "aws_lambda_permission" "allow_reporter_cloudwatch_trigger" {
      + action              = "lambda:InvokeFunction"
      + function_name       = "ebsco-adapter-ftp"
      + id                  = (known after apply)
      + principal           = "events.amazonaws.com"
      + source_arn          = (known after apply)
      + statement_id        = (known after apply)
      + statement_id_prefix = (known after apply)
    }

Plan: 3 to add, 0 to change, 0 to destroy.
```

Part of:
- https://github.com/wellcomecollection/platform/issues/5738

## How to test

- [ ] Apply the terraform, is the lambda triggered daily?

## How can we measure success?

The EBSCO data source is kept up to date.

## Have we considered potential risks?

Risks should be minimal as running between updates should not make any changes.

