### PR TITLE
Schedule EBSCO adapter

### DIFF
--- a/ebsco_adapter/terraform/ftp_task.tf
+++ b/ebsco_adapter/terraform/ftp_task.tf
@@ -28,10 +28,10 @@ resource "aws_scheduler_schedule" "ftp_task_schedule" {
     mode = "OFF"
   }
 
-  schedule_expression = "rate(1 days)"
+  schedule_expression = "at(2024-08-05T10:30:00)"
 
   # Disable the schedule for now
-  state = "DISABLED"
+  state = "ENABLED"
 
   target {
     arn      = aws_ecs_cluster.cluster.arn


### PR DESCRIPTION
## What does this change?

`terraform plan` output:

```tf
Terraform will perform the following actions:

  # aws_scheduler_schedule.ftp_task_schedule will be updated in-place
  ~ resource "aws_scheduler_schedule" "ftp_task_schedule" {
        id                           = "default/ebsco-adapter-ftp-schedule"
        name                         = "ebsco-adapter-ftp-schedule"
      ~ schedule_expression          = "rate(1 days)" -> "at(2024-08-03T12:00:00)"
      ~ state                        = "DISABLED" -> "ENABLED"
        # (8 unchanged attributes hidden)

        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```