### PR TITLE
fix problem with blank subjects

### DIFF
--- a/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/subjects/MarcSubject.scala
+++ b/pipeline/transformer/transformer_marc_common/src/main/scala/weco/pipeline/transformer/marc_common/transformers/subjects/MarcSubject.scala
@@ -28,12 +28,13 @@ trait MarcSubject extends MarcFieldTransformer with MarcHasRecordControlNumber {
   ): Output = getSubjectConcepts(field) match {
     case Success(Nil) => None
     case Success(entities) =>
-      Some(
-        Subject(
-          label = getLabel(field).get,
-          concepts = entities.toList,
-          id = getIdState(field)
-        )
+      getLabel(field).map(
+        label =>
+          Subject(
+            label = label,
+            concepts = entities.toList,
+            id = getIdState(field)
+          )
       )
     case Failure(exception) =>
       None

--- a/pipeline/transformer/transformer_marc_common/src/test/scala/weco/pipeline/transformer/marc_common/transformers/MarcSubjectsTest.scala
+++ b/pipeline/transformer/transformer_marc_common/src/test/scala/weco/pipeline/transformer/marc_common/transformers/MarcSubjectsTest.scala
@@ -38,16 +38,27 @@ class MarcSubjectsTest
       MarcSubjects(
         MarcTestRecord(fields =
           Seq(
+            // with no subfields
             MarcField(
               marcTag = "610",
               subfields = Nil
             ),
+            // with blank or blank-like subfields
             MarcField(
-              marcTag = "600",
+              marcTag = "650",
+              indicator2 = "0",
               subfields = Seq(
                 MarcSubfield(tag = "a", content = "   "),
                 MarcSubfield(tag = "b", content = ""),
                 MarcSubfield(tag = "c", content = "  ")
+              )
+            ),
+            // with a dodgy second indicator
+            MarcField(
+              marcTag = "650",
+              indicator2 = "x",
+              subfields = Seq(
+                MarcSubfield(tag = "a", content = "Hello, World!")
               )
             )
           )


### PR DESCRIPTION
## What does this change?

This allows Sierra Works with blank subjects to pass through the pipeline.  The problematic subjects do not pass through.

## How to test

The corresponding test has been updated.  The previous version of `returns nothing if the only relevant fields are invalid`, which appeared to be checking for empty labels was passing because the field had an undesirable value of indicator2 (it was empty, rather than 0,2 or 7).


 
## How can we measure success?

More Sierra records make it through the pipeline.

There are currently over 400 messages on the Sierra transformer DLQ.  Some (maybe all) of these are there because of this problem.  Once deployed, redrive the DLQ and we should see fewer (I hope none) on the DLQ afterwards.


## Have we considered potential risks?

This looks like a cataloguing error.  We could end up masking an issue in source data (e.g. from a supplier) that would be better fixed at source.  However, even with perfectly clean source data, we should program defensively here.