### PR TITLE
Update rules for requesting (06/06/24)

### DIFF
--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala
@@ -159,6 +159,8 @@ object SierraRulesForRequesting {
       //    v|i||79||=|dingo||
       //    v|i||79||=|dpleg||
       //    v|i||79||=|dpuih||
+      //    v|i||79||=|enhal||
+      //    #line above added so that laptops (enhal) cannot be requested online  ls 30/05/24
       //    v|i||79||=|gblip||
       //    q|i||79||=|ofvds||This item cannot be requested online. Please place a manual request.
       //
@@ -179,6 +181,7 @@ object SierraRulesForRequesting {
               "dingo",
               "dpleg",
               "dpuih",
+              "enhal",
               "gblip",
               "ofvds"
             ) =>

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequestingTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequestingTest.scala
@@ -105,6 +105,7 @@ class SierraRulesForRequestingTest
         "dingo",
         "dpleg",
         "dpuih",
+        "enhal",
         "gblip",
         "ofvds"
       )


### PR DESCRIPTION
## What does this change?

This change updates the [rules for requesting](https://github.com/wellcomecollection/docs/blob/main/rfcs/042-requesting-model/README.md?plain=1#L119) which need to match those in Sierra, following an update from LS in Collection Product Lines:

> The update adds location ‘enhal’ which is being used as the item location for the loanable laptops soon to be available in the library.  For info, the laptops are being treated like books and there is one bib record with 8 item records attached - b33320524.  There will be a soft launch of the service in the next week or two, exact date to be confirmed.  It’s not crucial that the laptop record is unrequestable at the time of the soft launch.

See [similar changes](https://github.com/search?q=org%3Awellcomecollection+%22rules+for+requesting%22&type=pullrequests).

## How to test

- [ ] Run the tests, do they pass?
- [ ] Deploy this change, are the items specified un-requestable?

## How can we measure success?

Folk can't request laptops online!

## Have we considered potential risks?

This change is fairly self contained, and does not need a [corresponding catalogue-api update](https://github.com/wellcomecollection/catalogue-api/blob/main/common/stacks/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala) as these are permanently unrequestable.
