### PR TITLE
Read license information from licenseNote in premis access condition

### DIFF
--- a/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformers/PremisAccessConditions.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformers/PremisAccessConditions.scala
@@ -19,7 +19,7 @@ case class PremisAccessConditions(
     )
 }
 
-object PremisAccessConditions extends Logging{
+object PremisAccessConditions extends Logging {
 
   /** The access conditions are encoded a premis elementin the METS. For
     * example:
@@ -67,7 +67,7 @@ object PremisAccessConditions extends Logging{
     // https://wellcome.slack.com/archives/C02ANCYL90E/p1725026316294549
     val rightsNote = rightsBasis match {
       case Some(basis) if basis.text == "Copyright" => copyrightNoteElem
-      case Some(basis) if basis.text == "License" => licenseNoteElem
+      case Some(basis) if basis.text == "License"   => licenseNoteElem
 
       // If we don't have a rightsBasis, pick from either copyright or
       // license preferring copyright
@@ -76,7 +76,7 @@ object PremisAccessConditions extends Logging{
 
         List(
           copyrightNoteElem,
-          licenseNoteElem,
+          licenseNoteElem
         ).flatten.headOption
     }
 

--- a/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/generators/PremisAccessConditionsGenerators.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/generators/PremisAccessConditionsGenerators.scala
@@ -5,24 +5,21 @@ import scala.xml.Elem
 trait PremisAccessConditionsGenerators {
 
   def rightsMDWith(
-    copyrightInformation: Option[Elem] = None,
-    licenceInformation: Option[Elem] = None,
-    rightsGranted: Seq[Elem] = Nil
-  ): Elem = <mets:rightsMD ID="rightsMD_1">
+                    copyrightInformation: Option[Elem] = None,
+                    licenceInformation: Option[Elem] = None,
+                    rightsGranted: Seq[Elem] = Nil
+                  ): Elem = <mets:rightsMD ID="rightsMD_1">
     <mets:mdWrap MDTYPE="PREMIS:RIGHTS">
-    <mets:xmlData>
-      <premis:rightsStatement xmlns:premis="http://www.loc.gov/premis/v3" xsi:schemaLocation="http://www.loc.gov/premis/v3 http://www.loc.gov/standards/premis/v3/premis.xsd">
-        <premis:rightsStatementIdentifier>
-          <premis:rightsStatementIdentifierType>UUID</premis:rightsStatementIdentifierType>
-          <premis:rightsStatementIdentifierValue>3392668a-4503-462c-ba68-1d17c853f17c</premis:rightsStatementIdentifierValue>
-        </premis:rightsStatementIdentifier>
-        <premis:rightsBasis>???</premis:rightsBasis>
-        {copyrightInformation}
-        {licenceInformation}
-        {rightsGranted}
-      </premis:rightsStatement>
-    </mets:xmlData>
-  </mets:mdWrap>
+      <mets:xmlData>
+        <premis:rightsStatement xmlns:premis="http://www.loc.gov/premis/v3" xsi:schemaLocation="http://www.loc.gov/premis/v3 http://www.loc.gov/standards/premis/v3/premis.xsd">
+          <premis:rightsStatementIdentifier>
+            <premis:rightsStatementIdentifierType>UUID</premis:rightsStatementIdentifierType>
+            <premis:rightsStatementIdentifierValue>3392668a-4503-462c-ba68-1d17c853f17c</premis:rightsStatementIdentifierValue>
+          </premis:rightsStatementIdentifier>
+          <premis:rightsBasis>???</premis:rightsBasis>{copyrightInformation}{licenceInformation}{rightsGranted}
+        </premis:rightsStatement>
+      </mets:xmlData>
+    </mets:mdWrap>
   </mets:rightsMD>
 
   lazy val emptyRightsMD = rightsMDWith(None, None, Nil)
@@ -54,4 +51,64 @@ trait PremisAccessConditionsGenerators {
       </mets:xmlData>
     </mets:mdWrap>
   </mets:rightsMD>
+
+  val openCCBYNCRightsMD = <mets:rightsMD ID="rightsMD_1">
+    <mets:mdWrap MDTYPE="PREMIS:RIGHTS">
+      <mets:xmlData>
+        <premis:rightsStatement xmlns:premis="http://www.loc.gov/premis/v3" xsi:schemaLocation="http://www.loc.gov/premis/v3 http://www.loc.gov/standards/premis/v3/premis.xsd">
+          <premis:rightsStatementIdentifier>
+            <premis:rightsStatementIdentifierType>UUID</premis:rightsStatementIdentifierType>
+            <premis:rightsStatementIdentifierValue>a93acc1b-7978-4107-80f7-a4bdf5787a85</premis:rightsStatementIdentifierValue>
+          </premis:rightsStatementIdentifier>
+          <premis:rightsBasis>License</premis:rightsBasis>
+          <premis:licenseInformation>
+            <premis:licenseTerms/>
+            <premis:licenseNote>CC-BY-NC</premis:licenseNote>
+          </premis:licenseInformation>
+          <premis:rightsGranted>
+            <premis:act>use</premis:act>
+            <premis:rightsGrantedNote>Open</premis:rightsGrantedNote>
+          </premis:rightsGranted>
+          <premis:linkingObjectIdentifier>
+            <premis:linkingObjectIdentifierType>UUID</premis:linkingObjectIdentifierType>
+            <premis:linkingObjectIdentifierValue>433cbf46-4ce1-421d-bf4f-2bc13f9450a7</premis:linkingObjectIdentifierValue>
+          </premis:linkingObjectIdentifier>
+        </premis:rightsStatement>
+      </mets:xmlData>
+    </mets:mdWrap>
+  </mets:rightsMD>
+
+  // This should never happen in practice, as we should always have a rightsBasis
+  // but we fail gracefully if it does, preferring copyrightInformation
+  val openMixedCCBYNCWithCopyrightRightsMD = <mets:rightsMD ID="rightsMD_1">
+    <mets:mdWrap MDTYPE="PREMIS:RIGHTS">
+      <mets:xmlData>
+        <premis:rightsStatement xmlns:premis="http://www.loc.gov/premis/v3" xsi:schemaLocation="http://www.loc.gov/premis/v3 http://www.loc.gov/standards/premis/v3/premis.xsd">
+          <premis:rightsStatementIdentifier>
+            <premis:rightsStatementIdentifierType>UUID</premis:rightsStatementIdentifierType>
+            <premis:rightsStatementIdentifierValue>a93acc1b-7978-4107-80f7-a4bdf5787a85</premis:rightsStatementIdentifierValue>
+          </premis:rightsStatementIdentifier>
+          <premis:licenseInformation>
+            <premis:licenseTerms/>
+            <premis:licenseNote>CC-BY-NC</premis:licenseNote>
+          </premis:licenseInformation>
+          <premis:copyrightInformation>
+            <premis:copyrightStatus>copyrighted</premis:copyrightStatus>
+            <premis:copyrightJurisdiction>UK</premis:copyrightJurisdiction>
+            <premis:copyrightStatusDeterminationDate/>
+            <premis:copyrightNote>In copyright</premis:copyrightNote>
+          </premis:copyrightInformation>
+          <premis:rightsGranted>
+            <premis:act>use</premis:act>
+            <premis:rightsGrantedNote>Open</premis:rightsGrantedNote>
+          </premis:rightsGranted>
+          <premis:linkingObjectIdentifier>
+            <premis:linkingObjectIdentifierType>UUID</premis:linkingObjectIdentifierType>
+            <premis:linkingObjectIdentifierValue>433cbf46-4ce1-421d-bf4f-2bc13f9450a7</premis:linkingObjectIdentifierValue>
+          </premis:linkingObjectIdentifier>
+        </premis:rightsStatement>
+      </mets:xmlData>
+    </mets:mdWrap>
+  </mets:rightsMD>
 }
+

--- a/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformers/PremisAccessConditionsTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformers/PremisAccessConditionsTest.scala
@@ -19,12 +19,14 @@ class PremisAccessConditionsTest
           Some("Open")
         ).parse.right.get.accessStatus.get shouldBe AccessStatus.Open
       }
+
       it("translates the copyrightNote into a Licence") {
         PremisAccessConditions(
           Some("In Copyright"),
           None
         ).parse.right.get.licence.get shouldBe License.InCopyright
       }
+
       it("has no access conditions if none are given") {
         val conditions = PremisAccessConditions(
           None,
@@ -50,14 +52,35 @@ class PremisAccessConditionsTest
     }
 
     describe("extracting values from a rightsMD section") {
-      it("pulls out the copyrightNote for the licence") {
+      it("pulls out the copyrightNote where rightsBasis is 'Copyright'") {
         PremisAccessConditions(
           openInCopyrightRightsMD
         ).copyrightNote shouldBe Some(
           "In copyright"
         )
       }
+
+      it("pulls out the licenceNote where rightsBasis is 'License'") {
+        PremisAccessConditions(
+          openCCBYNCRightsMD
+        ).copyrightNote shouldBe Some("CC-BY-NC")
+      }
+
+      it("pulls out the copyrightNote where rightsBasis is not specified") {
+        PremisAccessConditions(
+          openMixedCCBYNCWithCopyrightRightsMD
+        ).copyrightNote shouldBe Some(
+          "In copyright"
+        )
+      }
+
       it("pulls out the rightsGrantedNote for the access status") {
+        PremisAccessConditions(
+          openInCopyrightRightsMD
+        ).useRightsGrantedNote shouldBe Some("Open")
+      }
+
+      it("pulls out the copy for the access status") {
         PremisAccessConditions(
           openInCopyrightRightsMD
         ).useRightsGrantedNote shouldBe Some("Open")

--- a/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformers/PremisAccessConditionsTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformers/PremisAccessConditionsTest.scala
@@ -80,12 +80,6 @@ class PremisAccessConditionsTest
         ).useRightsGrantedNote shouldBe Some("Open")
       }
 
-      it("pulls out the copy for the access status") {
-        PremisAccessConditions(
-          openInCopyrightRightsMD
-        ).useRightsGrantedNote shouldBe Some("Open")
-      }
-
       it("creates empty accessConditions if the relevant fields are absent") {
         val conditions = PremisAccessConditions(
           emptyRightsMD


### PR DESCRIPTION
## What does this change?

This PR updates how license information can be derived from METS where the PREMIS element is used to provide access conditions. 

Currently where the `rightsBasis` is "License" we ignore the `licenseNote` field when parsing METS that contains the PREMIS element (i.e. Works sourced from Archivematica AKA anything "Born Digital"). This change addresses that problem to ensure the correct license information is available on Works.

See this Slack thread: https://wellcome.slack.com/archives/C02ANCYL90E/p1724408305952489

Addresses https://github.com/wellcomecollection/wellcomecollection.org/issues/11016

> [!Note]
> This change is currently deployed manually to a `dev` tag [here](https://eu-west-1.console.aws.amazon.com/ecs/v2/clusters/catalogue-2024-08-15/services/transformer_mets/update?region=eu-west-1). Ensure it is returned to the correct tag after release.

## How to test

- [x] Run the tests, do they pass?
- [x] Deploy a dev METS transformer image into the pipeline and reindex some works with METS that match the license pattern this addresses ([qd84awx8](https://api.wellcomecollection.org/catalogue/v2/works/qd84awx8)). Do they get the expected license?

Here is an [example of a work with the CC-BY-NC license added](https://wellcomecollection.org/works/ecnf4mvj) by this process.

When the born digital toggle is turned on, this is what it looks like in the front-end:
<img width="1299" alt="Screenshot 2024-09-02 at 11 41 22" src="https://github.com/user-attachments/assets/19ef7154-3da8-44d8-bb44-5ec49e080a89">

## How can we measure success?

Born Digital items have the correct license information and can be made available to the public for viewing.

## Have we considered potential risks?

This change updates how we read existing licenses, referring to the `rightsBasis` for which field to read, this opens the possibility existing correctly licensed works will be changed. This risk is mitigated by falling back to existing behaviour and spot checking METS to see that the behaviour will remain as expected.
