### PR TITLE
Resolve Python security alerts

### DIFF
--- a/calm_adapter/calm_deletion_check_initiator/src/test_requirements.txt
+++ b/calm_adapter/calm_deletion_check_initiator/src/test_requirements.txt
@@ -92,7 +92,7 @@ urllib3==2.0.7
     #   docker
     #   requests
     #   responses
-werkzeug==3.0.1
+werkzeug==3.0.3
     # via moto
 xmltodict==0.13.0
     # via moto

--- a/reindexer/scripts/requirements.txt
+++ b/reindexer/scripts/requirements.txt
@@ -10,7 +10,7 @@ botocore==1.27.64
     # via
     #   boto3
     #   s3transfer
-certifi==2022.6.15
+certifi==2024.8.30
     # via elastic-transport
 click==8.1.3
     # via -r ./requirements.in

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -14,7 +14,7 @@ botocore==1.20.103
     # via
     #   boto3
     #   s3transfer
-certifi==2021.5.30
+certifi==2024.8.30
     # via
     #   elasticsearch
     #   httpx

--- a/sierra_adapter/sierra_progress_reporter/requirements.txt
+++ b/sierra_adapter/sierra_progress_reporter/requirements.txt
@@ -6,7 +6,7 @@
 #
 attrs==20.3.0
     # via -r requirements.in
-certifi==2020.12.5
+certifi==2024.8.30
     # via requests
 chardet==4.0.0
     # via requests

--- a/sierra_adapter/sierra_reader/requirements.txt
+++ b/sierra_adapter/sierra_reader/requirements.txt
@@ -6,7 +6,7 @@
 #
 anyio==3.6.2
     # via httpcore
-certifi==2023.5.7
+certifi==2024.8.30
     # via
     #   httpcore
     #   httpx

--- a/sierra_adapter/update_embargoed_holdings/requirements.txt
+++ b/sierra_adapter/update_embargoed_holdings/requirements.txt
@@ -6,7 +6,7 @@
 #
 anyio==3.7.1
     # via httpcore
-certifi==2021.5.30
+certifi==2024.8.30
     # via
     #   httpcore
     #   httpx

--- a/tei_adapter/tei_updater/src/test_requirements.txt
+++ b/tei_adapter/tei_updater/src/test_requirements.txt
@@ -94,7 +94,7 @@ urllib3==2.0.7
     #   docker
     #   requests
     #   responses
-werkzeug==3.0.1
+werkzeug==3.0.3
     # via moto
 xmltodict==0.13.0
     # via moto


### PR DESCRIPTION
## What does this change?

Resolves the following security alerts by updating Python packages:
* All `Removal of e-Tugra root certificate` alerts
* All `Werkzeug debugger vulnerable to remote execution when interacting with attacker controlled domain` alerts

This is done by updating the `werkzeug` and `certifi` packages in several Python services. 

## How to test

I believe that no testing is required for this change. We don't use either of these packages directly, and all packages which require either of these packages are version agnostic (verified using the `pipdeptree` command).

Furthermore, the `werkzeug` package is only used in unit tests (`test_requirements.txt`), so updating it does not risk breaking production code. 

## How can we measure success?

All listed Python-related security alerts in this repo are addressed.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? -->

