### PR TITLE
New ArchivesDigital format, transformed from CALM Material type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -398,3 +398,13 @@ update_task_for_config_change/src/simplejson/
 update_task_for_config_change/src/structlog/
 
 .hydra/
+
+# Ignore pyenv virtualenvs
+**/*/bin
+pyvenv.cfg
+
+# Ignore input to reindexer
+reindexer/scripts/ids
+
+# Ignore output miro links script
+scripts/mirolinks.csv

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Format.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Format.scala
@@ -100,6 +100,15 @@ object Format extends Enum[Format] {
     override val label: String = "Archives and manuscripts"
   }
 
+  case object ArchivesDigital extends Unlinked {
+    // This format is found in CALM material type, not Sierra.
+    // We have been using ArchivesAndManuscripts as the format
+    // for all CALM sourced works, hence the id here is prefixed
+    // with a "h" to namespace it within "ArchivesAndManuscripts".
+    override val id: String = "hdig"
+    override val label: String = "Archives (Digital)"
+  }
+
   case object Film extends Unlinked with Audiovisual {
     override val id: String = "n"
     override val label: String = "Film"

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Format.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Format.scala
@@ -106,7 +106,7 @@ object Format extends Enum[Format] {
     // for all CALM sourced works, hence the id here is prefixed
     // with a "h" to namespace it within "ArchivesAndManuscripts".
     override val id: String = "hdig"
-    override val label: String = "Archives (Digital)"
+    override val label: String = "Archives - Digital"
   }
 
   case object Film extends Unlinked with Audiovisual {

--- a/pipeline/ingestor/test_documents/work.items-with-location-types.0.json
+++ b/pipeline/ingestor/test_documents/work.items-with-location-types.0.json
@@ -1,22 +1,22 @@
 {
   "description" : "items with different location types",
-  "createdAt" : "2024-05-15T08:17:25.530111Z",
-  "id" : "tnnwysoe",
+  "createdAt" : "2024-08-15T08:40:28.317189Z",
+  "id" : "4zaferi8",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "tnnwysoe",
+        "id" : "4zaferi8",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
-          "value" : "JC6PIObmiP"
+          "value" : "lfxMM8GfuD"
         },
-        "version" : 42,
-        "modifiedTime" : "1968-08-04T13:15:13Z"
+        "version" : 86,
+        "modifiedTime" : "2038-12-13T02:35:56Z"
       },
-      "mergedTime" : "1968-08-04T13:15:13Z",
+      "mergedTime" : "2038-12-13T02:35:56Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "tnnwysoe",
-      "title" : "title-ydewbq2T7l",
+      "id" : "4zaferi8",
+      "title" : "title-7W1WKu978d",
       "alternativeTitles" : [
       ],
       "contributors" : [
@@ -33,11 +33,11 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
-          "value" : "JC6PIObmiP",
+          "value" : "lfxMM8GfuD",
           "type" : "Identifier"
         }
       ],
@@ -47,15 +47,15 @@
       ],
       "items" : [
         {
-          "id" : "4bhmwgtz",
+          "id" : "xato6wyi",
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "calm-record-id",
-                "label" : "Calm RecordIdentifier",
+                "id" : "sierra-system-number",
+                "label" : "Sierra system number",
                 "type" : "IdentifierType"
               },
-              "value" : "0FUCKKVOQZ",
+              "value" : "aLacffLiQz",
               "type" : "Identifier"
             }
           ],
@@ -66,9 +66,8 @@
                 "label" : "IIIF Image API",
                 "type" : "LocationType"
               },
-              "url" : "https://iiif.wellcomecollection.org/image/Fmn.jpg/info.json",
-              "credit" : "Credit line: IEpzyM",
-              "linkText" : "Link text: tI2pjU6",
+              "url" : "https://iiif.wellcomecollection.org/image/n6e.jpg/info.json",
+              "linkText" : "Link text: UShs8ZXp5K",
               "license" : {
                 "id" : "cc-by",
                 "label" : "Attribution 4.0 International (CC BY 4.0)",
@@ -120,20 +119,20 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "tnnwysoe",
-      "sourceIdentifier.value" : "JC6PIObmiP",
+      "id" : "4zaferi8",
+      "sourceIdentifier.value" : "lfxMM8GfuD",
       "identifiers.value" : [
-        "JC6PIObmiP"
+        "lfxMM8GfuD"
       ],
       "images.id" : [
       ],
       "images.identifiers.value" : [
       ],
       "items.id" : [
-        "4bhmwgtz"
+        "xato6wyi"
       ],
       "items.identifiers.value" : [
-        "0FUCKKVOQZ"
+        "aLacffLiQz"
       ],
       "languages.label" : [
       ],
@@ -148,7 +147,7 @@
       "referenceNumber" : null,
       "subjects.concepts.label" : [
       ],
-      "title" : "title-ydewbq2T7l"
+      "title" : "title-7W1WKu978d"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -185,7 +184,7 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "JC6PIObmiP"
+        "lfxMM8GfuD"
       ],
       "items.locations.license.id" : [
         "cc-by"
@@ -193,10 +192,10 @@
       "items.locations.accessConditions.status.id" : [
       ],
       "items.id" : [
-        "4bhmwgtz"
+        "xato6wyi"
       ],
       "items.identifiers.value" : [
-        "0FUCKKVOQZ"
+        "aLacffLiQz"
       ],
       "items.locations.locationType.id" : [
         "iiif-image"

--- a/pipeline/ingestor/test_documents/work.items-with-location-types.1.json
+++ b/pipeline/ingestor/test_documents/work.items-with-location-types.1.json
@@ -1,22 +1,22 @@
 {
   "description" : "items with different location types",
-  "createdAt" : "2024-05-15T08:17:25.530744Z",
-  "id" : "feri8p7w",
+  "createdAt" : "2024-08-15T08:40:28.317581Z",
+  "id" : "pfnxzwsg",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "feri8p7w",
+        "id" : "pfnxzwsg",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
-          "value" : "MM8GfuD4za"
+          "value" : "3WPG6KR1Dm"
         },
-        "version" : 53,
-        "modifiedTime" : "2033-07-23T10:10:36Z"
+        "version" : 86,
+        "modifiedTime" : "2009-12-08T11:45:37Z"
       },
-      "mergedTime" : "2033-07-23T10:10:36Z",
+      "mergedTime" : "2009-12-08T11:45:37Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "feri8p7w",
-      "title" : "title-WKu978dFW3",
+      "id" : "pfnxzwsg",
+      "title" : "title-KiQpo5xNC2",
       "alternativeTitles" : [
       ],
       "contributors" : [
@@ -33,11 +33,11 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
-          "value" : "MM8GfuD4za",
+          "value" : "3WPG6KR1Dm",
           "type" : "Identifier"
         }
       ],
@@ -47,7 +47,7 @@
       ],
       "items" : [
         {
-          "id" : "lwa6uwtq",
+          "id" : "k2sxfzy9",
           "identifiers" : [
             {
               "identifierType" : {
@@ -55,7 +55,7 @@
                 "label" : "Calm RecordIdentifier",
                 "type" : "IdentifierType"
               },
-              "value" : "XaTo6WyiCa",
+              "value" : "dRJC6PIObm",
               "type" : "Identifier"
             }
           ],
@@ -66,7 +66,9 @@
                 "label" : "IIIF Image API",
                 "type" : "LocationType"
               },
-              "url" : "https://iiif.wellcomecollection.org/image/nVo.jpg/info.json",
+              "url" : "https://iiif.wellcomecollection.org/image/LKO.jpg/info.json",
+              "credit" : "Credit line: PPIvUnh",
+              "linkText" : "Link text: 2Z5Ks7",
               "license" : {
                 "id" : "cc-by",
                 "label" : "Attribution 4.0 International (CC BY 4.0)",
@@ -83,7 +85,8 @@
                 "label" : "IIIF Presentation API",
                 "type" : "LocationType"
               },
-              "url" : "https://iiif.wellcomecollection.org/image/QUS.jpg/info.json",
+              "url" : "https://iiif.wellcomecollection.org/image/7v4.jpg/info.json",
+              "linkText" : "Link text: UCKKVOQ",
               "license" : {
                 "id" : "cc-by",
                 "label" : "Attribution 4.0 International (CC BY 4.0)",
@@ -135,20 +138,20 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "feri8p7w",
-      "sourceIdentifier.value" : "MM8GfuD4za",
+      "id" : "pfnxzwsg",
+      "sourceIdentifier.value" : "3WPG6KR1Dm",
       "identifiers.value" : [
-        "MM8GfuD4za"
+        "3WPG6KR1Dm"
       ],
       "images.id" : [
       ],
       "images.identifiers.value" : [
       ],
       "items.id" : [
-        "lwa6uwtq"
+        "k2sxfzy9"
       ],
       "items.identifiers.value" : [
-        "XaTo6WyiCa"
+        "dRJC6PIObm"
       ],
       "languages.label" : [
       ],
@@ -163,7 +166,7 @@
       "referenceNumber" : null,
       "subjects.concepts.label" : [
       ],
-      "title" : "title-WKu978dFW3"
+      "title" : "title-KiQpo5xNC2"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -201,7 +204,7 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "MM8GfuD4za"
+        "3WPG6KR1Dm"
       ],
       "items.locations.license.id" : [
         "cc-by",
@@ -210,10 +213,10 @@
       "items.locations.accessConditions.status.id" : [
       ],
       "items.id" : [
-        "lwa6uwtq"
+        "k2sxfzy9"
       ],
       "items.identifiers.value" : [
-        "XaTo6WyiCa"
+        "dRJC6PIObm"
       ],
       "items.locations.locationType.id" : [
         "iiif-image",

--- a/pipeline/ingestor/test_documents/work.items-with-location-types.2.json
+++ b/pipeline/ingestor/test_documents/work.items-with-location-types.2.json
@@ -1,22 +1,22 @@
 {
   "description" : "items with different location types",
-  "createdAt" : "2024-05-15T08:17:25.531459Z",
-  "id" : "xzwsggki",
+  "createdAt" : "2024-08-15T08:40:28.317933Z",
+  "id" : "gubhlxq1",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "xzwsggki",
+        "id" : "gubhlxq1",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
-          "value" : "G6KR1DmPfn"
+          "value" : "Qiy0B0TSmD"
         },
-        "version" : 27,
-        "modifiedTime" : "1950-04-09T22:30:42Z"
+        "version" : 52,
+        "modifiedTime" : "1954-07-26T16:28:04Z"
       },
-      "mergedTime" : "1950-04-09T22:30:42Z",
+      "mergedTime" : "1954-07-26T16:28:04Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "xzwsggki",
-      "title" : "title-po5xNC2PnQ",
+      "id" : "gubhlxq1",
+      "title" : "title-wO98EpYD0E",
       "alternativeTitles" : [
       ],
       "contributors" : [
@@ -33,11 +33,11 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
-          "value" : "G6KR1DmPfn",
+          "value" : "Qiy0B0TSmD",
           "type" : "Identifier"
         }
       ],
@@ -47,15 +47,15 @@
       ],
       "items" : [
         {
-          "id" : "lacffliq",
+          "id" : "iptnnwys",
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "sierra-system-number",
-                "label" : "Sierra system number",
+                "id" : "calm-record-id",
+                "label" : "Calm RecordIdentifier",
                 "type" : "IdentifierType"
               },
-              "value" : "k2sxFZY9hd",
+              "value" : "EYydewbq2T",
               "type" : "Identifier"
             }
           ],
@@ -68,11 +68,12 @@
               },
               "label" : "locationLabel",
               "license" : {
-                "id" : "pdm",
-                "label" : "Public Domain Mark",
-                "url" : "https://creativecommons.org/share-your-work/public-domain/pdm/",
+                "id" : "ogl",
+                "label" : "Open Government Licence",
+                "url" : "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
                 "type" : "License"
               },
+              "shelfmark" : "Shelfmark: A6uWTQ",
               "accessConditions" : [
               ],
               "type" : "PhysicalLocation"
@@ -123,20 +124,20 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "xzwsggki",
-      "sourceIdentifier.value" : "G6KR1DmPfn",
+      "id" : "gubhlxq1",
+      "sourceIdentifier.value" : "Qiy0B0TSmD",
       "identifiers.value" : [
-        "G6KR1DmPfn"
+        "Qiy0B0TSmD"
       ],
       "images.id" : [
       ],
       "images.identifiers.value" : [
       ],
       "items.id" : [
-        "lacffliq"
+        "iptnnwys"
       ],
       "items.identifiers.value" : [
-        "k2sxFZY9hd"
+        "EYydewbq2T"
       ],
       "languages.label" : [
       ],
@@ -151,7 +152,7 @@
       "referenceNumber" : null,
       "subjects.concepts.label" : [
       ],
-      "title" : "title-po5xNC2PnQ"
+      "title" : "title-wO98EpYD0E"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -167,7 +168,7 @@
       "contributors.agent.label" : [
       ],
       "items.locations.license" : [
-        "{\"id\":\"pdm\",\"label\":\"Public Domain Mark\",\"url\":\"https://creativecommons.org/share-your-work/public-domain/pdm/\",\"type\":\"License\"}"
+        "{\"id\":\"ogl\",\"label\":\"Open Government Licence\",\"url\":\"http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/\",\"type\":\"License\"}"
       ],
       "availabilities" : [
         "{\"id\":\"closed-stores\",\"label\":\"Closed stores\",\"type\":\"Availability\"}"
@@ -189,18 +190,18 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "G6KR1DmPfn"
+        "Qiy0B0TSmD"
       ],
       "items.locations.license.id" : [
-        "pdm"
+        "ogl"
       ],
       "items.locations.accessConditions.status.id" : [
       ],
       "items.id" : [
-        "lacffliq"
+        "iptnnwys"
       ],
       "items.identifiers.value" : [
-        "k2sxFZY9hd"
+        "EYydewbq2T"
       ],
       "items.locations.locationType.id" : [
         "closed-stores"

--- a/pipeline/ingestor/test_documents/works.every-format.13.json
+++ b/pipeline/ingestor/test_documents/works.every-format.13.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-05-15T08:17:25.505036Z",
+  "createdAt" : "2024-08-15T08:40:28.289755Z",
   "id" : "83tyy1gh",
   "document" : {
     "debug" : {
@@ -29,8 +29,8 @@
       "alternativeTitles" : [
       ],
       "workType" : {
-        "id" : "n",
-        "label" : "Film",
+        "id" : "hdig",
+        "label" : "Archives - Digital",
         "type" : "Format"
       },
       "contributors" : [
@@ -119,7 +119,7 @@
     },
     "aggregatableValues" : {
       "workType" : [
-        "{\"id\":\"n\",\"label\":\"Film\",\"type\":\"Format\"}"
+        "{\"id\":\"hdig\",\"label\":\"Archives - Digital\",\"type\":\"Format\"}"
       ],
       "genres.label" : [
       ],
@@ -137,7 +137,7 @@
       ]
     },
     "filterableValues" : {
-      "format.id" : "n",
+      "format.id" : "hdig",
       "workType" : "Standard",
       "production.dates.range.from" : [
       ],

--- a/pipeline/ingestor/test_documents/works.every-format.14.json
+++ b/pipeline/ingestor/test_documents/works.every-format.14.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-05-15T08:17:25.505354Z",
+  "createdAt" : "2024-08-15T08:40:28.290020Z",
   "id" : "vwzsza7o",
   "document" : {
     "debug" : {
@@ -29,8 +29,8 @@
       "alternativeTitles" : [
       ],
       "workType" : {
-        "id" : "b",
-        "label" : "Manuscripts",
+        "id" : "n",
+        "label" : "Film",
         "type" : "Format"
       },
       "contributors" : [
@@ -119,7 +119,7 @@
     },
     "aggregatableValues" : {
       "workType" : [
-        "{\"id\":\"b\",\"label\":\"Manuscripts\",\"type\":\"Format\"}"
+        "{\"id\":\"n\",\"label\":\"Film\",\"type\":\"Format\"}"
       ],
       "genres.label" : [
       ],
@@ -137,7 +137,7 @@
       ]
     },
     "filterableValues" : {
-      "format.id" : "b",
+      "format.id" : "n",
       "workType" : "Standard",
       "production.dates.range.from" : [
       ],

--- a/pipeline/ingestor/test_documents/works.every-format.15.json
+++ b/pipeline/ingestor/test_documents/works.every-format.15.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-05-15T08:17:25.505666Z",
+  "createdAt" : "2024-08-15T08:40:28.290287Z",
   "id" : "9vihnjwg",
   "document" : {
     "debug" : {
@@ -29,8 +29,8 @@
       "alternativeTitles" : [
       ],
       "workType" : {
-        "id" : "c",
-        "label" : "Music",
+        "id" : "b",
+        "label" : "Manuscripts",
         "type" : "Format"
       },
       "contributors" : [
@@ -119,7 +119,7 @@
     },
     "aggregatableValues" : {
       "workType" : [
-        "{\"id\":\"c\",\"label\":\"Music\",\"type\":\"Format\"}"
+        "{\"id\":\"b\",\"label\":\"Manuscripts\",\"type\":\"Format\"}"
       ],
       "genres.label" : [
       ],
@@ -137,7 +137,7 @@
       ]
     },
     "filterableValues" : {
-      "format.id" : "c",
+      "format.id" : "b",
       "workType" : "Standard",
       "production.dates.range.from" : [
       ],

--- a/pipeline/ingestor/test_documents/works.every-format.16.json
+++ b/pipeline/ingestor/test_documents/works.every-format.16.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-05-15T08:17:25.506034Z",
+  "createdAt" : "2024-08-15T08:40:28.290551Z",
   "id" : "4blsy3iy",
   "document" : {
     "debug" : {
@@ -29,8 +29,8 @@
       "alternativeTitles" : [
       ],
       "workType" : {
-        "id" : "u",
-        "label" : "Standing order",
+        "id" : "c",
+        "label" : "Music",
         "type" : "Format"
       },
       "contributors" : [
@@ -119,7 +119,7 @@
     },
     "aggregatableValues" : {
       "workType" : [
-        "{\"id\":\"u\",\"label\":\"Standing order\",\"type\":\"Format\"}"
+        "{\"id\":\"c\",\"label\":\"Music\",\"type\":\"Format\"}"
       ],
       "genres.label" : [
       ],
@@ -137,7 +137,7 @@
       ]
     },
     "filterableValues" : {
-      "format.id" : "u",
+      "format.id" : "c",
       "workType" : "Standard",
       "production.dates.range.from" : [
       ],

--- a/pipeline/ingestor/test_documents/works.every-format.17.json
+++ b/pipeline/ingestor/test_documents/works.every-format.17.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-05-15T08:17:25.506336Z",
+  "createdAt" : "2024-08-15T08:40:28.290816Z",
   "id" : "9is9e3tz",
   "document" : {
     "debug" : {
@@ -29,8 +29,8 @@
       "alternativeTitles" : [
       ],
       "workType" : {
-        "id" : "z",
-        "label" : "Web sites",
+        "id" : "u",
+        "label" : "Standing order",
         "type" : "Format"
       },
       "contributors" : [
@@ -119,7 +119,7 @@
     },
     "aggregatableValues" : {
       "workType" : [
-        "{\"id\":\"z\",\"label\":\"Web sites\",\"type\":\"Format\"}"
+        "{\"id\":\"u\",\"label\":\"Standing order\",\"type\":\"Format\"}"
       ],
       "genres.label" : [
       ],
@@ -137,7 +137,7 @@
       ]
     },
     "filterableValues" : {
-      "format.id" : "z",
+      "format.id" : "u",
       "workType" : "Standard",
       "production.dates.range.from" : [
       ],

--- a/pipeline/ingestor/test_documents/works.every-format.18.json
+++ b/pipeline/ingestor/test_documents/works.every-format.18.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-02-16T15:36:44.899391Z",
+  "createdAt" : "2024-08-15T08:40:28.291090Z",
   "id" : "4pxxngz8",
   "document" : {
     "debug" : {
@@ -29,8 +29,8 @@
       "alternativeTitles" : [
       ],
       "workType" : {
-        "id" : "v",
-        "label" : "E-books",
+        "id" : "z",
+        "label" : "Web sites",
         "type" : "Format"
       },
       "contributors" : [
@@ -119,7 +119,7 @@
     },
     "aggregatableValues" : {
       "workType" : [
-        "{\"id\":\"v\",\"label\":\"E-books\",\"type\":\"Format\"}"
+        "{\"id\":\"z\",\"label\":\"Web sites\",\"type\":\"Format\"}"
       ],
       "genres.label" : [
       ],
@@ -137,7 +137,7 @@
       ]
     },
     "filterableValues" : {
-      "format.id" : "v",
+      "format.id" : "z",
       "workType" : "Standard",
       "production.dates.range.from" : [
       ],

--- a/pipeline/ingestor/test_documents/works.every-format.19.json
+++ b/pipeline/ingestor/test_documents/works.every-format.19.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-02-16T15:36:44.899867Z",
+  "createdAt" : "2024-08-15T08:40:28.291344Z",
   "id" : "pujta45z",
   "document" : {
     "debug" : {
@@ -29,8 +29,8 @@
       "alternativeTitles" : [
       ],
       "workType" : {
-        "id" : "s",
-        "label" : "E-sound",
+        "id" : "v",
+        "label" : "E-books",
         "type" : "Format"
       },
       "contributors" : [
@@ -119,7 +119,7 @@
     },
     "aggregatableValues" : {
       "workType" : [
-        "{\"id\":\"s\",\"label\":\"E-sound\",\"type\":\"Format\"}"
+        "{\"id\":\"v\",\"label\":\"E-books\",\"type\":\"Format\"}"
       ],
       "genres.label" : [
       ],
@@ -137,7 +137,7 @@
       ]
     },
     "filterableValues" : {
-      "format.id" : "s",
+      "format.id" : "v",
       "workType" : "Standard",
       "production.dates.range.from" : [
       ],

--- a/pipeline/ingestor/test_documents/works.every-format.20.json
+++ b/pipeline/ingestor/test_documents/works.every-format.20.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-02-16T15:36:44.900335Z",
+  "createdAt" : "2024-08-15T08:40:28.291586Z",
   "id" : "qph7iot8",
   "document" : {
     "debug" : {
@@ -29,8 +29,8 @@
       "alternativeTitles" : [
       ],
       "workType" : {
-        "id" : "j",
-        "label" : "E-journals",
+        "id" : "s",
+        "label" : "E-sound",
         "type" : "Format"
       },
       "contributors" : [
@@ -119,7 +119,7 @@
     },
     "aggregatableValues" : {
       "workType" : [
-        "{\"id\":\"j\",\"label\":\"E-journals\",\"type\":\"Format\"}"
+        "{\"id\":\"s\",\"label\":\"E-sound\",\"type\":\"Format\"}"
       ],
       "genres.label" : [
       ],
@@ -137,7 +137,7 @@
       ]
     },
     "filterableValues" : {
-      "format.id" : "j",
+      "format.id" : "s",
       "workType" : "Standard",
       "production.dates.range.from" : [
       ],

--- a/pipeline/ingestor/test_documents/works.every-format.21.json
+++ b/pipeline/ingestor/test_documents/works.every-format.21.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-05-15T08:17:25.507529Z",
+  "createdAt" : "2024-08-15T08:40:28.291826Z",
   "id" : "3ygkb1yd",
   "document" : {
     "debug" : {
@@ -29,8 +29,8 @@
       "alternativeTitles" : [
       ],
       "workType" : {
-        "id" : "f",
-        "label" : "E-videos",
+        "id" : "j",
+        "label" : "E-journals",
         "type" : "Format"
       },
       "contributors" : [
@@ -119,7 +119,7 @@
     },
     "aggregatableValues" : {
       "workType" : [
-        "{\"id\":\"f\",\"label\":\"E-videos\",\"type\":\"Format\"}"
+        "{\"id\":\"j\",\"label\":\"E-journals\",\"type\":\"Format\"}"
       ],
       "genres.label" : [
       ],
@@ -137,7 +137,7 @@
       ]
     },
     "filterableValues" : {
-      "format.id" : "f",
+      "format.id" : "j",
       "workType" : "Standard",
       "production.dates.range.from" : [
       ],

--- a/pipeline/ingestor/test_documents/works.every-format.22.json
+++ b/pipeline/ingestor/test_documents/works.every-format.22.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2024-05-15T08:17:25.507841Z",
+  "createdAt" : "2024-08-15T08:40:28.292074Z",
   "id" : "ccfchgq4",
   "document" : {
     "debug" : {
@@ -29,8 +29,8 @@
       "alternativeTitles" : [
       ],
       "workType" : {
-        "id" : "x",
-        "label" : "Manuscripts",
+        "id" : "f",
+        "label" : "E-videos",
         "type" : "Format"
       },
       "contributors" : [
@@ -119,7 +119,7 @@
     },
     "aggregatableValues" : {
       "workType" : [
-        "{\"id\":\"x\",\"label\":\"Manuscripts\",\"type\":\"Format\"}"
+        "{\"id\":\"f\",\"label\":\"E-videos\",\"type\":\"Format\"}"
       ],
       "genres.label" : [
       ],
@@ -137,7 +137,7 @@
       ]
     },
     "filterableValues" : {
-      "format.id" : "x",
+      "format.id" : "f",
       "workType" : "Standard",
       "production.dates.range.from" : [
       ],

--- a/pipeline/ingestor/test_documents/works.every-format.23.json
+++ b/pipeline/ingestor/test_documents/works.every-format.23.json
@@ -1,22 +1,22 @@
 {
-  "description" : "examples for the contributor filter tests",
-  "createdAt" : "2024-08-15T08:40:28.367350Z",
-  "id" : "ijnwmvup",
+  "description" : "works with every format",
+  "createdAt" : "2024-08-15T08:40:28.292331Z",
+  "id" : "cgfghm8m",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "ijnwmvup",
+        "id" : "cgfghm8m",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
-          "value" : "Kd2KzPZAnM"
+          "value" : "mh0pYazvpR"
         },
-        "version" : 98,
-        "modifiedTime" : "1968-12-03T01:32:55Z"
+        "version" : 37,
+        "modifiedTime" : "1945-01-10T19:58:56Z"
       },
-      "mergedTime" : "1968-12-03T01:32:55Z",
+      "mergedTime" : "1945-01-10T19:58:56Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,30 +24,25 @@
       ]
     },
     "display" : {
-      "id" : "ijnwmvup",
-      "title" : "title-uMNql7LBhP",
+      "id" : "cgfghm8m",
+      "title" : "title-oOAv5vdS0Y",
       "alternativeTitles" : [
       ],
+      "workType" : {
+        "id" : "x",
+        "label" : "Manuscripts",
+        "type" : "Format"
+      },
       "contributors" : [
-        {
-          "agent" : {
-            "label" : "Bath, Patricia",
-            "type" : "Person"
-          },
-          "roles" : [
-          ],
-          "primary" : true,
-          "type" : "Contributor"
-        }
       ],
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
-          "value" : "Kd2KzPZAnM",
+          "value" : "mh0pYazvpR",
           "type" : "Identifier"
         }
       ],
@@ -89,16 +84,15 @@
       "alternativeTitles" : [
       ],
       "contributors.agent.label" : [
-        "Bath, Patricia"
       ],
       "description" : null,
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "ijnwmvup",
-      "sourceIdentifier.value" : "Kd2KzPZAnM",
+      "id" : "cgfghm8m",
+      "sourceIdentifier.value" : "mh0pYazvpR",
       "identifiers.value" : [
-        "Kd2KzPZAnM"
+        "mh0pYazvpR"
       ],
       "images.id" : [
       ],
@@ -121,10 +115,11 @@
       "referenceNumber" : null,
       "subjects.concepts.label" : [
       ],
-      "title" : "title-uMNql7LBhP"
+      "title" : "title-oOAv5vdS0Y"
     },
     "aggregatableValues" : {
       "workType" : [
+        "{\"id\":\"x\",\"label\":\"Manuscripts\",\"type\":\"Format\"}"
       ],
       "genres.label" : [
       ],
@@ -135,7 +130,6 @@
       "languages" : [
       ],
       "contributors.agent.label" : [
-        "{\"label\":\"Bath, Patricia\",\"type\":\"Person\"}"
       ],
       "items.locations.license" : [
       ],
@@ -143,7 +137,7 @@
       ]
     },
     "filterableValues" : {
-      "format.id" : null,
+      "format.id" : "x",
       "workType" : "Standard",
       "production.dates.range.from" : [
       ],
@@ -156,10 +150,9 @@
       "subjects.label" : [
       ],
       "contributors.agent.label" : [
-        "Bath, Patricia"
       ],
       "identifiers.value" : [
-        "Kd2KzPZAnM"
+        "mh0pYazvpR"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.0.json
+++ b/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.0.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2024-05-15T08:17:25.600488Z",
-  "id" : "i2iqani2",
+  "createdAt" : "2024-08-15T08:40:28.385931Z",
+  "id" : "e9alfxx5",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "i2iqani2",
+        "id" : "e9alfxx5",
         "identifier" : {
           "identifierType" : {
             "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
-          "value" : "w5jYpuBxun"
+          "value" : "I95Gazclr9"
         },
-        "version" : 36,
-        "modifiedTime" : "1994-07-09T07:36:53Z"
+        "version" : 99,
+        "modifiedTime" : "2029-10-27T02:35:11Z"
       },
-      "mergedTime" : "1994-07-09T07:36:53Z",
+      "mergedTime" : "2029-10-27T02:35:11Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "i2iqani2",
-      "title" : "title-Um7p7NJFW4",
+      "id" : "e9alfxx5",
+      "title" : "title-bPGXaLqwYH",
       "alternativeTitles" : [
       ],
       "contributors" : [
@@ -37,7 +37,7 @@
             "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
-          "value" : "w5jYpuBxun",
+          "value" : "I95Gazclr9",
           "type" : "Identifier"
         }
       ],
@@ -47,7 +47,7 @@
       ],
       "items" : [
         {
-          "id" : "wxjwbli9",
+          "id" : "8tetlds3",
           "identifiers" : [
             {
               "identifierType" : {
@@ -55,7 +55,7 @@
                 "label" : "Calm RecordIdentifier",
                 "type" : "IdentifierType"
               },
-              "value" : "Gazclr9E9a",
+              "value" : "TJcj7uta7H",
               "type" : "Identifier"
             }
           ],
@@ -66,8 +66,9 @@
                 "label" : "IIIF Presentation API",
                 "type" : "LocationType"
               },
-              "url" : "https://iiif.wellcomecollection.org/image/xc6.jpg/info.json",
-              "linkText" : "Link text: 7GjbSjf9",
+              "url" : "https://iiif.wellcomecollection.org/image/sk7.jpg/info.json",
+              "credit" : "Credit line: VBr7VL",
+              "linkText" : "Link text: fab67TffQN",
               "license" : {
                 "id" : "cc-by",
                 "label" : "Attribution 4.0 International (CC BY 4.0)",
@@ -132,20 +133,20 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "i2iqani2",
-      "sourceIdentifier.value" : "w5jYpuBxun",
+      "id" : "e9alfxx5",
+      "sourceIdentifier.value" : "I95Gazclr9",
       "identifiers.value" : [
-        "w5jYpuBxun"
+        "I95Gazclr9"
       ],
       "images.id" : [
       ],
       "images.identifiers.value" : [
       ],
       "items.id" : [
-        "wxjwbli9"
+        "8tetlds3"
       ],
       "items.identifiers.value" : [
-        "Gazclr9E9a"
+        "TJcj7uta7H"
       ],
       "languages.label" : [
       ],
@@ -160,7 +161,7 @@
       "referenceNumber" : null,
       "subjects.concepts.label" : [
       ],
-      "title" : "title-Um7p7NJFW4"
+      "title" : "title-bPGXaLqwYH"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -197,7 +198,7 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "w5jYpuBxun"
+        "I95Gazclr9"
       ],
       "items.locations.license.id" : [
         "cc-by"
@@ -206,10 +207,10 @@
         "restricted"
       ],
       "items.id" : [
-        "wxjwbli9"
+        "8tetlds3"
       ],
       "items.identifiers.value" : [
-        "Gazclr9E9a"
+        "TJcj7uta7H"
       ],
       "items.locations.locationType.id" : [
         "iiif-presentation"

--- a/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.1.json
+++ b/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.1.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2024-05-15T08:17:25.600906Z",
-  "id" : "lqwyh6sk",
+  "createdAt" : "2024-08-15T08:40:28.386335Z",
+  "id" : "xmya3fco",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "lqwyh6sk",
+        "id" : "xmya3fco",
         "identifier" : {
           "identifierType" : {
             "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
-          "value" : "fxX5tbPGXa"
+          "value" : "2KTE1hWM7i"
         },
-        "version" : 89,
-        "modifiedTime" : "2025-11-25T23:47:59Z"
+        "version" : 3,
+        "modifiedTime" : "2013-12-02T22:04:38Z"
       },
-      "mergedTime" : "2025-11-25T23:47:59Z",
+      "mergedTime" : "2013-12-02T22:04:38Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "lqwyh6sk",
-      "title" : "title-PVBr7VLiwf",
+      "id" : "xmya3fco",
+      "title" : "title-y1hoMJJvcU",
       "alternativeTitles" : [
       ],
       "contributors" : [
@@ -37,7 +37,7 @@
             "label" : "Miro image number",
             "type" : "IdentifierType"
           },
-          "value" : "fxX5tbPGXa",
+          "value" : "2KTE1hWM7i",
           "type" : "Identifier"
         }
       ],
@@ -47,7 +47,7 @@
       ],
       "items" : [
         {
-          "id" : "a7h42kte",
+          "id" : "p5y6nhmj",
           "identifiers" : [
             {
               "identifierType" : {
@@ -55,7 +55,7 @@
                 "label" : "Miro image number",
                 "type" : "IdentifierType"
               },
-              "value" : "hWM7iXmYa3",
+              "value" : "383Pmg46QE",
               "type" : "Identifier"
             }
           ],
@@ -66,8 +66,9 @@
                 "label" : "IIIF Presentation API",
                 "type" : "LocationType"
               },
-              "url" : "https://iiif.wellcomecollection.org/image/b67.jpg/info.json",
-              "credit" : "Credit line: ffQNH8tet",
+              "url" : "https://iiif.wellcomecollection.org/image/hxo.jpg/info.json",
+              "credit" : "Credit line: VFqtU49",
+              "linkText" : "Link text: vqxD7y5YI",
               "license" : {
                 "id" : "cc-by",
                 "label" : "Attribution 4.0 International (CC BY 4.0)",
@@ -132,20 +133,20 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "lqwyh6sk",
-      "sourceIdentifier.value" : "fxX5tbPGXa",
+      "id" : "xmya3fco",
+      "sourceIdentifier.value" : "2KTE1hWM7i",
       "identifiers.value" : [
-        "fxX5tbPGXa"
+        "2KTE1hWM7i"
       ],
       "images.id" : [
       ],
       "images.identifiers.value" : [
       ],
       "items.id" : [
-        "a7h42kte"
+        "p5y6nhmj"
       ],
       "items.identifiers.value" : [
-        "hWM7iXmYa3"
+        "383Pmg46QE"
       ],
       "languages.label" : [
       ],
@@ -160,7 +161,7 @@
       "referenceNumber" : null,
       "subjects.concepts.label" : [
       ],
-      "title" : "title-PVBr7VLiwf"
+      "title" : "title-y1hoMJJvcU"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -197,7 +198,7 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "fxX5tbPGXa"
+        "2KTE1hWM7i"
       ],
       "items.locations.license.id" : [
         "cc-by"
@@ -206,10 +207,10 @@
         "restricted"
       ],
       "items.id" : [
-        "a7h42kte"
+        "p5y6nhmj"
       ],
       "items.identifiers.value" : [
-        "hWM7iXmYa3"
+        "383Pmg46QE"
       ],
       "items.locations.locationType.id" : [
         "iiif-presentation"

--- a/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.2.json
+++ b/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.2.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2024-05-15T08:17:25.601305Z",
-  "id" : "vcuqhxox",
+  "createdAt" : "2024-08-15T08:40:28.386674Z",
+  "id" : "1pknkhek",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "vcuqhxox",
+        "id" : "1pknkhek",
         "identifier" : {
           "identifierType" : {
             "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
-          "value" : "coEy1hoMJJ"
+          "value" : "eKWAvLy8mU"
         },
-        "version" : 42,
-        "modifiedTime" : "1934-03-30T22:58:00Z"
+        "version" : 87,
+        "modifiedTime" : "1954-11-04T23:55:41Z"
       },
-      "mergedTime" : "1934-03-30T22:58:00Z",
+      "mergedTime" : "1954-11-04T23:55:41Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "vcuqhxox",
-      "title" : "title-FqtU496lvq",
+      "id" : "1pknkhek",
+      "title" : "title-l7z2IaIyPh",
       "alternativeTitles" : [
       ],
       "contributors" : [
@@ -37,7 +37,7 @@
             "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
-          "value" : "coEy1hoMJJ",
+          "value" : "eKWAvLy8mU",
           "type" : "Identifier"
         }
       ],
@@ -47,15 +47,15 @@
       ],
       "items" : [
         {
-          "id" : "qeaekwav",
+          "id" : "ojhcs580",
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "calm-record-id",
-                "label" : "Calm RecordIdentifier",
+                "id" : "sierra-system-number",
+                "label" : "Sierra system number",
                 "type" : "IdentifierType"
               },
-              "value" : "y8mU1pknKH",
+              "value" : "NPfAWzhVvX",
               "type" : "Identifier"
             }
           ],
@@ -66,8 +66,8 @@
                 "label" : "IIIF Presentation API",
                 "type" : "LocationType"
               },
-              "url" : "https://iiif.wellcomecollection.org/image/D7y.jpg/info.json",
-              "credit" : "Credit line: YIlP5y6",
+              "url" : "https://iiif.wellcomecollection.org/image/dmV.jpg/info.json",
+              "linkText" : "Link text: 9ffwz2O",
               "license" : {
                 "id" : "cc-by",
                 "label" : "Attribution 4.0 International (CC BY 4.0)",
@@ -132,20 +132,20 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "vcuqhxox",
-      "sourceIdentifier.value" : "coEy1hoMJJ",
+      "id" : "1pknkhek",
+      "sourceIdentifier.value" : "eKWAvLy8mU",
       "identifiers.value" : [
-        "coEy1hoMJJ"
+        "eKWAvLy8mU"
       ],
       "images.id" : [
       ],
       "images.identifiers.value" : [
       ],
       "items.id" : [
-        "qeaekwav"
+        "ojhcs580"
       ],
       "items.identifiers.value" : [
-        "y8mU1pknKH"
+        "NPfAWzhVvX"
       ],
       "languages.label" : [
       ],
@@ -160,7 +160,7 @@
       "referenceNumber" : null,
       "subjects.concepts.label" : [
       ],
-      "title" : "title-FqtU496lvq"
+      "title" : "title-l7z2IaIyPh"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -197,7 +197,7 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "coEy1hoMJJ"
+        "eKWAvLy8mU"
       ],
       "items.locations.license.id" : [
         "cc-by"
@@ -206,10 +206,10 @@
         "closed"
       ],
       "items.id" : [
-        "qeaekwav"
+        "ojhcs580"
       ],
       "items.identifiers.value" : [
-        "y8mU1pknKH"
+        "NPfAWzhVvX"
       ],
       "items.locations.locationType.id" : [
         "iiif-presentation"

--- a/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.3.json
+++ b/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.3.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2024-05-15T08:17:25.601756Z",
-  "id" : "phodmv5g",
+  "createdAt" : "2024-08-15T08:40:28.387042Z",
+  "id" : "f1p8iujf",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "phodmv5g",
+        "id" : "f1p8iujf",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
-          "value" : "kSl7z2IaIy"
+          "value" : "3dCafwzrSa"
         },
-        "version" : 2,
-        "modifiedTime" : "2040-01-22T01:35:50Z"
+        "version" : 96,
+        "modifiedTime" : "2028-04-10T13:33:03Z"
       },
-      "mergedTime" : "2040-01-22T01:35:50Z",
+      "mergedTime" : "2028-04-10T13:33:03Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "phodmv5g",
-      "title" : "title-M6hdH9AyS9",
+      "id" : "f1p8iujf",
+      "title" : "title-YmrG23dzV6",
       "alternativeTitles" : [
       ],
       "contributors" : [
@@ -33,11 +33,11 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
-          "value" : "kSl7z2IaIy",
+          "value" : "3dCafwzrSa",
           "type" : "Identifier"
         }
       ],
@@ -47,15 +47,15 @@
       ],
       "items" : [
         {
-          "id" : "dcafwzrs",
+          "id" : "oz1fy94z",
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "sierra-system-number",
-                "label" : "Sierra system number",
+                "id" : "calm-record-id",
+                "label" : "Calm RecordIdentifier",
                 "type" : "IdentifierType"
               },
-              "value" : "F1p8IUjfnY",
+              "value" : "rLthDeNIu1",
               "type" : "Identifier"
             }
           ],
@@ -66,8 +66,8 @@
                 "label" : "IIIF Presentation API",
                 "type" : "LocationType"
               },
-              "url" : "https://iiif.wellcomecollection.org/image/fwz.jpg/info.json",
-              "linkText" : "Link text: PfAWzhVvXA",
+              "url" : "https://iiif.wellcomecollection.org/image/XTq.jpg/info.json",
+              "linkText" : "Link text: nmb6il",
               "license" : {
                 "id" : "cc-by",
                 "label" : "Attribution 4.0 International (CC BY 4.0)",
@@ -137,20 +137,20 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "phodmv5g",
-      "sourceIdentifier.value" : "kSl7z2IaIy",
+      "id" : "f1p8iujf",
+      "sourceIdentifier.value" : "3dCafwzrSa",
       "identifiers.value" : [
-        "kSl7z2IaIy"
+        "3dCafwzrSa"
       ],
       "images.id" : [
       ],
       "images.identifiers.value" : [
       ],
       "items.id" : [
-        "dcafwzrs"
+        "oz1fy94z"
       ],
       "items.identifiers.value" : [
-        "F1p8IUjfnY"
+        "rLthDeNIu1"
       ],
       "languages.label" : [
       ],
@@ -165,7 +165,7 @@
       "referenceNumber" : null,
       "subjects.concepts.label" : [
       ],
-      "title" : "title-M6hdH9AyS9"
+      "title" : "title-YmrG23dzV6"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -203,7 +203,7 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "kSl7z2IaIy"
+        "3dCafwzrSa"
       ],
       "items.locations.license.id" : [
         "cc-by"
@@ -212,10 +212,10 @@
         "open"
       ],
       "items.id" : [
-        "dcafwzrs"
+        "oz1fy94z"
       ],
       "items.identifiers.value" : [
-        "F1p8IUjfnY"
+        "rLthDeNIu1"
       ],
       "items.locations.locationType.id" : [
         "iiif-presentation"

--- a/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.4.json
+++ b/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.4.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2024-05-15T08:17:25.602142Z",
-  "id" : "tq4mfefg",
+  "createdAt" : "2024-08-15T08:40:28.387403Z",
+  "id" : "n2u7aru7",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "tq4mfefg",
+        "id" : "n2u7aru7",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
-          "value" : "rG23dzV6hX"
+          "value" : "HrklHuS07i"
         },
-        "version" : 48,
-        "modifiedTime" : "2012-04-21T19:28:19Z"
+        "version" : 73,
+        "modifiedTime" : "1979-09-22T19:35:19Z"
       },
-      "mergedTime" : "2012-04-21T19:28:19Z",
+      "mergedTime" : "1979-09-22T19:35:19Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "tq4mfefg",
-      "title" : "title-Pdnmb6ilPO",
+      "id" : "n2u7aru7",
+      "title" : "title-CiTs5auwvX",
       "alternativeTitles" : [
       ],
       "contributors" : [
@@ -33,11 +33,11 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
-          "value" : "rG23dzV6hX",
+          "value" : "HrklHuS07i",
           "type" : "Identifier"
         }
       ],
@@ -47,15 +47,15 @@
       ],
       "items" : [
         {
-          "id" : "klhus07i",
+          "id" : "9xyhqdqn",
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "sierra-system-number",
-                "label" : "Sierra system number",
+                "id" : "miro-image-number",
+                "label" : "Miro image number",
                 "type" : "IdentifierType"
               },
-              "value" : "2u7aRU7LCi",
+              "value" : "XRANbEFIYK",
               "type" : "Identifier"
             }
           ],
@@ -66,8 +66,8 @@
                 "label" : "IIIF Presentation API",
                 "type" : "LocationType"
               },
-              "url" : "https://iiif.wellcomecollection.org/image/1fY.jpg/info.json",
-              "linkText" : "Link text: NIu1OH",
+              "url" : "https://iiif.wellcomecollection.org/image/SKp.jpg/info.json",
+              "linkText" : "Link text: X5AiO63s6",
               "license" : {
                 "id" : "cc-by",
                 "label" : "Attribution 4.0 International (CC BY 4.0)",
@@ -137,20 +137,20 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "tq4mfefg",
-      "sourceIdentifier.value" : "rG23dzV6hX",
+      "id" : "n2u7aru7",
+      "sourceIdentifier.value" : "HrklHuS07i",
       "identifiers.value" : [
-        "rG23dzV6hX"
+        "HrklHuS07i"
       ],
       "images.id" : [
       ],
       "images.identifiers.value" : [
       ],
       "items.id" : [
-        "klhus07i"
+        "9xyhqdqn"
       ],
       "items.identifiers.value" : [
-        "2u7aRU7LCi"
+        "XRANbEFIYK"
       ],
       "languages.label" : [
       ],
@@ -165,7 +165,7 @@
       "referenceNumber" : null,
       "subjects.concepts.label" : [
       ],
-      "title" : "title-Pdnmb6ilPO"
+      "title" : "title-CiTs5auwvX"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -203,7 +203,7 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "rG23dzV6hX"
+        "HrklHuS07i"
       ],
       "items.locations.license.id" : [
         "cc-by"
@@ -212,10 +212,10 @@
         "open-with-advisory"
       ],
       "items.id" : [
-        "klhus07i"
+        "9xyhqdqn"
       ],
       "items.identifiers.value" : [
-        "2u7aRU7LCi"
+        "XRANbEFIYK"
       ],
       "items.locations.locationType.id" : [
         "iiif-presentation"

--- a/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.5.json
+++ b/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.5.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2024-05-15T08:17:25.602538Z",
-  "id" : "phdnojlc",
+  "createdAt" : "2024-08-15T08:40:28.387760Z",
+  "id" : "8ezcyfql",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "phdnojlc",
+        "id" : "8ezcyfql",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
-          "value" : "s5auwvXuSK"
+          "value" : "uDZSkVVbac"
         },
-        "version" : 92,
-        "modifiedTime" : "2032-11-02T13:47:49Z"
+        "version" : 71,
+        "modifiedTime" : "1955-12-31T01:30:20Z"
       },
-      "mergedTime" : "2032-11-02T13:47:49Z",
+      "mergedTime" : "1955-12-31T01:30:20Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "phdnojlc",
-      "title" : "title-kzJLX5AiO6",
+      "id" : "8ezcyfql",
+      "title" : "title-GTOMLJUBPs",
       "alternativeTitles" : [
       ],
       "contributors" : [
@@ -33,11 +33,11 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
-          "value" : "s5auwvXuSK",
+          "value" : "uDZSkVVbac",
           "type" : "Identifier"
         }
       ],
@@ -47,15 +47,15 @@
       ],
       "items" : [
         {
-          "id" : "udzskvvb",
+          "id" : "rk57syon",
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "miro-image-number",
-                "label" : "Miro image number",
+                "id" : "sierra-system-number",
+                "label" : "Sierra system number",
                 "type" : "IdentifierType"
               },
-              "value" : "c8ezCyfQlB",
+              "value" : "rNNX4MZClE",
               "type" : "Identifier"
             }
           ],
@@ -66,8 +66,8 @@
                 "label" : "IIIF Presentation API",
                 "type" : "LocationType"
               },
-              "url" : "https://iiif.wellcomecollection.org/image/s66.jpg/info.json",
-              "linkText" : "Link text: bEFIYK",
+              "url" : "https://iiif.wellcomecollection.org/image/vH8.jpg/info.json",
+              "linkText" : "Link text: h1czKSHpT0",
               "license" : {
                 "id" : "cc-by",
                 "label" : "Attribution 4.0 International (CC BY 4.0)",
@@ -137,20 +137,20 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "phdnojlc",
-      "sourceIdentifier.value" : "s5auwvXuSK",
+      "id" : "8ezcyfql",
+      "sourceIdentifier.value" : "uDZSkVVbac",
       "identifiers.value" : [
-        "s5auwvXuSK"
+        "uDZSkVVbac"
       ],
       "images.id" : [
       ],
       "images.identifiers.value" : [
       ],
       "items.id" : [
-        "udzskvvb"
+        "rk57syon"
       ],
       "items.identifiers.value" : [
-        "c8ezCyfQlB"
+        "rNNX4MZClE"
       ],
       "languages.label" : [
       ],
@@ -165,7 +165,7 @@
       "referenceNumber" : null,
       "subjects.concepts.label" : [
       ],
-      "title" : "title-kzJLX5AiO6"
+      "title" : "title-GTOMLJUBPs"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -203,7 +203,7 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "s5auwvXuSK"
+        "uDZSkVVbac"
       ],
       "items.locations.license.id" : [
         "cc-by"
@@ -212,10 +212,10 @@
         "licensed-resources"
       ],
       "items.id" : [
-        "udzskvvb"
+        "rk57syon"
       ],
       "items.identifiers.value" : [
-        "c8ezCyfQlB"
+        "rNNX4MZClE"
       ],
       "items.locations.locationType.id" : [
         "iiif-presentation"

--- a/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.6.json
+++ b/pipeline/ingestor/test_documents/works.examples.access-status-filters-tests.6.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2024-05-15T08:17:25.603058Z",
-  "id" : "vh87ts9v",
+  "createdAt" : "2024-08-15T08:40:28.388074Z",
+  "id" : "dulkq8ny",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "vh87ts9v",
+        "id" : "dulkq8ny",
         "identifier" : {
           "identifierType" : {
             "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
-          "value" : "TOMLJUBPsk"
+          "value" : "HeUBhh45MM"
         },
-        "version" : 66,
-        "modifiedTime" : "1979-11-26T18:18:50Z"
+        "version" : 16,
+        "modifiedTime" : "2044-10-23T23:53:45Z"
       },
-      "mergedTime" : "1979-11-26T18:18:50Z",
+      "mergedTime" : "2044-10-23T23:53:45Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "vh87ts9v",
-      "title" : "title-AfYGNPFh1c",
+      "id" : "dulkq8ny",
+      "title" : "title-jzx3mO0u9h",
       "alternativeTitles" : [
       ],
       "contributors" : [
@@ -37,7 +37,7 @@
             "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
-          "value" : "TOMLJUBPsk",
+          "value" : "HeUBhh45MM",
           "type" : "Identifier"
         }
       ],
@@ -47,15 +47,15 @@
       ],
       "items" : [
         {
-          "id" : "mzclelhe",
+          "id" : "sfx1ndk3",
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "sierra-system-number",
-                "label" : "Sierra system number",
+                "id" : "calm-record-id",
+                "label" : "Calm RecordIdentifier",
                 "type" : "IdentifierType"
               },
-              "value" : "Bhh45MMdul",
+              "value" : "ONjKwKKAUF",
               "type" : "Identifier"
             }
           ],
@@ -66,8 +66,8 @@
                 "label" : "IIIF Presentation API",
                 "type" : "LocationType"
               },
-              "url" : "https://iiif.wellcomecollection.org/image/KSH.jpg/info.json",
-              "credit" : "Credit line: T0IRk57s",
+              "url" : "https://iiif.wellcomecollection.org/image/wtG.jpg/info.json",
+              "credit" : "Credit line: O1husne0",
               "license" : {
                 "id" : "cc-by",
                 "label" : "Attribution 4.0 International (CC BY 4.0)",
@@ -132,20 +132,20 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "vh87ts9v",
-      "sourceIdentifier.value" : "TOMLJUBPsk",
+      "id" : "dulkq8ny",
+      "sourceIdentifier.value" : "HeUBhh45MM",
       "identifiers.value" : [
-        "TOMLJUBPsk"
+        "HeUBhh45MM"
       ],
       "images.id" : [
       ],
       "images.identifiers.value" : [
       ],
       "items.id" : [
-        "mzclelhe"
+        "sfx1ndk3"
       ],
       "items.identifiers.value" : [
-        "Bhh45MMdul"
+        "ONjKwKKAUF"
       ],
       "languages.label" : [
       ],
@@ -160,7 +160,7 @@
       "referenceNumber" : null,
       "subjects.concepts.label" : [
       ],
-      "title" : "title-AfYGNPFh1c"
+      "title" : "title-jzx3mO0u9h"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -197,7 +197,7 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "TOMLJUBPsk"
+        "HeUBhh45MM"
       ],
       "items.locations.license.id" : [
         "cc-by"
@@ -206,10 +206,10 @@
         "licensed-resources"
       ],
       "items.id" : [
-        "mzclelhe"
+        "sfx1ndk3"
       ],
       "items.identifiers.value" : [
-        "Bhh45MMdul"
+        "ONjKwKKAUF"
       ],
       "items.locations.locationType.id" : [
         "iiif-presentation"

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.0.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.0.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-02-16T15:36:44.959157Z",
-  "id" : "kbmotyqc",
+  "createdAt" : "2024-08-15T08:40:28.322642Z",
+  "id" : "vu0ulwn0",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "kbmotyqc",
+        "id" : "vu0ulwn0",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
-          "value" : "vZCvYXWMl0"
+          "value" : "MOpZRqzugp"
         },
-        "version" : 61,
-        "modifiedTime" : "2014-03-15T15:15:55Z"
+        "version" : 58,
+        "modifiedTime" : "1999-06-22T21:21:08Z"
       },
-      "mergedTime" : "2014-03-15T15:15:55Z",
+      "mergedTime" : "1999-06-22T21:21:08Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "kbmotyqc",
-      "title" : "title-IXUuyd8hWM",
+      "id" : "vu0ulwn0",
+      "title" : "title-8F6gzFFn0M",
       "alternativeTitles" : [
       ],
       "workType" : {
@@ -38,28 +38,28 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
-          "value" : "vZCvYXWMl0",
+          "value" : "MOpZRqzugp",
           "type" : "Identifier"
         }
       ],
       "subjects" : [
         {
-          "label" : "y0B0TSmDGU",
+          "label" : "6rJpSUKd2d",
           "concepts" : [
             {
-              "label" : "bHlXq1fwO98EpYD",
+              "label" : "biOiRlog5DCYVH5",
               "type" : "Concept"
             },
             {
-              "label" : "0Ex6rJpSUKd2dbi",
+              "label" : "TP1tcWDr9iToVJb",
               "type" : "Concept"
             },
             {
-              "label" : "OiRlog5DCYVH5TP",
+              "label" : "p9ESZHkohLBqVqY",
               "type" : "Concept"
             }
           ],
@@ -107,10 +107,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "kbmotyqc",
-      "sourceIdentifier.value" : "vZCvYXWMl0",
+      "id" : "vu0ulwn0",
+      "sourceIdentifier.value" : "MOpZRqzugp",
       "identifiers.value" : [
-        "vZCvYXWMl0"
+        "MOpZRqzugp"
       ],
       "images.id" : [
       ],
@@ -132,11 +132,11 @@
       ],
       "referenceNumber" : null,
       "subjects.concepts.label" : [
-        "bHlXq1fwO98EpYD",
-        "0Ex6rJpSUKd2dbi",
-        "OiRlog5DCYVH5TP"
+        "biOiRlog5DCYVH5",
+        "TP1tcWDr9iToVJb",
+        "p9ESZHkohLBqVqY"
       ],
-      "title" : "title-IXUuyd8hWM"
+      "title" : "title-8F6gzFFn0M"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -147,7 +147,7 @@
       "production.dates" : [
       ],
       "subjects.label" : [
-        "{\"label\":\"y0B0TSmDGU\",\"concepts\":[],\"type\":\"Subject\"}"
+        "{\"label\":\"6rJpSUKd2d\",\"concepts\":[],\"type\":\"Subject\"}"
       ],
       "languages" : [
       ],
@@ -170,12 +170,12 @@
       "genres.concepts.id" : [
       ],
       "subjects.label" : [
-        "y0B0TSmDGU"
+        "6rJpSUKd2d"
       ],
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "vZCvYXWMl0"
+        "MOpZRqzugp"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.1.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.1.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-05-15T08:17:25.536447Z",
-  "id" : "ulwn0n8f",
+  "createdAt" : "2024-08-15T08:40:28.323034Z",
+  "id" : "k9rmsgky",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "ulwn0n8f",
+        "id" : "k9rmsgky",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
-          "value" : "ZRqzugpVU0"
+          "value" : "Sw2fZgItN5"
         },
-        "version" : 59,
-        "modifiedTime" : "1933-06-27T10:36:37Z"
+        "version" : 75,
+        "modifiedTime" : "1939-02-16T16:18:24Z"
       },
-      "mergedTime" : "1933-06-27T10:36:37Z",
+      "mergedTime" : "1939-02-16T16:18:24Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "ulwn0n8f",
-      "title" : "title-gzFFn0MzMS",
+      "id" : "k9rmsgky",
+      "title" : "title-11WyiVFCED",
       "alternativeTitles" : [
       ],
       "workType" : {
@@ -38,28 +38,28 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
-          "value" : "ZRqzugpVU0",
+          "value" : "Sw2fZgItN5",
           "type" : "Identifier"
         }
       ],
       "subjects" : [
         {
-          "label" : "y0B0TSmDGU",
+          "label" : "6rJpSUKd2d",
           "concepts" : [
             {
-              "label" : "bHlXq1fwO98EpYD",
+              "label" : "biOiRlog5DCYVH5",
               "type" : "Concept"
             },
             {
-              "label" : "0Ex6rJpSUKd2dbi",
+              "label" : "TP1tcWDr9iToVJb",
               "type" : "Concept"
             },
             {
-              "label" : "OiRlog5DCYVH5TP",
+              "label" : "p9ESZHkohLBqVqY",
               "type" : "Concept"
             }
           ],
@@ -107,10 +107,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "ulwn0n8f",
-      "sourceIdentifier.value" : "ZRqzugpVU0",
+      "id" : "k9rmsgky",
+      "sourceIdentifier.value" : "Sw2fZgItN5",
       "identifiers.value" : [
-        "ZRqzugpVU0"
+        "Sw2fZgItN5"
       ],
       "images.id" : [
       ],
@@ -132,11 +132,11 @@
       ],
       "referenceNumber" : null,
       "subjects.concepts.label" : [
-        "bHlXq1fwO98EpYD",
-        "0Ex6rJpSUKd2dbi",
-        "OiRlog5DCYVH5TP"
+        "biOiRlog5DCYVH5",
+        "TP1tcWDr9iToVJb",
+        "p9ESZHkohLBqVqY"
       ],
-      "title" : "title-gzFFn0MzMS"
+      "title" : "title-11WyiVFCED"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -147,7 +147,7 @@
       "production.dates" : [
       ],
       "subjects.label" : [
-        "{\"label\":\"y0B0TSmDGU\",\"concepts\":[],\"type\":\"Subject\"}"
+        "{\"label\":\"6rJpSUKd2d\",\"concepts\":[],\"type\":\"Subject\"}"
       ],
       "languages" : [
       ],
@@ -170,12 +170,12 @@
       "genres.concepts.id" : [
       ],
       "subjects.label" : [
-        "y0B0TSmDGU"
+        "6rJpSUKd2d"
       ],
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "ZRqzugpVU0"
+        "Sw2fZgItN5"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.10.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.10.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-05-15T08:17:25.540993Z",
-  "id" : "uoi8tp8u",
+  "createdAt" : "2024-08-15T08:40:28.326948Z",
+  "id" : "lusxgqii",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "uoi8tp8u",
+        "id" : "lusxgqii",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
-          "value" : "Y14qUDXX1m"
+          "value" : "SVR3x3Cael"
         },
-        "version" : 44,
-        "modifiedTime" : "1966-02-08T17:51:28Z"
+        "version" : 38,
+        "modifiedTime" : "1998-04-06T11:45:48Z"
       },
-      "mergedTime" : "1966-02-08T17:51:28Z",
+      "mergedTime" : "1998-04-06T11:45:48Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "uoi8tp8u",
-      "title" : "title-RfKD3vr5oS",
+      "id" : "lusxgqii",
+      "title" : "title-3BP7HD59gW",
       "alternativeTitles" : [
       ],
       "workType" : {
@@ -38,28 +38,28 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
-          "value" : "Y14qUDXX1m",
+          "value" : "SVR3x3Cael",
           "type" : "Identifier"
         }
       ],
       "subjects" : [
         {
-          "label" : "1tcWDr9iTo",
+          "label" : "S4hioTvwQl",
           "concepts" : [
             {
-              "label" : "VJbp9ESZHkohLBq",
+              "label" : "eJkqVbD7mxTT1Dn",
               "type" : "Concept"
             },
             {
-              "label" : "VqYS4hioTvwQleJ",
+              "label" : "ad9SceRNaTElZtf",
               "type" : "Concept"
             },
             {
-              "label" : "kqVbD7mxTT1Dnad",
+              "label" : "G4qEc4MTvdPAcgp",
               "type" : "Concept"
             }
           ],
@@ -107,10 +107,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "uoi8tp8u",
-      "sourceIdentifier.value" : "Y14qUDXX1m",
+      "id" : "lusxgqii",
+      "sourceIdentifier.value" : "SVR3x3Cael",
       "identifiers.value" : [
-        "Y14qUDXX1m"
+        "SVR3x3Cael"
       ],
       "images.id" : [
       ],
@@ -132,11 +132,11 @@
       ],
       "referenceNumber" : null,
       "subjects.concepts.label" : [
-        "VJbp9ESZHkohLBq",
-        "VqYS4hioTvwQleJ",
-        "kqVbD7mxTT1Dnad"
+        "eJkqVbD7mxTT1Dn",
+        "ad9SceRNaTElZtf",
+        "G4qEc4MTvdPAcgp"
       ],
-      "title" : "title-RfKD3vr5oS"
+      "title" : "title-3BP7HD59gW"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -147,7 +147,7 @@
       "production.dates" : [
       ],
       "subjects.label" : [
-        "{\"label\":\"1tcWDr9iTo\",\"concepts\":[],\"type\":\"Subject\"}"
+        "{\"label\":\"S4hioTvwQl\",\"concepts\":[],\"type\":\"Subject\"}"
       ],
       "languages" : [
       ],
@@ -170,12 +170,12 @@
       "genres.concepts.id" : [
       ],
       "subjects.label" : [
-        "1tcWDr9iTo"
+        "S4hioTvwQl"
       ],
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "Y14qUDXX1m"
+        "SVR3x3Cael"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.11.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.11.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-05-15T08:17:25.541489Z",
-  "id" : "xgqiid3b",
+  "createdAt" : "2024-08-15T08:40:28.327319Z",
+  "id" : "uwotqemj",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "xgqiid3b",
+        "id" : "uwotqemj",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
-          "value" : "3x3CaelluS"
+          "value" : "w4lFJUZazq"
         },
-        "version" : 49,
-        "modifiedTime" : "2024-03-26T00:53:12Z"
+        "version" : 90,
+        "modifiedTime" : "2017-05-26T17:27:26Z"
       },
-      "mergedTime" : "2024-03-26T00:53:12Z",
+      "mergedTime" : "2017-05-26T17:27:26Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "xgqiid3b",
-      "title" : "title-7HD59gW9tw",
+      "id" : "uwotqemj",
+      "title" : "title-yTPyW5z3uV",
       "alternativeTitles" : [
       ],
       "workType" : {
@@ -38,28 +38,28 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
-          "value" : "3x3CaelluS",
+          "value" : "w4lFJUZazq",
           "type" : "Identifier"
         }
       ],
       "subjects" : [
         {
-          "label" : "1tcWDr9iTo",
+          "label" : "S4hioTvwQl",
           "concepts" : [
             {
-              "label" : "VJbp9ESZHkohLBq",
+              "label" : "eJkqVbD7mxTT1Dn",
               "type" : "Concept"
             },
             {
-              "label" : "VqYS4hioTvwQleJ",
+              "label" : "ad9SceRNaTElZtf",
               "type" : "Concept"
             },
             {
-              "label" : "kqVbD7mxTT1Dnad",
+              "label" : "G4qEc4MTvdPAcgp",
               "type" : "Concept"
             }
           ],
@@ -107,10 +107,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "xgqiid3b",
-      "sourceIdentifier.value" : "3x3CaelluS",
+      "id" : "uwotqemj",
+      "sourceIdentifier.value" : "w4lFJUZazq",
       "identifiers.value" : [
-        "3x3CaelluS"
+        "w4lFJUZazq"
       ],
       "images.id" : [
       ],
@@ -132,11 +132,11 @@
       ],
       "referenceNumber" : null,
       "subjects.concepts.label" : [
-        "VJbp9ESZHkohLBq",
-        "VqYS4hioTvwQleJ",
-        "kqVbD7mxTT1Dnad"
+        "eJkqVbD7mxTT1Dn",
+        "ad9SceRNaTElZtf",
+        "G4qEc4MTvdPAcgp"
       ],
-      "title" : "title-7HD59gW9tw"
+      "title" : "title-yTPyW5z3uV"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -147,7 +147,7 @@
       "production.dates" : [
       ],
       "subjects.label" : [
-        "{\"label\":\"1tcWDr9iTo\",\"concepts\":[],\"type\":\"Subject\"}"
+        "{\"label\":\"S4hioTvwQl\",\"concepts\":[],\"type\":\"Subject\"}"
       ],
       "languages" : [
       ],
@@ -170,12 +170,12 @@
       "genres.concepts.id" : [
       ],
       "subjects.label" : [
-        "1tcWDr9iTo"
+        "S4hioTvwQl"
       ],
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "3x3CaelluS"
+        "w4lFJUZazq"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.12.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.12.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-05-15T08:17:25.541943Z",
-  "id" : "tqemj6yt",
+  "createdAt" : "2024-08-15T08:40:28.327702Z",
+  "id" : "tbkbsxzf",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "tqemj6yt",
+        "id" : "tbkbsxzf",
         "identifier" : {
           "identifierType" : {
             "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
-          "value" : "FJUZazquWo"
+          "value" : "5HlMPZzhLJ"
         },
-        "version" : 82,
-        "modifiedTime" : "1982-09-21T18:42:16Z"
+        "version" : 50,
+        "modifiedTime" : "2003-11-07T03:23:26Z"
       },
-      "mergedTime" : "1982-09-21T18:42:16Z",
+      "mergedTime" : "2003-11-07T03:23:26Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "tqemj6yt",
-      "title" : "title-yW5z3uVBA5",
+      "id" : "tbkbsxzf",
+      "title" : "title-7HDIlUXQf0",
       "alternativeTitles" : [
       ],
       "workType" : {
@@ -42,24 +42,24 @@
             "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
-          "value" : "FJUZazquWo",
+          "value" : "5HlMPZzhLJ",
           "type" : "Identifier"
         }
       ],
       "subjects" : [
         {
-          "label" : "9SceRNaTEl",
+          "label" : "fIbfVPkqaf",
           "concepts" : [
             {
-              "label" : "ZtfG4qEc4MTvdPA",
+              "label" : "Pgpz7am59I9Cwkj",
               "type" : "Concept"
             },
             {
-              "label" : "cgpfIbfVPkqafPg",
+              "label" : "zoIhNdLDgGiVW1m",
               "type" : "Concept"
             },
             {
-              "label" : "pz7am59I9Cwkjzo",
+              "label" : "Q40pgbiIgGzgYBC",
               "type" : "Concept"
             }
           ],
@@ -107,10 +107,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "tqemj6yt",
-      "sourceIdentifier.value" : "FJUZazquWo",
+      "id" : "tbkbsxzf",
+      "sourceIdentifier.value" : "5HlMPZzhLJ",
       "identifiers.value" : [
-        "FJUZazquWo"
+        "5HlMPZzhLJ"
       ],
       "images.id" : [
       ],
@@ -132,11 +132,11 @@
       ],
       "referenceNumber" : null,
       "subjects.concepts.label" : [
-        "ZtfG4qEc4MTvdPA",
-        "cgpfIbfVPkqafPg",
-        "pz7am59I9Cwkjzo"
+        "Pgpz7am59I9Cwkj",
+        "zoIhNdLDgGiVW1m",
+        "Q40pgbiIgGzgYBC"
       ],
-      "title" : "title-yW5z3uVBA5"
+      "title" : "title-7HDIlUXQf0"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -147,7 +147,7 @@
       "production.dates" : [
       ],
       "subjects.label" : [
-        "{\"label\":\"9SceRNaTEl\",\"concepts\":[],\"type\":\"Subject\"}"
+        "{\"label\":\"fIbfVPkqaf\",\"concepts\":[],\"type\":\"Subject\"}"
       ],
       "languages" : [
       ],
@@ -170,12 +170,12 @@
       "genres.concepts.id" : [
       ],
       "subjects.label" : [
-        "9SceRNaTEl"
+        "fIbfVPkqaf"
       ],
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "FJUZazquWo"
+        "5HlMPZzhLJ"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.13.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.13.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-02-16T15:36:44.970667Z",
-  "id" : "bsxzfe7h",
+  "createdAt" : "2024-08-15T08:40:28.328063Z",
+  "id" : "qr2rdsof",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "bsxzfe7h",
+        "id" : "qr2rdsof",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
-          "value" : "MPZzhLJtbk"
+          "value" : "b5lYlQvQzS"
         },
-        "version" : 88,
-        "modifiedTime" : "1998-08-02T02:39:28Z"
+        "version" : 25,
+        "modifiedTime" : "1934-10-12T18:01:51Z"
       },
-      "mergedTime" : "1998-08-02T02:39:28Z",
+      "mergedTime" : "1934-10-12T18:01:51Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,13 +24,13 @@
       ]
     },
     "display" : {
-      "id" : "bsxzfe7h",
-      "title" : "title-IlUXQf0x4b",
+      "id" : "qr2rdsof",
+      "title" : "title-PTXo35aec2",
       "alternativeTitles" : [
       ],
       "workType" : {
-        "id" : "n",
-        "label" : "Film",
+        "id" : "hdig",
+        "label" : "Archives - Digital",
         "type" : "Format"
       },
       "contributors" : [
@@ -38,28 +38,28 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
-          "value" : "MPZzhLJtbk",
+          "value" : "b5lYlQvQzS",
           "type" : "Identifier"
         }
       ],
       "subjects" : [
         {
-          "label" : "9SceRNaTEl",
+          "label" : "fIbfVPkqaf",
           "concepts" : [
             {
-              "label" : "ZtfG4qEc4MTvdPA",
+              "label" : "Pgpz7am59I9Cwkj",
               "type" : "Concept"
             },
             {
-              "label" : "cgpfIbfVPkqafPg",
+              "label" : "zoIhNdLDgGiVW1m",
               "type" : "Concept"
             },
             {
-              "label" : "pz7am59I9Cwkjzo",
+              "label" : "Q40pgbiIgGzgYBC",
               "type" : "Concept"
             }
           ],
@@ -107,10 +107,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "bsxzfe7h",
-      "sourceIdentifier.value" : "MPZzhLJtbk",
+      "id" : "qr2rdsof",
+      "sourceIdentifier.value" : "b5lYlQvQzS",
       "identifiers.value" : [
-        "MPZzhLJtbk"
+        "b5lYlQvQzS"
       ],
       "images.id" : [
       ],
@@ -132,22 +132,22 @@
       ],
       "referenceNumber" : null,
       "subjects.concepts.label" : [
-        "ZtfG4qEc4MTvdPA",
-        "cgpfIbfVPkqafPg",
-        "pz7am59I9Cwkjzo"
+        "Pgpz7am59I9Cwkj",
+        "zoIhNdLDgGiVW1m",
+        "Q40pgbiIgGzgYBC"
       ],
-      "title" : "title-IlUXQf0x4b"
+      "title" : "title-PTXo35aec2"
     },
     "aggregatableValues" : {
       "workType" : [
-        "{\"id\":\"n\",\"label\":\"Film\",\"type\":\"Format\"}"
+        "{\"id\":\"hdig\",\"label\":\"Archives - Digital\",\"type\":\"Format\"}"
       ],
       "genres.label" : [
       ],
       "production.dates" : [
       ],
       "subjects.label" : [
-        "{\"label\":\"9SceRNaTEl\",\"concepts\":[],\"type\":\"Subject\"}"
+        "{\"label\":\"fIbfVPkqaf\",\"concepts\":[],\"type\":\"Subject\"}"
       ],
       "languages" : [
       ],
@@ -159,7 +159,7 @@
       ]
     },
     "filterableValues" : {
-      "format.id" : "n",
+      "format.id" : "hdig",
       "workType" : "Standard",
       "production.dates.range.from" : [
       ],
@@ -170,12 +170,12 @@
       "genres.concepts.id" : [
       ],
       "subjects.label" : [
-        "9SceRNaTEl"
+        "fIbfVPkqaf"
       ],
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "MPZzhLJtbk"
+        "b5lYlQvQzS"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.14.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.14.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-02-16T15:36:44.971237Z",
-  "id" : "rdsofxpt",
+  "createdAt" : "2024-08-15T08:40:28.328417Z",
+  "id" : "5klfzrze",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "rdsofxpt",
+        "id" : "5klfzrze",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
-          "value" : "YlQvQzSQr2"
+          "value" : "Iw5fNUyylf"
         },
-        "version" : 35,
-        "modifiedTime" : "2033-03-18T16:57:24Z"
+        "version" : 52,
+        "modifiedTime" : "1983-11-07T09:48:39Z"
       },
-      "mergedTime" : "2033-03-18T16:57:24Z",
+      "mergedTime" : "1983-11-07T09:48:39Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,13 +24,13 @@
       ]
     },
     "display" : {
-      "id" : "rdsofxpt",
-      "title" : "title-o35aec2IoI",
+      "id" : "5klfzrze",
+      "title" : "title-XXZiS5MlN0",
       "alternativeTitles" : [
       ],
       "workType" : {
-        "id" : "b",
-        "label" : "Manuscripts",
+        "id" : "n",
+        "label" : "Film",
         "type" : "Format"
       },
       "contributors" : [
@@ -38,28 +38,28 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
-          "value" : "YlQvQzSQr2",
+          "value" : "Iw5fNUyylf",
           "type" : "Identifier"
         }
       ],
       "subjects" : [
         {
-          "label" : "9SceRNaTEl",
+          "label" : "fIbfVPkqaf",
           "concepts" : [
             {
-              "label" : "ZtfG4qEc4MTvdPA",
+              "label" : "Pgpz7am59I9Cwkj",
               "type" : "Concept"
             },
             {
-              "label" : "cgpfIbfVPkqafPg",
+              "label" : "zoIhNdLDgGiVW1m",
               "type" : "Concept"
             },
             {
-              "label" : "pz7am59I9Cwkjzo",
+              "label" : "Q40pgbiIgGzgYBC",
               "type" : "Concept"
             }
           ],
@@ -107,10 +107,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "rdsofxpt",
-      "sourceIdentifier.value" : "YlQvQzSQr2",
+      "id" : "5klfzrze",
+      "sourceIdentifier.value" : "Iw5fNUyylf",
       "identifiers.value" : [
-        "YlQvQzSQr2"
+        "Iw5fNUyylf"
       ],
       "images.id" : [
       ],
@@ -132,22 +132,22 @@
       ],
       "referenceNumber" : null,
       "subjects.concepts.label" : [
-        "ZtfG4qEc4MTvdPA",
-        "cgpfIbfVPkqafPg",
-        "pz7am59I9Cwkjzo"
+        "Pgpz7am59I9Cwkj",
+        "zoIhNdLDgGiVW1m",
+        "Q40pgbiIgGzgYBC"
       ],
-      "title" : "title-o35aec2IoI"
+      "title" : "title-XXZiS5MlN0"
     },
     "aggregatableValues" : {
       "workType" : [
-        "{\"id\":\"b\",\"label\":\"Manuscripts\",\"type\":\"Format\"}"
+        "{\"id\":\"n\",\"label\":\"Film\",\"type\":\"Format\"}"
       ],
       "genres.label" : [
       ],
       "production.dates" : [
       ],
       "subjects.label" : [
-        "{\"label\":\"9SceRNaTEl\",\"concepts\":[],\"type\":\"Subject\"}"
+        "{\"label\":\"fIbfVPkqaf\",\"concepts\":[],\"type\":\"Subject\"}"
       ],
       "languages" : [
       ],
@@ -159,7 +159,7 @@
       ]
     },
     "filterableValues" : {
-      "format.id" : "b",
+      "format.id" : "n",
       "workType" : "Standard",
       "production.dates.range.from" : [
       ],
@@ -170,12 +170,12 @@
       "genres.concepts.id" : [
       ],
       "subjects.label" : [
-        "9SceRNaTEl"
+        "fIbfVPkqaf"
       ],
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "YlQvQzSQr2"
+        "Iw5fNUyylf"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.15.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.15.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-05-15T08:17:25.543166Z",
-  "id" : "fzrzebxx",
+  "createdAt" : "2024-08-15T08:40:28.328797Z",
+  "id" : "lwpiautl",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "fzrzebxx",
+        "id" : "lwpiautl",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
-          "value" : "fNUyylf5KL"
+          "value" : "2tqCcLh1PJ"
         },
-        "version" : 100,
-        "modifiedTime" : "1939-09-12T19:57:56Z"
+        "version" : 33,
+        "modifiedTime" : "2049-05-05T22:23:19Z"
       },
-      "mergedTime" : "1939-09-12T19:57:56Z",
+      "mergedTime" : "2049-05-05T22:23:19Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,13 +24,13 @@
       ]
     },
     "display" : {
-      "id" : "fzrzebxx",
-      "title" : "title-iS5MlN0hQ2",
+      "id" : "lwpiautl",
+      "title" : "title-kWyW6CgVzw",
       "alternativeTitles" : [
       ],
       "workType" : {
-        "id" : "c",
-        "label" : "Music",
+        "id" : "b",
+        "label" : "Manuscripts",
         "type" : "Format"
       },
       "contributors" : [
@@ -38,28 +38,28 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
-          "value" : "fNUyylf5KL",
+          "value" : "2tqCcLh1PJ",
           "type" : "Identifier"
         }
       ],
       "subjects" : [
         {
-          "label" : "9SceRNaTEl",
+          "label" : "fIbfVPkqaf",
           "concepts" : [
             {
-              "label" : "ZtfG4qEc4MTvdPA",
+              "label" : "Pgpz7am59I9Cwkj",
               "type" : "Concept"
             },
             {
-              "label" : "cgpfIbfVPkqafPg",
+              "label" : "zoIhNdLDgGiVW1m",
               "type" : "Concept"
             },
             {
-              "label" : "pz7am59I9Cwkjzo",
+              "label" : "Q40pgbiIgGzgYBC",
               "type" : "Concept"
             }
           ],
@@ -107,10 +107,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "fzrzebxx",
-      "sourceIdentifier.value" : "fNUyylf5KL",
+      "id" : "lwpiautl",
+      "sourceIdentifier.value" : "2tqCcLh1PJ",
       "identifiers.value" : [
-        "fNUyylf5KL"
+        "2tqCcLh1PJ"
       ],
       "images.id" : [
       ],
@@ -132,22 +132,22 @@
       ],
       "referenceNumber" : null,
       "subjects.concepts.label" : [
-        "ZtfG4qEc4MTvdPA",
-        "cgpfIbfVPkqafPg",
-        "pz7am59I9Cwkjzo"
+        "Pgpz7am59I9Cwkj",
+        "zoIhNdLDgGiVW1m",
+        "Q40pgbiIgGzgYBC"
       ],
-      "title" : "title-iS5MlN0hQ2"
+      "title" : "title-kWyW6CgVzw"
     },
     "aggregatableValues" : {
       "workType" : [
-        "{\"id\":\"c\",\"label\":\"Music\",\"type\":\"Format\"}"
+        "{\"id\":\"b\",\"label\":\"Manuscripts\",\"type\":\"Format\"}"
       ],
       "genres.label" : [
       ],
       "production.dates" : [
       ],
       "subjects.label" : [
-        "{\"label\":\"9SceRNaTEl\",\"concepts\":[],\"type\":\"Subject\"}"
+        "{\"label\":\"fIbfVPkqaf\",\"concepts\":[],\"type\":\"Subject\"}"
       ],
       "languages" : [
       ],
@@ -159,7 +159,7 @@
       ]
     },
     "filterableValues" : {
-      "format.id" : "c",
+      "format.id" : "b",
       "workType" : "Standard",
       "production.dates.range.from" : [
       ],
@@ -170,12 +170,12 @@
       "genres.concepts.id" : [
       ],
       "subjects.label" : [
-        "9SceRNaTEl"
+        "fIbfVPkqaf"
       ],
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "fNUyylf5KL"
+        "2tqCcLh1PJ"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.16.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.16.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-05-15T08:17:25.543585Z",
-  "id" : "iautlnkw",
+  "createdAt" : "2024-08-15T08:40:28.329179Z",
+  "id" : "ior3tm3c",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "iautlnkw",
+        "id" : "ior3tm3c",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
-          "value" : "CcLh1PJlWp"
+          "value" : "FndKxMxs7k"
         },
-        "version" : 42,
-        "modifiedTime" : "1945-03-21T21:20:18Z"
+        "version" : 73,
+        "modifiedTime" : "1966-09-05T20:54:00Z"
       },
-      "mergedTime" : "1945-03-21T21:20:18Z",
+      "mergedTime" : "1966-09-05T20:54:00Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,13 +24,13 @@
       ]
     },
     "display" : {
-      "id" : "iautlnkw",
-      "title" : "title-W6CgVzwIJF",
+      "id" : "ior3tm3c",
+      "title" : "title-Oqp5RA4f5g",
       "alternativeTitles" : [
       ],
       "workType" : {
-        "id" : "u",
-        "label" : "Standing order",
+        "id" : "c",
+        "label" : "Music",
         "type" : "Format"
       },
       "contributors" : [
@@ -38,28 +38,28 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
-          "value" : "CcLh1PJlWp",
+          "value" : "FndKxMxs7k",
           "type" : "Identifier"
         }
       ],
       "subjects" : [
         {
-          "label" : "9SceRNaTEl",
+          "label" : "fIbfVPkqaf",
           "concepts" : [
             {
-              "label" : "ZtfG4qEc4MTvdPA",
+              "label" : "Pgpz7am59I9Cwkj",
               "type" : "Concept"
             },
             {
-              "label" : "cgpfIbfVPkqafPg",
+              "label" : "zoIhNdLDgGiVW1m",
               "type" : "Concept"
             },
             {
-              "label" : "pz7am59I9Cwkjzo",
+              "label" : "Q40pgbiIgGzgYBC",
               "type" : "Concept"
             }
           ],
@@ -107,10 +107,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "iautlnkw",
-      "sourceIdentifier.value" : "CcLh1PJlWp",
+      "id" : "ior3tm3c",
+      "sourceIdentifier.value" : "FndKxMxs7k",
       "identifiers.value" : [
-        "CcLh1PJlWp"
+        "FndKxMxs7k"
       ],
       "images.id" : [
       ],
@@ -132,22 +132,22 @@
       ],
       "referenceNumber" : null,
       "subjects.concepts.label" : [
-        "ZtfG4qEc4MTvdPA",
-        "cgpfIbfVPkqafPg",
-        "pz7am59I9Cwkjzo"
+        "Pgpz7am59I9Cwkj",
+        "zoIhNdLDgGiVW1m",
+        "Q40pgbiIgGzgYBC"
       ],
-      "title" : "title-W6CgVzwIJF"
+      "title" : "title-Oqp5RA4f5g"
     },
     "aggregatableValues" : {
       "workType" : [
-        "{\"id\":\"u\",\"label\":\"Standing order\",\"type\":\"Format\"}"
+        "{\"id\":\"c\",\"label\":\"Music\",\"type\":\"Format\"}"
       ],
       "genres.label" : [
       ],
       "production.dates" : [
       ],
       "subjects.label" : [
-        "{\"label\":\"9SceRNaTEl\",\"concepts\":[],\"type\":\"Subject\"}"
+        "{\"label\":\"fIbfVPkqaf\",\"concepts\":[],\"type\":\"Subject\"}"
       ],
       "languages" : [
       ],
@@ -159,7 +159,7 @@
       ]
     },
     "filterableValues" : {
-      "format.id" : "u",
+      "format.id" : "c",
       "workType" : "Standard",
       "production.dates.range.from" : [
       ],
@@ -170,12 +170,12 @@
       "genres.concepts.id" : [
       ],
       "subjects.label" : [
-        "9SceRNaTEl"
+        "fIbfVPkqaf"
       ],
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "CcLh1PJlWp"
+        "FndKxMxs7k"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.17.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.17.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-05-15T08:17:25.544011Z",
-  "id" : "3tm3cnoq",
+  "createdAt" : "2024-08-15T08:40:28.329559Z",
+  "id" : "bpisihnt",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "3tm3cnoq",
+        "id" : "bpisihnt",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
-          "value" : "KxMxs7kIOR"
+          "value" : "IptlxE0qlB"
         },
-        "version" : 74,
-        "modifiedTime" : "2019-08-09T21:38:32Z"
+        "version" : 96,
+        "modifiedTime" : "1998-11-30T20:57:58Z"
       },
-      "mergedTime" : "2019-08-09T21:38:32Z",
+      "mergedTime" : "1998-11-30T20:57:58Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,13 +24,13 @@
       ]
     },
     "display" : {
-      "id" : "3tm3cnoq",
-      "title" : "title-5RA4f5gWVI",
+      "id" : "bpisihnt",
+      "title" : "title-JBs3eSemcG",
       "alternativeTitles" : [
       ],
       "workType" : {
-        "id" : "z",
-        "label" : "Web sites",
+        "id" : "u",
+        "label" : "Standing order",
         "type" : "Format"
       },
       "contributors" : [
@@ -38,28 +38,28 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
-          "value" : "KxMxs7kIOR",
+          "value" : "IptlxE0qlB",
           "type" : "Identifier"
         }
       ],
       "subjects" : [
         {
-          "label" : "9SceRNaTEl",
+          "label" : "fIbfVPkqaf",
           "concepts" : [
             {
-              "label" : "ZtfG4qEc4MTvdPA",
+              "label" : "Pgpz7am59I9Cwkj",
               "type" : "Concept"
             },
             {
-              "label" : "cgpfIbfVPkqafPg",
+              "label" : "zoIhNdLDgGiVW1m",
               "type" : "Concept"
             },
             {
-              "label" : "pz7am59I9Cwkjzo",
+              "label" : "Q40pgbiIgGzgYBC",
               "type" : "Concept"
             }
           ],
@@ -107,10 +107,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "3tm3cnoq",
-      "sourceIdentifier.value" : "KxMxs7kIOR",
+      "id" : "bpisihnt",
+      "sourceIdentifier.value" : "IptlxE0qlB",
       "identifiers.value" : [
-        "KxMxs7kIOR"
+        "IptlxE0qlB"
       ],
       "images.id" : [
       ],
@@ -132,22 +132,22 @@
       ],
       "referenceNumber" : null,
       "subjects.concepts.label" : [
-        "ZtfG4qEc4MTvdPA",
-        "cgpfIbfVPkqafPg",
-        "pz7am59I9Cwkjzo"
+        "Pgpz7am59I9Cwkj",
+        "zoIhNdLDgGiVW1m",
+        "Q40pgbiIgGzgYBC"
       ],
-      "title" : "title-5RA4f5gWVI"
+      "title" : "title-JBs3eSemcG"
     },
     "aggregatableValues" : {
       "workType" : [
-        "{\"id\":\"z\",\"label\":\"Web sites\",\"type\":\"Format\"}"
+        "{\"id\":\"u\",\"label\":\"Standing order\",\"type\":\"Format\"}"
       ],
       "genres.label" : [
       ],
       "production.dates" : [
       ],
       "subjects.label" : [
-        "{\"label\":\"9SceRNaTEl\",\"concepts\":[],\"type\":\"Subject\"}"
+        "{\"label\":\"fIbfVPkqaf\",\"concepts\":[],\"type\":\"Subject\"}"
       ],
       "languages" : [
       ],
@@ -159,7 +159,7 @@
       ]
     },
     "filterableValues" : {
-      "format.id" : "z",
+      "format.id" : "u",
       "workType" : "Standard",
       "production.dates.range.from" : [
       ],
@@ -170,12 +170,12 @@
       "genres.concepts.id" : [
       ],
       "subjects.label" : [
-        "9SceRNaTEl"
+        "fIbfVPkqaf"
       ],
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "KxMxs7kIOR"
+        "IptlxE0qlB"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.18.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.18.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-05-15T08:17:25.544443Z",
-  "id" : "sihntejb",
+  "createdAt" : "2024-08-15T08:40:28.329924Z",
+  "id" : "gms4hdjm",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "sihntejb",
+        "id" : "gms4hdjm",
         "identifier" : {
           "identifierType" : {
             "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
-          "value" : "lxE0qlBbPi"
+          "value" : "Xd87ZYKrzx"
         },
-        "version" : 14,
-        "modifiedTime" : "1968-01-10T17:53:21Z"
+        "version" : 78,
+        "modifiedTime" : "2057-03-30T08:52:31Z"
       },
-      "mergedTime" : "1968-01-10T17:53:21Z",
+      "mergedTime" : "2057-03-30T08:52:31Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,13 +24,13 @@
       ]
     },
     "display" : {
-      "id" : "sihntejb",
-      "title" : "title-3eSemcGNQX",
+      "id" : "gms4hdjm",
+      "title" : "title-ToBweq2UFK",
       "alternativeTitles" : [
       ],
       "workType" : {
-        "id" : "v",
-        "label" : "E-books",
+        "id" : "z",
+        "label" : "Web sites",
         "type" : "Format"
       },
       "contributors" : [
@@ -42,24 +42,24 @@
             "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
-          "value" : "lxE0qlBbPi",
+          "value" : "Xd87ZYKrzx",
           "type" : "Identifier"
         }
       ],
       "subjects" : [
         {
-          "label" : "IhNdLDgGiV",
+          "label" : "hQnFei9OwD",
           "concepts" : [
             {
-              "label" : "W1mQ40pgbiIgGzg",
+              "label" : "HmXSsBa8UqTG3Gu",
               "type" : "Concept"
             },
             {
-              "label" : "YBChQnFei9OwDHm",
+              "label" : "W07LA7wtXxMtg7d",
               "type" : "Concept"
             },
             {
-              "label" : "XSsBa8UqTG3GuW0",
+              "label" : "koPI8hxmCeKjABF",
               "type" : "Concept"
             }
           ],
@@ -107,10 +107,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "sihntejb",
-      "sourceIdentifier.value" : "lxE0qlBbPi",
+      "id" : "gms4hdjm",
+      "sourceIdentifier.value" : "Xd87ZYKrzx",
       "identifiers.value" : [
-        "lxE0qlBbPi"
+        "Xd87ZYKrzx"
       ],
       "images.id" : [
       ],
@@ -132,22 +132,22 @@
       ],
       "referenceNumber" : null,
       "subjects.concepts.label" : [
-        "W1mQ40pgbiIgGzg",
-        "YBChQnFei9OwDHm",
-        "XSsBa8UqTG3GuW0"
+        "HmXSsBa8UqTG3Gu",
+        "W07LA7wtXxMtg7d",
+        "koPI8hxmCeKjABF"
       ],
-      "title" : "title-3eSemcGNQX"
+      "title" : "title-ToBweq2UFK"
     },
     "aggregatableValues" : {
       "workType" : [
-        "{\"id\":\"v\",\"label\":\"E-books\",\"type\":\"Format\"}"
+        "{\"id\":\"z\",\"label\":\"Web sites\",\"type\":\"Format\"}"
       ],
       "genres.label" : [
       ],
       "production.dates" : [
       ],
       "subjects.label" : [
-        "{\"label\":\"IhNdLDgGiV\",\"concepts\":[],\"type\":\"Subject\"}"
+        "{\"label\":\"hQnFei9OwD\",\"concepts\":[],\"type\":\"Subject\"}"
       ],
       "languages" : [
       ],
@@ -159,7 +159,7 @@
       ]
     },
     "filterableValues" : {
-      "format.id" : "v",
+      "format.id" : "z",
       "workType" : "Standard",
       "production.dates.range.from" : [
       ],
@@ -170,12 +170,12 @@
       "genres.concepts.id" : [
       ],
       "subjects.label" : [
-        "IhNdLDgGiV"
+        "hQnFei9OwD"
       ],
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "lxE0qlBbPi"
+        "Xd87ZYKrzx"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.19.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.19.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-05-15T08:17:25.544863Z",
-  "id" : "4hdjmnto",
+  "createdAt" : "2024-08-15T08:40:28.330293Z",
+  "id" : "kw3kldau",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "4hdjmnto",
+        "id" : "kw3kldau",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
-          "value" : "7ZYKrzxgMS"
+          "value" : "lzYfNgtG1S"
         },
-        "version" : 70,
-        "modifiedTime" : "1970-06-23T06:21:51Z"
+        "version" : 8,
+        "modifiedTime" : "1959-09-06T22:36:54Z"
       },
-      "mergedTime" : "1970-06-23T06:21:51Z",
+      "mergedTime" : "1959-09-06T22:36:54Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,13 +24,13 @@
       ]
     },
     "display" : {
-      "id" : "4hdjmnto",
-      "title" : "title-weq2UFKJPl",
+      "id" : "kw3kldau",
+      "title" : "title-4GKNsXvX3N",
       "alternativeTitles" : [
       ],
       "workType" : {
-        "id" : "s",
-        "label" : "E-sound",
+        "id" : "v",
+        "label" : "E-books",
         "type" : "Format"
       },
       "contributors" : [
@@ -38,28 +38,28 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
-          "value" : "7ZYKrzxgMS",
+          "value" : "lzYfNgtG1S",
           "type" : "Identifier"
         }
       ],
       "subjects" : [
         {
-          "label" : "IhNdLDgGiV",
+          "label" : "hQnFei9OwD",
           "concepts" : [
             {
-              "label" : "W1mQ40pgbiIgGzg",
+              "label" : "HmXSsBa8UqTG3Gu",
               "type" : "Concept"
             },
             {
-              "label" : "YBChQnFei9OwDHm",
+              "label" : "W07LA7wtXxMtg7d",
               "type" : "Concept"
             },
             {
-              "label" : "XSsBa8UqTG3GuW0",
+              "label" : "koPI8hxmCeKjABF",
               "type" : "Concept"
             }
           ],
@@ -107,10 +107,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "4hdjmnto",
-      "sourceIdentifier.value" : "7ZYKrzxgMS",
+      "id" : "kw3kldau",
+      "sourceIdentifier.value" : "lzYfNgtG1S",
       "identifiers.value" : [
-        "7ZYKrzxgMS"
+        "lzYfNgtG1S"
       ],
       "images.id" : [
       ],
@@ -132,22 +132,22 @@
       ],
       "referenceNumber" : null,
       "subjects.concepts.label" : [
-        "W1mQ40pgbiIgGzg",
-        "YBChQnFei9OwDHm",
-        "XSsBa8UqTG3GuW0"
+        "HmXSsBa8UqTG3Gu",
+        "W07LA7wtXxMtg7d",
+        "koPI8hxmCeKjABF"
       ],
-      "title" : "title-weq2UFKJPl"
+      "title" : "title-4GKNsXvX3N"
     },
     "aggregatableValues" : {
       "workType" : [
-        "{\"id\":\"s\",\"label\":\"E-sound\",\"type\":\"Format\"}"
+        "{\"id\":\"v\",\"label\":\"E-books\",\"type\":\"Format\"}"
       ],
       "genres.label" : [
       ],
       "production.dates" : [
       ],
       "subjects.label" : [
-        "{\"label\":\"IhNdLDgGiV\",\"concepts\":[],\"type\":\"Subject\"}"
+        "{\"label\":\"hQnFei9OwD\",\"concepts\":[],\"type\":\"Subject\"}"
       ],
       "languages" : [
       ],
@@ -159,7 +159,7 @@
       ]
     },
     "filterableValues" : {
-      "format.id" : "s",
+      "format.id" : "v",
       "workType" : "Standard",
       "production.dates.range.from" : [
       ],
@@ -170,12 +170,12 @@
       "genres.concepts.id" : [
       ],
       "subjects.label" : [
-        "IhNdLDgGiV"
+        "hQnFei9OwD"
       ],
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "7ZYKrzxgMS"
+        "lzYfNgtG1S"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.2.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.2.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-05-15T08:17:25.536896Z",
-  "id" : "msgkyj11",
+  "createdAt" : "2024-08-15T08:40:28.323568Z",
+  "id" : "zh75axbz",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "msgkyj11",
+        "id" : "zh75axbz",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
-          "value" : "fZgItN5K9R"
+          "value" : "4ElQJncU8p"
         },
-        "version" : 9,
-        "modifiedTime" : "2025-06-19T20:45:06Z"
+        "version" : 97,
+        "modifiedTime" : "1962-06-27T00:05:10Z"
       },
-      "mergedTime" : "2025-06-19T20:45:06Z",
+      "mergedTime" : "1962-06-27T00:05:10Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "msgkyj11",
-      "title" : "title-yiVFCEDYI4",
+      "id" : "zh75axbz",
+      "title" : "title-v3a33KTr4g",
       "alternativeTitles" : [
       ],
       "workType" : {
@@ -38,28 +38,28 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
-          "value" : "fZgItN5K9R",
+          "value" : "4ElQJncU8p",
           "type" : "Identifier"
         }
       ],
       "subjects" : [
         {
-          "label" : "y0B0TSmDGU",
+          "label" : "6rJpSUKd2d",
           "concepts" : [
             {
-              "label" : "bHlXq1fwO98EpYD",
+              "label" : "biOiRlog5DCYVH5",
               "type" : "Concept"
             },
             {
-              "label" : "0Ex6rJpSUKd2dbi",
+              "label" : "TP1tcWDr9iToVJb",
               "type" : "Concept"
             },
             {
-              "label" : "OiRlog5DCYVH5TP",
+              "label" : "p9ESZHkohLBqVqY",
               "type" : "Concept"
             }
           ],
@@ -107,10 +107,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "msgkyj11",
-      "sourceIdentifier.value" : "fZgItN5K9R",
+      "id" : "zh75axbz",
+      "sourceIdentifier.value" : "4ElQJncU8p",
       "identifiers.value" : [
-        "fZgItN5K9R"
+        "4ElQJncU8p"
       ],
       "images.id" : [
       ],
@@ -132,11 +132,11 @@
       ],
       "referenceNumber" : null,
       "subjects.concepts.label" : [
-        "bHlXq1fwO98EpYD",
-        "0Ex6rJpSUKd2dbi",
-        "OiRlog5DCYVH5TP"
+        "biOiRlog5DCYVH5",
+        "TP1tcWDr9iToVJb",
+        "p9ESZHkohLBqVqY"
       ],
-      "title" : "title-yiVFCEDYI4"
+      "title" : "title-v3a33KTr4g"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -147,7 +147,7 @@
       "production.dates" : [
       ],
       "subjects.label" : [
-        "{\"label\":\"y0B0TSmDGU\",\"concepts\":[],\"type\":\"Subject\"}"
+        "{\"label\":\"6rJpSUKd2d\",\"concepts\":[],\"type\":\"Subject\"}"
       ],
       "languages" : [
       ],
@@ -170,12 +170,12 @@
       "genres.concepts.id" : [
       ],
       "subjects.label" : [
-        "y0B0TSmDGU"
+        "6rJpSUKd2d"
       ],
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "fZgItN5K9R"
+        "4ElQJncU8p"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.20.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.20.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-05-15T08:17:25.545284Z",
-  "id" : "kldauk4g",
+  "createdAt" : "2024-08-15T08:40:28.330680Z",
+  "id" : "lmxtr1wn",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "kldauk4g",
+        "id" : "lmxtr1wn",
         "identifier" : {
           "identifierType" : {
             "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
-          "value" : "fNgtG1SKw3"
+          "value" : "IXCFVccBcF"
         },
-        "version" : 62,
-        "modifiedTime" : "2064-03-27T14:42:18Z"
+        "version" : 47,
+        "modifiedTime" : "2040-03-06T15:16:33Z"
       },
-      "mergedTime" : "2064-03-27T14:42:18Z",
+      "mergedTime" : "2040-03-06T15:16:33Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,13 +24,13 @@
       ]
     },
     "display" : {
-      "id" : "kldauk4g",
-      "title" : "title-NsXvX3NJfI",
+      "id" : "lmxtr1wn",
+      "title" : "title-mlLNPr0YHU",
       "alternativeTitles" : [
       ],
       "workType" : {
-        "id" : "j",
-        "label" : "E-journals",
+        "id" : "s",
+        "label" : "E-sound",
         "type" : "Format"
       },
       "contributors" : [
@@ -42,24 +42,24 @@
             "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
-          "value" : "fNgtG1SKw3",
+          "value" : "IXCFVccBcF",
           "type" : "Identifier"
         }
       ],
       "subjects" : [
         {
-          "label" : "IhNdLDgGiV",
+          "label" : "hQnFei9OwD",
           "concepts" : [
             {
-              "label" : "W1mQ40pgbiIgGzg",
+              "label" : "HmXSsBa8UqTG3Gu",
               "type" : "Concept"
             },
             {
-              "label" : "YBChQnFei9OwDHm",
+              "label" : "W07LA7wtXxMtg7d",
               "type" : "Concept"
             },
             {
-              "label" : "XSsBa8UqTG3GuW0",
+              "label" : "koPI8hxmCeKjABF",
               "type" : "Concept"
             }
           ],
@@ -107,10 +107,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "kldauk4g",
-      "sourceIdentifier.value" : "fNgtG1SKw3",
+      "id" : "lmxtr1wn",
+      "sourceIdentifier.value" : "IXCFVccBcF",
       "identifiers.value" : [
-        "fNgtG1SKw3"
+        "IXCFVccBcF"
       ],
       "images.id" : [
       ],
@@ -132,22 +132,22 @@
       ],
       "referenceNumber" : null,
       "subjects.concepts.label" : [
-        "W1mQ40pgbiIgGzg",
-        "YBChQnFei9OwDHm",
-        "XSsBa8UqTG3GuW0"
+        "HmXSsBa8UqTG3Gu",
+        "W07LA7wtXxMtg7d",
+        "koPI8hxmCeKjABF"
       ],
-      "title" : "title-NsXvX3NJfI"
+      "title" : "title-mlLNPr0YHU"
     },
     "aggregatableValues" : {
       "workType" : [
-        "{\"id\":\"j\",\"label\":\"E-journals\",\"type\":\"Format\"}"
+        "{\"id\":\"s\",\"label\":\"E-sound\",\"type\":\"Format\"}"
       ],
       "genres.label" : [
       ],
       "production.dates" : [
       ],
       "subjects.label" : [
-        "{\"label\":\"IhNdLDgGiV\",\"concepts\":[],\"type\":\"Subject\"}"
+        "{\"label\":\"hQnFei9OwD\",\"concepts\":[],\"type\":\"Subject\"}"
       ],
       "languages" : [
       ],
@@ -159,7 +159,7 @@
       ]
     },
     "filterableValues" : {
-      "format.id" : "j",
+      "format.id" : "s",
       "workType" : "Standard",
       "production.dates.range.from" : [
       ],
@@ -170,12 +170,12 @@
       "genres.concepts.id" : [
       ],
       "subjects.label" : [
-        "IhNdLDgGiV"
+        "hQnFei9OwD"
       ],
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "fNgtG1SKw3"
+        "IXCFVccBcF"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.21.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.21.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-05-15T08:17:25.545714Z",
-  "id" : "tr1wn4ml",
+  "createdAt" : "2024-08-15T08:40:28.331062Z",
+  "id" : "exjvuylz",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "tr1wn4ml",
+        "id" : "exjvuylz",
         "identifier" : {
           "identifierType" : {
             "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
-          "value" : "FVccBcFLmx"
+          "value" : "7V2pOSQnJO"
         },
-        "version" : 38,
-        "modifiedTime" : "1949-02-04T09:29:35Z"
+        "version" : 50,
+        "modifiedTime" : "1971-07-30T21:22:12Z"
       },
-      "mergedTime" : "1949-02-04T09:29:35Z",
+      "mergedTime" : "1971-07-30T21:22:12Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,13 +24,13 @@
       ]
     },
     "display" : {
-      "id" : "tr1wn4ml",
-      "title" : "title-NPr0YHU0g7",
+      "id" : "exjvuylz",
+      "title" : "title-BDWIViYo3q",
       "alternativeTitles" : [
       ],
       "workType" : {
-        "id" : "f",
-        "label" : "E-videos",
+        "id" : "j",
+        "label" : "E-journals",
         "type" : "Format"
       },
       "contributors" : [
@@ -42,24 +42,24 @@
             "label" : "Miro image number",
             "type" : "IdentifierType"
           },
-          "value" : "FVccBcFLmx",
+          "value" : "7V2pOSQnJO",
           "type" : "Identifier"
         }
       ],
       "subjects" : [
         {
-          "label" : "IhNdLDgGiV",
+          "label" : "hQnFei9OwD",
           "concepts" : [
             {
-              "label" : "W1mQ40pgbiIgGzg",
+              "label" : "HmXSsBa8UqTG3Gu",
               "type" : "Concept"
             },
             {
-              "label" : "YBChQnFei9OwDHm",
+              "label" : "W07LA7wtXxMtg7d",
               "type" : "Concept"
             },
             {
-              "label" : "XSsBa8UqTG3GuW0",
+              "label" : "koPI8hxmCeKjABF",
               "type" : "Concept"
             }
           ],
@@ -107,10 +107,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "tr1wn4ml",
-      "sourceIdentifier.value" : "FVccBcFLmx",
+      "id" : "exjvuylz",
+      "sourceIdentifier.value" : "7V2pOSQnJO",
       "identifiers.value" : [
-        "FVccBcFLmx"
+        "7V2pOSQnJO"
       ],
       "images.id" : [
       ],
@@ -132,22 +132,22 @@
       ],
       "referenceNumber" : null,
       "subjects.concepts.label" : [
-        "W1mQ40pgbiIgGzg",
-        "YBChQnFei9OwDHm",
-        "XSsBa8UqTG3GuW0"
+        "HmXSsBa8UqTG3Gu",
+        "W07LA7wtXxMtg7d",
+        "koPI8hxmCeKjABF"
       ],
-      "title" : "title-NPr0YHU0g7"
+      "title" : "title-BDWIViYo3q"
     },
     "aggregatableValues" : {
       "workType" : [
-        "{\"id\":\"f\",\"label\":\"E-videos\",\"type\":\"Format\"}"
+        "{\"id\":\"j\",\"label\":\"E-journals\",\"type\":\"Format\"}"
       ],
       "genres.label" : [
       ],
       "production.dates" : [
       ],
       "subjects.label" : [
-        "{\"label\":\"IhNdLDgGiV\",\"concepts\":[],\"type\":\"Subject\"}"
+        "{\"label\":\"hQnFei9OwD\",\"concepts\":[],\"type\":\"Subject\"}"
       ],
       "languages" : [
       ],
@@ -159,7 +159,7 @@
       ]
     },
     "filterableValues" : {
-      "format.id" : "f",
+      "format.id" : "j",
       "workType" : "Standard",
       "production.dates.range.from" : [
       ],
@@ -170,12 +170,12 @@
       "genres.concepts.id" : [
       ],
       "subjects.label" : [
-        "IhNdLDgGiV"
+        "hQnFei9OwD"
       ],
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "FVccBcFLmx"
+        "7V2pOSQnJO"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.22.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.22.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-02-16T15:36:44.979281Z",
-  "id" : "vuylz3bd",
+  "createdAt" : "2024-08-15T08:40:28.331753Z",
+  "id" : "fnqpflgg",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "vuylz3bd",
+        "id" : "fnqpflgg",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
-          "value" : "pOSQnJOeXj"
+          "value" : "J0y4QwQTlr"
         },
-        "version" : 13,
-        "modifiedTime" : "1943-07-01T12:05:25Z"
+        "version" : 57,
+        "modifiedTime" : "1967-06-20T04:44:31Z"
       },
-      "mergedTime" : "1943-07-01T12:05:25Z",
+      "mergedTime" : "1967-06-20T04:44:31Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,13 +24,13 @@
       ]
     },
     "display" : {
-      "id" : "vuylz3bd",
-      "title" : "title-IViYo3qvsJ",
+      "id" : "fnqpflgg",
+      "title" : "title-RAV0ZsJywt",
       "alternativeTitles" : [
       ],
       "workType" : {
-        "id" : "x",
-        "label" : "Manuscripts",
+        "id" : "f",
+        "label" : "E-videos",
         "type" : "Format"
       },
       "contributors" : [
@@ -38,28 +38,28 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
-          "value" : "pOSQnJOeXj",
+          "value" : "J0y4QwQTlr",
           "type" : "Identifier"
         }
       ],
       "subjects" : [
         {
-          "label" : "IhNdLDgGiV",
+          "label" : "hQnFei9OwD",
           "concepts" : [
             {
-              "label" : "W1mQ40pgbiIgGzg",
+              "label" : "HmXSsBa8UqTG3Gu",
               "type" : "Concept"
             },
             {
-              "label" : "YBChQnFei9OwDHm",
+              "label" : "W07LA7wtXxMtg7d",
               "type" : "Concept"
             },
             {
-              "label" : "XSsBa8UqTG3GuW0",
+              "label" : "koPI8hxmCeKjABF",
               "type" : "Concept"
             }
           ],
@@ -107,10 +107,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "vuylz3bd",
-      "sourceIdentifier.value" : "pOSQnJOeXj",
+      "id" : "fnqpflgg",
+      "sourceIdentifier.value" : "J0y4QwQTlr",
       "identifiers.value" : [
-        "pOSQnJOeXj"
+        "J0y4QwQTlr"
       ],
       "images.id" : [
       ],
@@ -132,22 +132,22 @@
       ],
       "referenceNumber" : null,
       "subjects.concepts.label" : [
-        "W1mQ40pgbiIgGzg",
-        "YBChQnFei9OwDHm",
-        "XSsBa8UqTG3GuW0"
+        "HmXSsBa8UqTG3Gu",
+        "W07LA7wtXxMtg7d",
+        "koPI8hxmCeKjABF"
       ],
-      "title" : "title-IViYo3qvsJ"
+      "title" : "title-RAV0ZsJywt"
     },
     "aggregatableValues" : {
       "workType" : [
-        "{\"id\":\"x\",\"label\":\"Manuscripts\",\"type\":\"Format\"}"
+        "{\"id\":\"f\",\"label\":\"E-videos\",\"type\":\"Format\"}"
       ],
       "genres.label" : [
       ],
       "production.dates" : [
       ],
       "subjects.label" : [
-        "{\"label\":\"IhNdLDgGiV\",\"concepts\":[],\"type\":\"Subject\"}"
+        "{\"label\":\"hQnFei9OwD\",\"concepts\":[],\"type\":\"Subject\"}"
       ],
       "languages" : [
       ],
@@ -159,7 +159,7 @@
       ]
     },
     "filterableValues" : {
-      "format.id" : "x",
+      "format.id" : "f",
       "workType" : "Standard",
       "production.dates.range.from" : [
       ],
@@ -170,12 +170,12 @@
       "genres.concepts.id" : [
       ],
       "subjects.label" : [
-        "IhNdLDgGiV"
+        "hQnFei9OwD"
       ],
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "pOSQnJOeXj"
+        "J0y4QwQTlr"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.23.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.23.json
@@ -1,22 +1,22 @@
 {
-  "description" : "examples for the contributor filter tests",
-  "createdAt" : "2024-08-15T08:40:28.367350Z",
-  "id" : "ijnwmvup",
+  "description" : "examples for the aggregation-with-filters tests",
+  "createdAt" : "2024-08-15T08:40:28.332265Z",
+  "id" : "y6iujg4j",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "ijnwmvup",
+        "id" : "y6iujg4j",
         "identifier" : {
           "identifierType" : {
             "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
-          "value" : "Kd2KzPZAnM"
+          "value" : "xGjZEnp6i2"
         },
-        "version" : 98,
-        "modifiedTime" : "1968-12-03T01:32:55Z"
+        "version" : 42,
+        "modifiedTime" : "2052-01-06T08:18:52Z"
       },
-      "mergedTime" : "1968-12-03T01:32:55Z",
+      "mergedTime" : "2052-01-06T08:18:52Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,21 +24,16 @@
       ]
     },
     "display" : {
-      "id" : "ijnwmvup",
-      "title" : "title-uMNql7LBhP",
+      "id" : "y6iujg4j",
+      "title" : "title-CRDZnkaHR8",
       "alternativeTitles" : [
       ],
+      "workType" : {
+        "id" : "x",
+        "label" : "Manuscripts",
+        "type" : "Format"
+      },
       "contributors" : [
-        {
-          "agent" : {
-            "label" : "Bath, Patricia",
-            "type" : "Person"
-          },
-          "roles" : [
-          ],
-          "primary" : true,
-          "type" : "Contributor"
-        }
       ],
       "identifiers" : [
         {
@@ -47,11 +42,29 @@
             "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
-          "value" : "Kd2KzPZAnM",
+          "value" : "xGjZEnp6i2",
           "type" : "Identifier"
         }
       ],
       "subjects" : [
+        {
+          "label" : "hQnFei9OwD",
+          "concepts" : [
+            {
+              "label" : "HmXSsBa8UqTG3Gu",
+              "type" : "Concept"
+            },
+            {
+              "label" : "W07LA7wtXxMtg7d",
+              "type" : "Concept"
+            },
+            {
+              "label" : "koPI8hxmCeKjABF",
+              "type" : "Concept"
+            }
+          ],
+          "type" : "Subject"
+        }
       ],
       "genres" : [
       ],
@@ -89,16 +102,15 @@
       "alternativeTitles" : [
       ],
       "contributors.agent.label" : [
-        "Bath, Patricia"
       ],
       "description" : null,
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "ijnwmvup",
-      "sourceIdentifier.value" : "Kd2KzPZAnM",
+      "id" : "y6iujg4j",
+      "sourceIdentifier.value" : "xGjZEnp6i2",
       "identifiers.value" : [
-        "Kd2KzPZAnM"
+        "xGjZEnp6i2"
       ],
       "images.id" : [
       ],
@@ -120,22 +132,26 @@
       ],
       "referenceNumber" : null,
       "subjects.concepts.label" : [
+        "HmXSsBa8UqTG3Gu",
+        "W07LA7wtXxMtg7d",
+        "koPI8hxmCeKjABF"
       ],
-      "title" : "title-uMNql7LBhP"
+      "title" : "title-CRDZnkaHR8"
     },
     "aggregatableValues" : {
       "workType" : [
+        "{\"id\":\"x\",\"label\":\"Manuscripts\",\"type\":\"Format\"}"
       ],
       "genres.label" : [
       ],
       "production.dates" : [
       ],
       "subjects.label" : [
+        "{\"label\":\"hQnFei9OwD\",\"concepts\":[],\"type\":\"Subject\"}"
       ],
       "languages" : [
       ],
       "contributors.agent.label" : [
-        "{\"label\":\"Bath, Patricia\",\"type\":\"Person\"}"
       ],
       "items.locations.license" : [
       ],
@@ -143,7 +159,7 @@
       ]
     },
     "filterableValues" : {
-      "format.id" : null,
+      "format.id" : "x",
       "workType" : "Standard",
       "production.dates.range.from" : [
       ],
@@ -154,12 +170,12 @@
       "genres.concepts.id" : [
       ],
       "subjects.label" : [
+        "hQnFei9OwD"
       ],
       "contributors.agent.label" : [
-        "Bath, Patricia"
       ],
       "identifiers.value" : [
-        "Kd2KzPZAnM"
+        "xGjZEnp6i2"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.3.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.3.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-05-15T08:17:25.537351Z",
-  "id" : "5axbzov3",
+  "createdAt" : "2024-08-15T08:40:28.324208Z",
+  "id" : "z92kvukz",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "5axbzov3",
+        "id" : "z92kvukz",
         "identifier" : {
           "identifierType" : {
             "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
-          "value" : "QJncU8pZH7"
+          "value" : "8YItYtyWP3"
         },
-        "version" : 53,
-        "modifiedTime" : "1958-04-28T22:37:25Z"
+        "version" : 56,
+        "modifiedTime" : "2024-03-02T14:57:12Z"
       },
-      "mergedTime" : "1958-04-28T22:37:25Z",
+      "mergedTime" : "2024-03-02T14:57:12Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "5axbzov3",
-      "title" : "title-33KTr4gSW8",
+      "id" : "z92kvukz",
+      "title" : "title-4ht9Z95L7c",
       "alternativeTitles" : [
       ],
       "workType" : {
@@ -42,24 +42,24 @@
             "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
-          "value" : "QJncU8pZH7",
+          "value" : "8YItYtyWP3",
           "type" : "Identifier"
         }
       ],
       "subjects" : [
         {
-          "label" : "y0B0TSmDGU",
+          "label" : "6rJpSUKd2d",
           "concepts" : [
             {
-              "label" : "bHlXq1fwO98EpYD",
+              "label" : "biOiRlog5DCYVH5",
               "type" : "Concept"
             },
             {
-              "label" : "0Ex6rJpSUKd2dbi",
+              "label" : "TP1tcWDr9iToVJb",
               "type" : "Concept"
             },
             {
-              "label" : "OiRlog5DCYVH5TP",
+              "label" : "p9ESZHkohLBqVqY",
               "type" : "Concept"
             }
           ],
@@ -107,10 +107,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "5axbzov3",
-      "sourceIdentifier.value" : "QJncU8pZH7",
+      "id" : "z92kvukz",
+      "sourceIdentifier.value" : "8YItYtyWP3",
       "identifiers.value" : [
-        "QJncU8pZH7"
+        "8YItYtyWP3"
       ],
       "images.id" : [
       ],
@@ -132,11 +132,11 @@
       ],
       "referenceNumber" : null,
       "subjects.concepts.label" : [
-        "bHlXq1fwO98EpYD",
-        "0Ex6rJpSUKd2dbi",
-        "OiRlog5DCYVH5TP"
+        "biOiRlog5DCYVH5",
+        "TP1tcWDr9iToVJb",
+        "p9ESZHkohLBqVqY"
       ],
-      "title" : "title-33KTr4gSW8"
+      "title" : "title-4ht9Z95L7c"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -147,7 +147,7 @@
       "production.dates" : [
       ],
       "subjects.label" : [
-        "{\"label\":\"y0B0TSmDGU\",\"concepts\":[],\"type\":\"Subject\"}"
+        "{\"label\":\"6rJpSUKd2d\",\"concepts\":[],\"type\":\"Subject\"}"
       ],
       "languages" : [
       ],
@@ -170,12 +170,12 @@
       "genres.concepts.id" : [
       ],
       "subjects.label" : [
-        "y0B0TSmDGU"
+        "6rJpSUKd2d"
       ],
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "QJncU8pZH7"
+        "8YItYtyWP3"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.4.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.4.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-05-15T08:17:25.537776Z",
-  "id" : "kvukzd4h",
+  "createdAt" : "2024-08-15T08:40:28.324672Z",
+  "id" : "m9cvkukq",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "kvukzd4h",
+        "id" : "m9cvkukq",
         "identifier" : {
           "identifierType" : {
             "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
-          "value" : "tYtyWP3z92"
+          "value" : "66BwUadwA2"
         },
-        "version" : 89,
-        "modifiedTime" : "1934-09-28T19:42:39Z"
+        "version" : 1,
+        "modifiedTime" : "1938-04-20T22:56:50Z"
       },
-      "mergedTime" : "1934-09-28T19:42:39Z",
+      "mergedTime" : "1938-04-20T22:56:50Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "kvukzd4h",
-      "title" : "title-9Z95L7cLo6",
+      "id" : "m9cvkukq",
+      "title" : "title-ogxZlpWaXi",
       "alternativeTitles" : [
       ],
       "workType" : {
@@ -42,24 +42,24 @@
             "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
-          "value" : "tYtyWP3z92",
+          "value" : "66BwUadwA2",
           "type" : "Identifier"
         }
       ],
       "subjects" : [
         {
-          "label" : "y0B0TSmDGU",
+          "label" : "6rJpSUKd2d",
           "concepts" : [
             {
-              "label" : "bHlXq1fwO98EpYD",
+              "label" : "biOiRlog5DCYVH5",
               "type" : "Concept"
             },
             {
-              "label" : "0Ex6rJpSUKd2dbi",
+              "label" : "TP1tcWDr9iToVJb",
               "type" : "Concept"
             },
             {
-              "label" : "OiRlog5DCYVH5TP",
+              "label" : "p9ESZHkohLBqVqY",
               "type" : "Concept"
             }
           ],
@@ -107,10 +107,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "kvukzd4h",
-      "sourceIdentifier.value" : "tYtyWP3z92",
+      "id" : "m9cvkukq",
+      "sourceIdentifier.value" : "66BwUadwA2",
       "identifiers.value" : [
-        "tYtyWP3z92"
+        "66BwUadwA2"
       ],
       "images.id" : [
       ],
@@ -132,11 +132,11 @@
       ],
       "referenceNumber" : null,
       "subjects.concepts.label" : [
-        "bHlXq1fwO98EpYD",
-        "0Ex6rJpSUKd2dbi",
-        "OiRlog5DCYVH5TP"
+        "biOiRlog5DCYVH5",
+        "TP1tcWDr9iToVJb",
+        "p9ESZHkohLBqVqY"
       ],
-      "title" : "title-9Z95L7cLo6"
+      "title" : "title-ogxZlpWaXi"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -147,7 +147,7 @@
       "production.dates" : [
       ],
       "subjects.label" : [
-        "{\"label\":\"y0B0TSmDGU\",\"concepts\":[],\"type\":\"Subject\"}"
+        "{\"label\":\"6rJpSUKd2d\",\"concepts\":[],\"type\":\"Subject\"}"
       ],
       "languages" : [
       ],
@@ -170,12 +170,12 @@
       "genres.concepts.id" : [
       ],
       "subjects.label" : [
-        "y0B0TSmDGU"
+        "6rJpSUKd2d"
       ],
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "tYtyWP3z92"
+        "66BwUadwA2"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.5.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.5.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-05-15T08:17:25.538492Z",
-  "id" : "vkukqiog",
+  "createdAt" : "2024-08-15T08:40:28.325080Z",
+  "id" : "n4dq7ypg",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "vkukqiog",
+        "id" : "n4dq7ypg",
         "identifier" : {
           "identifierType" : {
             "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
-          "value" : "wUadwA2M9C"
+          "value" : "dBoRzqlD5L"
         },
-        "version" : 54,
-        "modifiedTime" : "1942-01-27T06:45:07Z"
+        "version" : 37,
+        "modifiedTime" : "1962-10-07T16:30:13Z"
       },
-      "mergedTime" : "1942-01-27T06:45:07Z",
+      "mergedTime" : "1962-10-07T16:30:13Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "vkukqiog",
-      "title" : "title-ZlpWaXi4Yd",
+      "id" : "n4dq7ypg",
+      "title" : "title-B2SlRRldG9",
       "alternativeTitles" : [
       ],
       "workType" : {
@@ -42,24 +42,24 @@
             "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
-          "value" : "wUadwA2M9C",
+          "value" : "dBoRzqlD5L",
           "type" : "Identifier"
         }
       ],
       "subjects" : [
         {
-          "label" : "y0B0TSmDGU",
+          "label" : "6rJpSUKd2d",
           "concepts" : [
             {
-              "label" : "bHlXq1fwO98EpYD",
+              "label" : "biOiRlog5DCYVH5",
               "type" : "Concept"
             },
             {
-              "label" : "0Ex6rJpSUKd2dbi",
+              "label" : "TP1tcWDr9iToVJb",
               "type" : "Concept"
             },
             {
-              "label" : "OiRlog5DCYVH5TP",
+              "label" : "p9ESZHkohLBqVqY",
               "type" : "Concept"
             }
           ],
@@ -107,10 +107,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "vkukqiog",
-      "sourceIdentifier.value" : "wUadwA2M9C",
+      "id" : "n4dq7ypg",
+      "sourceIdentifier.value" : "dBoRzqlD5L",
       "identifiers.value" : [
-        "wUadwA2M9C"
+        "dBoRzqlD5L"
       ],
       "images.id" : [
       ],
@@ -132,11 +132,11 @@
       ],
       "referenceNumber" : null,
       "subjects.concepts.label" : [
-        "bHlXq1fwO98EpYD",
-        "0Ex6rJpSUKd2dbi",
-        "OiRlog5DCYVH5TP"
+        "biOiRlog5DCYVH5",
+        "TP1tcWDr9iToVJb",
+        "p9ESZHkohLBqVqY"
       ],
-      "title" : "title-ZlpWaXi4Yd"
+      "title" : "title-B2SlRRldG9"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -147,7 +147,7 @@
       "production.dates" : [
       ],
       "subjects.label" : [
-        "{\"label\":\"y0B0TSmDGU\",\"concepts\":[],\"type\":\"Subject\"}"
+        "{\"label\":\"6rJpSUKd2d\",\"concepts\":[],\"type\":\"Subject\"}"
       ],
       "languages" : [
       ],
@@ -170,12 +170,12 @@
       "genres.concepts.id" : [
       ],
       "subjects.label" : [
-        "y0B0TSmDGU"
+        "6rJpSUKd2d"
       ],
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "wUadwA2M9C"
+        "dBoRzqlD5L"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.6.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.6.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-05-15T08:17:25.539138Z",
-  "id" : "q7ypgqb2",
+  "createdAt" : "2024-08-15T08:40:28.325442Z",
+  "id" : "4cicdqpx",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "q7ypgqb2",
+        "id" : "4cicdqpx",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
-          "value" : "RzqlD5LN4d"
+          "value" : "FU0kYbman5"
         },
-        "version" : 75,
-        "modifiedTime" : "2012-02-21T12:08:18Z"
+        "version" : 16,
+        "modifiedTime" : "2048-11-03T20:54:50Z"
       },
-      "mergedTime" : "2012-02-21T12:08:18Z",
+      "mergedTime" : "2048-11-03T20:54:50Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "q7ypgqb2",
-      "title" : "title-lRRldG9e4F",
+      "id" : "4cicdqpx",
+      "title" : "title-AZqajt54m4",
       "alternativeTitles" : [
       ],
       "workType" : {
@@ -38,28 +38,28 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
-          "value" : "RzqlD5LN4d",
+          "value" : "FU0kYbman5",
           "type" : "Identifier"
         }
       ],
       "subjects" : [
         {
-          "label" : "1tcWDr9iTo",
+          "label" : "S4hioTvwQl",
           "concepts" : [
             {
-              "label" : "VJbp9ESZHkohLBq",
+              "label" : "eJkqVbD7mxTT1Dn",
               "type" : "Concept"
             },
             {
-              "label" : "VqYS4hioTvwQleJ",
+              "label" : "ad9SceRNaTElZtf",
               "type" : "Concept"
             },
             {
-              "label" : "kqVbD7mxTT1Dnad",
+              "label" : "G4qEc4MTvdPAcgp",
               "type" : "Concept"
             }
           ],
@@ -107,10 +107,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "q7ypgqb2",
-      "sourceIdentifier.value" : "RzqlD5LN4d",
+      "id" : "4cicdqpx",
+      "sourceIdentifier.value" : "FU0kYbman5",
       "identifiers.value" : [
-        "RzqlD5LN4d"
+        "FU0kYbman5"
       ],
       "images.id" : [
       ],
@@ -132,11 +132,11 @@
       ],
       "referenceNumber" : null,
       "subjects.concepts.label" : [
-        "VJbp9ESZHkohLBq",
-        "VqYS4hioTvwQleJ",
-        "kqVbD7mxTT1Dnad"
+        "eJkqVbD7mxTT1Dn",
+        "ad9SceRNaTElZtf",
+        "G4qEc4MTvdPAcgp"
       ],
-      "title" : "title-lRRldG9e4F"
+      "title" : "title-AZqajt54m4"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -147,7 +147,7 @@
       "production.dates" : [
       ],
       "subjects.label" : [
-        "{\"label\":\"1tcWDr9iTo\",\"concepts\":[],\"type\":\"Subject\"}"
+        "{\"label\":\"S4hioTvwQl\",\"concepts\":[],\"type\":\"Subject\"}"
       ],
       "languages" : [
       ],
@@ -170,12 +170,12 @@
       "genres.concepts.id" : [
       ],
       "subjects.label" : [
-        "1tcWDr9iTo"
+        "S4hioTvwQl"
       ],
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "RzqlD5LN4d"
+        "FU0kYbman5"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.7.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.7.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-05-15T08:17:25.539638Z",
-  "id" : "cdqpxiaz",
+  "createdAt" : "2024-08-15T08:40:28.325798Z",
+  "id" : "p7zbfaov",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "cdqpxiaz",
+        "id" : "p7zbfaov",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
-          "value" : "kYbman54cI"
+          "value" : "pYub9JXopb"
         },
-        "version" : 11,
-        "modifiedTime" : "1975-05-07T19:46:33Z"
+        "version" : 85,
+        "modifiedTime" : "1944-12-17T09:08:30Z"
       },
-      "mergedTime" : "1975-05-07T19:46:33Z",
+      "mergedTime" : "1944-12-17T09:08:30Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "cdqpxiaz",
-      "title" : "title-ajt54m4dWp",
+      "id" : "p7zbfaov",
+      "title" : "title-IZx0zgHgbz",
       "alternativeTitles" : [
       ],
       "workType" : {
@@ -38,28 +38,28 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
-          "value" : "kYbman54cI",
+          "value" : "pYub9JXopb",
           "type" : "Identifier"
         }
       ],
       "subjects" : [
         {
-          "label" : "1tcWDr9iTo",
+          "label" : "S4hioTvwQl",
           "concepts" : [
             {
-              "label" : "VJbp9ESZHkohLBq",
+              "label" : "eJkqVbD7mxTT1Dn",
               "type" : "Concept"
             },
             {
-              "label" : "VqYS4hioTvwQleJ",
+              "label" : "ad9SceRNaTElZtf",
               "type" : "Concept"
             },
             {
-              "label" : "kqVbD7mxTT1Dnad",
+              "label" : "G4qEc4MTvdPAcgp",
               "type" : "Concept"
             }
           ],
@@ -107,10 +107,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "cdqpxiaz",
-      "sourceIdentifier.value" : "kYbman54cI",
+      "id" : "p7zbfaov",
+      "sourceIdentifier.value" : "pYub9JXopb",
       "identifiers.value" : [
-        "kYbman54cI"
+        "pYub9JXopb"
       ],
       "images.id" : [
       ],
@@ -132,11 +132,11 @@
       ],
       "referenceNumber" : null,
       "subjects.concepts.label" : [
-        "VJbp9ESZHkohLBq",
-        "VqYS4hioTvwQleJ",
-        "kqVbD7mxTT1Dnad"
+        "eJkqVbD7mxTT1Dn",
+        "ad9SceRNaTElZtf",
+        "G4qEc4MTvdPAcgp"
       ],
-      "title" : "title-ajt54m4dWp"
+      "title" : "title-IZx0zgHgbz"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -147,7 +147,7 @@
       "production.dates" : [
       ],
       "subjects.label" : [
-        "{\"label\":\"1tcWDr9iTo\",\"concepts\":[],\"type\":\"Subject\"}"
+        "{\"label\":\"S4hioTvwQl\",\"concepts\":[],\"type\":\"Subject\"}"
       ],
       "languages" : [
       ],
@@ -170,12 +170,12 @@
       "genres.concepts.id" : [
       ],
       "subjects.label" : [
-        "1tcWDr9iTo"
+        "S4hioTvwQl"
       ],
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "kYbman54cI"
+        "pYub9JXopb"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.8.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.8.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-02-16T15:36:44.966109Z",
-  "id" : "bfaov6iz",
+  "createdAt" : "2024-08-15T08:40:28.326170Z",
+  "id" : "nuuq84cr",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "bfaov6iz",
+        "id" : "nuuq84cr",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
-          "value" : "b9JXopbp7Z"
+          "value" : "IzLCv3sMYa"
         },
-        "version" : 96,
-        "modifiedTime" : "2060-01-23T11:20:20Z"
+        "version" : 39,
+        "modifiedTime" : "1954-05-22T01:33:53Z"
       },
-      "mergedTime" : "2060-01-23T11:20:20Z",
+      "mergedTime" : "1954-05-22T01:33:53Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "bfaov6iz",
-      "title" : "title-0zgHgbzqMI",
+      "id" : "nuuq84cr",
+      "title" : "title-J5Ue8m3HVu",
       "alternativeTitles" : [
       ],
       "workType" : {
@@ -38,28 +38,28 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
-          "value" : "b9JXopbp7Z",
+          "value" : "IzLCv3sMYa",
           "type" : "Identifier"
         }
       ],
       "subjects" : [
         {
-          "label" : "1tcWDr9iTo",
+          "label" : "S4hioTvwQl",
           "concepts" : [
             {
-              "label" : "VJbp9ESZHkohLBq",
+              "label" : "eJkqVbD7mxTT1Dn",
               "type" : "Concept"
             },
             {
-              "label" : "VqYS4hioTvwQleJ",
+              "label" : "ad9SceRNaTElZtf",
               "type" : "Concept"
             },
             {
-              "label" : "kqVbD7mxTT1Dnad",
+              "label" : "G4qEc4MTvdPAcgp",
               "type" : "Concept"
             }
           ],
@@ -107,10 +107,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "bfaov6iz",
-      "sourceIdentifier.value" : "b9JXopbp7Z",
+      "id" : "nuuq84cr",
+      "sourceIdentifier.value" : "IzLCv3sMYa",
       "identifiers.value" : [
-        "b9JXopbp7Z"
+        "IzLCv3sMYa"
       ],
       "images.id" : [
       ],
@@ -132,11 +132,11 @@
       ],
       "referenceNumber" : null,
       "subjects.concepts.label" : [
-        "VJbp9ESZHkohLBq",
-        "VqYS4hioTvwQleJ",
-        "kqVbD7mxTT1Dnad"
+        "eJkqVbD7mxTT1Dn",
+        "ad9SceRNaTElZtf",
+        "G4qEc4MTvdPAcgp"
       ],
-      "title" : "title-0zgHgbzqMI"
+      "title" : "title-J5Ue8m3HVu"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -147,7 +147,7 @@
       "production.dates" : [
       ],
       "subjects.label" : [
-        "{\"label\":\"1tcWDr9iTo\",\"concepts\":[],\"type\":\"Subject\"}"
+        "{\"label\":\"S4hioTvwQl\",\"concepts\":[],\"type\":\"Subject\"}"
       ],
       "languages" : [
       ],
@@ -170,12 +170,12 @@
       "genres.concepts.id" : [
       ],
       "subjects.label" : [
-        "1tcWDr9iTo"
+        "S4hioTvwQl"
       ],
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "b9JXopbp7Z"
+        "IzLCv3sMYa"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.9.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.9.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2024-02-16T15:36:44.966741Z",
-  "id" : "q84crgj5",
+  "createdAt" : "2024-08-15T08:40:28.326558Z",
+  "id" : "x1muoi8t",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "q84crgj5",
+        "id" : "x1muoi8t",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
-          "value" : "Cv3sMYaNuU"
+          "value" : "s4RY14qUDX"
         },
-        "version" : 33,
-        "modifiedTime" : "2034-10-22T02:22:22Z"
+        "version" : 10,
+        "modifiedTime" : "2033-02-03T15:52:28Z"
       },
-      "mergedTime" : "2034-10-22T02:22:22Z",
+      "mergedTime" : "2033-02-03T15:52:28Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "q84crgj5",
-      "title" : "title-e8m3HVuers",
+      "id" : "x1muoi8t",
+      "title" : "title-8uFRfKD3vr",
       "alternativeTitles" : [
       ],
       "workType" : {
@@ -38,28 +38,28 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
-          "value" : "Cv3sMYaNuU",
+          "value" : "s4RY14qUDX",
           "type" : "Identifier"
         }
       ],
       "subjects" : [
         {
-          "label" : "1tcWDr9iTo",
+          "label" : "S4hioTvwQl",
           "concepts" : [
             {
-              "label" : "VJbp9ESZHkohLBq",
+              "label" : "eJkqVbD7mxTT1Dn",
               "type" : "Concept"
             },
             {
-              "label" : "VqYS4hioTvwQleJ",
+              "label" : "ad9SceRNaTElZtf",
               "type" : "Concept"
             },
             {
-              "label" : "kqVbD7mxTT1Dnad",
+              "label" : "G4qEc4MTvdPAcgp",
               "type" : "Concept"
             }
           ],
@@ -107,10 +107,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "q84crgj5",
-      "sourceIdentifier.value" : "Cv3sMYaNuU",
+      "id" : "x1muoi8t",
+      "sourceIdentifier.value" : "s4RY14qUDX",
       "identifiers.value" : [
-        "Cv3sMYaNuU"
+        "s4RY14qUDX"
       ],
       "images.id" : [
       ],
@@ -132,11 +132,11 @@
       ],
       "referenceNumber" : null,
       "subjects.concepts.label" : [
-        "VJbp9ESZHkohLBq",
-        "VqYS4hioTvwQleJ",
-        "kqVbD7mxTT1Dnad"
+        "eJkqVbD7mxTT1Dn",
+        "ad9SceRNaTElZtf",
+        "G4qEc4MTvdPAcgp"
       ],
-      "title" : "title-e8m3HVuers"
+      "title" : "title-8uFRfKD3vr"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -147,7 +147,7 @@
       "production.dates" : [
       ],
       "subjects.label" : [
-        "{\"label\":\"1tcWDr9iTo\",\"concepts\":[],\"type\":\"Subject\"}"
+        "{\"label\":\"S4hioTvwQl\",\"concepts\":[],\"type\":\"Subject\"}"
       ],
       "languages" : [
       ],
@@ -170,12 +170,12 @@
       "genres.concepts.id" : [
       ],
       "subjects.label" : [
-        "1tcWDr9iTo"
+        "S4hioTvwQl"
       ],
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "Cv3sMYaNuU"
+        "s4RY14qUDX"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.availabilities.closed-only.json
+++ b/pipeline/ingestor/test_documents/works.examples.availabilities.closed-only.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for availabilities tests",
-  "createdAt" : "2024-05-15T08:17:25.619978Z",
-  "id" : "bb4tv6zd",
+  "createdAt" : "2024-08-15T08:40:28.404121Z",
+  "id" : "iopgf0nj",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "bb4tv6zd",
+        "id" : "iopgf0nj",
         "identifier" : {
           "identifierType" : {
             "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
-          "value" : "rXrfr8eL5R"
+          "value" : "3glZntXsvt"
         },
-        "version" : 47,
-        "modifiedTime" : "1969-11-05T18:12:49Z"
+        "version" : 64,
+        "modifiedTime" : "1940-10-05T05:45:04Z"
       },
-      "mergedTime" : "1969-11-05T18:12:49Z",
+      "mergedTime" : "1940-10-05T05:45:04Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "bb4tv6zd",
-      "title" : "title-uptWXSBlJF",
+      "id" : "iopgf0nj",
+      "title" : "title-tuZQUd4A61",
       "alternativeTitles" : [
       ],
       "contributors" : [
@@ -37,7 +37,7 @@
             "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
-          "value" : "rXrfr8eL5R",
+          "value" : "3glZntXsvt",
           "type" : "Identifier"
         }
       ],
@@ -47,7 +47,7 @@
       ],
       "items" : [
         {
-          "id" : "lbwsensp",
+          "id" : "wpw7kqmd",
           "identifiers" : [
             {
               "identifierType" : {
@@ -55,7 +55,7 @@
                 "label" : "Miro image number",
                 "type" : "IdentifierType"
               },
-              "value" : "JJ01MHKXQ3",
+              "value" : "vOEvkncTXy",
               "type" : "Identifier"
             }
           ],
@@ -68,11 +68,12 @@
               },
               "label" : "locationLabel",
               "license" : {
-                "id" : "cc-by",
-                "label" : "Attribution 4.0 International (CC BY 4.0)",
-                "url" : "http://creativecommons.org/licenses/by/4.0/",
+                "id" : "ogl",
+                "label" : "Open Government Licence",
+                "url" : "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
                 "type" : "License"
               },
+              "shelfmark" : "Shelfmark: UIgSWmx",
               "accessConditions" : [
               ],
               "type" : "PhysicalLocation"
@@ -123,20 +124,20 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "bb4tv6zd",
-      "sourceIdentifier.value" : "rXrfr8eL5R",
+      "id" : "iopgf0nj",
+      "sourceIdentifier.value" : "3glZntXsvt",
       "identifiers.value" : [
-        "rXrfr8eL5R"
+        "3glZntXsvt"
       ],
       "images.id" : [
       ],
       "images.identifiers.value" : [
       ],
       "items.id" : [
-        "lbwsensp"
+        "wpw7kqmd"
       ],
       "items.identifiers.value" : [
-        "JJ01MHKXQ3"
+        "vOEvkncTXy"
       ],
       "languages.label" : [
       ],
@@ -151,7 +152,7 @@
       "referenceNumber" : null,
       "subjects.concepts.label" : [
       ],
-      "title" : "title-uptWXSBlJF"
+      "title" : "title-tuZQUd4A61"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -167,7 +168,7 @@
       "contributors.agent.label" : [
       ],
       "items.locations.license" : [
-        "{\"id\":\"cc-by\",\"label\":\"Attribution 4.0 International (CC BY 4.0)\",\"url\":\"http://creativecommons.org/licenses/by/4.0/\",\"type\":\"License\"}"
+        "{\"id\":\"ogl\",\"label\":\"Open Government Licence\",\"url\":\"http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/\",\"type\":\"License\"}"
       ],
       "availabilities" : [
         "{\"id\":\"closed-stores\",\"label\":\"Closed stores\",\"type\":\"Availability\"}"
@@ -189,18 +190,18 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "rXrfr8eL5R"
+        "3glZntXsvt"
       ],
       "items.locations.license.id" : [
-        "cc-by"
+        "ogl"
       ],
       "items.locations.accessConditions.status.id" : [
       ],
       "items.id" : [
-        "lbwsensp"
+        "wpw7kqmd"
       ],
       "items.identifiers.value" : [
-        "JJ01MHKXQ3"
+        "vOEvkncTXy"
       ],
       "items.locations.locationType.id" : [
         "closed-stores"

--- a/pipeline/ingestor/test_documents/works.examples.availabilities.everywhere.json
+++ b/pipeline/ingestor/test_documents/works.examples.availabilities.everywhere.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for availabilities tests",
-  "createdAt" : "2024-05-15T08:17:25.623181Z",
-  "id" : "ntlrk7nw",
+  "createdAt" : "2024-08-15T08:40:28.406646Z",
+  "id" : "9stpxl39",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "ntlrk7nw",
+        "id" : "9stpxl39",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
-          "value" : "9pCp7jd9rF"
+          "value" : "iOhIDpmZQS"
         },
-        "version" : 85,
-        "modifiedTime" : "2003-11-23T19:57:31Z"
+        "version" : 90,
+        "modifiedTime" : "2053-10-10T09:57:01Z"
       },
-      "mergedTime" : "2003-11-23T19:57:31Z",
+      "mergedTime" : "2053-10-10T09:57:01Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "ntlrk7nw",
-      "title" : "title-5hDXNpf0jl",
+      "id" : "9stpxl39",
+      "title" : "title-ZJBZp7GTBM",
       "alternativeTitles" : [
       ],
       "contributors" : [
@@ -33,11 +33,11 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
-          "value" : "9pCp7jd9rF",
+          "value" : "iOhIDpmZQS",
           "type" : "Identifier"
         }
       ],
@@ -47,15 +47,15 @@
       ],
       "items" : [
         {
-          "id" : "dc51h9g3",
+          "id" : "qdr9gb06",
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "calm-record-id",
-                "label" : "Calm RecordIdentifier",
+                "id" : "sierra-system-number",
+                "label" : "Sierra system number",
                 "type" : "IdentifierType"
               },
-              "value" : "S97qOpHViO",
+              "value" : "szcI3pLB8w",
               "type" : "Identifier"
             }
           ],
@@ -67,6 +67,12 @@
                 "type" : "LocationType"
               },
               "label" : "locationLabel",
+              "license" : {
+                "id" : "pdm",
+                "label" : "Public Domain Mark",
+                "url" : "https://creativecommons.org/share-your-work/public-domain/pdm/",
+                "type" : "License"
+              },
               "accessConditions" : [
               ],
               "type" : "PhysicalLocation"
@@ -75,15 +81,15 @@
           "type" : "Item"
         },
         {
-          "id" : "tpxl396z",
+          "id" : "y1i7iplx",
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "miro-image-number",
-                "label" : "Miro image number",
+                "id" : "calm-record-id",
+                "label" : "Calm RecordIdentifier",
                 "type" : "IdentifierType"
               },
-              "value" : "BZp7GTBM7U",
+              "value" : "9QmlF92mk9",
               "type" : "Identifier"
             }
           ],
@@ -95,12 +101,7 @@
                 "type" : "LocationType"
               },
               "label" : "locationLabel",
-              "license" : {
-                "id" : "cc-by",
-                "label" : "Attribution 4.0 International (CC BY 4.0)",
-                "url" : "http://creativecommons.org/licenses/by/4.0/",
-                "type" : "License"
-              },
+              "shelfmark" : "Shelfmark: cCc2QL7V8",
               "accessConditions" : [
               ],
               "type" : "PhysicalLocation"
@@ -118,7 +119,8 @@
                 "label" : "IIIF Presentation API",
                 "type" : "LocationType"
               },
-              "url" : "https://iiif.wellcomecollection.org/image/TvJ.jpg/info.json",
+              "url" : "https://iiif.wellcomecollection.org/image/AUd.jpg/info.json",
+              "linkText" : "Link text: zYQpvm",
               "license" : {
                 "id" : "cc-by",
                 "label" : "Attribution 4.0 International (CC BY 4.0)",
@@ -198,22 +200,22 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "ntlrk7nw",
-      "sourceIdentifier.value" : "9pCp7jd9rF",
+      "id" : "9stpxl39",
+      "sourceIdentifier.value" : "iOhIDpmZQS",
       "identifiers.value" : [
-        "9pCp7jd9rF"
+        "iOhIDpmZQS"
       ],
       "images.id" : [
       ],
       "images.identifiers.value" : [
       ],
       "items.id" : [
-        "dc51h9g3",
-        "tpxl396z"
+        "qdr9gb06",
+        "y1i7iplx"
       ],
       "items.identifiers.value" : [
-        "S97qOpHViO",
-        "BZp7GTBM7U"
+        "szcI3pLB8w",
+        "9QmlF92mk9"
       ],
       "languages.label" : [
       ],
@@ -228,7 +230,7 @@
       "referenceNumber" : null,
       "subjects.concepts.label" : [
       ],
-      "title" : "title-5hDXNpf0jl"
+      "title" : "title-ZJBZp7GTBM"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -244,7 +246,7 @@
       "contributors.agent.label" : [
       ],
       "items.locations.license" : [
-        "{\"id\":\"cc-by\",\"label\":\"Attribution 4.0 International (CC BY 4.0)\",\"url\":\"http://creativecommons.org/licenses/by/4.0/\",\"type\":\"License\"}",
+        "{\"id\":\"pdm\",\"label\":\"Public Domain Mark\",\"url\":\"https://creativecommons.org/share-your-work/public-domain/pdm/\",\"type\":\"License\"}",
         "{\"id\":\"cc-by\",\"label\":\"Attribution 4.0 International (CC BY 4.0)\",\"url\":\"http://creativecommons.org/licenses/by/4.0/\",\"type\":\"License\"}"
       ],
       "availabilities" : [
@@ -269,22 +271,22 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "9pCp7jd9rF"
+        "iOhIDpmZQS"
       ],
       "items.locations.license.id" : [
-        "cc-by",
+        "pdm",
         "cc-by"
       ],
       "items.locations.accessConditions.status.id" : [
         "open-with-advisory"
       ],
       "items.id" : [
-        "dc51h9g3",
-        "tpxl396z"
+        "qdr9gb06",
+        "y1i7iplx"
       ],
       "items.identifiers.value" : [
-        "S97qOpHViO",
-        "BZp7GTBM7U"
+        "szcI3pLB8w",
+        "9QmlF92mk9"
       ],
       "items.locations.locationType.id" : [
         "closed-stores",

--- a/pipeline/ingestor/test_documents/works.examples.availabilities.nowhere.json
+++ b/pipeline/ingestor/test_documents/works.examples.availabilities.nowhere.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for availabilities tests",
-  "createdAt" : "2024-05-15T08:17:25.621915Z",
-  "id" : "cc2ql7v8",
+  "createdAt" : "2024-08-15T08:40:28.405827Z",
+  "id" : "jy8lcdnc",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "cc2ql7v8",
+        "id" : "jy8lcdnc",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
-          "value" : "I3pLB8wFUc"
+          "value" : "r5gilWx8gA"
         },
-        "version" : 97,
-        "modifiedTime" : "1994-05-11T15:38:25Z"
+        "version" : 60,
+        "modifiedTime" : "1938-04-17T00:01:19Z"
       },
-      "mergedTime" : "1994-05-11T15:38:25Z",
+      "mergedTime" : "1938-04-17T00:01:19Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "cc2ql7v8",
-      "title" : "title-Y1i7IPlxU9",
+      "id" : "jy8lcdnc",
+      "title" : "title-EVdllKtj1b",
       "alternativeTitles" : [
       ],
       "contributors" : [
@@ -33,11 +33,11 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
-          "value" : "I3pLB8wFUc",
+          "value" : "r5gilWx8gA",
           "type" : "Identifier"
         }
       ],
@@ -84,10 +84,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "cc2ql7v8",
-      "sourceIdentifier.value" : "I3pLB8wFUc",
+      "id" : "jy8lcdnc",
+      "sourceIdentifier.value" : "r5gilWx8gA",
       "identifiers.value" : [
-        "I3pLB8wFUc"
+        "r5gilWx8gA"
       ],
       "images.id" : [
       ],
@@ -110,7 +110,7 @@
       "referenceNumber" : null,
       "subjects.concepts.label" : [
       ],
-      "title" : "title-Y1i7IPlxU9"
+      "title" : "title-EVdllKtj1b"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -146,7 +146,7 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "I3pLB8wFUc"
+        "r5gilWx8gA"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.availabilities.online-only.json
+++ b/pipeline/ingestor/test_documents/works.examples.availabilities.online-only.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for availabilities tests",
-  "createdAt" : "2024-05-15T08:17:25.620995Z",
-  "id" : "pgf0nj3t",
+  "createdAt" : "2024-08-15T08:40:28.405074Z",
+  "id" : "yz6gwbs7",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "pgf0nj3t",
+        "id" : "yz6gwbs7",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
-          "value" : "lZntXsvtio"
+          "value" : "DnY4M5JWvJ"
         },
-        "version" : 12,
-        "modifiedTime" : "2066-01-29T23:42:50Z"
+        "version" : 7,
+        "modifiedTime" : "2019-08-06T06:56:41Z"
       },
-      "mergedTime" : "2066-01-29T23:42:50Z",
+      "mergedTime" : "2019-08-06T06:56:41Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "pgf0nj3t",
-      "title" : "title-ZQUd4A611O",
+      "id" : "yz6gwbs7",
+      "title" : "title-CJMNnr9kNr",
       "alternativeTitles" : [
       ],
       "contributors" : [
@@ -33,11 +33,11 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
-          "value" : "lZntXsvtio",
+          "value" : "DnY4M5JWvJ",
           "type" : "Identifier"
         }
       ],
@@ -56,9 +56,7 @@
                 "label" : "IIIF Presentation API",
                 "type" : "LocationType"
               },
-              "url" : "https://iiif.wellcomecollection.org/image/UIg.jpg/info.json",
-              "credit" : "Credit line: WmxlWpw7kQ",
-              "linkText" : "Link text: qvOEvk",
+              "url" : "https://iiif.wellcomecollection.org/image/YBu.jpg/info.json",
               "license" : {
                 "id" : "cc-by",
                 "label" : "Attribution 4.0 International (CC BY 4.0)",
@@ -128,10 +126,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "pgf0nj3t",
-      "sourceIdentifier.value" : "lZntXsvtio",
+      "id" : "yz6gwbs7",
+      "sourceIdentifier.value" : "DnY4M5JWvJ",
       "identifiers.value" : [
-        "lZntXsvtio"
+        "DnY4M5JWvJ"
       ],
       "images.id" : [
       ],
@@ -154,7 +152,7 @@
       "referenceNumber" : null,
       "subjects.concepts.label" : [
       ],
-      "title" : "title-ZQUd4A611O"
+      "title" : "title-CJMNnr9kNr"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -192,7 +190,7 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "lZntXsvtio"
+        "DnY4M5JWvJ"
       ],
       "items.locations.license.id" : [
         "cc-by"

--- a/pipeline/ingestor/test_documents/works.examples.availabilities.open-only.json
+++ b/pipeline/ingestor/test_documents/works.examples.availabilities.open-only.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for availabilities tests",
-  "createdAt" : "2024-05-15T08:17:25.618844Z",
-  "id" : "jwvjyz6g",
+  "createdAt" : "2024-08-15T08:40:28.403172Z",
+  "id" : "fntlrk7n",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "jwvjyz6g",
+        "id" : "fntlrk7n",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
-          "value" : "TXyrDnY4M5"
+          "value" : "y9pCp7jd9r"
         },
-        "version" : 36,
-        "modifiedTime" : "2067-09-08T00:34:22Z"
+        "version" : 28,
+        "modifiedTime" : "2007-03-29T14:43:02Z"
       },
-      "mergedTime" : "2067-09-08T00:34:22Z",
+      "mergedTime" : "2007-03-29T14:43:02Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "jwvjyz6g",
-      "title" : "title-bs7oCJMNnr",
+      "id" : "fntlrk7n",
+      "title" : "title-d5hDXNpf0j",
       "alternativeTitles" : [
       ],
       "contributors" : [
@@ -33,11 +33,11 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
-          "value" : "TXyrDnY4M5",
+          "value" : "y9pCp7jd9r",
           "type" : "Identifier"
         }
       ],
@@ -47,15 +47,15 @@
       ],
       "items" : [
         {
-          "id" : "mvr7oym6",
+          "id" : "tfqdc51h",
           "identifiers" : [
             {
               "identifierType" : {
-                "id" : "miro-image-number",
-                "label" : "Miro image number",
+                "id" : "sierra-system-number",
+                "label" : "Sierra system number",
                 "type" : "IdentifierType"
               },
-              "value" : "gjgNk1LNtP",
+              "value" : "g38S97qOpH",
               "type" : "Identifier"
             }
           ],
@@ -67,12 +67,7 @@
                 "type" : "LocationType"
               },
               "label" : "locationLabel",
-              "license" : {
-                "id" : "ogl",
-                "label" : "Open Government Licence",
-                "url" : "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
-                "type" : "License"
-              },
+              "shelfmark" : "Shelfmark: l0IywWR",
               "accessConditions" : [
               ],
               "type" : "PhysicalLocation"
@@ -123,20 +118,20 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "jwvjyz6g",
-      "sourceIdentifier.value" : "TXyrDnY4M5",
+      "id" : "fntlrk7n",
+      "sourceIdentifier.value" : "y9pCp7jd9r",
       "identifiers.value" : [
-        "TXyrDnY4M5"
+        "y9pCp7jd9r"
       ],
       "images.id" : [
       ],
       "images.identifiers.value" : [
       ],
       "items.id" : [
-        "mvr7oym6"
+        "tfqdc51h"
       ],
       "items.identifiers.value" : [
-        "gjgNk1LNtP"
+        "g38S97qOpH"
       ],
       "languages.label" : [
       ],
@@ -151,7 +146,7 @@
       "referenceNumber" : null,
       "subjects.concepts.label" : [
       ],
-      "title" : "title-bs7oCJMNnr"
+      "title" : "title-d5hDXNpf0j"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -167,7 +162,6 @@
       "contributors.agent.label" : [
       ],
       "items.locations.license" : [
-        "{\"id\":\"ogl\",\"label\":\"Open Government Licence\",\"url\":\"http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/\",\"type\":\"License\"}"
       ],
       "availabilities" : [
         "{\"id\":\"open-shelves\",\"label\":\"Open shelves\",\"type\":\"Availability\"}"
@@ -189,18 +183,17 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "TXyrDnY4M5"
+        "y9pCp7jd9r"
       ],
       "items.locations.license.id" : [
-        "ogl"
       ],
       "items.locations.accessConditions.status.id" : [
       ],
       "items.id" : [
-        "mvr7oym6"
+        "tfqdc51h"
       ],
       "items.identifiers.value" : [
-        "gjgNk1LNtP"
+        "g38S97qOpH"
       ],
       "items.locations.locationType.id" : [
         "open-shelves"

--- a/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.1.json
+++ b/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.1.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2024-05-15T08:17:25.583261Z",
-  "id" : "r7wachux",
+  "createdAt" : "2024-08-15T08:40:28.367729Z",
+  "id" : "mzvvcba0",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "r7wachux",
+        "id" : "mzvvcba0",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
-          "value" : "GY2AKxyW0l"
+          "value" : "gDuSiI3pPI"
         },
-        "version" : 16,
-        "modifiedTime" : "1986-10-13T12:45:40Z"
+        "version" : 29,
+        "modifiedTime" : "1993-02-03T00:28:21Z"
       },
-      "mergedTime" : "1986-10-13T12:45:40Z",
+      "mergedTime" : "1993-02-03T00:28:21Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "r7wachux",
-      "title" : "title-rv8PglAGaK",
+      "id" : "mzvvcba0",
+      "title" : "title-h0iB2aGWT6",
       "alternativeTitles" : [
       ],
       "contributors" : [
@@ -43,11 +43,11 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
-          "value" : "GY2AKxyW0l",
+          "value" : "gDuSiI3pPI",
           "type" : "Identifier"
         }
       ],
@@ -95,10 +95,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "r7wachux",
-      "sourceIdentifier.value" : "GY2AKxyW0l",
+      "id" : "mzvvcba0",
+      "sourceIdentifier.value" : "gDuSiI3pPI",
       "identifiers.value" : [
-        "GY2AKxyW0l"
+        "gDuSiI3pPI"
       ],
       "images.id" : [
       ],
@@ -121,7 +121,7 @@
       "referenceNumber" : null,
       "subjects.concepts.label" : [
       ],
-      "title" : "title-rv8PglAGaK"
+      "title" : "title-h0iB2aGWT6"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -159,7 +159,7 @@
         "Karl Marx"
       ],
       "identifiers.value" : [
-        "GY2AKxyW0l"
+        "gDuSiI3pPI"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.2.json
+++ b/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.2.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2024-05-15T08:17:25.583599Z",
-  "id" : "wmvuppum",
+  "createdAt" : "2024-08-15T08:40:28.368053Z",
+  "id" : "5ramofto",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "wmvuppum",
+        "id" : "5ramofto",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
-          "value" : "KzPZAnMiJN"
+          "value" : "iZ6KWys5lZ"
         },
-        "version" : 60,
-        "modifiedTime" : "1945-07-07T10:18:32Z"
+        "version" : 77,
+        "modifiedTime" : "1998-03-21T07:04:06Z"
       },
-      "mergedTime" : "1945-07-07T10:18:32Z",
+      "mergedTime" : "1998-03-21T07:04:06Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "wmvuppum",
-      "title" : "title-ql7LBhP7Ng",
+      "id" : "5ramofto",
+      "title" : "title-5bCvMTmP7w",
       "alternativeTitles" : [
       ],
       "contributors" : [
@@ -43,11 +43,11 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
-          "value" : "KzPZAnMiJN",
+          "value" : "iZ6KWys5lZ",
           "type" : "Identifier"
         }
       ],
@@ -95,10 +95,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "wmvuppum",
-      "sourceIdentifier.value" : "KzPZAnMiJN",
+      "id" : "5ramofto",
+      "sourceIdentifier.value" : "iZ6KWys5lZ",
       "identifiers.value" : [
-        "KzPZAnMiJN"
+        "iZ6KWys5lZ"
       ],
       "images.id" : [
       ],
@@ -121,7 +121,7 @@
       "referenceNumber" : null,
       "subjects.concepts.label" : [
       ],
-      "title" : "title-ql7LBhP7Ng"
+      "title" : "title-5bCvMTmP7w"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -159,7 +159,7 @@
         "Jake Paul"
       ],
       "identifiers.value" : [
-        "KzPZAnMiJN"
+        "iZ6KWys5lZ"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.3.json
+++ b/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.3.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2024-05-15T08:17:25.583925Z",
-  "id" : "vcba0kh0",
+  "createdAt" : "2024-08-15T08:40:28.368346Z",
+  "id" : "816tru6j",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "vcba0kh0",
+        "id" : "816tru6j",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
-          "value" : "SiI3pPIMZv"
+          "value" : "9jNNS7lxBF"
         },
-        "version" : 82,
-        "modifiedTime" : "2043-08-15T21:52:17Z"
+        "version" : 90,
+        "modifiedTime" : "1969-03-18T15:11:34Z"
       },
-      "mergedTime" : "2043-08-15T21:52:17Z",
+      "mergedTime" : "1969-03-18T15:11:34Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "vcba0kh0",
-      "title" : "title-B2aGWT6gTi",
+      "id" : "816tru6j",
+      "title" : "title-q4UJD6zf5r",
       "alternativeTitles" : [
       ],
       "contributors" : [
@@ -43,11 +43,11 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
-          "value" : "SiI3pPIMZv",
+          "value" : "9jNNS7lxBF",
           "type" : "Identifier"
         }
       ],
@@ -95,10 +95,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "vcba0kh0",
-      "sourceIdentifier.value" : "SiI3pPIMZv",
+      "id" : "816tru6j",
+      "sourceIdentifier.value" : "9jNNS7lxBF",
       "identifiers.value" : [
-        "SiI3pPIMZv"
+        "9jNNS7lxBF"
       ],
       "images.id" : [
       ],
@@ -121,7 +121,7 @@
       "referenceNumber" : null,
       "subjects.concepts.label" : [
       ],
-      "title" : "title-B2aGWT6gTi"
+      "title" : "title-q4UJD6zf5r"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -159,7 +159,7 @@
         "Darwin \"Jones\", Charles"
       ],
       "identifiers.value" : [
-        "SiI3pPIMZv"
+        "9jNNS7lxBF"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.4.json
+++ b/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.4.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2024-02-16T15:36:45.065295Z",
-  "id" : "moftow5b",
+  "createdAt" : "2024-08-15T08:40:28.368687Z",
+  "id" : "xuni2iqa",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "moftow5b",
+        "id" : "xuni2iqa",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
-          "value" : "KWys5lZ5ra"
+          "value" : "XzQw5jYpuB"
         },
-        "version" : 66,
-        "modifiedTime" : "1950-07-15T20:46:42Z"
+        "version" : 100,
+        "modifiedTime" : "1968-08-03T10:25:48Z"
       },
-      "mergedTime" : "1950-07-15T20:46:42Z",
+      "mergedTime" : "1968-08-03T10:25:48Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "moftow5b",
-      "title" : "title-vMTmP7wsQ9",
+      "id" : "xuni2iqa",
+      "title" : "title-I2SUm7p7NJ",
       "alternativeTitles" : [
       ],
       "contributors" : [
@@ -53,11 +53,11 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
-          "value" : "KWys5lZ5ra",
+          "value" : "XzQw5jYpuB",
           "type" : "Identifier"
         }
       ],
@@ -106,10 +106,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "moftow5b",
-      "sourceIdentifier.value" : "KWys5lZ5ra",
+      "id" : "xuni2iqa",
+      "sourceIdentifier.value" : "XzQw5jYpuB",
       "identifiers.value" : [
-        "KWys5lZ5ra"
+        "XzQw5jYpuB"
       ],
       "images.id" : [
       ],
@@ -132,7 +132,7 @@
       "referenceNumber" : null,
       "subjects.concepts.label" : [
       ],
-      "title" : "title-vMTmP7wsQ9"
+      "title" : "title-I2SUm7p7NJ"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -172,7 +172,7 @@
         "Darwin \"Jones\", Charles"
       ],
       "identifiers.value" : [
-        "KWys5lZ5ra"
+        "XzQw5jYpuB"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.5.json
+++ b/pipeline/ingestor/test_documents/works.examples.contributor-filters-tests.5.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2024-02-16T15:36:45.065713Z",
-  "id" : "tru6joq4",
+  "createdAt" : "2024-08-15T08:40:28.368935Z",
+  "id" : "syv21f7g",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "tru6joq4",
+        "id" : "syv21f7g",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
-          "value" : "NS7lxBF816"
+          "value" : "4Dxc6NTEVZ"
         },
-        "version" : 38,
-        "modifiedTime" : "2022-09-30T14:40:50Z"
+        "version" : 40,
+        "modifiedTime" : "2031-05-07T13:00:36Z"
       },
-      "mergedTime" : "2022-09-30T14:40:50Z",
+      "mergedTime" : "2031-05-07T13:00:36Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "tru6joq4",
-      "title" : "title-JD6zf5rF0X",
+      "id" : "syv21f7g",
+      "title" : "title-bSjf9AwXjw",
       "alternativeTitles" : [
       ],
       "contributors" : [
@@ -33,11 +33,11 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
-          "value" : "NS7lxBF816",
+          "value" : "4Dxc6NTEVZ",
           "type" : "Identifier"
         }
       ],
@@ -84,10 +84,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "tru6joq4",
-      "sourceIdentifier.value" : "NS7lxBF816",
+      "id" : "syv21f7g",
+      "sourceIdentifier.value" : "4Dxc6NTEVZ",
       "identifiers.value" : [
-        "NS7lxBF816"
+        "4Dxc6NTEVZ"
       ],
       "images.id" : [
       ],
@@ -110,7 +110,7 @@
       "referenceNumber" : null,
       "subjects.concepts.label" : [
       ],
-      "title" : "title-JD6zf5rF0X"
+      "title" : "title-bSjf9AwXjw"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -146,7 +146,7 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "NS7lxBF816"
+        "4Dxc6NTEVZ"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.different-work-types.Collection.json
+++ b/pipeline/ingestor/test_documents/works.examples.different-work-types.Collection.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples of works with different types",
-  "createdAt" : "2024-02-16T15:36:45.015019Z",
-  "id" : "ujg4jncr",
+  "createdAt" : "2024-08-15T08:40:28.350191Z",
+  "id" : "osineemq",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "ujg4jncr",
+        "id" : "osineemq",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
-          "value" : "ZEnp6i2y6i"
+          "value" : "oFYwsvmZKL"
         },
-        "version" : 27,
-        "modifiedTime" : "1951-02-24T01:30:35Z"
+        "version" : 88,
+        "modifiedTime" : "1982-02-15T00:55:59Z"
       },
-      "mergedTime" : "1951-02-24T01:30:35Z",
+      "mergedTime" : "1982-02-15T00:55:59Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,7 +24,7 @@
       ]
     },
     "display" : {
-      "id" : "ujg4jncr",
+      "id" : "osineemq",
       "title" : "rats",
       "alternativeTitles" : [
       ],
@@ -33,11 +33,11 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
-          "value" : "ZEnp6i2y6i",
+          "value" : "oFYwsvmZKL",
           "type" : "Identifier"
         }
       ],
@@ -84,10 +84,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "ujg4jncr",
-      "sourceIdentifier.value" : "ZEnp6i2y6i",
+      "id" : "osineemq",
+      "sourceIdentifier.value" : "oFYwsvmZKL",
       "identifiers.value" : [
-        "ZEnp6i2y6i"
+        "oFYwsvmZKL"
       ],
       "images.id" : [
       ],
@@ -146,7 +146,7 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "ZEnp6i2y6i"
+        "oFYwsvmZKL"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.different-work-types.Section.json
+++ b/pipeline/ingestor/test_documents/works.examples.different-work-types.Section.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples of works with different types",
-  "createdAt" : "2024-05-15T08:17:25.560405Z",
-  "id" : "pflggfra",
+  "createdAt" : "2024-08-15T08:40:28.349121Z",
+  "id" : "48vvelyd",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "pflggfra",
+        "id" : "48vvelyd",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
-          "value" : "4QwQTlrFnQ"
+          "value" : "eiJRew3RmJ"
         },
-        "version" : 71,
-        "modifiedTime" : "1996-07-06T15:31:03Z"
+        "version" : 38,
+        "modifiedTime" : "1943-05-14T19:16:03Z"
       },
-      "mergedTime" : "1996-07-06T15:31:03Z",
+      "mergedTime" : "1943-05-14T19:16:03Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,7 +24,7 @@
       ]
     },
     "display" : {
-      "id" : "pflggfra",
+      "id" : "48vvelyd",
       "title" : "rats",
       "alternativeTitles" : [
       ],
@@ -33,11 +33,11 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
-          "value" : "4QwQTlrFnQ",
+          "value" : "eiJRew3RmJ",
           "type" : "Identifier"
         }
       ],
@@ -84,10 +84,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "pflggfra",
-      "sourceIdentifier.value" : "4QwQTlrFnQ",
+      "id" : "48vvelyd",
+      "sourceIdentifier.value" : "eiJRew3RmJ",
       "identifiers.value" : [
-        "4QwQTlrFnQ"
+        "eiJRew3RmJ"
       ],
       "images.id" : [
       ],
@@ -146,7 +146,7 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "4QwQTlrFnQ"
+        "eiJRew3RmJ"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.different-work-types.Series.json
+++ b/pipeline/ingestor/test_documents/works.examples.different-work-types.Series.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples of works with different types",
-  "createdAt" : "2024-02-16T15:36:45.016661Z",
-  "id" : "velydjdv",
+  "createdAt" : "2024-08-15T08:40:28.350941Z",
+  "id" : "pbeanc7x",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "velydjdv",
+        "id" : "pbeanc7x",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
-          "value" : "Rew3RmJ48v"
+          "value" : "ZmmbPJWDqm"
         },
-        "version" : 20,
-        "modifiedTime" : "1960-03-11T19:55:05Z"
+        "version" : 82,
+        "modifiedTime" : "2049-02-26T19:42:13Z"
       },
-      "mergedTime" : "1960-03-11T19:55:05Z",
+      "mergedTime" : "2049-02-26T19:42:13Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,7 +24,7 @@
       ]
     },
     "display" : {
-      "id" : "velydjdv",
+      "id" : "pbeanc7x",
       "title" : "rats",
       "alternativeTitles" : [
       ],
@@ -33,11 +33,11 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
-          "value" : "Rew3RmJ48v",
+          "value" : "ZmmbPJWDqm",
           "type" : "Identifier"
         }
       ],
@@ -84,10 +84,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "velydjdv",
-      "sourceIdentifier.value" : "Rew3RmJ48v",
+      "id" : "pbeanc7x",
+      "sourceIdentifier.value" : "ZmmbPJWDqm",
       "identifiers.value" : [
-        "Rew3RmJ48v"
+        "ZmmbPJWDqm"
       ],
       "images.id" : [
       ],
@@ -146,7 +146,7 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "Rew3RmJ48v"
+        "ZmmbPJWDqm"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.0.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.0.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2024-05-15T08:17:25.609178Z",
-  "id" : "o0u9h1wt",
+  "createdAt" : "2024-08-15T08:40:28.394389Z",
+  "id" : "pgnx8xiu",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "o0u9h1wt",
+        "id" : "pgnx8xiu",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
-          "value" : "Q8nyGjzx3m"
+          "value" : "ahC4keAffG"
         },
-        "version" : 97,
-        "modifiedTime" : "1998-09-03T03:15:10Z"
+        "version" : 53,
+        "modifiedTime" : "2044-04-23T02:39:03Z"
       },
-      "mergedTime" : "1998-09-03T03:15:10Z",
+      "mergedTime" : "2044-04-23T02:39:03Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,7 +24,7 @@
       ]
     },
     "display" : {
-      "id" : "o0u9h1wt",
+      "id" : "pgnx8xiu",
       "title" : "rats",
       "alternativeTitles" : [
       ],
@@ -38,11 +38,11 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
-          "value" : "Q8nyGjzx3m",
+          "value" : "ahC4keAffG",
           "type" : "Identifier"
         }
       ],
@@ -94,10 +94,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "o0u9h1wt",
-      "sourceIdentifier.value" : "Q8nyGjzx3m",
+      "id" : "pgnx8xiu",
+      "sourceIdentifier.value" : "ahC4keAffG",
       "identifiers.value" : [
-        "Q8nyGjzx3m"
+        "ahC4keAffG"
       ],
       "images.id" : [
       ],
@@ -160,7 +160,7 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "Q8nyGjzx3m"
+        "ahC4keAffG"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.1.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.1.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2024-05-15T08:17:25.609517Z",
-  "id" : "1ndk3ton",
+  "createdAt" : "2024-08-15T08:40:28.394666Z",
+  "id" : "ryawvgup",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "1ndk3ton",
+        "id" : "ryawvgup",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
-          "value" : "HgjmZ1Psfx"
+          "value" : "jHeY6Fz9Kp"
         },
-        "version" : 31,
-        "modifiedTime" : "1942-02-08T16:28:55Z"
+        "version" : 72,
+        "modifiedTime" : "2059-12-28T14:23:34Z"
       },
-      "mergedTime" : "1942-02-08T16:28:55Z",
+      "mergedTime" : "2059-12-28T14:23:34Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,7 +24,7 @@
       ]
     },
     "display" : {
-      "id" : "1ndk3ton",
+      "id" : "ryawvgup",
       "title" : "capybara",
       "alternativeTitles" : [
       ],
@@ -38,11 +38,11 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
-          "value" : "HgjmZ1Psfx",
+          "value" : "jHeY6Fz9Kp",
           "type" : "Identifier"
         }
       ],
@@ -94,10 +94,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "1ndk3ton",
-      "sourceIdentifier.value" : "HgjmZ1Psfx",
+      "id" : "ryawvgup",
+      "sourceIdentifier.value" : "jHeY6Fz9Kp",
       "identifiers.value" : [
-        "HgjmZ1Psfx"
+        "jHeY6Fz9Kp"
       ],
       "images.id" : [
       ],
@@ -160,7 +160,7 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "HgjmZ1Psfx"
+        "jHeY6Fz9Kp"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.2.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.2.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2024-02-16T15:36:45.102261Z",
-  "id" : "8xiun5qm",
+  "createdAt" : "2024-08-15T08:40:28.394935Z",
+  "id" : "z5orxsbq",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "8xiun5qm",
+        "id" : "z5orxsbq",
         "identifier" : {
           "identifierType" : {
             "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
-          "value" : "keAffGPGNx"
+          "value" : "K1TpzZmCli"
         },
-        "version" : 75,
-        "modifiedTime" : "1992-09-20T01:47:13Z"
+        "version" : 66,
+        "modifiedTime" : "1981-06-28T10:43:18Z"
       },
-      "mergedTime" : "1992-09-20T01:47:13Z",
+      "mergedTime" : "1981-06-28T10:43:18Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,7 +24,7 @@
       ]
     },
     "display" : {
-      "id" : "8xiun5qm",
+      "id" : "z5orxsbq",
       "title" : "tapirs",
       "alternativeTitles" : [
       ],
@@ -42,7 +42,7 @@
             "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
-          "value" : "keAffGPGNx",
+          "value" : "K1TpzZmCli",
           "type" : "Identifier"
         }
       ],
@@ -94,10 +94,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "8xiun5qm",
-      "sourceIdentifier.value" : "keAffGPGNx",
+      "id" : "z5orxsbq",
+      "sourceIdentifier.value" : "K1TpzZmCli",
       "identifiers.value" : [
-        "keAffGPGNx"
+        "K1TpzZmCli"
       ],
       "images.id" : [
       ],
@@ -160,7 +160,7 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "keAffGPGNx"
+        "K1TpzZmCli"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.3.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.3.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2024-05-15T08:17:25.610122Z",
-  "id" : "vguputez",
+  "createdAt" : "2024-08-15T08:40:28.395177Z",
+  "id" : "sts5c3ls",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "vguputez",
+        "id" : "sts5c3ls",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
-          "value" : "6Fz9KprYAw"
+          "value" : "bQuZPdet7f"
         },
-        "version" : 80,
-        "modifiedTime" : "2031-04-11T11:09:11Z"
+        "version" : 36,
+        "modifiedTime" : "1950-01-25T21:30:47Z"
       },
-      "mergedTime" : "2031-04-11T11:09:11Z",
+      "mergedTime" : "1950-01-25T21:30:47Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,7 +24,7 @@
       ]
     },
     "display" : {
-      "id" : "vguputez",
+      "id" : "sts5c3ls",
       "title" : "rats",
       "alternativeTitles" : [
       ],
@@ -38,11 +38,11 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
-          "value" : "6Fz9KprYAw",
+          "value" : "bQuZPdet7f",
           "type" : "Identifier"
         }
       ],
@@ -94,10 +94,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "vguputez",
-      "sourceIdentifier.value" : "6Fz9KprYAw",
+      "id" : "sts5c3ls",
+      "sourceIdentifier.value" : "bQuZPdet7f",
       "identifiers.value" : [
-        "6Fz9KprYAw"
+        "bQuZPdet7f"
       ],
       "images.id" : [
       ],
@@ -160,7 +160,7 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "6Fz9KprYAw"
+        "bQuZPdet7f"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.4.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.4.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2024-05-15T08:17:25.610416Z",
-  "id" : "xsbqgayk",
+  "createdAt" : "2024-08-15T08:40:28.395413Z",
+  "id" : "ursfcpyu",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "xsbqgayk",
+        "id" : "ursfcpyu",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
-          "value" : "zZmCliZ5OR"
+          "value" : "DATqKSqlcV"
         },
-        "version" : 75,
-        "modifiedTime" : "2065-03-14T20:41:38Z"
+        "version" : 18,
+        "modifiedTime" : "2068-12-03T06:41:51Z"
       },
-      "mergedTime" : "2065-03-14T20:41:38Z",
+      "mergedTime" : "2068-12-03T06:41:51Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,7 +24,7 @@
       ]
     },
     "display" : {
-      "id" : "xsbqgayk",
+      "id" : "ursfcpyu",
       "title" : "capybara",
       "alternativeTitles" : [
       ],
@@ -38,11 +38,11 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
-          "value" : "zZmCliZ5OR",
+          "value" : "DATqKSqlcV",
           "type" : "Identifier"
         }
       ],
@@ -94,10 +94,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "xsbqgayk",
-      "sourceIdentifier.value" : "zZmCliZ5OR",
+      "id" : "ursfcpyu",
+      "sourceIdentifier.value" : "DATqKSqlcV",
       "identifiers.value" : [
-        "zZmCliZ5OR"
+        "DATqKSqlcV"
       ],
       "images.id" : [
       ],
@@ -160,7 +160,7 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "zZmCliZ5OR"
+        "DATqKSqlcV"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.5.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.5.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2024-02-16T15:36:45.103483Z",
-  "id" : "c3ls9khw",
+  "createdAt" : "2024-08-15T08:40:28.395670Z",
+  "id" : "crmdnx7u",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "c3ls9khw",
+        "id" : "crmdnx7u",
         "identifier" : {
           "identifierType" : {
             "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
-          "value" : "Pdet7fsTs5"
+          "value" : "7z5sgyOBC4"
         },
-        "version" : 22,
-        "modifiedTime" : "2041-05-31T20:04:19Z"
+        "version" : 86,
+        "modifiedTime" : "2054-08-12T01:30:45Z"
       },
-      "mergedTime" : "2041-05-31T20:04:19Z",
+      "mergedTime" : "2054-08-12T01:30:45Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,7 +24,7 @@
       ]
     },
     "display" : {
-      "id" : "c3ls9khw",
+      "id" : "crmdnx7u",
       "title" : "tapirs",
       "alternativeTitles" : [
       ],
@@ -42,7 +42,7 @@
             "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
-          "value" : "Pdet7fsTs5",
+          "value" : "7z5sgyOBC4",
           "type" : "Identifier"
         }
       ],
@@ -94,10 +94,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "c3ls9khw",
-      "sourceIdentifier.value" : "Pdet7fsTs5",
+      "id" : "crmdnx7u",
+      "sourceIdentifier.value" : "7z5sgyOBC4",
       "identifiers.value" : [
-        "Pdet7fsTs5"
+        "7z5sgyOBC4"
       ],
       "images.id" : [
       ],
@@ -160,7 +160,7 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "Pdet7fsTs5"
+        "7z5sgyOBC4"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.6.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.6.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2024-05-15T08:17:25.611067Z",
-  "id" : "cpyuhtp8",
+  "createdAt" : "2024-08-15T08:40:28.395909Z",
+  "id" : "7dzlu1am",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "cpyuhtp8",
+        "id" : "7dzlu1am",
         "identifier" : {
           "identifierType" : {
             "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
-          "value" : "KSqlcVurSf"
+          "value" : "2z2trB0Sw2"
         },
-        "version" : 26,
-        "modifiedTime" : "1958-09-25T01:35:38Z"
+        "version" : 87,
+        "modifiedTime" : "2005-08-09T18:48:42Z"
       },
-      "mergedTime" : "1958-09-25T01:35:38Z",
+      "mergedTime" : "2005-08-09T18:48:42Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,7 +24,7 @@
       ]
     },
     "display" : {
-      "id" : "cpyuhtp8",
+      "id" : "7dzlu1am",
       "title" : "rats",
       "alternativeTitles" : [
       ],
@@ -42,7 +42,7 @@
             "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
-          "value" : "KSqlcVurSf",
+          "value" : "2z2trB0Sw2",
           "type" : "Identifier"
         }
       ],
@@ -94,10 +94,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "cpyuhtp8",
-      "sourceIdentifier.value" : "KSqlcVurSf",
+      "id" : "7dzlu1am",
+      "sourceIdentifier.value" : "2z2trB0Sw2",
       "identifiers.value" : [
-        "KSqlcVurSf"
+        "2z2trB0Sw2"
       ],
       "images.id" : [
       ],
@@ -160,7 +160,7 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "KSqlcVurSf"
+        "2z2trB0Sw2"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.7.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.7.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2024-02-16T15:36:45.104231Z",
-  "id" : "nx7u2kmr",
+  "createdAt" : "2024-08-15T08:40:28.396139Z",
+  "id" : "rfckqwuh",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "nx7u2kmr",
+        "id" : "rfckqwuh",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
-          "value" : "gyOBC4cRmD"
+          "value" : "e1HWk1Ah2x"
         },
-        "version" : 57,
-        "modifiedTime" : "2059-06-20T15:32:07Z"
+        "version" : 48,
+        "modifiedTime" : "1997-05-16T00:21:21Z"
       },
-      "mergedTime" : "2059-06-20T15:32:07Z",
+      "mergedTime" : "1997-05-16T00:21:21Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,7 +24,7 @@
       ]
     },
     "display" : {
-      "id" : "nx7u2kmr",
+      "id" : "rfckqwuh",
       "title" : "capybara",
       "alternativeTitles" : [
       ],
@@ -38,11 +38,11 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
-          "value" : "gyOBC4cRmD",
+          "value" : "e1HWk1Ah2x",
           "type" : "Identifier"
         }
       ],
@@ -94,10 +94,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "nx7u2kmr",
-      "sourceIdentifier.value" : "gyOBC4cRmD",
+      "id" : "rfckqwuh",
+      "sourceIdentifier.value" : "e1HWk1Ah2x",
       "identifiers.value" : [
-        "gyOBC4cRmD"
+        "e1HWk1Ah2x"
       ],
       "images.id" : [
       ],
@@ -160,7 +160,7 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "gyOBC4cRmD"
+        "e1HWk1Ah2x"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.8.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.8.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2024-05-15T08:17:25.611669Z",
-  "id" : "u1amc1nv",
+  "createdAt" : "2024-08-15T08:40:28.396366Z",
+  "id" : "el5rbb4t",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "u1amc1nv",
+        "id" : "el5rbb4t",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
-          "value" : "rB0Sw27DZl"
+          "value" : "uNmLrXrfr8"
         },
-        "version" : 30,
-        "modifiedTime" : "1945-11-08T14:38:47Z"
+        "version" : 48,
+        "modifiedTime" : "2036-09-29T11:49:16Z"
       },
-      "mergedTime" : "1945-11-08T14:38:47Z",
+      "mergedTime" : "2036-09-29T11:49:16Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,7 +24,7 @@
       ]
     },
     "display" : {
-      "id" : "u1amc1nv",
+      "id" : "el5rbb4t",
       "title" : "tapirs",
       "alternativeTitles" : [
       ],
@@ -38,11 +38,11 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
-          "value" : "rB0Sw27DZl",
+          "value" : "uNmLrXrfr8",
           "type" : "Identifier"
         }
       ],
@@ -94,10 +94,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "u1amc1nv",
-      "sourceIdentifier.value" : "rB0Sw27DZl",
+      "id" : "el5rbb4t",
+      "sourceIdentifier.value" : "uNmLrXrfr8",
       "identifiers.value" : [
-        "rB0Sw27DZl"
+        "uNmLrXrfr8"
       ],
       "images.id" : [
       ],
@@ -160,7 +160,7 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "rB0Sw27DZl"
+        "uNmLrXrfr8"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.9.json
+++ b/pipeline/ingestor/test_documents/works.examples.filtered-aggregations-tests.9.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2024-02-16T15:36:45.104986Z",
-  "id" : "qwuhqead",
+  "createdAt" : "2024-08-15T08:40:28.396598Z",
+  "id" : "svnlbwse",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "qwuhqead",
+        "id" : "svnlbwse",
         "identifier" : {
           "identifierType" : {
             "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
-          "value" : "k1Ah2xRfCk"
+          "value" : "JFu0QVu8iR"
         },
-        "version" : 61,
-        "modifiedTime" : "1940-07-03T22:01:02Z"
+        "version" : 62,
+        "modifiedTime" : "2025-11-29T16:51:43Z"
       },
-      "mergedTime" : "1940-07-03T22:01:02Z",
+      "mergedTime" : "2025-11-29T16:51:43Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,7 +24,7 @@
       ]
     },
     "display" : {
-      "id" : "qwuhqead",
+      "id" : "svnlbwse",
       "title" : "rats",
       "alternativeTitles" : [
       ],
@@ -42,7 +42,7 @@
             "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
-          "value" : "k1Ah2xRfCk",
+          "value" : "JFu0QVu8iR",
           "type" : "Identifier"
         }
       ],
@@ -94,10 +94,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "qwuhqead",
-      "sourceIdentifier.value" : "k1Ah2xRfCk",
+      "id" : "svnlbwse",
+      "sourceIdentifier.value" : "JFu0QVu8iR",
       "identifiers.value" : [
-        "k1Ah2xRfCk"
+        "JFu0QVu8iR"
       ],
       "images.id" : [
       ],
@@ -160,7 +160,7 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "k1Ah2xRfCk"
+        "JFu0QVu8iR"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.0.json
+++ b/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.0.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2024-05-15T08:17:25.564538Z",
-  "id" : "oxbsq4ck",
+  "createdAt" : "2024-08-15T08:40:28.352663Z",
+  "id" : "xowd5kj1",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "oxbsq4ck",
+        "id" : "xowd5kj1",
         "identifier" : {
           "identifierType" : {
             "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
-          "value" : "xukacPWKUR"
+          "value" : "tYS1KOlZmZ"
         },
-        "version" : 53,
-        "modifiedTime" : "2011-03-12T19:27:33Z"
+        "version" : 99,
+        "modifiedTime" : "1971-02-26T13:40:07Z"
       },
-      "mergedTime" : "2011-03-12T19:27:33Z",
+      "mergedTime" : "1971-02-26T13:40:07Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "oxbsq4ck",
-      "title" : "title-DrDsk2kCAG",
+      "id" : "xowd5kj1",
+      "title" : "title-X3OfWNE6m5",
       "alternativeTitles" : [
       ],
       "contributors" : [
@@ -37,7 +37,7 @@
             "label" : "Miro image number",
             "type" : "IdentifierType"
           },
-          "value" : "xukacPWKUR",
+          "value" : "tYS1KOlZmZ",
           "type" : "Identifier"
         }
       ],
@@ -56,11 +56,11 @@
                     "label" : "Sierra system number",
                     "type" : "IdentifierType"
                   },
-                  "value" : "hmRoJyr1Mq",
+                  "value" : "T9fhswtSuP",
                   "type" : "Identifier"
                 }
               ],
-              "label" : "YwsvmZKLOsIneEm",
+              "label" : "mWNKiLGpm85YYFF",
               "type" : "Genre"
             },
             {
@@ -72,11 +72,11 @@
                     "label" : "Miro image number",
                     "type" : "IdentifierType"
                   },
-                  "value" : "aNC7XCeymD",
+                  "value" : "WKJQbCBtOF",
                   "type" : "Identifier"
                 }
               ],
-              "label" : "UtqZmmbPJWDqmpb",
+              "label" : "Oo0o5Odfdodercw",
               "type" : "Concept"
             }
           ],
@@ -121,13 +121,13 @@
       "description" : null,
       "edition" : null,
       "genres.concepts.label" : [
-        "YwsvmZKLOsIneEm",
-        "UtqZmmbPJWDqmpb"
+        "mWNKiLGpm85YYFF",
+        "Oo0o5Odfdodercw"
       ],
-      "id" : "oxbsq4ck",
-      "sourceIdentifier.value" : "xukacPWKUR",
+      "id" : "xowd5kj1",
+      "sourceIdentifier.value" : "tYS1KOlZmZ",
       "identifiers.value" : [
-        "xukacPWKUR"
+        "tYS1KOlZmZ"
       ],
       "images.id" : [
       ],
@@ -150,7 +150,7 @@
       "referenceNumber" : null,
       "subjects.concepts.label" : [
       ],
-      "title" : "title-DrDsk2kCAG"
+      "title" : "title-X3OfWNE6m5"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -189,7 +189,7 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "xukacPWKUR"
+        "tYS1KOlZmZ"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.1.json
+++ b/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.1.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2024-05-15T08:17:25.565005Z",
-  "id" : "wdnn2etp",
+  "createdAt" : "2024-08-15T08:40:28.353024Z",
+  "id" : "yzj9dwdl",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "wdnn2etp",
+        "id" : "yzj9dwdl",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
-          "value" : "hx40zJbSlL"
+          "value" : "AYys6jP7Ji"
         },
-        "version" : 23,
-        "modifiedTime" : "1953-09-20T12:06:56Z"
+        "version" : 36,
+        "modifiedTime" : "1955-12-24T22:52:57Z"
       },
-      "mergedTime" : "1953-09-20T12:06:56Z",
+      "mergedTime" : "1955-12-24T22:52:57Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "wdnn2etp",
-      "title" : "title-zfssscK3St",
+      "id" : "yzj9dwdl",
+      "title" : "title-2RdbNpFC2P",
       "alternativeTitles" : [
       ],
       "contributors" : [
@@ -33,11 +33,11 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
-          "value" : "hx40zJbSlL",
+          "value" : "AYys6jP7Ji",
           "type" : "Identifier"
         }
       ],
@@ -52,15 +52,15 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "calm-record-id",
-                    "label" : "Calm RecordIdentifier",
+                    "id" : "sierra-system-number",
+                    "label" : "Sierra system number",
                     "type" : "IdentifierType"
                   },
-                  "value" : "85YYFFvT9f",
+                  "value" : "dmKTFidDls",
                   "type" : "Identifier"
                 }
               ],
-              "label" : "df4bTPrmWNKiLGp",
+              "label" : "9X3cVR8q4GIgcsJ",
               "type" : "Genre"
             }
           ],
@@ -105,12 +105,12 @@
       "description" : null,
       "edition" : null,
       "genres.concepts.label" : [
-        "df4bTPrmWNKiLGp"
+        "9X3cVR8q4GIgcsJ"
       ],
-      "id" : "wdnn2etp",
-      "sourceIdentifier.value" : "hx40zJbSlL",
+      "id" : "yzj9dwdl",
+      "sourceIdentifier.value" : "AYys6jP7Ji",
       "identifiers.value" : [
-        "hx40zJbSlL"
+        "AYys6jP7Ji"
       ],
       "images.id" : [
       ],
@@ -133,7 +133,7 @@
       "referenceNumber" : null,
       "subjects.concepts.label" : [
       ],
-      "title" : "title-zfssscK3St"
+      "title" : "title-2RdbNpFC2P"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -172,7 +172,7 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "hx40zJbSlL"
+        "AYys6jP7Ji"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.2.json
+++ b/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.2.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2024-05-15T08:17:25.565376Z",
-  "id" : "d5kj1fx3",
+  "createdAt" : "2024-08-15T08:40:28.353332Z",
+  "id" : "avugqd3s",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "d5kj1fx3",
+        "id" : "avugqd3s",
         "identifier" : {
           "identifierType" : {
             "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
-          "value" : "1KOlZmZXOW"
+          "value" : "WGGaiNvMk5"
         },
-        "version" : 51,
-        "modifiedTime" : "2047-04-18T16:27:14Z"
+        "version" : 67,
+        "modifiedTime" : "2031-04-13T18:09:40Z"
       },
-      "mergedTime" : "2047-04-18T16:27:14Z",
+      "mergedTime" : "2031-04-13T18:09:40Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "d5kj1fx3",
-      "title" : "title-fWNE6m5ytA",
+      "id" : "avugqd3s",
+      "title" : "title-RQFJOR9VqA",
       "alternativeTitles" : [
       ],
       "contributors" : [
@@ -37,7 +37,7 @@
             "label" : "Miro image number",
             "type" : "IdentifierType"
           },
-          "value" : "1KOlZmZXOW",
+          "value" : "WGGaiNvMk5",
           "type" : "Identifier"
         }
       ],
@@ -52,15 +52,15 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "calm-record-id",
-                    "label" : "Calm RecordIdentifier",
+                    "id" : "miro-image-number",
+                    "label" : "Miro image number",
                     "type" : "IdentifierType"
                   },
-                  "value" : "odercwIWKJ",
+                  "value" : "um1qUlCcjg",
                   "type" : "Identifier"
                 }
               ],
-              "label" : "hswtSuPOo0o5Odf",
+              "label" : "qnu7hZZtHlWPIpZ",
               "type" : "Genre"
             }
           ],
@@ -105,12 +105,12 @@
       "description" : null,
       "edition" : null,
       "genres.concepts.label" : [
-        "hswtSuPOo0o5Odf"
+        "qnu7hZZtHlWPIpZ"
       ],
-      "id" : "d5kj1fx3",
-      "sourceIdentifier.value" : "1KOlZmZXOW",
+      "id" : "avugqd3s",
+      "sourceIdentifier.value" : "WGGaiNvMk5",
       "identifiers.value" : [
-        "1KOlZmZXOW"
+        "WGGaiNvMk5"
       ],
       "images.id" : [
       ],
@@ -133,7 +133,7 @@
       "referenceNumber" : null,
       "subjects.concepts.label" : [
       ],
-      "title" : "title-fWNE6m5ytA"
+      "title" : "title-RQFJOR9VqA"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -172,7 +172,7 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "1KOlZmZXOW"
+        "WGGaiNvMk5"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.3.json
+++ b/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.3.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2024-05-15T08:17:25.565802Z",
-  "id" : "9dwdlo2r",
+  "createdAt" : "2024-08-15T08:40:28.353683Z",
+  "id" : "vr490vab",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "9dwdlo2r",
+        "id" : "vr490vab",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
-          "value" : "s6jP7JiYzJ"
+          "value" : "AzAiZFAZvT"
         },
-        "version" : 97,
-        "modifiedTime" : "2067-03-09T21:26:20Z"
+        "version" : 34,
+        "modifiedTime" : "1956-06-20T09:37:32Z"
       },
-      "mergedTime" : "2067-03-09T21:26:20Z",
+      "mergedTime" : "1956-06-20T09:37:32Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "9dwdlo2r",
-      "title" : "title-bNpFC2P5ZW",
+      "id" : "vr490vab",
+      "title" : "title-q4zh18D0cb",
       "alternativeTitles" : [
       ],
       "contributors" : [
@@ -33,11 +33,11 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
-          "value" : "s6jP7JiYzJ",
+          "value" : "AzAiZFAZvT",
           "type" : "Identifier"
         }
       ],
@@ -48,39 +48,23 @@
           "label" : "Darwin \"Jones\", Charles",
           "concepts" : [
             {
-              "id" : "qbcbtof9",
+              "id" : "lmpakqz5",
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "calm-record-id",
-                    "label" : "Calm RecordIdentifier",
+                    "id" : "sierra-system-number",
+                    "label" : "Sierra system number",
                     "type" : "IdentifierType"
                   },
-                  "value" : "mKTFidDlsq",
+                  "value" : "DpKgb0Wdy2",
                   "type" : "Identifier"
                 }
               ],
-              "label" : "X3cVR8q4GIgcsJh",
+              "label" : "5SIuLPMgIG177tc",
               "type" : "Genre"
             },
             {
-              "id" : "nu7hzzth",
-              "identifiers" : [
-                {
-                  "identifierType" : {
-                    "id" : "miro-image-number",
-                    "label" : "Miro image number",
-                    "type" : "IdentifierType"
-                  },
-                  "value" : "glMPaKQZ55",
-                  "type" : "Identifier"
-                }
-              ],
-              "label" : "lWPIpZYum1qUlCc",
-              "type" : "Concept"
-            },
-            {
-              "id" : "siulpmgi",
+              "id" : "nmumczq1",
               "identifiers" : [
                 {
                   "identifierType" : {
@@ -88,11 +72,27 @@
                     "label" : "Calm RecordIdentifier",
                     "type" : "IdentifierType"
                   },
-                  "value" : "2nMuMcZq1J",
+                  "value" : "Q4CK8DrDsk",
                   "type" : "Identifier"
                 }
               ],
-              "label" : "G177tcCDpKgb0Wd",
+              "label" : "JcxukacPWKUROxB",
+              "type" : "Concept"
+            },
+            {
+              "id" : "2kcagurh",
+              "identifiers" : [
+                {
+                  "identifierType" : {
+                    "id" : "calm-record-id",
+                    "label" : "Calm RecordIdentifier",
+                    "type" : "IdentifierType"
+                  },
+                  "value" : "p5zfssscK3",
+                  "type" : "Identifier"
+                }
+              ],
+              "label" : "x40zJbSlLwDNn2E",
               "type" : "Concept"
             }
           ],
@@ -137,14 +137,14 @@
       "description" : null,
       "edition" : null,
       "genres.concepts.label" : [
-        "X3cVR8q4GIgcsJh",
-        "lWPIpZYum1qUlCc",
-        "G177tcCDpKgb0Wd"
+        "5SIuLPMgIG177tc",
+        "JcxukacPWKUROxB",
+        "x40zJbSlLwDNn2E"
       ],
-      "id" : "9dwdlo2r",
-      "sourceIdentifier.value" : "s6jP7JiYzJ",
+      "id" : "vr490vab",
+      "sourceIdentifier.value" : "AzAiZFAZvT",
       "identifiers.value" : [
-        "s6jP7JiYzJ"
+        "AzAiZFAZvT"
       ],
       "images.id" : [
       ],
@@ -167,7 +167,7 @@
       "referenceNumber" : null,
       "subjects.concepts.label" : [
       ],
-      "title" : "title-bNpFC2P5ZW"
+      "title" : "title-q4zh18D0cb"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -199,14 +199,14 @@
         "Darwin \"Jones\", Charles"
       ],
       "genres.concepts.id" : [
-        "qbcbtof9"
+        "lmpakqz5"
       ],
       "subjects.label" : [
       ],
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "s6jP7JiYzJ"
+        "AzAiZFAZvT"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.4.json
+++ b/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.4.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2024-05-15T08:17:25.566560Z",
-  "id" : "gqd3shrq",
+  "createdAt" : "2024-08-15T08:40:28.354132Z",
+  "id" : "plxkke6n",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "gqd3shrq",
+        "id" : "plxkke6n",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
-          "value" : "aiNvMk5aVu"
+          "value" : "1R485o02Dx"
         },
-        "version" : 30,
-        "modifiedTime" : "1996-04-23T23:20:16Z"
+        "version" : 26,
+        "modifiedTime" : "1986-05-12T09:04:10Z"
       },
-      "mergedTime" : "1996-04-23T23:20:16Z",
+      "mergedTime" : "1986-05-12T09:04:10Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "gqd3shrq",
-      "title" : "title-JOR9VqAEmA",
+      "id" : "plxkke6n",
+      "title" : "title-cQ8QOPJdAX",
       "alternativeTitles" : [
       ],
       "contributors" : [
@@ -33,11 +33,11 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
-          "value" : "aiNvMk5aVu",
+          "value" : "1R485o02Dx",
           "type" : "Identifier"
         }
       ],
@@ -52,15 +52,15 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "calm-record-id",
-                    "label" : "Calm RecordIdentifier",
+                    "id" : "sierra-system-number",
+                    "label" : "Sierra system number",
                     "type" : "IdentifierType"
                   },
-                  "value" : "85YYFFvT9f",
+                  "value" : "dmKTFidDls",
                   "type" : "Identifier"
                 }
               ],
-              "label" : "df4bTPrmWNKiLGp",
+              "label" : "9X3cVR8q4GIgcsJ",
               "type" : "Genre"
             }
           ],
@@ -74,15 +74,15 @@
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "calm-record-id",
-                    "label" : "Calm RecordIdentifier",
+                    "id" : "miro-image-number",
+                    "label" : "Miro image number",
                     "type" : "IdentifierType"
                   },
-                  "value" : "odercwIWKJ",
+                  "value" : "um1qUlCcjg",
                   "type" : "Identifier"
                 }
               ],
-              "label" : "hswtSuPOo0o5Odf",
+              "label" : "qnu7hZZtHlWPIpZ",
               "type" : "Genre"
             }
           ],
@@ -92,39 +92,23 @@
           "label" : "Darwin \"Jones\", Charles",
           "concepts" : [
             {
-              "id" : "qbcbtof9",
+              "id" : "lmpakqz5",
               "identifiers" : [
                 {
                   "identifierType" : {
-                    "id" : "calm-record-id",
-                    "label" : "Calm RecordIdentifier",
+                    "id" : "sierra-system-number",
+                    "label" : "Sierra system number",
                     "type" : "IdentifierType"
                   },
-                  "value" : "mKTFidDlsq",
+                  "value" : "DpKgb0Wdy2",
                   "type" : "Identifier"
                 }
               ],
-              "label" : "X3cVR8q4GIgcsJh",
+              "label" : "5SIuLPMgIG177tc",
               "type" : "Genre"
             },
             {
-              "id" : "nu7hzzth",
-              "identifiers" : [
-                {
-                  "identifierType" : {
-                    "id" : "miro-image-number",
-                    "label" : "Miro image number",
-                    "type" : "IdentifierType"
-                  },
-                  "value" : "glMPaKQZ55",
-                  "type" : "Identifier"
-                }
-              ],
-              "label" : "lWPIpZYum1qUlCc",
-              "type" : "Concept"
-            },
-            {
-              "id" : "siulpmgi",
+              "id" : "nmumczq1",
               "identifiers" : [
                 {
                   "identifierType" : {
@@ -132,11 +116,27 @@
                     "label" : "Calm RecordIdentifier",
                     "type" : "IdentifierType"
                   },
-                  "value" : "2nMuMcZq1J",
+                  "value" : "Q4CK8DrDsk",
                   "type" : "Identifier"
                 }
               ],
-              "label" : "G177tcCDpKgb0Wd",
+              "label" : "JcxukacPWKUROxB",
+              "type" : "Concept"
+            },
+            {
+              "id" : "2kcagurh",
+              "identifiers" : [
+                {
+                  "identifierType" : {
+                    "id" : "calm-record-id",
+                    "label" : "Calm RecordIdentifier",
+                    "type" : "IdentifierType"
+                  },
+                  "value" : "p5zfssscK3",
+                  "type" : "Identifier"
+                }
+              ],
+              "label" : "x40zJbSlLwDNn2E",
               "type" : "Concept"
             }
           ],
@@ -181,16 +181,16 @@
       "description" : null,
       "edition" : null,
       "genres.concepts.label" : [
-        "df4bTPrmWNKiLGp",
-        "hswtSuPOo0o5Odf",
-        "X3cVR8q4GIgcsJh",
-        "lWPIpZYum1qUlCc",
-        "G177tcCDpKgb0Wd"
+        "9X3cVR8q4GIgcsJ",
+        "qnu7hZZtHlWPIpZ",
+        "5SIuLPMgIG177tc",
+        "JcxukacPWKUROxB",
+        "x40zJbSlLwDNn2E"
       ],
-      "id" : "gqd3shrq",
-      "sourceIdentifier.value" : "aiNvMk5aVu",
+      "id" : "plxkke6n",
+      "sourceIdentifier.value" : "1R485o02Dx",
       "identifiers.value" : [
-        "aiNvMk5aVu"
+        "1R485o02Dx"
       ],
       "images.id" : [
       ],
@@ -213,7 +213,7 @@
       "referenceNumber" : null,
       "subjects.concepts.label" : [
       ],
-      "title" : "title-JOR9VqAEmA"
+      "title" : "title-cQ8QOPJdAX"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -251,14 +251,14 @@
       "genres.concepts.id" : [
         "g00dcafe",
         "baadf00d",
-        "qbcbtof9"
+        "lmpakqz5"
       ],
       "subjects.label" : [
       ],
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "aiNvMk5aVu"
+        "1R485o02Dx"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.5.json
+++ b/pipeline/ingestor/test_documents/works.examples.genre-filters-tests.5.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2024-05-15T08:17:25.566950Z",
-  "id" : "90vab5q4",
+  "createdAt" : "2024-08-15T08:40:28.354387Z",
+  "id" : "wbrfsaz5",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "90vab5q4",
+        "id" : "wbrfsaz5",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
-          "value" : "iZFAZvTVR4"
+          "value" : "MzC1ICZOvN"
         },
-        "version" : 58,
-        "modifiedTime" : "1955-01-25T23:49:35Z"
+        "version" : 83,
+        "modifiedTime" : "2016-08-14T05:01:03Z"
       },
-      "mergedTime" : "1955-01-25T23:49:35Z",
+      "mergedTime" : "2016-08-14T05:01:03Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "90vab5q4",
-      "title" : "title-h18D0cbFB1",
+      "id" : "wbrfsaz5",
+      "title" : "title-u5hoUH5ZhF",
       "alternativeTitles" : [
       ],
       "contributors" : [
@@ -33,11 +33,11 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
-          "value" : "iZFAZvTVR4",
+          "value" : "MzC1ICZOvN",
           "type" : "Identifier"
         }
       ],
@@ -84,10 +84,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "90vab5q4",
-      "sourceIdentifier.value" : "iZFAZvTVR4",
+      "id" : "wbrfsaz5",
+      "sourceIdentifier.value" : "MzC1ICZOvN",
       "identifiers.value" : [
-        "iZFAZvTVR4"
+        "MzC1ICZOvN"
       ],
       "images.id" : [
       ],
@@ -110,7 +110,7 @@
       "referenceNumber" : null,
       "subjects.concepts.label" : [
       ],
-      "title" : "title-h18D0cbFB1"
+      "title" : "title-u5hoUH5ZhF"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -146,7 +146,7 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "iZFAZvTVR4"
+        "MzC1ICZOvN"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.0.json
+++ b/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.0.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2024-02-16T15:36:45.048867Z",
-  "id" : "inoolbps",
+  "createdAt" : "2024-08-15T08:40:28.359513Z",
+  "id" : "kx6ceruj",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "inoolbps",
+        "id" : "kx6ceruj",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
-          "value" : "bh6q7wkoWR"
+          "value" : "KEnxzBExh6"
         },
-        "version" : 4,
-        "modifiedTime" : "1988-02-26T07:09:16Z"
+        "version" : 84,
+        "modifiedTime" : "1971-05-14T11:26:40Z"
       },
-      "mergedTime" : "1988-02-26T07:09:16Z",
+      "mergedTime" : "1971-05-14T11:26:40Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "inoolbps",
-      "title" : "title-jRX3FqozNG",
+      "id" : "kx6ceruj",
+      "title" : "title-ArEMdSJPD8",
       "alternativeTitles" : [
       ],
       "contributors" : [
@@ -33,11 +33,11 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
-          "value" : "bh6q7wkoWR",
+          "value" : "KEnxzBExh6",
           "type" : "Identifier"
         }
       ],
@@ -67,15 +67,15 @@
           "label" : "Sanitation.",
           "concepts" : [
             {
-              "label" : "485o02DxPLXKke6",
+              "label" : "rBAO66qqlbcmHn7",
               "type" : "Concept"
             },
             {
-              "label" : "NacQ8QOPJdAXFgM",
+              "label" : "act97zOQ6G6Rkv6",
               "type" : "Concept"
             },
             {
-              "label" : "zC1ICZOvNWbRfsA",
+              "label" : "QH5zn9bqmY6Obq6",
               "type" : "Concept"
             }
           ],
@@ -123,10 +123,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "inoolbps",
-      "sourceIdentifier.value" : "bh6q7wkoWR",
+      "id" : "kx6ceruj",
+      "sourceIdentifier.value" : "KEnxzBExh6",
       "identifiers.value" : [
-        "bh6q7wkoWR"
+        "KEnxzBExh6"
       ],
       "images.id" : [
       ],
@@ -148,11 +148,11 @@
       ],
       "referenceNumber" : null,
       "subjects.concepts.label" : [
-        "485o02DxPLXKke6",
-        "NacQ8QOPJdAXFgM",
-        "zC1ICZOvNWbRfsA"
+        "rBAO66qqlbcmHn7",
+        "act97zOQ6G6Rkv6",
+        "QH5zn9bqmY6Obq6"
       ],
-      "title" : "title-jRX3FqozNG"
+      "title" : "title-ArEMdSJPD8"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -190,7 +190,7 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "bh6q7wkoWR"
+        "KEnxzBExh6"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.1.json
+++ b/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.1.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2024-02-16T15:36:45.049770Z",
-  "id" : "6vp3bulw",
+  "createdAt" : "2024-08-15T08:40:28.360001Z",
+  "id" : "85vigluy",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "6vp3bulw",
+        "id" : "85vigluy",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
-          "value" : "PfCPwnrkDO"
+          "value" : "0xrR5Stsp3"
         },
-        "version" : 45,
-        "modifiedTime" : "2034-03-26T04:42:25Z"
+        "version" : 24,
+        "modifiedTime" : "1940-04-20T21:57:32Z"
       },
-      "mergedTime" : "2034-03-26T04:42:25Z",
+      "mergedTime" : "1940-04-20T21:57:32Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "6vp3bulw",
-      "title" : "title-hZ3Z5q2ktK",
+      "id" : "85vigluy",
+      "title" : "title-YlnwWOedI3",
       "alternativeTitles" : [
       ],
       "contributors" : [
@@ -33,11 +33,11 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
-          "value" : "PfCPwnrkDO",
+          "value" : "0xrR5Stsp3",
           "type" : "Identifier"
         }
       ],
@@ -46,15 +46,15 @@
           "label" : "London (England)",
           "concepts" : [
             {
-              "label" : "Z5Ju5hoUH5ZhFqr",
+              "label" : "lxZzGryOg3KGy7M",
               "type" : "Concept"
             },
             {
-              "label" : "BAO66qqlbcmHn7a",
+              "label" : "z5GNUj1it3ic4OR",
               "type" : "Concept"
             },
             {
-              "label" : "ct97zOQ6G6Rkv6Q",
+              "label" : "9LzJV7M3Kvqw9fG",
               "type" : "Concept"
             }
           ],
@@ -102,10 +102,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "6vp3bulw",
-      "sourceIdentifier.value" : "PfCPwnrkDO",
+      "id" : "85vigluy",
+      "sourceIdentifier.value" : "0xrR5Stsp3",
       "identifiers.value" : [
-        "PfCPwnrkDO"
+        "0xrR5Stsp3"
       ],
       "images.id" : [
       ],
@@ -127,11 +127,11 @@
       ],
       "referenceNumber" : null,
       "subjects.concepts.label" : [
-        "Z5Ju5hoUH5ZhFqr",
-        "BAO66qqlbcmHn7a",
-        "ct97zOQ6G6Rkv6Q"
+        "lxZzGryOg3KGy7M",
+        "z5GNUj1it3ic4OR",
+        "9LzJV7M3Kvqw9fG"
       ],
-      "title" : "title-hZ3Z5q2ktK"
+      "title" : "title-YlnwWOedI3"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -169,7 +169,7 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "PfCPwnrkDO"
+        "0xrR5Stsp3"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.2.json
+++ b/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.2.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2024-05-15T08:17:25.576574Z",
-  "id" : "cerujhar",
+  "createdAt" : "2024-08-15T08:40:28.360376Z",
+  "id" : "eadt8hhm",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "cerujhar",
+        "id" : "eadt8hhm",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
-          "value" : "xzBExh6kx6"
+          "value" : "SSg7erLcgx"
         },
-        "version" : 30,
-        "modifiedTime" : "2050-03-03T12:29:26Z"
+        "version" : 18,
+        "modifiedTime" : "2010-09-19T13:34:03Z"
       },
-      "mergedTime" : "2050-03-03T12:29:26Z",
+      "mergedTime" : "2010-09-19T13:34:03Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "cerujhar",
-      "title" : "title-MdSJPD8H80",
+      "id" : "eadt8hhm",
+      "title" : "title-zSHRFusVBN",
       "alternativeTitles" : [
       ],
       "contributors" : [
@@ -33,11 +33,11 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
-          "value" : "xzBExh6kx6",
+          "value" : "SSg7erLcgx",
           "type" : "Identifier"
         }
       ],
@@ -46,15 +46,15 @@
           "label" : "Psychology, Pathological",
           "concepts" : [
             {
-              "label" : "H5zn9bqmY6Obq6l",
+              "label" : "ol7E1K1L8XUhcLZ",
               "type" : "Concept"
             },
             {
-              "label" : "xZzGryOg3KGy7Mz",
+              "label" : "hc35m9C4DAgxJAj",
               "type" : "Concept"
             },
             {
-              "label" : "5GNUj1it3ic4OR9",
+              "label" : "Eybh6q7wkoWRiNO",
               "type" : "Concept"
             }
           ],
@@ -102,10 +102,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "cerujhar",
-      "sourceIdentifier.value" : "xzBExh6kx6",
+      "id" : "eadt8hhm",
+      "sourceIdentifier.value" : "SSg7erLcgx",
       "identifiers.value" : [
-        "xzBExh6kx6"
+        "SSg7erLcgx"
       ],
       "images.id" : [
       ],
@@ -127,11 +127,11 @@
       ],
       "referenceNumber" : null,
       "subjects.concepts.label" : [
-        "H5zn9bqmY6Obq6l",
-        "xZzGryOg3KGy7Mz",
-        "5GNUj1it3ic4OR9"
+        "ol7E1K1L8XUhcLZ",
+        "hc35m9C4DAgxJAj",
+        "Eybh6q7wkoWRiNO"
       ],
-      "title" : "title-MdSJPD8H80"
+      "title" : "title-zSHRFusVBN"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -169,7 +169,7 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "xzBExh6kx6"
+        "SSg7erLcgx"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.3.json
+++ b/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.3.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2024-05-15T08:17:25.577010Z",
-  "id" : "igluyxyl",
+  "createdAt" : "2024-08-15T08:40:28.360946Z",
+  "id" : "3kdpeojw",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "igluyxyl",
+        "id" : "3kdpeojw",
         "identifier" : {
           "identifierType" : {
             "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
-          "value" : "R5Stsp385V"
+          "value" : "SqD7qcFvAY"
         },
-        "version" : 91,
-        "modifiedTime" : "2014-07-17T10:56:43Z"
+        "version" : 21,
+        "modifiedTime" : "2051-08-21T14:08:03Z"
       },
-      "mergedTime" : "2014-07-17T10:56:43Z",
+      "mergedTime" : "2051-08-21T14:08:03Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "igluyxyl",
-      "title" : "title-wWOedI3v8S",
+      "id" : "3kdpeojw",
+      "title" : "title-FeGzni8X1i",
       "alternativeTitles" : [
       ],
       "contributors" : [
@@ -37,7 +37,7 @@
             "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
-          "value" : "R5Stsp385V",
+          "value" : "SqD7qcFvAY",
           "type" : "Identifier"
         }
       ],
@@ -58,15 +58,15 @@
           "label" : "Darwin \"Jones\", Charles",
           "concepts" : [
             {
-              "label" : "LzJV7M3Kvqw9fGo",
+              "label" : "oLbpS5jRX3FqozN",
               "type" : "Concept"
             },
             {
-              "label" : "l7E1K1L8XUhcLZh",
+              "label" : "GJ9PfCPwnrkDO6V",
               "type" : "Concept"
             },
             {
-              "label" : "c35m9C4DAgxJAjE",
+              "label" : "p3bULWghZ3Z5q2k",
               "type" : "Concept"
             }
           ],
@@ -114,10 +114,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "igluyxyl",
-      "sourceIdentifier.value" : "R5Stsp385V",
+      "id" : "3kdpeojw",
+      "sourceIdentifier.value" : "SqD7qcFvAY",
       "identifiers.value" : [
-        "R5Stsp385V"
+        "SqD7qcFvAY"
       ],
       "images.id" : [
       ],
@@ -139,11 +139,11 @@
       ],
       "referenceNumber" : null,
       "subjects.concepts.label" : [
-        "LzJV7M3Kvqw9fGo",
-        "l7E1K1L8XUhcLZh",
-        "c35m9C4DAgxJAjE"
+        "oLbpS5jRX3FqozN",
+        "GJ9PfCPwnrkDO6V",
+        "p3bULWghZ3Z5q2k"
       ],
-      "title" : "title-wWOedI3v8S"
+      "title" : "title-FeGzni8X1i"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -181,7 +181,7 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "R5Stsp385V"
+        "SqD7qcFvAY"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.4.json
+++ b/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.4.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2024-05-15T08:17:25.577611Z",
-  "id" : "t8hhmnzs",
+  "createdAt" : "2024-08-15T08:40:28.361688Z",
+  "id" : "ppcdklf9",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "t8hhmnzs",
+        "id" : "ppcdklf9",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
-          "value" : "7erLcgxEad"
+          "value" : "3o0GGLKeJC"
         },
-        "version" : 3,
-        "modifiedTime" : "2013-05-09T02:35:31Z"
+        "version" : 31,
+        "modifiedTime" : "2004-11-14T20:49:37Z"
       },
-      "mergedTime" : "2013-05-09T02:35:31Z",
+      "mergedTime" : "2004-11-14T20:49:37Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "t8hhmnzs",
-      "title" : "title-RFusVBNn8S",
+      "id" : "ppcdklf9",
+      "title" : "title-BG0vJlw8MZ",
       "alternativeTitles" : [
       ],
       "contributors" : [
@@ -33,11 +33,11 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
-          "value" : "7erLcgxEad",
+          "value" : "3o0GGLKeJC",
           "type" : "Identifier"
         }
       ],
@@ -46,15 +46,15 @@
           "label" : "London (England)",
           "concepts" : [
             {
-              "label" : "Z5Ju5hoUH5ZhFqr",
+              "label" : "lxZzGryOg3KGy7M",
               "type" : "Concept"
             },
             {
-              "label" : "BAO66qqlbcmHn7a",
+              "label" : "z5GNUj1it3ic4OR",
               "type" : "Concept"
             },
             {
-              "label" : "ct97zOQ6G6Rkv6Q",
+              "label" : "9LzJV7M3Kvqw9fG",
               "type" : "Concept"
             }
           ],
@@ -64,15 +64,15 @@
           "label" : "Psychology, Pathological",
           "concepts" : [
             {
-              "label" : "H5zn9bqmY6Obq6l",
+              "label" : "ol7E1K1L8XUhcLZ",
               "type" : "Concept"
             },
             {
-              "label" : "xZzGryOg3KGy7Mz",
+              "label" : "hc35m9C4DAgxJAj",
               "type" : "Concept"
             },
             {
-              "label" : "5GNUj1it3ic4OR9",
+              "label" : "Eybh6q7wkoWRiNO",
               "type" : "Concept"
             }
           ],
@@ -94,15 +94,15 @@
           "label" : "Darwin \"Jones\", Charles",
           "concepts" : [
             {
-              "label" : "LzJV7M3Kvqw9fGo",
+              "label" : "oLbpS5jRX3FqozN",
               "type" : "Concept"
             },
             {
-              "label" : "l7E1K1L8XUhcLZh",
+              "label" : "GJ9PfCPwnrkDO6V",
               "type" : "Concept"
             },
             {
-              "label" : "c35m9C4DAgxJAjE",
+              "label" : "p3bULWghZ3Z5q2k",
               "type" : "Concept"
             }
           ],
@@ -150,10 +150,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "t8hhmnzs",
-      "sourceIdentifier.value" : "7erLcgxEad",
+      "id" : "ppcdklf9",
+      "sourceIdentifier.value" : "3o0GGLKeJC",
       "identifiers.value" : [
-        "7erLcgxEad"
+        "3o0GGLKeJC"
       ],
       "images.id" : [
       ],
@@ -175,17 +175,17 @@
       ],
       "referenceNumber" : null,
       "subjects.concepts.label" : [
-        "Z5Ju5hoUH5ZhFqr",
-        "BAO66qqlbcmHn7a",
-        "ct97zOQ6G6Rkv6Q",
-        "H5zn9bqmY6Obq6l",
-        "xZzGryOg3KGy7Mz",
-        "5GNUj1it3ic4OR9",
-        "LzJV7M3Kvqw9fGo",
-        "l7E1K1L8XUhcLZh",
-        "c35m9C4DAgxJAjE"
+        "lxZzGryOg3KGy7M",
+        "z5GNUj1it3ic4OR",
+        "9LzJV7M3Kvqw9fG",
+        "ol7E1K1L8XUhcLZ",
+        "hc35m9C4DAgxJAj",
+        "Eybh6q7wkoWRiNO",
+        "oLbpS5jRX3FqozN",
+        "GJ9PfCPwnrkDO6V",
+        "p3bULWghZ3Z5q2k"
       ],
-      "title" : "title-RFusVBNn8S"
+      "title" : "title-BG0vJlw8MZ"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -227,7 +227,7 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "7erLcgxEad"
+        "3o0GGLKeJC"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.5.json
+++ b/pipeline/ingestor/test_documents/works.examples.subject-filters-tests.5.json
@@ -1,22 +1,22 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2024-05-15T08:17:25.578138Z",
-  "id" : "peojwvfe",
+  "createdAt" : "2024-08-15T08:40:28.362009Z",
+  "id" : "w0lr7wac",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "peojwvfe",
+        "id" : "w0lr7wac",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
-          "value" : "7qcFvAY3kD"
+          "value" : "ty9GY2AKxy"
         },
         "version" : 93,
-        "modifiedTime" : "1989-01-11T05:04:05Z"
+        "modifiedTime" : "2032-06-12T10:57:16Z"
       },
-      "mergedTime" : "1989-01-11T05:04:05Z",
+      "mergedTime" : "2032-06-12T10:57:16Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "peojwvfe",
-      "title" : "title-zni8X1iQV3",
+      "id" : "w0lr7wac",
+      "title" : "title-uXzrv8PglA",
       "alternativeTitles" : [
       ],
       "contributors" : [
@@ -33,11 +33,11 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
-          "value" : "7qcFvAY3kD",
+          "value" : "ty9GY2AKxy",
           "type" : "Identifier"
         }
       ],
@@ -84,10 +84,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "peojwvfe",
-      "sourceIdentifier.value" : "7qcFvAY3kD",
+      "id" : "w0lr7wac",
+      "sourceIdentifier.value" : "ty9GY2AKxy",
       "identifiers.value" : [
-        "7qcFvAY3kD"
+        "ty9GY2AKxy"
       ],
       "images.id" : [
       ],
@@ -110,7 +110,7 @@
       "referenceNumber" : null,
       "subjects.concepts.label" : [
       ],
-      "title" : "title-zni8X1iQV3"
+      "title" : "title-uXzrv8PglA"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -146,7 +146,7 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "7qcFvAY3kD"
+        "ty9GY2AKxy"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.production.multi-year.0.json
+++ b/pipeline/ingestor/test_documents/works.production.multi-year.0.json
@@ -1,22 +1,22 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2024-05-15T08:17:25.522569Z",
-  "id" : "cgfghm8m",
+  "createdAt" : "2024-08-15T08:40:28.308959Z",
+  "id" : "wrhbusqt",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "cgfghm8m",
+        "id" : "wrhbusqt",
         "identifier" : {
           "identifierType" : {
             "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
-          "value" : "mh0pYazvpR"
+          "value" : "JWZRaIg4BP"
         },
-        "version" : 37,
-        "modifiedTime" : "1945-01-10T19:58:56Z"
+        "version" : 92,
+        "modifiedTime" : "1941-03-30T16:00:44Z"
       },
-      "mergedTime" : "1945-01-10T19:58:56Z",
+      "mergedTime" : "1941-03-30T16:00:44Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "cgfghm8m",
-      "title" : "title-oOAv5vdS0Y",
+      "id" : "wrhbusqt",
+      "title" : "title-zUOjOyKabH",
       "alternativeTitles" : [
       ],
       "contributors" : [
@@ -37,7 +37,7 @@
             "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
-          "value" : "mh0pYazvpR",
+          "value" : "JWZRaIg4BP",
           "type" : "Identifier"
         }
       ],
@@ -53,16 +53,16 @@
       ],
       "production" : [
         {
-          "label" : "aIg4BPWRHbuSqTDzUOjOyKabH",
+          "label" : "cUH8ak2gePdAnZy8IL7DS24A3",
           "places" : [
             {
-              "label" : "lF2fhJcUH8",
+              "label" : "bjh2WRDdYf",
               "type" : "Place"
             }
           ],
           "agents" : [
             {
-              "label" : "ak2gePdAnZ",
+              "label" : "1h8Be8UrT3",
               "type" : "Person"
             }
           ],
@@ -106,10 +106,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "cgfghm8m",
-      "sourceIdentifier.value" : "mh0pYazvpR",
+      "id" : "wrhbusqt",
+      "sourceIdentifier.value" : "JWZRaIg4BP",
       "identifiers.value" : [
-        "mh0pYazvpR"
+        "JWZRaIg4BP"
       ],
       "images.id" : [
       ],
@@ -128,14 +128,14 @@
       ],
       "physicalDescription" : null,
       "production.label" : [
-        "lF2fhJcUH8",
-        "ak2gePdAnZ",
+        "bjh2WRDdYf",
+        "1h8Be8UrT3",
         "1850"
       ],
       "referenceNumber" : null,
       "subjects.concepts.label" : [
       ],
-      "title" : "title-oOAv5vdS0Y"
+      "title" : "title-zUOjOyKabH"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -173,7 +173,7 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "mh0pYazvpR"
+        "JWZRaIg4BP"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.production.multi-year.1.json
+++ b/pipeline/ingestor/test_documents/works.production.multi-year.1.json
@@ -1,22 +1,22 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2024-05-15T08:17:25.522937Z",
-  "id" : "bjh2wrdd",
+  "createdAt" : "2024-08-15T08:40:28.309265Z",
+  "id" : "yjdmhccz",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "bjh2wrdd",
+        "id" : "yjdmhccz",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
-          "value" : "8IL7DS24A3"
+          "value" : "pvvnQHgcJP"
         },
-        "version" : 66,
-        "modifiedTime" : "2062-07-25T05:57:54Z"
+        "version" : 49,
+        "modifiedTime" : "1965-03-09T05:55:12Z"
       },
-      "mergedTime" : "2062-07-25T05:57:54Z",
+      "mergedTime" : "1965-03-09T05:55:12Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "bjh2wrdd",
-      "title" : "title-f1h8Be8UrT",
+      "id" : "yjdmhccz",
+      "title" : "title-NV4U4YKwyt",
       "alternativeTitles" : [
       ],
       "contributors" : [
@@ -33,11 +33,11 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
-          "value" : "8IL7DS24A3",
+          "value" : "pvvnQHgcJP",
           "type" : "Identifier"
         }
       ],
@@ -53,16 +53,16 @@
       ],
       "production" : [
         {
-          "label" : "QHgcJPyjdmhcczXNV4U4YKwyt",
+          "label" : "wmZcSQaFLtBeNhpR5aFhbmGJs",
           "places" : [
             {
-              "label" : "cvu6mFwmZc",
+              "label" : "Mse28ReU0t",
               "type" : "Place"
             }
           ],
           "agents" : [
             {
-              "label" : "SQaFLtBeNh",
+              "label" : "OIr878hfcC",
               "type" : "Person"
             }
           ],
@@ -106,10 +106,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "bjh2wrdd",
-      "sourceIdentifier.value" : "8IL7DS24A3",
+      "id" : "yjdmhccz",
+      "sourceIdentifier.value" : "pvvnQHgcJP",
       "identifiers.value" : [
-        "8IL7DS24A3"
+        "pvvnQHgcJP"
       ],
       "images.id" : [
       ],
@@ -128,14 +128,14 @@
       ],
       "physicalDescription" : null,
       "production.label" : [
-        "cvu6mFwmZc",
-        "SQaFLtBeNh",
+        "Mse28ReU0t",
+        "OIr878hfcC",
         "1850-2000"
       ],
       "referenceNumber" : null,
       "subjects.concepts.label" : [
       ],
-      "title" : "title-f1h8Be8UrT"
+      "title" : "title-NV4U4YKwyt"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -173,7 +173,7 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "8IL7DS24A3"
+        "pvvnQHgcJP"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.production.multi-year.2.json
+++ b/pipeline/ingestor/test_documents/works.production.multi-year.2.json
@@ -1,22 +1,22 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2024-05-15T08:17:25.523444Z",
-  "id" : "mse28reu",
+  "createdAt" : "2024-08-15T08:40:28.309548Z",
+  "id" : "v2jj5pko",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "mse28reu",
+        "id" : "v2jj5pko",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "sierra-system-number"
           },
           "ontologyType" : "Work",
-          "value" : "R5aFhbmGJs"
+          "value" : "XKeDQMh6zv"
         },
-        "version" : 65,
-        "modifiedTime" : "1981-12-24T12:24:54Z"
+        "version" : 34,
+        "modifiedTime" : "1975-08-31T16:12:40Z"
       },
-      "mergedTime" : "1981-12-24T12:24:54Z",
+      "mergedTime" : "1975-08-31T16:12:40Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "mse28reu",
-      "title" : "title-tOIr878hfc",
+      "id" : "v2jj5pko",
+      "title" : "title-kAlfIDxe8F",
       "alternativeTitles" : [
       ],
       "contributors" : [
@@ -33,11 +33,11 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
             "type" : "IdentifierType"
           },
-          "value" : "R5aFhbmGJs",
+          "value" : "XKeDQMh6zv",
           "type" : "Identifier"
         }
       ],
@@ -53,16 +53,16 @@
       ],
       "production" : [
         {
-          "label" : "QMh6zvv2Jj5pKO9kAlfIDxe8F",
+          "label" : "T0mobVH4nMKaFfllypAUqLQ0g",
           "places" : [
             {
-              "label" : "davLbUT0mo",
+              "label" : "UKbghZ727m",
               "type" : "Place"
             }
           ],
           "agents" : [
             {
-              "label" : "bVH4nMKaFf",
+              "label" : "8zTnSvRiZt",
               "type" : "Person"
             }
           ],
@@ -106,10 +106,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "mse28reu",
-      "sourceIdentifier.value" : "R5aFhbmGJs",
+      "id" : "v2jj5pko",
+      "sourceIdentifier.value" : "XKeDQMh6zv",
       "identifiers.value" : [
-        "R5aFhbmGJs"
+        "XKeDQMh6zv"
       ],
       "images.id" : [
       ],
@@ -128,14 +128,14 @@
       ],
       "physicalDescription" : null,
       "production.label" : [
-        "davLbUT0mo",
-        "bVH4nMKaFf",
+        "UKbghZ727m",
+        "8zTnSvRiZt",
         "1860-1960"
       ],
       "referenceNumber" : null,
       "subjects.concepts.label" : [
       ],
-      "title" : "title-tOIr878hfc"
+      "title" : "title-kAlfIDxe8F"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -173,7 +173,7 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "R5aFhbmGJs"
+        "XKeDQMh6zv"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.production.multi-year.3.json
+++ b/pipeline/ingestor/test_documents/works.production.multi-year.3.json
@@ -1,22 +1,22 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2024-02-16T15:36:44.931264Z",
-  "id" : "ukbghz72",
+  "createdAt" : "2024-08-15T08:40:28.309846Z",
+  "id" : "br9psxdd",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "ukbghz72",
+        "id" : "br9psxdd",
         "identifier" : {
           "identifierType" : {
-            "id" : "sierra-system-number"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
-          "value" : "lypAUqLQ0g"
+          "value" : "CpwHX9hOaw"
         },
-        "version" : 76,
-        "modifiedTime" : "2004-01-03T14:20:07Z"
+        "version" : 63,
+        "modifiedTime" : "1971-04-20T21:05:04Z"
       },
-      "mergedTime" : "2004-01-03T14:20:07Z",
+      "mergedTime" : "1971-04-20T21:05:04Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "ukbghz72",
-      "title" : "title-m8zTnSvRiZ",
+      "id" : "br9psxdd",
+      "title" : "title-TQ6alxfhhH",
       "alternativeTitles" : [
       ],
       "contributors" : [
@@ -33,11 +33,11 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "sierra-system-number",
-            "label" : "Sierra system number",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
-          "value" : "lypAUqLQ0g",
+          "value" : "CpwHX9hOaw",
           "type" : "Identifier"
         }
       ],
@@ -53,16 +53,16 @@
       ],
       "production" : [
         {
-          "label" : "X9hOawBR9PsxddZTQ6alxfhhH",
+          "label" : "lLIHkQjFHQROpFfnFl9elPj6a",
           "places" : [
             {
-              "label" : "cRBQaVlLIH",
+              "label" : "56tujbhysw",
               "type" : "Place"
             }
           ],
           "agents" : [
             {
-              "label" : "kQjFHQROpF",
+              "label" : "OpLeG3f7j0",
               "type" : "Person"
             }
           ],
@@ -106,10 +106,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "ukbghz72",
-      "sourceIdentifier.value" : "lypAUqLQ0g",
+      "id" : "br9psxdd",
+      "sourceIdentifier.value" : "CpwHX9hOaw",
       "identifiers.value" : [
-        "lypAUqLQ0g"
+        "CpwHX9hOaw"
       ],
       "images.id" : [
       ],
@@ -128,14 +128,14 @@
       ],
       "physicalDescription" : null,
       "production.label" : [
-        "cRBQaVlLIH",
-        "kQjFHQROpF",
+        "56tujbhysw",
+        "OpLeG3f7j0",
         "1960"
       ],
       "referenceNumber" : null,
       "subjects.concepts.label" : [
       ],
-      "title" : "title-m8zTnSvRiZ"
+      "title" : "title-TQ6alxfhhH"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -173,7 +173,7 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "lypAUqLQ0g"
+        "CpwHX9hOaw"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.production.multi-year.4.json
+++ b/pipeline/ingestor/test_documents/works.production.multi-year.4.json
@@ -1,22 +1,22 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2024-05-15T08:17:25.524311Z",
-  "id" : "56tujbhy",
+  "createdAt" : "2024-08-15T08:40:28.310160Z",
+  "id" : "rx3okdwc",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "56tujbhy",
+        "id" : "rx3okdwc",
         "identifier" : {
           "identifierType" : {
-            "id" : "calm-record-id"
+            "id" : "miro-image-number"
           },
           "ontologyType" : "Work",
-          "value" : "nFl9elPj6a"
+          "value" : "b0tnvUprsj"
         },
-        "version" : 81,
-        "modifiedTime" : "2056-06-05T14:49:37Z"
+        "version" : 80,
+        "modifiedTime" : "2029-08-13T07:01:03Z"
       },
-      "mergedTime" : "2056-06-05T14:49:37Z",
+      "mergedTime" : "2029-08-13T07:01:03Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "56tujbhy",
-      "title" : "title-wOpLeG3f7j",
+      "id" : "rx3okdwc",
+      "title" : "title-2lfjsLaubb",
       "alternativeTitles" : [
       ],
       "contributors" : [
@@ -33,11 +33,11 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "calm-record-id",
-            "label" : "Calm RecordIdentifier",
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
             "type" : "IdentifierType"
           },
-          "value" : "nFl9elPj6a",
+          "value" : "b0tnvUprsj",
           "type" : "Identifier"
         }
       ],
@@ -53,16 +53,16 @@
       ],
       "production" : [
         {
-          "label" : "vUprsjrX3OKDwcT2lfjsLaubb",
+          "label" : "GsIdzZyGYBSGAtphRApGkJTZW",
           "places" : [
             {
-              "label" : "73X6HqGsId",
+              "label" : "wn4AhFD31A",
               "type" : "Place"
             }
           ],
           "agents" : [
             {
-              "label" : "zZyGYBSGAt",
+              "label" : "dK5EfQwt6P",
               "type" : "Person"
             }
           ],
@@ -106,10 +106,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "56tujbhy",
-      "sourceIdentifier.value" : "nFl9elPj6a",
+      "id" : "rx3okdwc",
+      "sourceIdentifier.value" : "b0tnvUprsj",
       "identifiers.value" : [
-        "nFl9elPj6a"
+        "b0tnvUprsj"
       ],
       "images.id" : [
       ],
@@ -128,14 +128,14 @@
       ],
       "physicalDescription" : null,
       "production.label" : [
-        "73X6HqGsId",
-        "zZyGYBSGAt",
+        "wn4AhFD31A",
+        "dK5EfQwt6P",
         "1960-1964"
       ],
       "referenceNumber" : null,
       "subjects.concepts.label" : [
       ],
-      "title" : "title-wOpLeG3f7j"
+      "title" : "title-2lfjsLaubb"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -173,7 +173,7 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "nFl9elPj6a"
+        "b0tnvUprsj"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/ingestor/test_documents/works.production.multi-year.5.json
+++ b/pipeline/ingestor/test_documents/works.production.multi-year.5.json
@@ -1,22 +1,22 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2024-05-15T08:17:25.524738Z",
-  "id" : "wn4ahfd3",
+  "createdAt" : "2024-08-15T08:40:28.310453Z",
+  "id" : "dbkiu6iz",
   "document" : {
     "debug" : {
       "source" : {
-        "id" : "wn4ahfd3",
+        "id" : "dbkiu6iz",
         "identifier" : {
           "identifierType" : {
-            "id" : "miro-image-number"
+            "id" : "calm-record-id"
           },
           "ontologyType" : "Work",
-          "value" : "hRApGkJTZW"
+          "value" : "lbspe4jqB3"
         },
-        "version" : 60,
-        "modifiedTime" : "1951-03-21T03:54:08Z"
+        "version" : 18,
+        "modifiedTime" : "1958-05-09T13:19:17Z"
       },
-      "mergedTime" : "1951-03-21T03:54:08Z",
+      "mergedTime" : "1958-05-09T13:19:17Z",
       "indexedTime" : "2001-01-01T01:01:01Z",
       "redirectSources" : [
       ],
@@ -24,8 +24,8 @@
       ]
     },
     "display" : {
-      "id" : "wn4ahfd3",
-      "title" : "title-AdK5EfQwt6",
+      "id" : "dbkiu6iz",
+      "title" : "title-DrUzFkvgSy",
       "alternativeTitles" : [
       ],
       "contributors" : [
@@ -33,11 +33,11 @@
       "identifiers" : [
         {
           "identifierType" : {
-            "id" : "miro-image-number",
-            "label" : "Miro image number",
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
             "type" : "IdentifierType"
           },
-          "value" : "hRApGkJTZW",
+          "value" : "lbspe4jqB3",
           "type" : "Identifier"
         }
       ],
@@ -53,16 +53,16 @@
       ],
       "production" : [
         {
-          "label" : "e4jqB3DBkIu6IZ2DrUzFkvgSy",
+          "label" : "yMDGo2rBCSPBNfFmnJIEpzyMJ",
           "places" : [
             {
-              "label" : "VfmtHDyMDG",
+              "label" : "LtI2pjU6xn",
               "type" : "Place"
             }
           ],
           "agents" : [
             {
-              "label" : "o2rBCSPBNf",
+              "label" : "Vo8KntFwFf",
               "type" : "Person"
             }
           ],
@@ -106,10 +106,10 @@
       "edition" : null,
       "genres.concepts.label" : [
       ],
-      "id" : "wn4ahfd3",
-      "sourceIdentifier.value" : "hRApGkJTZW",
+      "id" : "dbkiu6iz",
+      "sourceIdentifier.value" : "lbspe4jqB3",
       "identifiers.value" : [
-        "hRApGkJTZW"
+        "lbspe4jqB3"
       ],
       "images.id" : [
       ],
@@ -128,14 +128,14 @@
       ],
       "physicalDescription" : null,
       "production.label" : [
-        "VfmtHDyMDG",
-        "o2rBCSPBNf",
+        "LtI2pjU6xn",
+        "Vo8KntFwFf",
         "1962"
       ],
       "referenceNumber" : null,
       "subjects.concepts.label" : [
       ],
-      "title" : "title-AdK5EfQwt6"
+      "title" : "title-DrUzFkvgSy"
     },
     "aggregatableValues" : {
       "workType" : [
@@ -173,7 +173,7 @@
       "contributors.agent.label" : [
       ],
       "identifiers.value" : [
-        "hRApGkJTZW"
+        "lbspe4jqB3"
       ],
       "items.locations.license.id" : [
       ],

--- a/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/CalmTransformer.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/CalmTransformer.scala
@@ -151,7 +151,7 @@ object CalmTransformer
       title = Some(title),
       alternativeTitles = CalmAlternativeTitles(record),
       otherIdentifiers = otherIdentifiers(record),
-      format = Some(Format.ArchivesAndManuscripts),
+      format = Some(CalmFormat(record)),
       collectionPath = Some(collectionPath),
       referenceNumber = collectionPath.label.map(ReferenceNumber(_)),
       subjects = subjects(record),

--- a/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/transformers/CalmFormat.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/transformers/CalmFormat.scala
@@ -1,0 +1,14 @@
+package weco.pipeline.transformer.calm.transformers
+
+import weco.catalogue.internal_model.work.Format
+import weco.catalogue.source_model.calm.CalmRecord
+import weco.pipeline.transformer.calm.models.CalmRecordOps
+
+object CalmFormat extends CalmRecordOps {
+  def apply(record: CalmRecord): Format = {
+    record.get("Material") match {
+      case Some("Archives - Digital") => Format.ArchivesDigital
+      case _  => Format.ArchivesAndManuscripts
+    }
+  }
+}

--- a/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/transformers/CalmFormat.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/transformers/CalmFormat.scala
@@ -8,7 +8,7 @@ object CalmFormat extends CalmRecordOps {
   def apply(record: CalmRecord): Format = {
     record.get("Material") match {
       case Some("Archives - Digital") => Format.ArchivesDigital
-      case _  => Format.ArchivesAndManuscripts
+      case _                          => Format.ArchivesAndManuscripts
     }
   }
 }

--- a/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/CalmTransformerTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/CalmTransformerTest.scala
@@ -31,6 +31,7 @@ class CalmTransformerTest
       "Level" -> "Collection",
       "RefNo" -> "a/b/c",
       "AltRefNo" -> "a.b.c",
+      "Material" -> "Archives - Non-digital",
       "CatalogueStatus" -> "Catalogued",
       "Language" -> "English, with Russian commentary",
       "AccNo" -> """<span class="HIT">WI</span>/<span class="HIT">86</span>"""

--- a/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/transformers/CalmFormatTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/transformers/CalmFormatTest.scala
@@ -15,6 +15,9 @@ class CalmFormatTest extends AnyFunSpec with Matchers with CalmRecordGenerators 
     val digitalFormat = CalmFormat(digitalRecord)
 
     digitalFormat shouldBe Format.ArchivesDigital
+
+    // Check that the label is "Archives - Digital"
+    Format.ArchivesDigital.label shouldBe("Archives - Digital")
   }
 
   it("Defaults to ArchivesAndManuscripts for all other contents of Material") {

--- a/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/transformers/CalmFormatTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/transformers/CalmFormatTest.scala
@@ -1,0 +1,31 @@
+package weco.pipeline.transformer.calm.transformers
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import weco.catalogue.internal_model.work._
+import weco.catalogue.source_model.generators.CalmRecordGenerators
+import weco.fixtures.RandomGenerators
+
+class CalmFormatTest extends AnyFunSpec with Matchers with CalmRecordGenerators with RandomGenerators {
+  it("Correctly extracts the ArchivesDigital Format when the appropriate Material string is present") {
+    val digitalRecord = createCalmRecordWith(
+      ("Material", "Archives - Digital"),
+    )
+
+    val digitalFormat = CalmFormat(digitalRecord)
+
+    digitalFormat shouldBe Format.ArchivesDigital
+  }
+
+  it("Defaults to ArchivesAndManuscripts for all other contents of Material") {
+    val nonDigitalRecords = (1 to 100)
+      .map(_ => randomAlphanumeric())
+      .map(materialName => createCalmRecordWith(
+        ("Material", materialName),
+      ))
+
+    val nonDigitalFormats = nonDigitalRecords.map(CalmFormat(_)).toSet
+
+    nonDigitalFormats shouldBe Set(Format.ArchivesAndManuscripts)
+  }
+}


### PR DESCRIPTION
## What does this change?

This change introduces a new `Format` or type `ArchivesDigital` intended to represent "born digital" content from CALM labelled with an "Archives - Digital" `Material` type. 

This is intended to allow "born digital" content to be distinguished from data in the Catalogue API without needing to infer this from the IIIF APIs.

> [!Important]
> This will manifest in the search UI by providing an new format to filter on labelled "Archives - Digital". We should confirm this is a suitable label.

See https://github.com/wellcomecollection/catalogue-pipeline/issues/2659

## How to test

- [x] Run the tests, do they pass?
- [ ] When run in a new pipeline do the API & front-end behave as expected?

## How can we measure success?

Users are better able to filter and view data related to "born digital" works on wellcomecollection.org.

## Have we considered potential risks?

This change introduces a new `Format` of our own invention, previously all formats and their IDs were mirrored from Sierra with that as the canonical source of truth, this is a digression from that pattern and may be undesirable to collection information. To mitigate this we've discussed this issue with that team and concluded we're happy to create a new Format in this case.

