### PR TITLE
Matcher version bug

### DIFF
--- a/pipeline/matcher_merger/matcher/src/main/scala/weco/pipeline/matcher/matcher/WorkMatcher.scala
+++ b/pipeline/matcher_merger/matcher/src/main/scala/weco/pipeline/matcher/matcher/WorkMatcher.scala
@@ -54,9 +54,6 @@ class WorkMatcher(
         matcherResult <-
           if (updatedNodes.isEmpty) {
             val result = MatcherResult(
-
-              // TODO: There could be an issue here - the merger relies on the versions reported here to be correct
-              // TODO: AAAAND the versions passed in and stored in the identified index may be higher than those in the graph store
               works = toMatchedIdentifiers(afterNodes),
               createdTime = Instant.now()
             )

--- a/pipeline/matcher_merger/matcher/src/main/scala/weco/pipeline/matcher/matcher/WorkMatcher.scala
+++ b/pipeline/matcher_merger/matcher/src/main/scala/weco/pipeline/matcher/matcher/WorkMatcher.scala
@@ -54,6 +54,9 @@ class WorkMatcher(
         matcherResult <-
           if (updatedNodes.isEmpty) {
             val result = MatcherResult(
+
+              // TODO: There could be an issue here - the merger relies on the versions reported here to be correct
+              // TODO: AAAAND the versions passed in and stored in the identified index may be higher than those in the graph store
               works = toMatchedIdentifiers(afterNodes),
               createdTime = Instant.now()
             )

--- a/pipeline/matcher_merger/merger/src/main/scala/weco/pipeline/merger/services/IdentifiedWorkLookup.scala
+++ b/pipeline/matcher_merger/merger/src/main/scala/weco/pipeline/merger/services/IdentifiedWorkLookup.scala
@@ -1,5 +1,6 @@
 package weco.pipeline.merger.services
 
+import grizzled.slf4j.Logging
 import weco.catalogue.internal_model.work.WorkState.Identified
 import weco.catalogue.internal_model.work.Work
 import weco.pipeline.matcher.models.WorkIdentifier
@@ -9,7 +10,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class IdentifiedWorkLookup(retriever: Retriever[Work[Identified]])(
   implicit ec: ExecutionContext
-) {
+) extends Logging {
   def fetchAllWorks(
     workIdentifiers: Seq[WorkIdentifier]
   ): Future[Seq[Option[Work[Identified]]]] = {
@@ -28,14 +29,21 @@ class IdentifiedWorkLookup(retriever: Retriever[Work[Identified]])(
             .map {
               case WorkIdentifier(id, version) =>
                 val work = works(id.toString)
-                // We only want to get the exact versions of the works specified
-                // by the matcher.
-                //
-                // e.g. if the matcher said "combine Av1 and Bv2", and we look
-                // in the retriever and find {Av2, Bv3}, we shouldn't merge
-                // these -- we should wait for the matcher to confirm we should
-                // still be merging these two works.
-                if (work.version == version) Some(work) else None
+                // Being asked to merge non-matching versions is incorrect
+                // but it is possible for the version in the identified index
+                // to be higher than the version in the graph store.
+                // Choosing between:
+                // (a) a complete failure where no works are merged
+                // (b) a partial failure where only the works with matching versions are merged
+                // (c) a partial success where all works are merged, accepting the risk of inconsistency
+                // We choose (c) as the least disruptive option.
+                if (work.version != version) {
+                  warn(
+                    "Matching version inconsistent! " +
+                      s"Found work $work with version $version, expected ${work.version}"
+                  )
+                }
+                Some(work)
             }
         case RetrieverMultiResult(_, notFound) =>
           throw new RuntimeException(s"Works not found: $notFound")

--- a/pipeline/matcher_merger/merger/src/test/scala/weco/pipeline/merger/services/IdentifiedWorkLookupTest.scala
+++ b/pipeline/matcher_merger/merger/src/test/scala/weco/pipeline/merger/services/IdentifiedWorkLookupTest.scala
@@ -41,7 +41,7 @@ class IdentifiedWorkLookupTest
     }
   }
 
-  it("returns None if the stored version has a higher version") {
+  it("returns Some even if the stored version has a higher version") {
     val oldWork = identifiedWork()
     val newWork = oldWork.withVersion(oldWork.version + 1)
 
@@ -50,7 +50,7 @@ class IdentifiedWorkLookupTest
     )
 
     whenReady(fetchAllWorks(retriever = retriever, oldWork)) {
-      _ shouldBe Seq(None)
+      _ shouldBe Seq(Some(newWork))
     }
   }
 
@@ -72,14 +72,8 @@ class IdentifiedWorkLookupTest
       }: _*)
     )
 
-    val expectedLookupResult =
-      unchangedWorks.map { Some(_) } ++ (4 to 5).map {
-        _ =>
-          None
-      }
-
     whenReady(fetchAllWorks(retriever = retriever, lookupWorks: _*)) {
-      _ shouldBe expectedLookupResult
+      _ shouldBe storedWorks.map(Some(_))
     }
   }
 

--- a/pipeline/matcher_merger/merger/src/test/scala/weco/pipeline/merger/services/MergerWorkerServiceTest.scala
+++ b/pipeline/matcher_merger/merger/src/test/scala/weco/pipeline/merger/services/MergerWorkerServiceTest.scala
@@ -373,7 +373,7 @@ class MergerWorkerServiceTest
     }
   }
 
-  it("doesn't send anything if the works are outdated") {
+  it("sends messages even if the works are outdated") {
     withMergerWorkerServiceFixtures {
       case (retriever, QueuePair(queue, dlq), senders, metrics, index) =>
         val work0 = identifiedWork().withVersion(0)
@@ -391,8 +391,10 @@ class MergerWorkerServiceTest
           assertQueueEmpty(queue)
           assertQueueEmpty(dlq)
 
-          getWorksSent(senders) shouldBe empty
-          index shouldBe Map()
+          getWorksSent(senders) shouldBe List(work1.id)
+          index shouldBe Map(
+            work1.id -> Left(work1.transition[Merged](matcherResult.createdTime))
+          )
 
           metrics.incrementedCounts.length shouldBe 1
           metrics.incrementedCounts.last should endWith("_success")


### PR DESCRIPTION
## What does this change?

This change fixes a bug with the matcher where it passes along incorrect version to the matcher. 

It is possible for the version of a work in the identified works index to get out of sync with that in the matcher graph store if updates are missed sent from the id_minter. In this case the out of sync work would always be excluded from graphs of which is a part when passed to the merger, resulting in bad merges.

We update this logis here, choosing between:

1. A complete failure where no works are merged
2. A partial failure where only the works with matching versions are merged
3. A partial success where all works are merged, accepting the risk of inconsistency

We choose (3) rather than (2) where works are excluded from a merge rather than included with the risk of inconsistency presuming this is less disruptive than a complete exclusion.

See this slack conversation for context: https://wellcome.slack.com/archives/C02ANCYL90E/p1725547846066509

Follows: https://github.com/wellcomecollection/catalogue-pipeline/issues/2701

## How to test

- [ ] Run the tests, do they pass?

## How can we measure success?

A reduced risk of confusing outputs from the merger in the event of a work version de-sync.

## Have we considered potential risks?

This will change the behaviour of the matcher / merger subsystem to merge works that otherwise would have been excluded. We propose that having seen a real issue in production caused by the exclusion, resolving that problem has better outcomes than protecting against the version inconsistency that we have not yet seen.
