### PR TITLE
Update rules for requesting (13/06/24)

### DIFF
--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala
@@ -202,7 +202,7 @@ object SierraRulesForRequesting {
           .containsAnyOf(
             "harcl",
           ) =>
-        NotRequestable.NeedsManualRequest(
+        NotRequestable.ItemUnavailable(
           "This item is unavailable."
         )
 

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala
@@ -197,11 +197,11 @@ object SierraRulesForRequesting {
       //    # line above added so that Offsite deepstore material is not requestable.  LS 13/06/24
       //
       case i
-        if i
-          .fixedField("79")
-          .containsAnyOf(
-            "harcl",
-          ) =>
+          if i
+            .fixedField("79")
+            .containsAnyOf(
+              "harcl"
+            ) =>
         NotRequestable.ItemUnavailable(
           "This item is unavailable."
         )

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala
@@ -162,6 +162,8 @@ object SierraRulesForRequesting {
       //    v|i||79||=|enhal||
       //    #line above added so that laptops (enhal) cannot be requested online  ls 30/05/24
       //    v|i||79||=|gblip||
+      //    v|i||79||=|harcl||
+      //    # line above added so that Offsite deepstore material is not requestable.  LS 13/06/24
       //    q|i||79||=|ofvds||This item cannot be requested online. Please place a manual request.
       //
       case i
@@ -183,6 +185,7 @@ object SierraRulesForRequesting {
               "dpuih",
               "enhal",
               "gblip",
+              "harcl",
               "ofvds"
             ) =>
         NotRequestable.NeedsManualRequest(

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala
@@ -185,11 +185,25 @@ object SierraRulesForRequesting {
               "dpuih",
               "enhal",
               "gblip",
-              "harcl",
               "ofvds"
             ) =>
         NotRequestable.NeedsManualRequest(
           "This item cannot be requested online. Please place a manual request."
+        )
+
+      // These cases cover the lines:
+      //
+      //    v|i||79||=|harcl||
+      //    # line above added so that Offsite deepstore material is not requestable.  LS 13/06/24
+      //
+      case i
+        if i
+          .fixedField("79")
+          .containsAnyOf(
+            "harcl",
+          ) =>
+        NotRequestable.NeedsManualRequest(
+          "This item is unavailable."
         )
 
       // These cases cover the lines:

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequestingTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequestingTest.scala
@@ -113,7 +113,7 @@ class SierraRulesForRequestingTest
       forAll(testCases) {
         assertBlockedWith(
           _,
-          expectedResult = NotRequestable.NeedsManualRequest(
+          expectedResult = NotRequestable.ItemUnavailable(
             "This item cannot be requested online. Please place a manual request."
           )
         )

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequestingTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequestingTest.scala
@@ -113,7 +113,7 @@ class SierraRulesForRequestingTest
       forAll(testCases) {
         assertBlockedWith(
           _,
-          expectedResult = NotRequestable.ItemUnavailable(
+          expectedResult = NotRequestable.NeedsManualRequest(
             "This item cannot be requested online. Please place a manual request."
           )
         )
@@ -129,7 +129,7 @@ class SierraRulesForRequestingTest
       forAll(testCases) {
         assertBlockedWith(
           _,
-          expectedResult = NotRequestable.NeedsManualRequest(
+          expectedResult = NotRequestable.ItemUnavailable(
             "This item is unavailable."
           )
         )

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequestingTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequestingTest.scala
@@ -107,7 +107,6 @@ class SierraRulesForRequestingTest
         "dpuih",
         "enhal",
         "gblip",
-        "harcl",
         "ofvds"
       )
 
@@ -116,6 +115,22 @@ class SierraRulesForRequestingTest
           _,
           expectedResult = NotRequestable.NeedsManualRequest(
             "This item cannot be requested online. Please place a manual request."
+          )
+        )
+      }
+    }
+
+    it("if it has a generic unavailable message") {
+      val testCases = Table(
+        "locationCode",
+        "harcl",
+      )
+
+      forAll(testCases) {
+        assertBlockedWith(
+          _,
+          expectedResult = NotRequestable.NeedsManualRequest(
+            "This item is unavailable."
           )
         )
       }

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequestingTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequestingTest.scala
@@ -107,6 +107,7 @@ class SierraRulesForRequestingTest
         "dpuih",
         "enhal",
         "gblip",
+        "harcl",
         "ofvds"
       )
 


### PR DESCRIPTION
## What does this change?

This change updates the [rules for requesting](https://github.com/wellcomecollection/docs/blob/main/rfcs/042-requesting-model/README.md?plain=1#L119) which need to match those in Sierra, following an update from LS in Collection Product Lines:

> This is to let you know that the Rules for Requesting file has been updated to include:
> Harcl     (Offsite Closed stores non-requestable Deepstore Archives)

See [similar changes](https://github.com/search?q=org%3Awellcomecollection+%22rules+for+requesting%22&type=pullrequests).

## How to test

- [x] Run the tests, do they pass?
- [ ] Deploy this change, are the items specified un-requestable?

## How can we measure success?

Folk can't request things in Deepstore online!

## Have we considered potential risks?

We may need to change this in the future to accomodate offsite requesting, see: https://github.com/wellcomecollection/platform/issues/5751