### PR TITLE
Update rules for requesting (13/08/24)

### DIFF
--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/RulesForRequestingResult.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/RulesForRequestingResult.scala
@@ -7,13 +7,18 @@ case object Requestable extends RulesForRequestingResult
 sealed trait NotRequestable extends RulesForRequestingResult
 
 object NotRequestable {
-  case class NeedsManualRequest(message: String) extends NotRequestable
+  val defaultManualRequestMessage =
+    "This item cannot be requested online. Please place a manual request."
+  val defaultItemUnavailableMessage =
+    "This item is unavailable."
+
+  case class NeedsManualRequest(message: String = defaultManualRequestMessage) extends NotRequestable
 
   case class ItemClosed(message: String) extends NotRequestable
   case class SafeguardedItem(message: String) extends NotRequestable
   case class ItemMissing(message: String) extends NotRequestable
   case class ItemOnSearch(message: String) extends NotRequestable
-  case class ItemUnavailable(message: String) extends NotRequestable
+  case class ItemUnavailable(message: String = defaultItemUnavailableMessage) extends NotRequestable
   case class ItemWithdrawn(message: String) extends NotRequestable
 
   case class ContactUs(message: String) extends NotRequestable

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/RulesForRequestingResult.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/RulesForRequestingResult.scala
@@ -12,13 +12,15 @@ object NotRequestable {
   val defaultItemUnavailableMessage =
     "This item is unavailable."
 
-  case class NeedsManualRequest(message: String = defaultManualRequestMessage) extends NotRequestable
+  case class NeedsManualRequest(message: String = defaultManualRequestMessage)
+      extends NotRequestable
 
   case class ItemClosed(message: String) extends NotRequestable
   case class SafeguardedItem(message: String) extends NotRequestable
   case class ItemMissing(message: String) extends NotRequestable
   case class ItemOnSearch(message: String) extends NotRequestable
-  case class ItemUnavailable(message: String = defaultItemUnavailableMessage) extends NotRequestable
+  case class ItemUnavailable(message: String = defaultItemUnavailableMessage)
+      extends NotRequestable
   case class ItemWithdrawn(message: String) extends NotRequestable
 
   case class ContactUs(message: String) extends NotRequestable

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala
@@ -130,6 +130,34 @@ object SierraRulesForRequesting {
 
       // These cases cover the lines:
       //
+      //    v|i||108||=|n||
+      //    #ls Line above opacmsg = manual request for vs 27/08/24
+      //    v|i||108||=|a||
+      //    #ls Line above opacmsg = By appointment for vs 27/08/24
+      //    v|i||108||=|p||
+      //    #ls Line above opacmsg = By approval for vs 27/08/24
+      case i
+        if i
+          .fixedField("108")
+          .containsAnyOf("n", "a", "p") =>
+        NotRequestable.NeedsManualRequest(
+          "This item cannot be requested online. Please place a manual request."
+        )
+
+      // These cases cover the lines:
+      //
+      //    q|i||108||=|u||
+      //    #ls Line above opacmsg = Unavailable for vs 27/08/24
+      case i
+        if i
+          .fixedField("108")
+          .contains("u") =>
+        NotRequestable.ItemUnavailable(
+          "This item is unavailable."
+        )
+
+      // These cases cover the lines:
+      //
       //    v|i||79||=|mfgmc||
       //    v|i||79||=|mfinc||
       //    v|i||79||=|mfwcm||

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala
@@ -137,9 +137,9 @@ object SierraRulesForRequesting {
       //    v|i||108||=|p||
       //    #ls Line above opacmsg = By approval for vs 27/08/24
       case i
-        if i
-          .fixedField("108")
-          .containsAnyOf("n", "a", "p") =>
+          if i
+            .fixedField("108")
+            .containsAnyOf("n", "a", "p") =>
         NotRequestable.NeedsManualRequest(
           "This item cannot be requested online. Please place a manual request."
         )
@@ -149,9 +149,9 @@ object SierraRulesForRequesting {
       //    q|i||108||=|u||
       //    #ls Line above opacmsg = Unavailable for vs 27/08/24
       case i
-        if i
-          .fixedField("108")
-          .contains("u") =>
+          if i
+            .fixedField("108")
+            .contains("u") =>
         NotRequestable.ItemUnavailable(
           "This item is unavailable."
         )

--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala
@@ -62,7 +62,7 @@ object SierraRulesForRequesting {
       case i if i.fixedField("88").contains("x") =>
         NotRequestable.ItemWithdrawn("This item is withdrawn.")
       case i if i.fixedField("88").contains("r") =>
-        NotRequestable.ItemUnavailable("This item is unavailable.")
+        NotRequestable.ItemUnavailable()
       case i if i.fixedField("88").contains("z") =>
         NotRequestable.NoPublicMessage("fixed field 88 = z")
       case i if i.fixedField("88").contains("v") =>
@@ -140,9 +140,7 @@ object SierraRulesForRequesting {
           if i
             .fixedField("108")
             .containsAnyOf("n", "a", "p") =>
-        NotRequestable.NeedsManualRequest(
-          "This item cannot be requested online. Please place a manual request."
-        )
+        NotRequestable.NeedsManualRequest()
 
       // These cases cover the lines:
       //
@@ -152,9 +150,7 @@ object SierraRulesForRequesting {
           if i
             .fixedField("108")
             .contains("u") =>
-        NotRequestable.ItemUnavailable(
-          "This item is unavailable."
-        )
+        NotRequestable.ItemUnavailable()
 
       // These cases cover the lines:
       //
@@ -215,9 +211,7 @@ object SierraRulesForRequesting {
               "gblip",
               "ofvds"
             ) =>
-        NotRequestable.NeedsManualRequest(
-          "This item cannot be requested online. Please place a manual request."
-        )
+        NotRequestable.NeedsManualRequest()
 
       // These cases cover the lines:
       //
@@ -230,9 +224,7 @@ object SierraRulesForRequesting {
             .containsAnyOf(
               "harcl"
             ) =>
-        NotRequestable.ItemUnavailable(
-          "This item is unavailable."
-        )
+        NotRequestable.ItemUnavailable()
 
       // These cases cover the lines:
       //
@@ -353,9 +345,7 @@ object SierraRulesForRequesting {
               "sompr",
               "somsy"
             ) =>
-        NotRequestable.NeedsManualRequest(
-          "Please complete a manual request slip.  This item cannot be requested online."
-        )
+        NotRequestable.NeedsManualRequest()
 
       // This case covers the line:
       //

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequestingTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequestingTest.scala
@@ -227,7 +227,7 @@ class SierraRulesForRequestingTest
         assertBlockedWith(
           _,
           expectedResult = NotRequestable.NeedsManualRequest(
-            "Please complete a manual request slip.  This item cannot be requested online."
+            "This item cannot be requested online. Please place a manual request."
           )
         )
       }
@@ -325,13 +325,13 @@ class SierraRulesForRequestingTest
       (
         "4",
         NotRequestable.NeedsManualRequest(
-          "Please complete a manual request slip.  This item cannot be requested online."
+          "This item cannot be requested online. Please place a manual request."
         )
       ),
       (
         "14",
         NotRequestable.NeedsManualRequest(
-          "Please complete a manual request slip.  This item cannot be requested online."
+          "This item cannot be requested online. Please place a manual request."
         )
       )
     )

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequestingTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequestingTest.scala
@@ -66,6 +66,22 @@ class SierraRulesForRequestingTest
     )
   }
 
+  it("blocks an item if fixed field 108 (status) is n,a,p or u") {
+    List("n","a","p").map { status =>
+      val item = createSierraItemDataWith(
+        fixedFields = Map("108" -> FixedField(label = "STATUS", value = status))
+      )
+
+      SierraRulesForRequesting(item) shouldBe a[NotRequestable.NeedsManualRequest]
+    }
+
+    val item = createSierraItemDataWith(
+      fixedFields = Map("108" -> FixedField(label = "STATUS", value = "u"))
+    )
+
+    SierraRulesForRequesting(item) shouldBe a[NotRequestable.ItemUnavailable]
+  }
+
   it("does not block an item if fixed field 87 (loan rule) is zero") {
     val item = createSierraItemDataWith(
       fixedFields = Map("87" -> FixedField(label = "LOANRULE", value = "0"))


### PR DESCRIPTION
## What does this change?

This change updates the [rules for requesting](https://github.com/wellcomecollection/docs/blob/main/rfcs/042-requesting-model/README.md?plain=1#L119) which need to match those in Sierra, following an update from LS in Collection Product Lines:

> Manual request: Sierra code = n
> By appointment Sierra code = a
> By approval Sierra code = p
> Unavailable Sierra code = u

See [similar changes](https://github.com/search?q=org%3Awellcomecollection+%22rules+for+requesting%22&type=pullrequests).

Resolves: https://github.com/wellcomecollection/catalogue-pipeline/issues/2697

## How to test

- [x] Run the tests, do they pass?
- [ ] Deploy this change, are the items specified un-requestable?

## How can we measure success?

Folk can't request things matching this pattern

## Have we considered potential risks?

This change is fairly self contained, and does not need a [corresponding catalogue-api update](https://github.com/wellcomecollection/catalogue-api/blob/main/common/stacks/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala) as these are permanently unrequestable.
