### PR TITLE
Revert Flyway package update

### DIFF
--- a/pipeline/id_minter/src/main/scala/weco/pipeline/id_minter/database/TableProvisioner.scala
+++ b/pipeline/id_minter/src/main/scala/weco/pipeline/id_minter/database/TableProvisioner.scala
@@ -8,17 +8,15 @@ import scala.collection.JavaConverters._
 class TableProvisioner(rdsClientConfig: RDSClientConfig) {
 
   def provision(database: String, tableName: String): Unit = {
-    val flyway = Flyway
-      .configure()
-      .dataSource(
-        s"jdbc:mysql://${rdsClientConfig.primaryHost}:${rdsClientConfig.port}/$database",
-        rdsClientConfig.username,
-        rdsClientConfig.password
-      )
-      .placeholders(
-        Map("database" -> database, "tableName" -> tableName).asJava
-      )
-      .load()
+    val flyway = new Flyway()
+    flyway.setDataSource(
+      s"jdbc:mysql://${rdsClientConfig.primaryHost}:${rdsClientConfig.port}/$database",
+      rdsClientConfig.username,
+      rdsClientConfig.password
+    )
+    flyway.setPlaceholders(
+      Map("database" -> database, "tableName" -> tableName).asJava
+    )
 
     flyway.migrate()
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -119,7 +119,7 @@ object ExternalDependencies {
   val mySqlDependencies = Seq(
     // Version 7.15.0 is the latest version of Flyway which supports MySQL 5.7. To update to a newer version of Flyway,
     // we would also need to update the MySQL tei-adapter-cluster and identifiers-delta-cluster databases in RDS.
-    "org.flywaydb" % "flyway-core" % "7.15.0",
+    "org.flywaydb" % "flyway-core" % "4.2.0",
     "org.scalikejdbc" %% "scalikejdbc" % "3.4.2",
     "com.mysql" % "mysql-connector-j" % "8.2.0"
   )

--- a/tei_adapter/tei_id_extractor/src/main/scala/weco/catalogue/tei/id_extractor/database/TableProvisioner.scala
+++ b/tei_adapter/tei_id_extractor/src/main/scala/weco/catalogue/tei/id_extractor/database/TableProvisioner.scala
@@ -10,20 +10,18 @@ class TableProvisioner(
 ) {
 
   def provision(): Unit = {
-    val flyway = Flyway
-      .configure()
-      .dataSource(
-        s"jdbc:mysql://${rdsClientConfig.host}:${rdsClientConfig.port}/${pathIdConfig.database}",
-        rdsClientConfig.username,
-        rdsClientConfig.password
-      )
-      .placeholders(
-        Map(
-          "database" -> pathIdConfig.database,
-          "tableName" -> pathIdConfig.tableName
-        ).asJava
-      )
-      .load()
+    val flyway = new Flyway()
+    flyway.setDataSource(
+      s"jdbc:mysql://${rdsClientConfig.host}:${rdsClientConfig.port}/${pathIdConfig.database}",
+      rdsClientConfig.username,
+      rdsClientConfig.password
+    )
+    flyway.setPlaceholders(
+      Map(
+        "database" -> pathIdConfig.database,
+        "tableName" -> pathIdConfig.tableName
+      ).asJava
+    )
 
     flyway.migrate()
   }


### PR DESCRIPTION
## What does this change?

This attempts to address an issue we've seen in production where we see this error: 

```
org.flywaydb.core.api.FlywayException: Found non-empty schema(s) `identifiers` but no schema history table. Use baseline() or set baselineOnMigrate to true to initialize the schema history table.
```

This change was introduced in https://github.com/wellcomecollection/catalogue-pipeline/pull/2720

## How to test

- [ ] Do the tests pass?

## How can we measure success?

Messages continue to flow through the pipeline.

## Have we considered potential risks?

Risks should be minimal, we're going back to a known good version.
