### PR TITLE
Integrate SQS into EBSCO indexer

### DIFF
--- a/ebsco_adapter/ebsco_indexer/README.md
+++ b/ebsco_adapter/ebsco_indexer/README.md
@@ -11,15 +11,15 @@ needs to be indexed/deleted.
 To manually index documents from a local environment, navigate to the `ebsco_indexer` directory and run:  
 ```sh
 AWS_PROFILE=platform-developer \
-ES_INDEX=ebsco-index \
-python3 src/main.py --ebsco-id <EBSCO_ITEM_ID> --s3-bucket <BUCKET_CONTAINING_EBSCO_XML> --s3-key <KEY_CONTAINING_EBSCO_XML>
+ES_INDEX=ebsco_fields \
+python3 src/main.py --s3-bucket <BUCKET_CONTAINING_EBSCO_XML> --s3-key <KEY_CONTAINING_EBSCO_XML>
 ```
 
 To delete a document from the index, run:
 ```sh
 AWS_PROFILE=platform-developer \
-ES_INDEX=ebsco-index \
-python3 src/main.py --ebsco-id <EBSCO_ITEM_ID> --s3-bucket <BUCKET_CONTAINING_EBSCO_XML> --s3-key <KEY_CONTAINING_EBSCO_XML> --delete true
+ES_INDEX=ebsco_fields \
+python3 src/main.py --s3-bucket <BUCKET_CONTAINING_EBSCO_XML> --s3-key <KEY_CONTAINING_EBSCO_XML> --delete true
 ```
 
 ## Recreating the index

--- a/ebsco_adapter/ebsco_indexer/src/fixtures/ebsco_item_fixture_2.xml
+++ b/ebsco_adapter/ebsco_indexer/src/fixtures/ebsco_item_fixture_2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<collection xmlns="http://www.loc.gov/MARC21/slim">
+    <record>
+        <leader>00000cas a22000003 4500</leader>
+        <controlfield tag="001">test_id_2</controlfield>
+        <datafield tag="776" ind1="0" ind2="8">
+            <subfield code="i">Online version:</subfield>
+            <subfield code="t">Behavioural processes (Online)</subfield>
+            <subfield code="w">(DLC) 2002238501</subfield>
+            <subfield code="w">(OCoLC)38491814</subfield>
+        </datafield>
+    </record>
+</collection>

--- a/ebsco_adapter/ebsco_indexer/src/local_utils.py
+++ b/ebsco_adapter/ebsco_indexer/src/local_utils.py
@@ -17,8 +17,8 @@ def construct_sns_message(s3_bucket: str, s3_key: str, delete: bool):
         },
         "deleted": delete,
     }
-
-    return message
+    # In AWS, the SNS object stores the message JSON as a string, so we do the same here
+    return {"Message": json.dumps(message)}
 
 
 def construct_sqs_event(s3_bucket: str, s3_keys_to_index_or_delete: dict[str, bool]):
@@ -30,7 +30,7 @@ def construct_sqs_event(s3_bucket: str, s3_keys_to_index_or_delete: dict[str, bo
 
     for s3_key, delete in s3_keys_to_index_or_delete.items():
         sns_message = construct_sns_message(s3_bucket, s3_key, delete)
-        # In AWS, the SQS object stores the message JSON as a string, so we do the same here
+        # In AWS, the SQS object stores the body JSON as a string, so we do the same here
         raw_sns_messages.append({"body": json.dumps(sns_message)})
 
     event = {"Records": raw_sns_messages}

--- a/ebsco_adapter/ebsco_indexer/src/local_utils.py
+++ b/ebsco_adapter/ebsco_indexer/src/local_utils.py
@@ -22,10 +22,15 @@ def construct_sns_message(s3_bucket: str, s3_key: str, delete: bool):
 
 
 def construct_sqs_event(s3_bucket: str, s3_keys_to_index_or_delete: dict[str, bool]):
+    """
+    Constructs a fake SQS event object mimicking a real object fed into the indexer lambda by SQS.
+    This is only used when running the indexer locally and for unit testing.
+    """
     raw_sns_messages = []
 
     for s3_key, delete in s3_keys_to_index_or_delete.items():
         sns_message = construct_sns_message(s3_bucket, s3_key, delete)
+        # In AWS, the SQS object stores the message JSON as a string, so we do the same here
         raw_sns_messages.append({"body": json.dumps(sns_message)})
 
     event = {"Records": raw_sns_messages}

--- a/ebsco_adapter/ebsco_indexer/src/main.py
+++ b/ebsco_adapter/ebsco_indexer/src/main.py
@@ -92,8 +92,8 @@ def extract_sns_messages_from_sqs_event(event):
     sns_messages = []
 
     for record in event["Records"]:
-        sns_message = json.loads(record["body"])
-        sns_messages.append(sns_message)
+        sns_message = json.loads(record["body"])["Message"]
+        sns_messages.append(json.loads(sns_message))
 
     return sns_messages
 

--- a/ebsco_adapter/ebsco_indexer/src/main.py
+++ b/ebsco_adapter/ebsco_indexer/src/main.py
@@ -132,7 +132,7 @@ def lambda_handler(event, context):
     elasticsearch_client = get_elasticsearch_client()
 
     if len(items_to_delete) > 0:
-        delete_documents_by_parent_id(elasticsearch_client, items_to_delete.keys())
+        delete_documents_by_parent_id(elasticsearch_client, list(items_to_delete.keys()))
 
     if len(items_to_index) > 0:
         index_ebsco_items_in_bulk(elasticsearch_client, items_to_index)

--- a/ebsco_adapter/ebsco_indexer/src/main.py
+++ b/ebsco_adapter/ebsco_indexer/src/main.py
@@ -6,7 +6,7 @@ import boto3
 import pymarc
 import elasticsearch
 
-from local_utils import construct_sns_event
+from local_utils import construct_sqs_event
 
 ES_INDEX_NAME = os.environ.get("ES_INDEX")
 
@@ -61,7 +61,7 @@ def construct_elasticsearch_documents(ebsco_record: pymarc.record.Record):
 
 
 def index_documents(
-    elasticsearch_client, documents: dict[str, dict], ebsco_item_id: str
+    elasticsearch_client: elasticsearch.Elasticsearch, documents: dict[str, dict]
 ):
     success_count, fail_count = 0, 0
     for document_id, document in documents.items():
@@ -75,55 +75,72 @@ def index_documents(
             fail_count += 1
 
     if success_count > 0:
-        print(
-            f"Successfully indexed {success_count} documents with the parent ID {ebsco_item_id}."
-        )
+        print(f"Successfully indexed {success_count} documents.")
     if fail_count > 0:
         raise Exception(
-            f"Failed to index {fail_count} documents with the parent ID {ebsco_item_id}. See above for individual exceptions for each document."
+            f"Failed to index {fail_count} documents. See above for individual exceptions for each document."
         )
 
 
-def delete_documents_by_parent_id(elasticsearch_client, ebsco_item_id: str):
-    body = {"query": {"match": {"parent.id": ebsco_item_id}}}
+def delete_documents_by_parent_id(elasticsearch_client, ebsco_item_ids: list[str]):
+    body = {"query": {"terms": {"parent.id": ebsco_item_ids}}}
     result = elasticsearch_client.delete_by_query(index=ES_INDEX_NAME, body=body)
-    print(f"Deleted {result['deleted']} documents with the parent ID {ebsco_item_id}.")
+    print(f"Deleted {result['deleted']} documents.")
 
 
-def extract_sns_message_from_event(event):
-    sns_message = json.loads(event["Records"][0]["Sns"]["Message"])
-    return sns_message
+def extract_sns_messages_from_sqs_event(event):
+    sns_messages = []
+
+    for record in event["Records"]:
+        sns_message = json.loads(record["body"])
+        sns_messages.append(sns_message)
+
+    return sns_messages
 
 
-def lambda_handler(event, context):
-    print(f"Starting lambda_handler, got event: {event}")
-
-    sns_message = extract_sns_message_from_event(event)
-    is_deleted = sns_message["deleted"]
-    ebsco_item_id = sns_message["id"]
-
-    elasticsearch_client = get_elasticsearch_client()
-
-    # If the item is flagged as deleted, remove it from the Elasticsearch index.
-    # Otherwise, extract the item from S3 and index it.
-    if is_deleted:
-        delete_documents_by_parent_id(elasticsearch_client, ebsco_item_id)
-    else:
+def index_ebsco_items_in_bulk(
+    elasticsearch_client: elasticsearch.Elasticsearch, items_to_index: dict[str, dict]
+):
+    all_documents = {}
+    for sns_message in items_to_index.values():
         s3_bucket = sns_message["location"]["bucket"]
         s3_key = sns_message["location"]["key"]
 
         ebsco_item_xml = load_s3_file_streaming_body(s3_bucket, s3_key)
         ebsco_item = pymarc.marcxml.parse_xml_to_array(ebsco_item_xml)[0]
-        documents = construct_elasticsearch_documents(ebsco_item)
-        index_documents(elasticsearch_client, documents, ebsco_item_id)
+        ebsco_item_documents = construct_elasticsearch_documents(ebsco_item)
+        all_documents |= ebsco_item_documents
+
+    index_documents(elasticsearch_client, all_documents)
+
+
+def lambda_handler(event, context):
+    print(f"Starting lambda_handler, got event: {event}")
+
+    sns_messages = extract_sns_messages_from_sqs_event(event)
+
+    items_to_index, items_to_delete = {}, {}
+    for sns_message in sns_messages:
+        is_deleted = sns_message["deleted"]
+        ebsco_item_id = sns_message["id"]
+
+        if is_deleted:
+            items_to_delete[ebsco_item_id] = sns_message
+        else:
+            items_to_index[ebsco_item_id] = sns_message
+
+    elasticsearch_client = get_elasticsearch_client()
+
+    if len(items_to_delete) > 0:
+        delete_documents_by_parent_id(elasticsearch_client, items_to_delete.keys())
+
+    if len(items_to_index) > 0:
+        index_ebsco_items_in_bulk(elasticsearch_client, items_to_index)
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Index EBSCO item fields into the Elasticsearch reporting cluster."
-    )
-    parser.add_argument(
-        "--ebsco-id", type=str, help="ID of the EBSCO item to index", required=True
     )
     parser.add_argument(
         "--s3-bucket",
@@ -145,5 +162,7 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    event = construct_sns_event(**vars(args))
+    event = construct_sqs_event(
+        s3_bucket=args.s3_bucket, s3_keys_to_index_or_delete={args.s3_key: args.delete}
+    )
     lambda_handler(event, None)

--- a/ebsco_adapter/ebsco_indexer/src/main.py
+++ b/ebsco_adapter/ebsco_indexer/src/main.py
@@ -132,7 +132,9 @@ def lambda_handler(event, context):
     elasticsearch_client = get_elasticsearch_client()
 
     if len(items_to_delete) > 0:
-        delete_documents_by_parent_id(elasticsearch_client, list(items_to_delete.keys()))
+        delete_documents_by_parent_id(
+            elasticsearch_client, list(items_to_delete.keys())
+        )
 
     if len(items_to_index) > 0:
         index_ebsco_items_in_bulk(elasticsearch_client, items_to_index)

--- a/ebsco_adapter/ebsco_indexer/src/test_main.py
+++ b/ebsco_adapter/ebsco_indexer/src/test_main.py
@@ -1,12 +1,10 @@
 from main import lambda_handler
 from test_mocks import MockElasticsearchClient
-from local_utils import construct_sns_event
+from local_utils import construct_sqs_event
 
 
 def test_lambda_handler_correctly_indexes_documents():
-    index_event = construct_sns_event(
-        "test_id_1", "test_bucket", "prod/test_id_1", False
-    )
+    index_event = construct_sqs_event("test_bucket", {"prod/test_id_1.xml": False})
 
     lambda_handler(index_event, None)
 
@@ -40,18 +38,14 @@ def test_lambda_handler_correctly_indexes_documents():
 
 
 def test_lambda_handler_deletes_indexed_documents():
-    index_event = construct_sns_event(
-        "test_id_1", "test_bucket", "prod/test_id_1", False
-    )
+    index_event = construct_sqs_event("test_bucket", {"prod/test_id_1.xml": False})
 
     lambda_handler(index_event, None)
 
     indexed_documents = MockElasticsearchClient.indexed_documents["test_ebsco_index"]
     assert len(indexed_documents.keys()) == 3
 
-    delete_event = construct_sns_event(
-        "test_id_1", "test_bucket", "prod/test_id_1", True
-    )
+    delete_event = construct_sqs_event("test_bucket", {"prod/test_id_1.xml": True})
     lambda_handler(delete_event, None)
 
     indexed_documents = MockElasticsearchClient.indexed_documents["test_ebsco_index"]
@@ -61,18 +55,14 @@ def test_lambda_handler_deletes_indexed_documents():
 def test_lambda_handler_does_not_delete_incorrect_documents():
     # Index all fields of EBSCO item `test_id_1` and then try to delete all fields of EBSCO item `test_id_2`.
     # No items should be deleted.
-    index_event = construct_sns_event(
-        "test_id_1", "test_bucket", "prod/test_id_1", False
-    )
+    index_event = construct_sqs_event("test_bucket", {"prod/test_id_1.xml": False})
 
     lambda_handler(index_event, None)
 
     indexed_documents = MockElasticsearchClient.indexed_documents["test_ebsco_index"]
     assert len(indexed_documents.keys()) == 3
 
-    delete_event = construct_sns_event(
-        "test_id_2", "test_bucket", "prod/test_id_2", True
-    )
+    delete_event = construct_sqs_event("test_bucket", {"prod/test_id_2.xml": True})
     lambda_handler(delete_event, None)
 
     indexed_documents = MockElasticsearchClient.indexed_documents["test_ebsco_index"]

--- a/ebsco_adapter/ebsco_indexer/src/test_mocks.py
+++ b/ebsco_adapter/ebsco_indexer/src/test_mocks.py
@@ -24,7 +24,7 @@ class MockSecretsManagerClient:
 
 class MockS3Client:
     def get_object(self, Bucket: str, Key: str):
-        if f"{Bucket}/{Key}" == "test_bucket/prod/test_id_1":
+        if f"{Bucket}/{Key}" == "test_bucket/prod/test_id_1.xml":
             fixture_name = "fixtures/ebsco_item_fixture_1.xml"
         else:
             raise FileNotFoundError(
@@ -48,13 +48,13 @@ class MockElasticsearchClient:
         self.indexed_documents[index][id] = document
 
     def delete_by_query(self, index: str, body: dict):
-        deleted_parent_id = body["query"]["match"]["parent.id"]
+        deleted_parent_ids = body["query"]["terms"]["parent.id"]
 
         new_indexed_documents = {}
 
         deleted_count = 0
         for _id, document in self.indexed_documents[index].items():
-            if document["parent.id"] != deleted_parent_id:
+            if document["parent.id"] not in deleted_parent_ids:
                 new_indexed_documents[_id] = document
             else:
                 deleted_count += 1

--- a/ebsco_adapter/ebsco_indexer/src/test_mocks.py
+++ b/ebsco_adapter/ebsco_indexer/src/test_mocks.py
@@ -26,6 +26,8 @@ class MockS3Client:
     def get_object(self, Bucket: str, Key: str):
         if f"{Bucket}/{Key}" == "test_bucket/prod/test_id_1.xml":
             fixture_name = "fixtures/ebsco_item_fixture_1.xml"
+        elif f"{Bucket}/{Key}" == "test_bucket/prod/test_id_2.xml":
+            fixture_name = "fixtures/ebsco_item_fixture_2.xml"
         else:
             raise FileNotFoundError(
                 "There is no fixture corresponding to this Bucket/Key combination."

--- a/ebsco_adapter/terraform/indexer_lambda.tf
+++ b/ebsco_adapter/terraform/indexer_lambda.tf
@@ -10,7 +10,7 @@ module "indexer_lambda" {
   memory_size = 512
   timeout     = 60 // 1 minute
 
-  #  error_alarm_topic_arn = data.terraform_remote_state.monitoring.outputs["platform_lambda_error_alerts_topic_arn"]
+  error_alarm_topic_arn = data.terraform_remote_state.monitoring.outputs["platform_lambda_error_alerts_topic_arn"]
 
   environment = {
     variables = {
@@ -45,20 +45,6 @@ data "aws_iam_policy_document" "allow_secret_read" {
   }
 }
 
-data "aws_iam_policy_document" "allow_sqs_receive_message" {
-  statement {
-    actions = [
-      "sqs:ReceiveMessage",
-      "sqs:DeleteMessage",
-      "sqs:GetQueueAttributes",
-      "sqs:GetQueueUrl"
-    ]
-    resources = [
-      aws_sqs_queue.indexer_message_queue.arn
-    ]
-  }
-}
-
 resource "aws_iam_role_policy" "read_secrets_policy" {
   role   = module.indexer_lambda.lambda_role.name
   policy = data.aws_iam_policy_document.allow_secret_read.json
@@ -69,43 +55,38 @@ resource "aws_iam_role_policy" "indexer_lambda_policy" {
   policy = data.aws_iam_policy_document.read_ebsco_adapter_bucket.json
 }
 
-resource "aws_iam_role_policy" "indexer_lambda_sqs_policy" {
-  role   = module.indexer_lambda.lambda_role.name
-  policy = data.aws_iam_policy_document.allow_sqs_receive_message.json
-}
-
 # Add an SQS queue which will collect messages from SNS
-resource "aws_sqs_queue" "indexer_message_queue" {
-  name                       = "ebsco-indexer-message-queue"
+module "indexer_message_queue" {
+  source = "github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.2.1"
+
+  queue_name = "ebsco-indexer-message-queue"
+
+  topic_arns                 = [module.ebsco_adapter_output_topic.arn]
   visibility_timeout_seconds = 90
+  max_receive_count          = 3
+  alarm_topic_arn = "arn:aws:sns:eu-west-1:760097843905:platform_dlq_non_empty_alarm"
 }
 
-resource "aws_sns_topic_subscription" "indexer_sqs_subscription" {
-  topic_arn = module.ebsco_adapter_output_topic.arn
-  protocol  = "sqs"
-  endpoint  = aws_sqs_queue.indexer_message_queue.arn
-}
-
-# Give SNS permission to send messages to SQS
-data "aws_iam_policy_document" "indexer_message_queue_policy_data" {
+data "aws_iam_policy_document" "allow_sqs_receive_message" {
   statement {
-    actions   = ["sqs:SendMessage"]
-    resources = [aws_sqs_queue.indexer_message_queue.arn]
-    condition {
-      test     = "ArnEquals"
-      values   = [module.ebsco_adapter_output_topic.arn]
-      variable = "aws:SourceArn"
-    }
-    principals {
-      identifiers = ["sns.amazonaws.com"]
-      type        = "Service"
-    }
+    actions = [
+      "sqs:ReceiveMessage",
+      "sqs:DeleteMessage",
+      "sqs:GetQueueAttributes",
+      "sqs:GetQueueUrl",
+      "sqs:ChangeMessageVisibilityBatch",
+      "sqs:ChangeMessageVisibility"
+    ]
+    resources = [
+      module.indexer_message_queue.arn
+    ]
   }
 }
 
-resource "aws_sqs_queue_policy" "indexer_message_queue_policy" {
-  queue_url = aws_sqs_queue.indexer_message_queue.id
-  policy    = data.aws_iam_policy_document.indexer_message_queue_policy_data.json
+# Allow the Lambda function to read from the queue
+resource "aws_iam_role_policy" "indexer_lambda_sqs_policy" {
+  role   = module.indexer_lambda.lambda_role.name
+  policy = data.aws_iam_policy_document.allow_sqs_receive_message.json
 }
 
 # This configures an EventSourceMapping which automatically polls the SQS queue for new messages and triggers
@@ -114,7 +95,7 @@ resource "aws_sqs_queue_policy" "indexer_message_queue_policy" {
 # Additionally, the `maximum_concurrency` parameter ensures that there are at most 10 active indexer Lambda functions
 # running at a time to make sure we don't overwhelm the Elasticsearch cluster.
 resource "aws_lambda_event_source_mapping" "sqs_to_indexer_lambda" {
-  event_source_arn                   = aws_sqs_queue.indexer_message_queue.arn
+  event_source_arn                   = module.indexer_message_queue.arn
   function_name                      = module.indexer_lambda.lambda.function_name
   batch_size                         = 10
   enabled                            = true
@@ -129,5 +110,5 @@ resource "aws_lambda_permission" "allow_indexer_lambda_sqs_trigger" {
   action        = "lambda:InvokeFunction"
   function_name = module.indexer_lambda.lambda.function_name
   principal     = "sqs.amazonaws.com"
-  source_arn    = aws_sqs_queue.indexer_message_queue.arn
+  source_arn    = module.indexer_message_queue.arn
 }


### PR DESCRIPTION
## What does this change?

This adds an SQS queue between SNS and the indexer Lambda function to prevent the Lambda function from overwhelming the Elasticsearch cluster.

The infrastructure now includes an event source mapping, which ensures that items are now indexed/deleted in batches of up to 10 items (instead of being indexed/deleted individually).

Additionally, the event source mapping defines a maximum concurrency of 10, ensuring that there are at most 10 Lambdas running at the same time.

## How to test

I added more unit tests and also did some load testing using the code below, which gets 3,000 EBSCO items from S3 and publishes a message into a test SNS topic for each of them. This resulted in 303 successful Lambda invocations.

<img width="534" alt="invocations_2" src="https://github.com/wellcomecollection/catalogue-pipeline/assets/55099240/3f4173e6-3b2c-4ec8-b80e-265a7286ec3e">

```python
import boto3
import re

session = boto3.Session(profile_name='platform-developer')

bucket_name = "wellcomecollection-platform-ebsco-adapter"

sns_events = []
ebsco_items = []

paginator = session.client("s3").get_paginator('list_objects_v2')
page_iterator = paginator.paginate(Bucket=bucket_name, Prefix='prod/xml/2024-06-13/ebs')

for page in page_iterator:
    ebsco_items = ebsco_items + page['Contents']

    if len(ebsco_items) >= 3000:
        break

for s3_object in ebsco_items:
    ebsco_id = s3_object["Key"].split("/")[-1].split(".")[0]
    sns_event = construct_sns_message(bucket_name, s3_object["Key"], True)
    sns_events.append(sns_event)

sns = session.client('sns')
for sns_event in sns_events:
    result = sns.publish(TopicArn="arn:aws:sns:eu-west-1:760097843905:stepan-test-topic", Message=json.dumps(sns_event))    
```

## How can we measure success?

The architecture should now be able handle thousands of EBSCO items being published to the SNS topic at once.

## Have we considered potential risks?

