### PR TITLE
update apache-commons

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,8 @@ import sbt._
 import scala.language.reflectiveCalls
 object WellcomeDependencies {
 
-  val defaultVersion = "32.42.0" // This is automatically bumped by the scala-libs release process, do not edit this line manually
+  val defaultVersion =
+    "32.42.0" // This is automatically bumped by the scala-libs release process, do not edit this line manually
 
   lazy val versions = new {
     val typesafe = defaultVersion
@@ -93,7 +94,7 @@ object WellcomeDependencies {
 
 object ExternalDependencies {
   lazy val versions = new {
-    val apacheCommons = "1.9"
+    val apacheCommons = "1.11.0"
     val circe = "0.14.1"
     val diffJson = "4.1.1"
     val fastparse = "2.3.0"


### PR DESCRIPTION
## What does this change?

This updates Apache Commons to defend against the [String Interpolation vulnerability](https://github.com/wellcomecollection/catalogue-pipeline/security/dependabot/230)

## How to test

Run existing tests

## How can we measure success?

Nothing should change.  I don't believe we use any of the forbidden prefixes

## Have we considered potential risks?

Maybe there's some other incompatibility somewhere for this version.  If it causes a problem, we'll just have to fix it.

