### PR TITLE
Migrate id_minter database to 8.0.mysql_aurora.3.07.1

### DIFF
--- a/infrastructure/critical/.terraform.lock.hcl
+++ b/infrastructure/critical/.terraform.lock.hcl
@@ -2,8 +2,23 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version = "4.61.0"
+  version = "5.69.0"
   hashes = [
-    "h1:GrboLwI2hok/i8xfq87uS9kUKPqAE8b/1iJTEupRthY=",
+    "h1:unGIj/eLOrl42LQm7u0fjtjQHp+FHKinpSxR1ZuWsfI=",
+    "zh:123af8815a80abfd62eab5f9fc3d9226735cfea3627e834a1b48321cd8d391a6",
+    "zh:1298f312e239768c1846541e89b4fbec7eb21769c4a488c87181909049219fbe",
+    "zh:4edc950b39f3653beb8cd3e0b86a7dc9b6a77e90e543ed7be72639107bbc48a9",
+    "zh:5f24c916d6d2ce51e18210628b3b1aca8b85b383982a920b2a6adc259bdbd4e9",
+    "zh:66f0b2f5869a4dfed7154444c272022c6d9350dc4dfa0fc6d87ccbfc983ec560",
+    "zh:67e3be60863cf1c51c5be866d8646d433cc31e07514b9121611f812e73f2400d",
+    "zh:884672345a1d0362644a4d1588085fd4c4f56d3ca61b10c0d25cd1940d828fec",
+    "zh:8ab0f92da124171c80a2361beb79822fb0f074ffab74e506f58e953a69b283ce",
+    "zh:908d879139f2246024b5510a38f00f61489eeee6f3f72be10acc5b424c8fc723",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9db6331398d648d9f2f4aa4db1eb9081e9bff584dcfe8f5350e04e6c5d339899",
+    "zh:a809bbd43bc392e91485b72bd9693874972bc5697b4f24fbcd61b461618ebb6d",
+    "zh:b9e9464458e7beb9fbf59f8db02f56138f398aaa6173b58a8bfa76aca82106d9",
+    "zh:cd7f041edaeeb1c4b06152ac8f3ce7b31c39a80a949083255f8fc81bbb11aeac",
+    "zh:eb71c9b2071ab2caa7aba577902df41c25ded1251c28560f0ac45f5e0f47360e",
   ]
 }

--- a/infrastructure/critical/modules/rds-serverless/main.tf
+++ b/infrastructure/critical/modules/rds-serverless/main.tf
@@ -37,10 +37,10 @@ resource "aws_rds_cluster_instance" "migration_instance" {
   engine_version     = aws_rds_cluster.serverless.engine_version
 }
 
-# resource "aws_rds_cluster_instance" "serverless_instance" {
-#   cluster_identifier = aws_rds_cluster.serverless.id
-#   instance_class     = "db.serverless"
-#   engine             = aws_rds_cluster.serverless.engine
-#   engine_version     = aws_rds_cluster.serverless.engine_version
-# }
+resource "aws_rds_cluster_instance" "serverless_instance" {
+  cluster_identifier = aws_rds_cluster.serverless.id
+  instance_class     = "db.serverless"
+  engine             = aws_rds_cluster.serverless.engine
+  engine_version     = aws_rds_cluster.serverless.engine_version
+}
 

--- a/infrastructure/critical/modules/rds-serverless/main.tf
+++ b/infrastructure/critical/modules/rds-serverless/main.tf
@@ -16,6 +16,7 @@ resource "aws_rds_cluster" "serverless" {
   storage_encrypted = false
   // This needs to be false until migration is complete
   enable_http_endpoint = true
+  deletion_protection  = true
 
   serverlessv2_scaling_configuration {
     max_capacity = var.max_scaling_capacity

--- a/infrastructure/critical/modules/rds-serverless/main.tf
+++ b/infrastructure/critical/modules/rds-serverless/main.tf
@@ -1,30 +1,46 @@
 resource "aws_rds_cluster" "serverless" {
-  cluster_identifier          = var.cluster_identifier
-  database_name               = var.database_name
-  master_username             = var.master_username
-  manage_master_user_password = true
+  cluster_identifier = var.cluster_identifier
+  database_name      = var.database_name
+  master_username    = var.master_username
+  master_password    = var.master_password
 
-  engine                      = "aurora-mysql"
-  engine_mode                 = "provisioned"
-  engine_version              = "8.0.mysql_aurora.3.05.2"
+  snapshot_identifier = var.snapshot_identifier
 
-  db_subnet_group_name = var.aws_db_subnet_group_name
+  engine         = "aurora-mysql"
+  engine_mode    = "provisioned"
+  engine_version = var.engine_version
 
-  storage_encrypted           = false
+  db_subnet_group_name   = var.aws_db_subnet_group_name
+  vpc_security_group_ids = [var.db_security_group_id]
+
+  storage_encrypted    = false
+  // This needs to be false until migration is complete
+  enable_http_endpoint = true
 
   serverlessv2_scaling_configuration {
-    max_capacity = 1.0
-    min_capacity = 0.5
+    max_capacity = var.max_scaling_capacity
+    min_capacity = var.min_scaling_capacity
   }
 }
 
-resource "aws_rds_cluster_instance" "serverless" {
+// Note when migrating we will need to:
+// - comment out the serverless cluster instance
+// - create a new serverless cluster instance with type "db.t3.medium"
+// - when complete uncomment the serverless cluster instance
+// - manual failover to the new serverless cluster
+// - delete the old serverless cluster instance
+
+# resource "aws_rds_cluster_instance" "migration_instance" {
+#   cluster_identifier = aws_rds_cluster.serverless.id
+#   instance_class     = "db.t3.medium"
+#   engine             = aws_rds_cluster.serverless.engine
+#   engine_version     = aws_rds_cluster.serverless.engine_version
+# }
+
+resource "aws_rds_cluster_instance" "serverless_instance" {
   cluster_identifier = aws_rds_cluster.serverless.id
   instance_class     = "db.serverless"
   engine             = aws_rds_cluster.serverless.engine
   engine_version     = aws_rds_cluster.serverless.engine_version
 }
 
-variable "aws_db_subnet_group_name" {
-  type = string
-}

--- a/infrastructure/critical/modules/rds-serverless/main.tf
+++ b/infrastructure/critical/modules/rds-serverless/main.tf
@@ -30,17 +30,17 @@ resource "aws_rds_cluster" "serverless" {
 // - manual failover to the new serverless cluster
 // - delete the old serverless cluster instance
 
-# resource "aws_rds_cluster_instance" "migration_instance" {
-#   cluster_identifier = aws_rds_cluster.serverless.id
-#   instance_class     = "db.t3.medium"
-#   engine             = aws_rds_cluster.serverless.engine
-#   engine_version     = aws_rds_cluster.serverless.engine_version
-# }
-
-resource "aws_rds_cluster_instance" "serverless_instance" {
+resource "aws_rds_cluster_instance" "migration_instance" {
   cluster_identifier = aws_rds_cluster.serverless.id
-  instance_class     = "db.serverless"
+  instance_class     = "db.t3.medium"
   engine             = aws_rds_cluster.serverless.engine
   engine_version     = aws_rds_cluster.serverless.engine_version
 }
+
+# resource "aws_rds_cluster_instance" "serverless_instance" {
+#   cluster_identifier = aws_rds_cluster.serverless.id
+#   instance_class     = "db.serverless"
+#   engine             = aws_rds_cluster.serverless.engine
+#   engine_version     = aws_rds_cluster.serverless.engine_version
+# }
 

--- a/infrastructure/critical/modules/rds-serverless/main.tf
+++ b/infrastructure/critical/modules/rds-serverless/main.tf
@@ -1,0 +1,30 @@
+resource "aws_rds_cluster" "serverless" {
+  cluster_identifier          = var.cluster_identifier
+  database_name               = var.database_name
+  master_username             = var.master_username
+  manage_master_user_password = true
+
+  engine                      = "aurora-mysql"
+  engine_mode                 = "provisioned"
+  engine_version              = "8.0.mysql_aurora.3.05.2"
+
+  db_subnet_group_name = var.aws_db_subnet_group_name
+
+  storage_encrypted           = false
+
+  serverlessv2_scaling_configuration {
+    max_capacity = 1.0
+    min_capacity = 0.5
+  }
+}
+
+resource "aws_rds_cluster_instance" "serverless" {
+  cluster_identifier = aws_rds_cluster.serverless.id
+  instance_class     = "db.serverless"
+  engine             = aws_rds_cluster.serverless.engine
+  engine_version     = aws_rds_cluster.serverless.engine_version
+}
+
+variable "aws_db_subnet_group_name" {
+  type = string
+}

--- a/infrastructure/critical/modules/rds-serverless/main.tf
+++ b/infrastructure/critical/modules/rds-serverless/main.tf
@@ -23,20 +23,6 @@ resource "aws_rds_cluster" "serverless" {
   }
 }
 
-// Note when migrating we will need to:
-// - comment out the serverless cluster instance
-// - create a new serverless cluster instance with type "db.t3.medium"
-// - when complete uncomment the serverless cluster instance
-// - manual failover to the new serverless cluster
-// - delete the old serverless cluster instance
-
-resource "aws_rds_cluster_instance" "migration_instance" {
-  cluster_identifier = aws_rds_cluster.serverless.id
-  instance_class     = "db.t3.medium"
-  engine             = aws_rds_cluster.serverless.engine
-  engine_version     = aws_rds_cluster.serverless.engine_version
-}
-
 resource "aws_rds_cluster_instance" "serverless_instance" {
   cluster_identifier = aws_rds_cluster.serverless.id
   instance_class     = "db.serverless"

--- a/infrastructure/critical/modules/rds-serverless/main.tf
+++ b/infrastructure/critical/modules/rds-serverless/main.tf
@@ -13,7 +13,7 @@ resource "aws_rds_cluster" "serverless" {
   db_subnet_group_name   = var.aws_db_subnet_group_name
   vpc_security_group_ids = [var.db_security_group_id]
 
-  storage_encrypted    = false
+  storage_encrypted = false
   // This needs to be false until migration is complete
   enable_http_endpoint = true
 

--- a/infrastructure/critical/modules/rds-serverless/outputs.tf
+++ b/infrastructure/critical/modules/rds-serverless/outputs.tf
@@ -1,0 +1,3 @@
+output "rds_cluster_id" {
+  value = aws_rds_cluster.serverless.id
+}

--- a/infrastructure/critical/modules/rds-serverless/secrets.tf
+++ b/infrastructure/critical/modules/rds-serverless/secrets.tf
@@ -1,0 +1,13 @@
+module "secrets" {
+  source = "github.com/wellcomecollection/terraform-aws-secrets.git?ref=v1.2.0"
+
+  key_value_map = {
+    "rds/${var.cluster_identifier}/endpoint"        = aws_rds_cluster.serverless.endpoint
+    "rds/${var.cluster_identifier}/reader_endpoint" = aws_rds_cluster.serverless.reader_endpoint
+    "rds/${var.cluster_identifier}/port"            = aws_rds_cluster.serverless.port
+  }
+}
+
+variable "engine_version" {
+  type = string
+}

--- a/infrastructure/critical/modules/rds-serverless/variables.tf
+++ b/infrastructure/critical/modules/rds-serverless/variables.tf
@@ -1,0 +1,11 @@
+variable "cluster_identifier" {
+  type = string
+}
+
+variable "database_name" {
+  type = string
+}
+
+variable "master_username" {
+  type = string
+}

--- a/infrastructure/critical/modules/rds-serverless/variables.tf
+++ b/infrastructure/critical/modules/rds-serverless/variables.tf
@@ -9,3 +9,30 @@ variable "database_name" {
 variable "master_username" {
   type = string
 }
+
+variable "master_password" {
+  type = string
+}
+
+variable "db_security_group_id" {
+  type = string
+}
+
+variable "aws_db_subnet_group_name" {
+  type = string
+}
+
+variable "snapshot_identifier" {
+  type = string
+}
+
+
+variable "max_scaling_capacity" {
+  type = number
+  default = 8.0
+}
+
+variable "min_scaling_capacity" {
+  type = number
+  default = 0.5
+}

--- a/infrastructure/critical/modules/rds-serverless/variables.tf
+++ b/infrastructure/critical/modules/rds-serverless/variables.tf
@@ -28,11 +28,11 @@ variable "snapshot_identifier" {
 
 
 variable "max_scaling_capacity" {
-  type = number
+  type    = number
   default = 8.0
 }
 
 variable "min_scaling_capacity" {
-  type = number
+  type    = number
   default = 0.5
 }

--- a/infrastructure/critical/outputs.tf
+++ b/infrastructure/critical/outputs.tf
@@ -4,6 +4,10 @@ output "rds_cluster_id" {
   value = module.identifiers_delta_rds_cluster.rds_cluster_id
 }
 
+output "rds_serverless_cluster_id" {
+  value = module.identifiers_serverless_rds_cluster.rds_cluster_id
+}
+
 output "rds_subnet_group_name" {
   value = aws_db_subnet_group.default.name
 }

--- a/infrastructure/critical/rds_id_minter.tf
+++ b/infrastructure/critical/rds_id_minter.tf
@@ -64,7 +64,7 @@ module "identifiers_delta_rds_cluster" {
   db_parameter_group_name = "default.aurora-mysql5.7"
 }
 
-This is the serverless RDS cluster that we will migrate to.
+# This is the serverless RDS cluster that we will migrate to.
 module "identifiers_serverless_rds_cluster" {
   source             = "./modules/rds-serverless"
 

--- a/infrastructure/critical/rds_id_minter.tf
+++ b/infrastructure/critical/rds_id_minter.tf
@@ -77,7 +77,7 @@ module "identifiers_serverless_rds_cluster" {
   aws_db_subnet_group_name = aws_db_subnet_group.default.name
 
   # This is the snapshot from the last time we migrated the database.
-  snapshot_identifier = "rds:identifiers-delta-cluster-2024-10-03-03-42"
+  snapshot_identifier = "rds:identifiers-delta-cluster-ADDNAMEOFSNAPSHOTHERE"
 
   engine_version = "8.0.mysql_aurora.3.07.1"
 }

--- a/infrastructure/critical/rds_id_minter.tf
+++ b/infrastructure/critical/rds_id_minter.tf
@@ -77,7 +77,7 @@ module "identifiers_serverless_rds_cluster" {
   aws_db_subnet_group_name = aws_db_subnet_group.default.name
 
   # This is the snapshot from the last time we migrated the database.
-  snapshot_identifier = "rds:identifiers-delta-cluster-ADDNAMEOFSNAPSHOTHERE"
+  snapshot_identifier = "aurora-mysql-v3-pre-migration-24-10-08"
 
   engine_version = "8.0.mysql_aurora.3.07.1"
 }

--- a/infrastructure/critical/rds_id_minter.tf
+++ b/infrastructure/critical/rds_id_minter.tf
@@ -64,7 +64,7 @@ module "identifiers_delta_rds_cluster" {
   db_parameter_group_name = "default.aurora-mysql5.7"
 }
 
-# This is the serverless RDS cluster that we will migrate to.
+This is the serverless RDS cluster that we will migrate to.
 module "identifiers_serverless_rds_cluster" {
   source             = "./modules/rds-serverless"
 

--- a/infrastructure/critical/rds_id_minter.tf
+++ b/infrastructure/critical/rds_id_minter.tf
@@ -57,8 +57,7 @@ module "identifiers_delta_rds_cluster" {
   instance_count = 1
   instance_class = "db.t3.medium"
 
-  db_security_group_id = aws_security_group.database_sg.id
-
+  db_security_group_id     = aws_security_group.database_sg.id
   aws_db_subnet_group_name = aws_db_subnet_group.default.name
 
   engine                  = "aurora-mysql"

--- a/infrastructure/critical/rds_id_minter.tf
+++ b/infrastructure/critical/rds_id_minter.tf
@@ -66,7 +66,7 @@ module "identifiers_delta_rds_cluster" {
 
 # This is the serverless RDS cluster that we will migrate to.
 module "identifiers_serverless_rds_cluster" {
-  source             = "./modules/rds-serverless"
+  source = "./modules/rds-serverless"
 
   cluster_identifier = "identifiers-serverless"
   database_name      = "identifiers"

--- a/infrastructure/critical/rds_id_minter.tf
+++ b/infrastructure/critical/rds_id_minter.tf
@@ -64,6 +64,25 @@ module "identifiers_delta_rds_cluster" {
   db_parameter_group_name = "default.aurora-mysql5.7"
 }
 
+# This is the serverless RDS cluster that we will migrate to.
+module "identifiers_serverless_rds_cluster" {
+  source             = "./modules/rds-serverless"
+
+  cluster_identifier = "identifiers-serverless"
+  database_name      = "identifiers"
+  master_username    = local.rds_username
+  master_password    = local.rds_password
+
+  db_security_group_id     = aws_security_group.database_sg.id
+  aws_db_subnet_group_name = aws_db_subnet_group.default.name
+
+  # This is the snapshot from the last time we migrated the database.
+  snapshot_identifier = "rds:identifiers-delta-cluster-2024-10-03-03-42"
+
+  engine_version = "8.0.mysql_aurora.3.07.1"
+}
+
+
 resource "aws_security_group" "rds_ingress_security_group" {
   name        = "pipeline_rds_ingress_security_group"
   description = "Allow traffic to rds database"

--- a/infrastructure/critical/rds_serverless_id_minter.tf
+++ b/infrastructure/critical/rds_serverless_id_minter.tf
@@ -1,9 +1,0 @@
-module "identifiers_serverless_rds_cluster" {
-  source             = "./modules/rds-serverless"
-
-  cluster_identifier = "identifiers-serverless"
-  database_name      = "identifiers"
-  master_username    = local.rds_username
-
-  aws_db_subnet_group_name = aws_db_subnet_group.default.name
-}

--- a/infrastructure/critical/rds_serverless_id_minter.tf
+++ b/infrastructure/critical/rds_serverless_id_minter.tf
@@ -1,0 +1,9 @@
+module "identifiers_serverless_rds_cluster" {
+  source             = "./modules/rds-serverless"
+
+  cluster_identifier = "identifiers-serverless"
+  database_name      = "identifiers"
+  master_username    = local.rds_username
+
+  aws_db_subnet_group_name = aws_db_subnet_group.default.name
+}

--- a/infrastructure/critical/terraform.tf
+++ b/infrastructure/critical/terraform.tf
@@ -1,6 +1,4 @@
 terraform {
-  required_version = ">= 0.12.29"
-
   backend "s3" {
     role_arn = "arn:aws:iam::760097843905:role/platform-developer"
 

--- a/infrastructure/critical/versions.tf
+++ b/infrastructure/critical/versions.tf
@@ -1,3 +1,0 @@
-terraform {
-  required_version = ">= 0.12"
-}

--- a/pipeline/id_minter/docker-compose.yml
+++ b/pipeline/id_minter/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.3'
 services:
   mysql:
-    image: "public.ecr.aws/docker/library/mysql:5.7"
+    image: "public.ecr.aws/docker/library/mysql:8.0"
     ports:
       - "3307:3306"
     environment:

--- a/pipeline/terraform/modules/stack/service_id_minter.tf
+++ b/pipeline/terraform/modules/stack/service_id_minter.tf
@@ -34,39 +34,26 @@ module "id_minter" {
     ingest_flush_interval_seconds = 30
   }
 
-  // TODO: Swap these two blocks when we're ready to switch to the new RDS cluster
-  secret_env_vars = merge({
-    cluster_url          = "rds/identifiers-delta-cluster/endpoint"
-    cluster_url_readonly = "rds/identifiers-delta-cluster/reader_endpoint"
-    db_port              = "rds/identifiers-delta-cluster/port"
-    db_username          = "catalogue/id_minter/rds_user"
-    db_password          = "catalogue/id_minter/rds_password"
-  }, local.pipeline_storage_es_service_secrets["id_minter"])
-
-  #   secret_env_vars = merge({
-  #     cluster_url          = "rds/identifiers-serverless/endpoint"
-  #     cluster_url_readonly = "rds/identifiers-serverless/reader_endpoint"
-  #     db_port              = "rds/identifiers-serverless/port"
-  #     db_username          = "catalogue/id_minter/rds_user"
-  #     db_password          = "catalogue/id_minter/rds_password"
-  #   }, local.pipeline_storage_es_service_secrets["id_minter"])
+    secret_env_vars = merge({
+      cluster_url          = "rds/identifiers-serverless/endpoint"
+      cluster_url_readonly = "rds/identifiers-serverless/reader_endpoint"
+      db_port              = "rds/identifiers-serverless/port"
+      db_username          = "catalogue/id_minter/rds_user"
+      db_password          = "catalogue/id_minter/rds_password"
+    }, local.pipeline_storage_es_service_secrets["id_minter"])
 
   cpu    = 2048
   memory = 4096
 
   # The total number of connections to RDS across all tasks from all ID minter
   # services must not exceed the maximum supported by the RDS instance.
-  #   min_capacity = var.min_capacity
-  #   max_capacity = min(
-  #     floor(
-  #       local.id_minter_rds_max_connections / local.id_minter_task_max_connections
-  #     ),
-  #     local.max_capacity
-  #   )
-
-  # Manually setting min_capacity and max_capacity to 0 to prevent autoscaling
-  max_capacity = 0
-  min_capacity = 0
+  min_capacity = var.min_capacity
+  max_capacity = min(
+    floor(
+      local.id_minter_rds_max_connections / local.id_minter_task_max_connections
+    ),
+    local.max_capacity
+  )
 
   fargate_service_boilerplate = local.fargate_service_boilerplate
 }

--- a/pipeline/terraform/modules/stack/service_id_minter.tf
+++ b/pipeline/terraform/modules/stack/service_id_minter.tf
@@ -34,13 +34,13 @@ module "id_minter" {
     ingest_flush_interval_seconds = 30
   }
 
-    secret_env_vars = merge({
-      cluster_url          = "rds/identifiers-serverless/endpoint"
-      cluster_url_readonly = "rds/identifiers-serverless/reader_endpoint"
-      db_port              = "rds/identifiers-serverless/port"
-      db_username          = "catalogue/id_minter/rds_user"
-      db_password          = "catalogue/id_minter/rds_password"
-    }, local.pipeline_storage_es_service_secrets["id_minter"])
+  secret_env_vars = merge({
+    cluster_url          = "rds/identifiers-serverless/endpoint"
+    cluster_url_readonly = "rds/identifiers-serverless/reader_endpoint"
+    db_port              = "rds/identifiers-serverless/port"
+    db_username          = "catalogue/id_minter/rds_user"
+    db_password          = "catalogue/id_minter/rds_password"
+  }, local.pipeline_storage_es_service_secrets["id_minter"])
 
   cpu    = 2048
   memory = 4096

--- a/pipeline/terraform/modules/stack/service_id_minter.tf
+++ b/pipeline/terraform/modules/stack/service_id_minter.tf
@@ -34,7 +34,7 @@ module "id_minter" {
     ingest_flush_interval_seconds = 30
   }
 
-  // TODO: These will need updating when the data is moved to the new RDS cluster
+  // TODO: Swap these two blocks when we're ready to switch to the new RDS cluster
   secret_env_vars = merge({
     cluster_url          = "rds/identifiers-delta-cluster/endpoint"
     cluster_url_readonly = "rds/identifiers-delta-cluster/reader_endpoint"
@@ -43,18 +43,30 @@ module "id_minter" {
     db_password          = "catalogue/id_minter/rds_password"
   }, local.pipeline_storage_es_service_secrets["id_minter"])
 
+#   secret_env_vars = merge({
+#     cluster_url          = "rds/identifiers-serverless/endpoint"
+#     cluster_url_readonly = "rds/identifiers-serverless/reader_endpoint"
+#     db_port              = "rds/identifiers-serverless/port"
+#     db_username          = "catalogue/id_minter/rds_user"
+#     db_password          = "catalogue/id_minter/rds_password"
+#   }, local.pipeline_storage_es_service_secrets["id_minter"])
+
   cpu    = 2048
   memory = 4096
 
   # The total number of connections to RDS across all tasks from all ID minter
   # services must not exceed the maximum supported by the RDS instance.
-  min_capacity = var.min_capacity
-  max_capacity = min(
-    floor(
-      local.id_minter_rds_max_connections / local.id_minter_task_max_connections
-    ),
-    local.max_capacity
-  )
+#   min_capacity = var.min_capacity
+#   max_capacity = min(
+#     floor(
+#       local.id_minter_rds_max_connections / local.id_minter_task_max_connections
+#     ),
+#     local.max_capacity
+#   )
+
+  # Manually setting min_capacity and max_capacity to 0 to prevent autoscaling
+  max_capacity = 0
+  min_capacity = 0
 
   fargate_service_boilerplate = local.fargate_service_boilerplate
 }

--- a/pipeline/terraform/modules/stack/service_id_minter.tf
+++ b/pipeline/terraform/modules/stack/service_id_minter.tf
@@ -34,6 +34,7 @@ module "id_minter" {
     ingest_flush_interval_seconds = 30
   }
 
+  // TODO: These will need updating when the data is moved to the new RDS cluster
   secret_env_vars = merge({
     cluster_url          = "rds/identifiers-delta-cluster/endpoint"
     cluster_url_readonly = "rds/identifiers-delta-cluster/reader_endpoint"

--- a/pipeline/terraform/modules/stack/service_id_minter.tf
+++ b/pipeline/terraform/modules/stack/service_id_minter.tf
@@ -43,26 +43,26 @@ module "id_minter" {
     db_password          = "catalogue/id_minter/rds_password"
   }, local.pipeline_storage_es_service_secrets["id_minter"])
 
-#   secret_env_vars = merge({
-#     cluster_url          = "rds/identifiers-serverless/endpoint"
-#     cluster_url_readonly = "rds/identifiers-serverless/reader_endpoint"
-#     db_port              = "rds/identifiers-serverless/port"
-#     db_username          = "catalogue/id_minter/rds_user"
-#     db_password          = "catalogue/id_minter/rds_password"
-#   }, local.pipeline_storage_es_service_secrets["id_minter"])
+  #   secret_env_vars = merge({
+  #     cluster_url          = "rds/identifiers-serverless/endpoint"
+  #     cluster_url_readonly = "rds/identifiers-serverless/reader_endpoint"
+  #     db_port              = "rds/identifiers-serverless/port"
+  #     db_username          = "catalogue/id_minter/rds_user"
+  #     db_password          = "catalogue/id_minter/rds_password"
+  #   }, local.pipeline_storage_es_service_secrets["id_minter"])
 
   cpu    = 2048
   memory = 4096
 
   # The total number of connections to RDS across all tasks from all ID minter
   # services must not exceed the maximum supported by the RDS instance.
-#   min_capacity = var.min_capacity
-#   max_capacity = min(
-#     floor(
-#       local.id_minter_rds_max_connections / local.id_minter_task_max_connections
-#     ),
-#     local.max_capacity
-#   )
+  #   min_capacity = var.min_capacity
+  #   max_capacity = min(
+  #     floor(
+  #       local.id_minter_rds_max_connections / local.id_minter_task_max_connections
+  #     ),
+  #     local.max_capacity
+  #   )
 
   # Manually setting min_capacity and max_capacity to 0 to prevent autoscaling
   max_capacity = 0


### PR DESCRIPTION
## What does this change?

Addressing https://github.com/wellcomecollection/platform/issues/5785. 

This change moves us to Aurora v3 (MySQL 8 compatible) Serverless V2 in order to prevent needing to move to extended support but also to offer us:

- Improved autoscaling with [Aurora Serverless V2,](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless-v2.html) so we can avoid manual scaling for reindexes
- Access to the [RDS Data API ](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html)to enable easier querying of the id_minter database.

This change requires a managed migration with a temporary pause in catalogue pipeline updates.

### Migration process
You should follow these steps to ensure a successful migration:

- [x] Ensure we have sent comms to collection staff indication catalogue updates will be paused
- [x] Disconnect the id_minter from all pipelines by running the current pipeline terraform (scale to zero)
- [x] Snapshot the current id_minter database and record the snapshot ARN
- [x] Update the critical terraform to reference the new snapshot ARN
- [x] Plan / Apply the critical terraform, using the latest snapshot identifier
- [x] Follow instructions in the critical terraform to migrate to serverless (manual failover)
- [x] Check you can connect to both the old and new database locally, do they have the same number of records?
- [x] Run the pipeline stack terraform after uncommenting the correct secret block to use the new database
- [x] Manually trigger the id_minter to process a record
- [x] ~Run a small reindex (perhaps EBSCO) to review scaling process~ edit: skipping, we'll review this when update the scaling logic (it looks quick enough processing the backlog)
- [x] Send comms indicating the migration process has completed

### Clean-up process
After you are sure the migration has completed successfully? If so, follow these steps (another PR to follow):

- [ ] Delete the old database, ensuring you keep a final snapshot
- [ ] Clean up the scaling infra code for the id_minter

## How to test

- [x] Can you connect to the new cluster locally? Does it have the same number of records as the old cluster.
- [x] Can you run the id_minter locally against the new cluster, does it process messages successfully?
- [x] Is the deployed id_minter processing messages successfully?
- [x] ~Does the new database scale to meet demand during a reindex?~ Skipping as described above.

## How can we measure success?

- Costs related to extended support are avoided
- Infrastructure & process is simplified by removing manual scaling during reindexes

## Have we considered potential risks?

- We have reserved cost (~$40 a month) for the previous instance type which we will not be able to take advantage of. This is acceptable to simplify process & avoid other costs.
- If there is some unknown issue we should keep a final snapshot of the existing database to allow us to rollback to existing infrastructure
