### PR TITLE
Loop suppress miro

### DIFF
--- a/scripts/suppress_miro.py
+++ b/scripts/suppress_miro.py
@@ -22,9 +22,7 @@ miro_id_regex = re.compile("^[A-Z][0-9]{7}[A-Z]{0,4}[0-9]{0,2}$")
     required=True,
 )
 @click.option(
-    "--dry-run",
-    help="Show what will happen, without actually doing it",
-    is_flag=True
+    "--dry-run", help="Show what will happen, without actually doing it", is_flag=True
 )
 def suppress_miro(id_source, message, dry_run):
     """

--- a/scripts/suppress_miro.py
+++ b/scripts/suppress_miro.py
@@ -10,10 +10,12 @@ miro_id_regex = re.compile("^[A-Z][0-9]{7}[A-Z]{0,4}[0-9]{0,2}$")
 
 
 @click.command()
-@click.option('--id_source',
-              help='newline-separated list of MIRO ids',
-              type=click.File('r'),
-              default=sys.stdin)
+@click.option(
+    "--id_source",
+    help="newline-separated list of MIRO ids",
+    type=click.File("r"),
+    default=sys.stdin,
+)
 @click.option(
     "--message",
     help="Why the image was removed, a link to a Slack message, etc.",

--- a/scripts/suppress_miro.py
+++ b/scripts/suppress_miro.py
@@ -2,49 +2,55 @@
 import click
 import re
 import httpx
+import sys
 
 from miro_updates import suppress_image, update_miro_image_suppressions_doc
-
 
 miro_id_regex = re.compile("^[A-Z][0-9]{7}[A-Z]{0,4}[0-9]{0,2}$")
 
 
 @click.command()
-@click.argument("id")
+@click.option('--id_source',
+              help='newline-separated list of MIRO ids',
+              type=click.File('r'),
+              default=sys.stdin)
 @click.option(
     "--message",
     help="Why the image was removed, a link to a Slack message, etc.",
     required=True,
 )
-def suppress_miro(id, message):
+def suppress_miro(id_source, message):
     """
     Suppresses a Miro image with a given ID.
 
     ID can be either a catalogue or a Miro identifier.
     """
-
-    if miro_id_regex.search(id):
-        miro_id = id
-    else:
-        catalogue_response = httpx.get(
-            f"https://api.wellcomecollection.org/catalogue/v2/works/{id}?include=identifiers"
-        )
-        try:
-            response_data = catalogue_response.json()
-            identifiers = response_data["identifiers"]
-            miro_id = next(
-                i["value"]
-                for i in identifiers
-                if i["identifierType"]["id"] == "miro-image-number"
-            )
-            print(f"Miro identifier: {miro_id}")
-        except Exception:
-            raise click.ClickException(
-                f"{id} doesn't look like a Miro ID and isn't the identifier of a catalogue record containing a Miro ID"
-            )
-
-    suppress_image(miro_id=miro_id, message=message)
+    for miro_id in valid_ids(id_source):
+        suppress_image(miro_id={miro_id}, message={message})
     update_miro_image_suppressions_doc()
+
+
+def valid_ids(id_source):
+    for single_id in id_source:
+        if miro_id_regex.search(single_id):
+            yield single_id
+        else:
+            catalogue_response = httpx.get(
+                f"https://api.wellcomecollection.org/catalogue/v2/works/{single_id}?include=identifiers"
+            )
+            try:
+                response_data = catalogue_response.json()
+                identifiers = response_data["identifiers"]
+                miro_id = next(
+                    i["value"]
+                    for i in identifiers
+                    if i["identifierType"]["id"] == "miro-image-number"
+                )
+                print(f"Miro identifier: {miro_id}")
+            except Exception:
+                raise click.ClickException(
+                    f"{single_id} doesn't look like a Miro ID and isn't the identifier of a catalogue record containing a Miro ID"
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What does this change?

Instead of passing an id as an argument to suppress_miro, it now accepts a list on stdin.  The current behaviour can be mimicked by simply echoing a single id and piping it, thus:

`echo L999999 | python suppress_miro.py`

This allows us to suppress multiple images in one call to suppress_miro, which previously took a long time due to the suppression list update being unnecessarily inside the loop (the script only worked on one id at a time, end-to-end, so the previous solution was to use `xargs`)

## How to test

This script operates on live data, so running it For Real Life is not really an option when testing.
I have added a dry-run flag so you can run it without doing anything, thus:
`python suppress_miro.py --id_source=suppress_list --message=hello --dry-run`
(assuming you have a file, suppress_list, that contains one id per line, e.g. :
```
L0025992
L0026124
L0026100
```
## How can we measure success?

Running a miro suppression for multiple ids will be much quicker (it used to take hours)

## Have we considered potential risks?

Ideally, we'd have dummy endpoints to call in a test situation, rather than bypassing all that with a print command.



