### PR TITLE
Create subgraph ids unique to components in the matcher

### DIFF
--- a/pipeline/matcher_merger/matcher/src/main/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdater.scala
+++ b/pipeline/matcher_merger/matcher/src/main/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdater.scala
@@ -139,13 +139,12 @@ private class WorkSubgraph(
     //              F - G       H
     //
     // Here there are two components: (A B C F G) and (D E H)
-    //
-    val subgraphId = SubgraphId(workIds)
 
     g.componentTraverser()
       .flatMap(
         component => {
           val componentIds = component.nodes.map(_.value).toList.sorted
+          val subgraphId = SubgraphId(componentIds.toSet)
 
           component.nodes.map(
             node => {

--- a/pipeline/matcher_merger/matcher/src/test/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdaterTest.scala
+++ b/pipeline/matcher_merger/matcher/src/test/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdaterTest.scala
@@ -317,10 +317,16 @@ class WorkGraphUpdaterTest
 
       result shouldBe Set(
         workA
-          .copy(componentIds = List(idA))
+          .copy(
+            componentIds = List(idA),
+            subgraphId = SubgraphId(idA)
+          )
           .updateSourceWork(version = 2),
         workB
-          .copy(componentIds = List(idB))
+          .copy(
+            componentIds = List(idB),
+            subgraphId = SubgraphId(idB)
+          )
       )
     }
 
@@ -336,12 +342,21 @@ class WorkGraphUpdaterTest
 
       result shouldBe Set(
         workA
-          .copy(componentIds = List(idA, idB)),
+          .copy(
+            componentIds = List(idA, idB),
+            subgraphId = SubgraphId(idA, idB)
+          ),
         workB
-          .copy(componentIds = List(idA, idB))
+          .copy(
+            componentIds = List(idA, idB),
+            subgraphId = SubgraphId(idA, idB)
+          )
           .updateSourceWork(version = 2),
         workC
-          .copy(componentIds = List(idC))
+          .copy(
+            componentIds = List(idC),
+            subgraphId = SubgraphId(idC)
+          )
       )
     }
 
@@ -376,7 +391,7 @@ class WorkGraphUpdaterTest
       result shouldBe Set(
         WorkNode(
           id = idA,
-          subgraphId = SubgraphId(idA, idB),
+          subgraphId = SubgraphId(idA),
           componentIds = List(idA),
           sourceWork = SourceWorkData(
             id = workA.state.sourceIdentifier,
@@ -385,7 +400,7 @@ class WorkGraphUpdaterTest
           )
         ),
         workB.copy(
-          subgraphId = SubgraphId(idA, idB),
+          subgraphId = SubgraphId(idB),
           componentIds = List(idB)
         )
       )
@@ -407,9 +422,15 @@ class WorkGraphUpdaterTest
 
       result shouldBe Set(
         workA
-          .copy(componentIds = List(idA)),
+          .copy(
+            componentIds = List(idA),
+            subgraphId = SubgraphId(idA)
+          ),
         workB
-          .copy(componentIds = List(idB))
+          .copy(
+            componentIds = List(idB),
+            subgraphId = SubgraphId(idB)
+          )
           .updateSourceWork(version = 2, suppressed = true)
       )
     }
@@ -428,16 +449,31 @@ class WorkGraphUpdaterTest
 
       result shouldBe Set(
         workA
-          .copy(componentIds = List(idA, idB))
+          .copy(
+            componentIds = List(idA, idB),
+            subgraphId = SubgraphId(idA, idB)
+          )
           .updateSourceWork(version = 2, mergeCandidateIds = Set(idB)),
         workB
-          .copy(componentIds = List(idA, idB)),
+          .copy(
+            componentIds = List(idA, idB),
+            subgraphId = SubgraphId(idA, idB)
+          ),
         suppressedWorkC
-          .copy(componentIds = List(idC)),
+          .copy(
+            componentIds = List(idC),
+            subgraphId = SubgraphId(idC)
+          ),
         workD
-          .copy(componentIds = List(idD, idE)),
+          .copy(
+            componentIds = List(idD, idE),
+            subgraphId = SubgraphId(idD, idE)
+          ),
         workE
-          .copy(componentIds = List(idD, idE))
+          .copy(
+            componentIds = List(idD, idE),
+            subgraphId = SubgraphId(idD, idE)
+          )
       )
     }
 


### PR DESCRIPTION
## What does this change?

This changes updates the way subgraph identifiers are generated in the matcher to ensure that when a graph of connected works with identical associated subgraph ids is split into disconnected component graphs, the works in the components get subgraph ids unique to that component.

An example of this might be:

1. We are told about a,b,c and d with relationships a->b, b->c, c->d eventually building a set of nodes with a subgraph id "abcd" work nodes are stored with id, subgraph,components id:

| id | subgraphId | components |
|----|------------|------------|
| a  | abcd       | (a,b,c,d)  |
| b  | abcd       | (a,b,c,d)  |
| c  | abcd       | (a,b,c,d)  |
| d  | abcd       | (a,b,c,d)  |

2. work b, no longer links to c, we are told about work b, the matcher retrieves works, a,b,c & d, builds a new graph internally with correct components, but an incorrect subgraphid like so:

| id | subgraphId | components |
|----|------------|------------|
| a  | abcd       | (a,b)      |
| b  | abcd       | (a,b)      |
| c  | abcd       | (c,d)      |
| d  | abcd       | (c,d)      |

4. Notice that the subgraphId has not changed, so now when we are told about a change in work c, we retrieve all works a,b,c,d even though a&b are no longer connected

In this situation we want to generate subgraph ids like:

| id | subgraphId | components |
|----|------------|------------|
| a  | ab         | (a,b)      |
| b  | ab         | (a,b)      |
| c  | cd         | (c,d)      |
| d  | cd         | (c,d)      |

Current behaviour results in inefficient querying for related nodes, _although they are sorted properly into components on disconnection_, it's also confusing behaviour for developers who query the source data looking for connected works.

See this slack conversation for context: https://wellcome.slack.com/archives/C02ANCYL90E/p1725889207079809

Follows: https://github.com/wellcomecollection/catalogue-pipeline/issues/2701

## How to test

- [ ] Run the tests, do they pass?

## How can we measure success?

Less confused developers.

## Have we considered potential risks?

Potentially this could have unforeseen impact elsewhere, although all tests in the matcher appear to pass. This has been tested splitting some larger graphs on a production pipeline with no ill effects noticed.
