### PR TITLE
Remove DLQ alarms from pipeline services

### DIFF
--- a/infrastructure/modules/scaling_service/queue.tf
+++ b/infrastructure/modules/scaling_service/queue.tf
@@ -1,5 +1,5 @@
 module "input_queue" {
-  source = "github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.2.1"
+  source = "github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.4.0"
 
   queue_name = var.queue_config.name
 

--- a/pipeline/terraform/modules/services_with_manager/variables.tf
+++ b/pipeline/terraform/modules/services_with_manager/variables.tf
@@ -155,6 +155,6 @@ variable "max_receive_count" {
 }
 
 variable "dlq_alarm_topic_arn" {
-  type = string
+  type    = string
   default = null
 }

--- a/pipeline/terraform/modules/services_with_manager/variables.tf
+++ b/pipeline/terraform/modules/services_with_manager/variables.tf
@@ -156,4 +156,5 @@ variable "max_receive_count" {
 
 variable "dlq_alarm_topic_arn" {
   type = string
+  default = null
 }

--- a/pipeline/terraform/modules/stack/locals.tf
+++ b/pipeline/terraform/modules/stack/locals.tf
@@ -177,7 +177,7 @@ locals {
   monitoring_config = {
     shared_logging_secrets = local.shared_infra["shared_secrets_logging"]
     logging_cluster_id     = local.shared_infra["logging_cluster_id"]
-    dlq_alarm_arn          = data.terraform_remote_state.monitoring.outputs.platform_dlq_alarm_topic_arn
+    dlq_alarm_arn          = null
   }
 
   network_config = {


### PR DESCRIPTION
## What does this change?

https://github.com/wellcomecollection/platform/issues/5777

This removes DLQ alarm for all 16 catalogue pipeline services. This change depends on https://github.com/wellcomecollection/terraform-aws-sqs/pull/11

## How to test

Once [this PR](https://github.com/wellcomecollection/terraform-aws-sqs/pull/11) is merged and the new version of the module is released, the result of running `terraform plan` from the `catalogue-pipeline/pipeline/terraform/2024-08-15` folder should include the removal of 16 DLQ alarm resources, one for each pipeline service.

## How can we measure success?

All catalogue pipeline DLQ alarms are removed, no other resources are affected.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? -->

