### PR TITLE
deepstore is a closed store

### DIFF
--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraPhysicalLocationType.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraPhysicalLocationType.scala
@@ -23,7 +23,8 @@ object SierraPhysicalLocationType extends Logging {
             "early printed books",
             "iconographic collection",
             "offsite",
-            "unrequestable"
+            "unrequestable",
+            "deepstore"
           ) =>
         Some(LocationType.ClosedStores)
 


### PR DESCRIPTION
## What does this change?

Nothing really 😄 the name of DeepStore location (in Sierra source data) will include "deepstore", "offsite" and "closed stores" so it would work as is. 
I just thought it would be helpful to explicitly add `deepstore` in the list of substring matches, for anyone coming across this in the future 

## How to test

Unsure, these items are already indexed as "closed stores" so even when Collection Info/research staff update the items with the new DeppStore location code and name, there will be no change in the indexed document's LocationType

## Have we considered potential risks?

Since the location name for DeepStore items will include "deepstore", "offsite" and "closed stores", if we ever were to create a new LocationType for DeepStore items, the location string from Sierra would match 2 cases 💥 is it worth adding a comment to look out for this?  

