### PR TITLE
Turn the EBSCO adapter schedule back on

### DIFF
--- a/ebsco_adapter/terraform/ftp_task.tf
+++ b/ebsco_adapter/terraform/ftp_task.tf
@@ -31,7 +31,7 @@ resource "aws_scheduler_schedule" "ftp_task_schedule" {
   schedule_expression = "rate(1 days)"
 
   # Disable the schedule for now
-  state = "DISABLED"
+  state = "ENABLED"
 
   target {
     arn      = aws_ecs_cluster.cluster.arn


### PR DESCRIPTION
## What does this change?

This change enables scheduling of the EBSCO adapter to pick up the regular updates by FTP. We may wish to disable it again in the future if we understand there to be future unexpected changes, but for now we should be ok.

Last change here: https://github.com/wellcomecollection/catalogue-pipeline/pull/2675/files#diff-dcc878b82b21131d4fcdd0f7d209c27d46e31f62cb260ca4e64cb134ef6c8300R33

See https://wellcome.slack.com/archives/C02ANCYL90E/p1723812637303309?thread_ts=1723811666.122799&cid=C02ANCYL90E for more context.

> [!Important]
> This is not yet applied, we're waiting for **Monday the 19th of August** to catch any potential problems during work time.

## How to test

- [x] Apply this terraform change, has the scheduled enabled? Does the job run as expected?

## How can we measure success?

This change will remove the need for manual running and demands on developer attention.

## Have we considered potential risks?

This has been off for a while (although has been run manually), it might behave unexpectedly and should be checked the first time it runs to mitigate risk.
