### PR TITLE
Increment version number in CALM VHS on deletion

### DIFF
--- a/calm_adapter/calm_deletion_checker/src/main/scala/weco/pipeline/calm_deletion_checker/DeletionMarker.scala
+++ b/calm_adapter/calm_deletion_checker/src/main/scala/weco/pipeline/calm_deletion_checker/DeletionMarker.scala
@@ -22,6 +22,9 @@ class DeletionMarker(sourceTable: String)(implicit client: DynamoDbClient)
             .when(attributeExists("id"))
             .update(
               "id" === record.id,
+              // Set isDeleted = true and increment the version
+              // We must increment the version to ensure downstream
+              // services detect that the record has been updated
               set("isDeleted", true) and add("version", 1)
             )
         )

--- a/calm_adapter/calm_deletion_checker/src/main/scala/weco/pipeline/calm_deletion_checker/DeletionMarker.scala
+++ b/calm_adapter/calm_deletion_checker/src/main/scala/weco/pipeline/calm_deletion_checker/DeletionMarker.scala
@@ -22,7 +22,7 @@ class DeletionMarker(sourceTable: String)(implicit client: DynamoDbClient)
             .when(attributeExists("id"))
             .update(
               "id" === record.id,
-              set("isDeleted", true) and add("version", 1),
+              set("isDeleted", true) and add("version", 1)
             )
         )
         .map(_.toPayload)

--- a/calm_adapter/calm_deletion_checker/src/main/scala/weco/pipeline/calm_deletion_checker/DeletionMarker.scala
+++ b/calm_adapter/calm_deletion_checker/src/main/scala/weco/pipeline/calm_deletion_checker/DeletionMarker.scala
@@ -22,7 +22,7 @@ class DeletionMarker(sourceTable: String)(implicit client: DynamoDbClient)
             .when(attributeExists("id"))
             .update(
               "id" === record.id,
-              set("isDeleted", true)
+              set("isDeleted", true) and add("version", 1),
             )
         )
         .map(_.toPayload)

--- a/calm_adapter/calm_deletion_checker/src/test/scala/weco/pipeline/calm_deletion_checker/DeletionMarkerTest.scala
+++ b/calm_adapter/calm_deletion_checker/src/test/scala/weco/pipeline/calm_deletion_checker/DeletionMarkerTest.scala
@@ -31,7 +31,10 @@ class DeletionMarkerTest
         val targetRecord = rows.head.toPayload
         val result = deletionMarker(targetRecord)
 
-        result.success.value shouldBe targetRecord.copy(isDeleted = true)
+        result.success.value shouldBe targetRecord.copy(
+            isDeleted = true,
+            version = targetRecord.version + 1
+        )
         getRecordFromTable(
           targetRecord.id,
           targetRecord.version,
@@ -48,7 +51,10 @@ class DeletionMarkerTest
         val targetRecord = rows.head.toPayload
         val result = deletionMarker(targetRecord)
 
-        result.success.value shouldBe targetRecord.copy(isDeleted = true)
+        result.success.value shouldBe targetRecord.copy(
+          isDeleted = true,
+          version = targetRecord.version + 1
+        )
         getRecordFromTable(
           targetRecord.id,
           targetRecord.version,
@@ -65,7 +71,10 @@ class DeletionMarkerTest
         val targetRecord = records.head.toPayload
         val result = deletionMarker(targetRecord)
 
-        result.success.value shouldBe targetRecord.copy(isDeleted = true)
+        result.success.value shouldBe targetRecord.copy(
+          isDeleted = true,
+          version = targetRecord.version + 1
+        )
         getRecordFromTable(
           targetRecord.id,
           targetRecord.version,


### PR DESCRIPTION
## What does this change?

This change updated the version number of a CALM record stored in the hybrid store when it is deleted in order to notify downstream systems there has been a change to the record properly. 

We've seen errors where deletion do not pass the matcher service [because of this check](https://github.com/wellcomecollection/catalogue-pipeline/blob/main/pipeline/matcher_merger/matcher/src/main/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdater.scala#L61). We attempt to prevent this error occurring with this change.

See this slack conversation for context: https://wellcome.slack.com/archives/C02ANCYL90E/p1726233083142129

Follows: https://github.com/wellcomecollection/catalogue-pipeline/issues/2701

## How to test

- [ ] Run the tests, do they pass?

## How can we measure success?

Less confusing results for cataloguers and collection information people on deletion of records in CALM.

## Have we considered potential risks?

There is some risk in making this change has unknown impact elsewhere in the pipeline that is not easily testable. The "update version when deleted" behaviour is implemented in the sierra adapter so if it works there, it should here 🤞 