### PR TITLE
Add shelfmark to index mapping

### DIFF
--- a/index_config/analysis.works_indexed.2024-08-20.json
+++ b/index_config/analysis.works_indexed.2024-08-20.json
@@ -1,0 +1,371 @@
+{
+  "filter": {
+    "pattern_replace_g_j": {
+      "pattern": "g",
+      "type": "pattern_replace",
+      "replacement": "j"
+    },
+    "pattern_replace_j_i": {
+      "pattern": "j",
+      "type": "pattern_replace",
+      "replacement": "i"
+    },
+    "french_elision": {
+      "type": "elision",
+      "articles": [
+        "l",
+        "m",
+        "t",
+        "qu",
+        "n",
+        "s",
+        "j",
+        "d",
+        "c",
+        "jusqu",
+        "quoiqu",
+        "lorsqu",
+        "puisqu"
+      ],
+      "articles_case": "true"
+    },
+    "pattern_replace_uu_w": {
+      "pattern": "uu",
+      "type": "pattern_replace",
+      "replacement": "w"
+    },
+    "pattern_replace_vv_w": {
+      "pattern": "vv",
+      "type": "pattern_replace",
+      "replacement": "w"
+    },
+    "hindi_stemmer": {
+      "type": "stemmer",
+      "language": "hindi"
+    },
+    "pattern_replace_v_u": {
+      "pattern": "v",
+      "type": "pattern_replace",
+      "replacement": "u"
+    },
+    "german_stemmer": {
+      "type": "stemmer",
+      "language": "light_german"
+    },
+    "english_stemmer": {
+      "type": "stemmer",
+      "language": "english"
+    },
+    "italian_elision": {
+      "type": "elision",
+      "articles": [
+        "c",
+        "l",
+        "all",
+        "dall",
+        "dell",
+        "nell",
+        "sull",
+        "coll",
+        "pell",
+        "gl",
+        "agl",
+        "dagl",
+        "degl",
+        "negl",
+        "sugl",
+        "un",
+        "m",
+        "t",
+        "s",
+        "v",
+        "d"
+      ],
+      "articles_case": "true"
+    },
+    "asciifolding": {
+      "type": "asciifolding"
+    },
+    "possessive_english": {
+      "type": "stemmer",
+      "language": "possessive_english"
+    },
+    "spanish_stemmer": {
+      "type": "stemmer",
+      "language": "light_spanish"
+    },
+    "arabic_stemmer": {
+      "type": "stemmer",
+      "language": "arabic"
+    },
+    "french_stemmer": {
+      "type": "stemmer",
+      "language": "light_french"
+    },
+    "italian_stemmer": {
+      "type": "stemmer",
+      "language": "light_italian"
+    },
+    "word_delimiter": {
+      "type": "word_delimiter_graph",
+      "preserve_original": "true"
+    },
+    "bengali_stemmer": {
+      "type": "stemmer",
+      "language": "bengali"
+    },
+    "long_query_token_limiter": {
+      "type": "limit",
+      "max_token_count": 75
+    }
+  },
+  "analyzer": {
+    "german": {
+      "filter": [
+        "word_delimiter",
+        "long_query_token_limiter",
+        "lowercase",
+        "german_normalization",
+        "german_stemmer"
+      ],
+      "char_filter": [
+        "slash_remover"
+      ],
+      "tokenizer": "whitespace"
+    },
+    "spanish": {
+      "filter": [
+        "word_delimiter",
+        "long_query_token_limiter",
+        "lowercase",
+        "spanish_stemmer"
+      ],
+      "char_filter": [
+        "slash_remover"
+      ],
+      "tokenizer": "whitespace"
+    },
+    "swappable_characters": {
+      "filter": [
+        "word_delimiter",
+        "long_query_token_limiter",
+        "asciifolding",
+        "lowercase",
+        "pattern_replace_vv_w",
+        "pattern_replace_uu_w",
+        "pattern_replace_v_u",
+        "pattern_replace_j_i",
+        "pattern_replace_g_j"
+      ],
+      "char_filter": [
+        "slash_remover"
+      ],
+      "type": "custom",
+      "tokenizer": "whitespace"
+    },
+    "lowercase": {
+      "filter": [
+        "asciifolding",
+        "word_delimiter",
+        "lowercase"
+      ],
+      "char_filter": [
+        "slash_remover"
+      ],
+      "type": "custom",
+      "tokenizer": "whitespace"
+    },
+    "lowercase_token_limited": {
+      "filter": [
+        "asciifolding",
+        "word_delimiter",
+        "long_query_token_limiter",
+        "lowercase"
+      ],
+      "char_filter": [
+        "slash_remover"
+      ],
+      "type": "custom",
+      "tokenizer": "whitespace"
+    },
+    "italian": {
+      "filter": [
+        "italian_elision",
+        "word_delimiter",
+        "long_query_token_limiter",
+        "lowercase",
+        "italian_stemmer"
+      ],
+      "char_filter": [
+        "slash_remover"
+      ],
+      "tokenizer": "whitespace"
+    },
+    "lowercase_whitespace_tokens": {
+      "filter": [
+        "lowercase"
+      ],
+      "type": "custom",
+      "tokenizer": "whitespace"
+    },
+    "path_analyzer": {
+      "filter": [
+        "asciifolding",
+        "lowercase"
+      ],
+      "type": "custom",
+      "tokenizer": "path_hierarchy"
+    },
+    "persian": {
+      "filter": [
+        "word_delimiter",
+        "long_query_token_limiter",
+        "lowercase",
+        "decimal_digit",
+        "arabic_normalization",
+        "persian_normalization"
+      ],
+      "char_filter": [
+        "zero_width_spaces",
+        "slash_remover"
+      ],
+      "tokenizer": "whitespace"
+    },
+    "cased": {
+      "filter": [
+        "asciifolding",
+        "word_delimiter",
+        "long_query_token_limiter"
+      ],
+      "char_filter": [
+        "slash_remover"
+      ],
+      "type": "custom",
+      "tokenizer": "whitespace"
+    },
+    "arabic": {
+      "filter": [
+        "word_delimiter",
+        "long_query_token_limiter",
+        "lowercase",
+        "decimal_digit",
+        "arabic_normalization",
+        "arabic_stemmer"
+      ],
+      "char_filter": [
+        "slash_remover"
+      ],
+      "tokenizer": "whitespace"
+    },
+    "bengali": {
+      "filter": [
+        "word_delimiter",
+        "long_query_token_limiter",
+        "lowercase",
+        "decimal_digit",
+        "indic_normalization",
+        "bengali_normalization",
+        "bengali_stemmer"
+      ],
+      "char_filter": [
+        "slash_remover"
+      ],
+      "tokenizer": "whitespace"
+    },
+    "english": {
+      "filter": [
+        "possessive_english",
+        "asciifolding",
+        "word_delimiter",
+        "lowercase",
+        "english_stemmer"
+      ],
+      "char_filter": [
+        "slash_remover"
+      ],
+      "tokenizer": "whitespace"
+    },
+    "english_token_limited": {
+      "filter": [
+        "possessive_english",
+        "asciifolding",
+        "word_delimiter",
+        "long_query_token_limiter",
+        "lowercase",
+        "english_stemmer"
+      ],
+      "char_filter": [
+        "slash_remover"
+      ],
+      "tokenizer": "whitespace"
+    },
+    "hindi": {
+      "filter": [
+        "word_delimiter",
+        "long_query_token_limiter",
+        "lowercase",
+        "decimal_digit",
+        "indic_normalization",
+        "hindi_normalization",
+        "hindi_stemmer"
+      ],
+      "char_filter": [
+        "slash_remover"
+      ],
+      "tokenizer": "whitespace"
+    },
+    "french": {
+      "filter": [
+        "french_elision",
+        "word_delimiter",
+        "long_query_token_limiter",
+        "lowercase",
+        "french_stemmer"
+      ],
+      "char_filter": [
+        "slash_remover"
+      ],
+      "tokenizer": "whitespace"
+    },
+    "base": {
+      "filter": [
+        "word_delimiter",
+        "long_query_token_limiter"
+      ],
+      "char_filter": [
+        "slash_remover"
+      ],
+      "type": "custom",
+      "tokenizer": "whitespace"
+    },
+    "normalized_whole_phrase": {
+      "filter": [
+        "asciifolding",
+        "lowercase"
+      ],
+      "char_filter": [
+        "remove_punctuation"
+      ],
+      "tokenizer": "keyword"
+    }
+  },
+  "char_filter": {
+    "slash_remover": {
+      "pattern": "/",
+      "type": "pattern_replace",
+      "replacement": ""
+    },
+    "remove_punctuation": {
+      "pattern": "[^\\p{L}\\p{Nd}\\s]",
+      "_name": "Removes non-letter, non-numeric, and non-whitespace characters. Respects other character sets.",
+      "type": "pattern_replace",
+      "replacement": ""
+    },
+    "zero_width_spaces": {
+      "type": "mapping",
+      "mappings": [
+        "\\u200C=>\\u0020"
+      ]
+    }
+  }
+}

--- a/index_config/mappings.works_indexed.2024-08-20.json
+++ b/index_config/mappings.works_indexed.2024-08-20.json
@@ -1,0 +1,804 @@
+{
+  "dynamic": "strict",
+  "properties": {
+    "aggregatableValues": {
+      "properties": {
+        "availabilities": {
+          "type": "keyword",
+          "eager_global_ordinals": true
+        },
+        "contributors": {
+          "properties": {
+            "agent": {
+              "properties": {
+                "label": {
+                  "type": "keyword",
+                  "eager_global_ordinals": true
+                }
+              }
+            }
+          }
+        },
+        "genres": {
+          "properties": {
+            "label": {
+              "type": "keyword",
+              "eager_global_ordinals": true
+            }
+          }
+        },
+        "items": {
+          "properties": {
+            "locations": {
+              "properties": {
+                "license": {
+                  "type": "keyword",
+                  "eager_global_ordinals": true
+                }
+              }
+            }
+          }
+        },
+        "languages": {
+          "type": "keyword",
+          "eager_global_ordinals": true
+        },
+        "production": {
+          "properties": {
+            "dates": {
+              "type": "keyword",
+              "eager_global_ordinals": true
+            }
+          }
+        },
+        "subjects": {
+          "properties": {
+            "label": {
+              "type": "keyword",
+              "eager_global_ordinals": true
+            }
+          }
+        },
+        "workType": {
+          "type": "keyword",
+          "eager_global_ordinals": true
+        }
+      }
+    },
+    "debug": {
+      "dynamic": "false",
+      "properties": {
+        "indexedTime": {
+          "type": "date"
+        },
+        "mergeCandidates": {
+          "properties": {
+            "id": {
+              "properties": {
+                "canonicalId": {
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "display": {
+      "type": "object",
+      "enabled": false
+    },
+    "filterableValues": {
+      "properties": {
+        "availabilities": {
+          "properties": {
+            "id": {
+              "type": "keyword"
+            }
+          }
+        },
+        "contributors": {
+          "properties": {
+            "agent": {
+              "properties": {
+                "label": {
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "format": {
+          "properties": {
+            "id": {
+              "type": "keyword"
+            }
+          }
+        },
+        "genres": {
+          "properties": {
+            "concepts": {
+              "properties": {
+                "id": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "label": {
+              "type": "keyword"
+            }
+          }
+        },
+        "identifiers": {
+          "properties": {
+            "value": {
+              "type": "keyword"
+            }
+          }
+        },
+        "items": {
+          "properties": {
+            "id": {
+              "type": "keyword"
+            },
+            "identifiers": {
+              "properties": {
+                "value": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "locations": {
+              "properties": {
+                "accessConditions": {
+                  "properties": {
+                    "status": {
+                      "properties": {
+                        "id": {
+                          "type": "keyword"
+                        }
+                      }
+                    }
+                  }
+                },
+                "license": {
+                  "properties": {
+                    "id": {
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "locationType": {
+                  "properties": {
+                    "id": {
+                      "type": "keyword"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "languages": {
+          "properties": {
+            "id": {
+              "type": "keyword"
+            }
+          }
+        },
+        "partOf": {
+          "properties": {
+            "id": {
+              "type": "keyword"
+            },
+            "title": {
+              "type": "keyword"
+            }
+          }
+        },
+        "production": {
+          "properties": {
+            "dates": {
+              "properties": {
+                "range": {
+                  "properties": {
+                    "from": {
+                      "type": "date"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "subjects": {
+          "properties": {
+            "label": {
+              "type": "keyword"
+            }
+          }
+        },
+        "workType": {
+          "type": "keyword"
+        }
+      }
+    },
+    "query": {
+      "properties": {
+        "alternativeTitles": {
+          "type": "text",
+          "fields": {
+            "arabic": {
+              "type": "text",
+              "analyzer": "arabic"
+            },
+            "base": {
+              "type": "text",
+              "analyzer": "base"
+            },
+            "bengali": {
+              "type": "text",
+              "analyzer": "bengali"
+            },
+            "cased": {
+              "type": "text",
+              "analyzer": "cased"
+            },
+            "english": {
+              "type": "text",
+              "analyzer": "english",
+              "search_analyzer": "english_token_limited"
+            },
+            "french": {
+              "type": "text",
+              "analyzer": "french"
+            },
+            "german": {
+              "type": "text",
+              "analyzer": "german"
+            },
+            "hindi": {
+              "type": "text",
+              "analyzer": "hindi"
+            },
+            "italian": {
+              "type": "text",
+              "analyzer": "italian"
+            },
+            "persian": {
+              "type": "text",
+              "analyzer": "persian"
+            },
+            "spanish": {
+              "type": "text",
+              "analyzer": "spanish"
+            },
+            "swappable_characters": {
+              "type": "text",
+              "analyzer": "swappable_characters"
+            }
+          },
+          "analyzer": "lowercase",
+          "search_analyzer": "lowercase_token_limited"
+        },
+        "collectionPath": {
+          "properties": {
+            "label": {
+              "type": "keyword",
+              "normalizer": "lowercase",
+              "fields": {
+                "path": {
+                  "type": "text",
+                  "analyzer": "path_analyzer",
+                  "search_analyzer": "lowercase_whitespace_tokens"
+                }
+              }
+            },
+            "path": {
+              "type": "keyword",
+              "normalizer": "lowercase",
+              "fields": {
+                "path": {
+                  "type": "text",
+                  "analyzer": "path_analyzer",
+                  "search_analyzer": "lowercase_whitespace_tokens"
+                }
+              }
+            }
+          }
+        },
+        "contributors": {
+          "properties": {
+            "agent": {
+              "properties": {
+                "label": {
+                  "type": "text",
+                  "analyzer": "english",
+                  "search_analyzer": "english_token_limited"
+                }
+              }
+            }
+          }
+        },
+        "description": {
+          "type": "text",
+          "fields": {
+            "arabic": {
+              "type": "text",
+              "analyzer": "arabic"
+            },
+            "base": {
+              "type": "text",
+              "analyzer": "base"
+            },
+            "bengali": {
+              "type": "text",
+              "analyzer": "bengali"
+            },
+            "cased": {
+              "type": "text",
+              "analyzer": "cased"
+            },
+            "english": {
+              "type": "text",
+              "analyzer": "english",
+              "search_analyzer": "english_token_limited"
+            },
+            "french": {
+              "type": "text",
+              "analyzer": "french"
+            },
+            "german": {
+              "type": "text",
+              "analyzer": "german"
+            },
+            "hindi": {
+              "type": "text",
+              "analyzer": "hindi"
+            },
+            "italian": {
+              "type": "text",
+              "analyzer": "italian"
+            },
+            "persian": {
+              "type": "text",
+              "analyzer": "persian"
+            },
+            "spanish": {
+              "type": "text",
+              "analyzer": "spanish"
+            }
+          },
+          "analyzer": "lowercase",
+          "search_analyzer": "lowercase_token_limited"
+        },
+        "edition": {
+          "type": "text",
+          "analyzer": "english",
+          "search_analyzer": "english_token_limited"
+        },
+        "genres": {
+          "properties": {
+            "concepts": {
+              "properties": {
+                "label": {
+                  "type": "text",
+                  "analyzer": "english",
+                  "search_analyzer": "english_token_limited"
+                }
+              }
+            }
+          }
+        },
+        "id": {
+          "type": "keyword",
+          "normalizer": "lowercase"
+        },
+        "identifiers": {
+          "properties": {
+            "value": {
+              "type": "keyword",
+              "normalizer": "lowercase"
+            }
+          }
+        },
+        "images": {
+          "properties": {
+            "id": {
+              "type": "keyword",
+              "normalizer": "lowercase"
+            },
+            "identifiers": {
+              "properties": {
+                "value": {
+                  "type": "keyword",
+                  "normalizer": "lowercase"
+                }
+              }
+            }
+          }
+        },
+        "items": {
+          "properties": {
+            "id": {
+              "type": "keyword",
+              "normalizer": "lowercase"
+            },
+            "identifiers": {
+              "properties": {
+                "value": {
+                  "type": "keyword",
+                  "normalizer": "lowercase"
+                }
+              }
+            },
+            "shelfmark": {
+              "properties": {
+                "value": {
+                  "type": "keyword",
+                  "normalizer": "lowercase",
+                  "fields": {
+                    "path": {
+                      "type": "text",
+                      "analyzer": "path_analyzer",
+                      "search_analyzer": "lowercase_whitespace_tokens"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "languages": {
+          "properties": {
+            "label": {
+              "type": "text",
+              "analyzer": "lowercase",
+              "search_analyzer": "lowercase_token_limited"
+            }
+          }
+        },
+        "lettering": {
+          "type": "text",
+          "fields": {
+            "arabic": {
+              "type": "text",
+              "analyzer": "arabic"
+            },
+            "base": {
+              "type": "text",
+              "analyzer": "base"
+            },
+            "bengali": {
+              "type": "text",
+              "analyzer": "bengali"
+            },
+            "cased": {
+              "type": "text",
+              "analyzer": "cased"
+            },
+            "english": {
+              "type": "text",
+              "analyzer": "english",
+              "search_analyzer": "english_token_limited"
+            },
+            "french": {
+              "type": "text",
+              "analyzer": "french"
+            },
+            "german": {
+              "type": "text",
+              "analyzer": "german"
+            },
+            "hindi": {
+              "type": "text",
+              "analyzer": "hindi"
+            },
+            "italian": {
+              "type": "text",
+              "analyzer": "italian"
+            },
+            "persian": {
+              "type": "text",
+              "analyzer": "persian"
+            },
+            "spanish": {
+              "type": "text",
+              "analyzer": "spanish"
+            },
+            "swappable_characters": {
+              "type": "text",
+              "analyzer": "swappable_characters"
+            }
+          },
+          "analyzer": "lowercase",
+          "search_analyzer": "lowercase_token_limited"
+        },
+        "notes": {
+          "properties": {
+            "contents": {
+              "type": "text",
+              "fields": {
+                "arabic": {
+                  "type": "text",
+                  "analyzer": "arabic"
+                },
+                "base": {
+                  "type": "text",
+                  "analyzer": "base"
+                },
+                "bengali": {
+                  "type": "text",
+                  "analyzer": "bengali"
+                },
+                "cased": {
+                  "type": "text",
+                  "analyzer": "cased"
+                },
+                "english": {
+                  "type": "text",
+                  "analyzer": "english",
+                  "search_analyzer": "english_token_limited"
+                },
+                "french": {
+                  "type": "text",
+                  "analyzer": "french"
+                },
+                "german": {
+                  "type": "text",
+                  "analyzer": "german"
+                },
+                "hindi": {
+                  "type": "text",
+                  "analyzer": "hindi"
+                },
+                "italian": {
+                  "type": "text",
+                  "analyzer": "italian"
+                },
+                "persian": {
+                  "type": "text",
+                  "analyzer": "persian"
+                },
+                "spanish": {
+                  "type": "text",
+                  "analyzer": "spanish"
+                },
+                "swappable_characters": {
+                  "type": "text",
+                  "analyzer": "swappable_characters"
+                }
+              },
+              "analyzer": "lowercase",
+              "search_analyzer": "lowercase_token_limited"
+            }
+          }
+        },
+        "partOf": {
+          "properties": {
+            "title": {
+              "type": "text",
+              "fields": {
+                "arabic": {
+                  "type": "text",
+                  "analyzer": "arabic"
+                },
+                "base": {
+                  "type": "text",
+                  "analyzer": "base"
+                },
+                "bengali": {
+                  "type": "text",
+                  "analyzer": "bengali"
+                },
+                "cased": {
+                  "type": "text",
+                  "analyzer": "cased"
+                },
+                "english": {
+                  "type": "text",
+                  "analyzer": "english",
+                  "search_analyzer": "english_token_limited"
+                },
+                "french": {
+                  "type": "text",
+                  "analyzer": "french"
+                },
+                "german": {
+                  "type": "text",
+                  "analyzer": "german"
+                },
+                "hindi": {
+                  "type": "text",
+                  "analyzer": "hindi"
+                },
+                "italian": {
+                  "type": "text",
+                  "analyzer": "italian"
+                },
+                "persian": {
+                  "type": "text",
+                  "analyzer": "persian"
+                },
+                "spanish": {
+                  "type": "text",
+                  "analyzer": "spanish"
+                },
+                "swappable_characters": {
+                  "type": "text",
+                  "analyzer": "swappable_characters"
+                }
+              },
+              "analyzer": "lowercase",
+              "search_analyzer": "lowercase_token_limited"
+            }
+          }
+        },
+        "physicalDescription": {
+          "type": "text",
+          "analyzer": "english",
+          "search_analyzer": "english_token_limited"
+        },
+        "production": {
+          "properties": {
+            "label": {
+              "type": "text",
+              "fields": {
+                "arabic": {
+                  "type": "text",
+                  "analyzer": "arabic"
+                },
+                "base": {
+                  "type": "text",
+                  "analyzer": "base"
+                },
+                "bengali": {
+                  "type": "text",
+                  "analyzer": "bengali"
+                },
+                "cased": {
+                  "type": "text",
+                  "analyzer": "cased"
+                },
+                "english": {
+                  "type": "text",
+                  "analyzer": "english",
+                  "search_analyzer": "english_token_limited"
+                },
+                "french": {
+                  "type": "text",
+                  "analyzer": "french"
+                },
+                "german": {
+                  "type": "text",
+                  "analyzer": "german"
+                },
+                "hindi": {
+                  "type": "text",
+                  "analyzer": "hindi"
+                },
+                "italian": {
+                  "type": "text",
+                  "analyzer": "italian"
+                },
+                "persian": {
+                  "type": "text",
+                  "analyzer": "persian"
+                },
+                "spanish": {
+                  "type": "text",
+                  "analyzer": "spanish"
+                },
+                "swappable_characters": {
+                  "type": "text",
+                  "analyzer": "swappable_characters"
+                }
+              },
+              "analyzer": "lowercase",
+              "search_analyzer": "lowercase_token_limited"
+            }
+          }
+        },
+        "referenceNumber": {
+          "type": "keyword",
+          "normalizer": "lowercase",
+          "fields": {
+            "path": {
+              "type": "text",
+              "analyzer": "path_analyzer",
+              "search_analyzer": "lowercase_whitespace_tokens"
+            }
+          }
+        },
+        "sourceIdentifier": {
+          "properties": {
+            "value": {
+              "type": "keyword",
+              "normalizer": "lowercase"
+            }
+          }
+        },
+        "subjects": {
+          "properties": {
+            "concepts": {
+              "properties": {
+                "label": {
+                  "type": "text",
+                  "analyzer": "english",
+                  "search_analyzer": "english_token_limited"
+                }
+              }
+            }
+          }
+        },
+        "title": {
+          "type": "text",
+          "fields": {
+            "arabic": {
+              "type": "text",
+              "analyzer": "arabic"
+            },
+            "base": {
+              "type": "text",
+              "analyzer": "base"
+            },
+            "bengali": {
+              "type": "text",
+              "analyzer": "bengali"
+            },
+            "cased": {
+              "type": "text",
+              "analyzer": "cased"
+            },
+            "english": {
+              "type": "text",
+              "analyzer": "english",
+              "search_analyzer": "english_token_limited"
+            },
+            "french": {
+              "type": "text",
+              "analyzer": "french"
+            },
+            "german": {
+              "type": "text",
+              "analyzer": "german"
+            },
+            "hindi": {
+              "type": "text",
+              "analyzer": "hindi"
+            },
+            "italian": {
+              "type": "text",
+              "analyzer": "italian"
+            },
+            "normalized_whole_phrase": {
+              "type": "text",
+              "analyzer": "normalized_whole_phrase"
+            },
+            "persian": {
+              "type": "text",
+              "analyzer": "persian"
+            },
+            "spanish": {
+              "type": "text",
+              "analyzer": "spanish"
+            },
+            "swappable_characters": {
+              "type": "text",
+              "analyzer": "swappable_characters"
+            }
+          },
+          "analyzer": "lowercase",
+          "search_analyzer": "lowercase_token_limited"
+        }
+      }
+    },
+    "redirectTarget": {
+      "type": "object",
+      "dynamic": "false"
+    },
+    "type": {
+      "type": "keyword"
+    }
+  }
+}

--- a/pipeline/ingestor/ingestor_common/src/main/scala/weco/pipeline/ingestor/common/models/ValueTransforms.scala
+++ b/pipeline/ingestor/ingestor_common/src/main/scala/weco/pipeline/ingestor/common/models/ValueTransforms.scala
@@ -39,6 +39,6 @@ object ValueTransforms {
   def locationShelfmark(location: Location): Option[String] =
     location match {
       case PhysicalLocation(_, _, _, shelfmark, _) => shelfmark
-      case _ => None
+      case _                                       => None
     }
 }

--- a/pipeline/ingestor/ingestor_common/src/main/scala/weco/pipeline/ingestor/common/models/ValueTransforms.scala
+++ b/pipeline/ingestor/ingestor_common/src/main/scala/weco/pipeline/ingestor/common/models/ValueTransforms.scala
@@ -1,6 +1,7 @@
 package weco.pipeline.ingestor.common.models
 
 import weco.catalogue.internal_model.identifiers.IdState
+import weco.catalogue.internal_model.locations.{Location, PhysicalLocation}
 import weco.catalogue.internal_model.work.{AbstractConcept, Genre}
 
 object ValueTransforms {
@@ -33,4 +34,11 @@ object ValueTransforms {
       .flatten
       .map(_.value)
   }
+
+  // Shelfmarks are only available on physical locations, so
+  def locationShelfmark(location: Location): Option[String] =
+    location match {
+      case PhysicalLocation(_, _, _, shelfmark, _) => shelfmark
+      case _ => None
+    }
 }

--- a/pipeline/ingestor/ingestor_common/src/main/scala/weco/pipeline/ingestor/common/models/WorkQueryableValues.scala
+++ b/pipeline/ingestor/ingestor_common/src/main/scala/weco/pipeline/ingestor/common/models/WorkQueryableValues.scala
@@ -1,7 +1,11 @@
 package weco.pipeline.ingestor.common.models
 
 import io.circe.generic.extras.JsonKey
-import weco.catalogue.internal_model.identifiers.{CanonicalId, DataState, SourceIdentifier}
+import weco.catalogue.internal_model.identifiers.{
+  CanonicalId,
+  DataState,
+  SourceIdentifier
+}
 import weco.catalogue.internal_model.work.{Relations, Work, WorkData, WorkState}
 
 case class WorkQueryableValues(

--- a/pipeline/ingestor/ingestor_common/src/main/scala/weco/pipeline/ingestor/common/models/WorkQueryableValues.scala
+++ b/pipeline/ingestor/ingestor_common/src/main/scala/weco/pipeline/ingestor/common/models/WorkQueryableValues.scala
@@ -1,11 +1,7 @@
 package weco.pipeline.ingestor.common.models
 
 import io.circe.generic.extras.JsonKey
-import weco.catalogue.internal_model.identifiers.{
-  CanonicalId,
-  DataState,
-  SourceIdentifier
-}
+import weco.catalogue.internal_model.identifiers.{CanonicalId, DataState, SourceIdentifier}
 import weco.catalogue.internal_model.work.{Relations, Work, WorkData, WorkState}
 
 case class WorkQueryableValues(
@@ -23,6 +19,7 @@ case class WorkQueryableValues(
   @JsonKey("images.identifiers.value") imagesIdentifiersValue: List[String],
   @JsonKey("items.id") itemsId: List[String],
   @JsonKey("items.identifiers.value") itemsIdentifiersValue: List[String],
+  @JsonKey("items.shelfmark.value") itemsShelfmarksValue: List[String],
   @JsonKey("languages.label") languagesLabel: List[String],
   @JsonKey("lettering") lettering: Option[String],
   @JsonKey("notes.contents") notesContents: List[String],
@@ -63,6 +60,9 @@ case object WorkQueryableValues {
       itemsId = data.items.map(_.id).canonicalIds,
       itemsIdentifiersValue =
         data.items.flatMap(_.id.allSourceIdentifiers).map(_.value),
+      itemsShelfmarksValue = data.items
+        .flatMap(_.locations)
+        .flatMap(locationShelfmark),
       languagesLabel = data.languages.map(_.label),
       lettering = data.lettering,
       notesContents = data.notes.map(_.contents),

--- a/pipeline/ingestor/ingestor_common/src/test/scala/weco/pipeline/ingestor/models/WorkQueryableValuesTest.scala
+++ b/pipeline/ingestor/ingestor_common/src/test/scala/weco/pipeline/ingestor/models/WorkQueryableValuesTest.scala
@@ -36,6 +36,7 @@ class WorkQueryableValuesTest
       imagesIdentifiersValue = List("L0045108"),
       itemsId = List("r8mz6j8c"),
       itemsIdentifiersValue = List("i15863207", "1586320"),
+      itemsShelfmarksValue = List("EPB/ENCY/1.v1"),
       languagesLabel = List("English"),
       lettering = Some("For Alan ..."),
       notesContents = List(

--- a/pipeline/terraform/2024-08-15/main.tf
+++ b/pipeline/terraform/2024-08-15/main.tf
@@ -2,9 +2,9 @@ module "pipeline" {
   source = "../modules/stack"
 
   reindexing_state = {
-    listen_to_reindexer      = false
-    scale_up_tasks           = false
-    scale_up_elastic_cluster = false
+    listen_to_reindexer      = true
+    scale_up_tasks           = true
+    scale_up_elastic_cluster = true
     scale_up_id_minter_db    = false
     scale_up_matcher_db      = false
   }
@@ -13,14 +13,15 @@ module "pipeline" {
     works = {
       identified = "works_identified.2023-05-26"
       merged     = "works_merged.2023-05-26"
-      indexed    = "works_indexed.2024-04-30"
+      indexed    = "works_indexed.2024-08-20"
     }
     images = {
       indexed        = "images_indexed.2024-01-09"
       works_analysis = "works_indexed.2024-04-30"
     }
   }
-  allow_delete_indices = false
+
+  allow_delete_indices = true
 
   pipeline_date = local.pipeline_date
   release_label = local.pipeline_date


### PR DESCRIPTION
## What does this change?

This change adds an index mapping and works ingestor update to index the shelfmark on works in order to make it easier for library staff and others to query on shelfmark.

The updated mapping includes this for items on the `query` property:

```
        "items": {
          "properties": {
            "id": {
              "type": "keyword",
              "normalizer": "lowercase"
            },
            "identifiers": {
              "properties": {
                "value": {
                  "type": "keyword",
                  "normalizer": "lowercase"
                }
              }
            },
            "shelfmark": {
              "properties": {
                "value": {
                  "type": "keyword",
                  "normalizer": "lowercase",
                  "fields": {
                    "path": {
                      "type": "text",
                      "analyzer": "path_analyzer",
                      "search_analyzer": "lowercase_whitespace_tokens"
                    }
                  }
                }
              }
            }
          }
        },
```

We have used a `path_analyzer` analyzer, as we do for collection path as shelfmarks similarly can use slash separated characters allowing more granular searching where available.

Working towards resolving https://github.com/wellcomecollection/catalogue-pipeline/issues/2453

Part of https://github.com/wellcomecollection/platform/issues/5757

## How to test

- [ ] Run the test, do they pass?

## How can we measure success?

Collection staff are more easily able to find 

## Have we considered potential risks?

We should test that things are indexed as expected and that the mapping can be queried on to mitigate any risk from this change before releasing.
