### PR TITLE
Reconfigure Flyway to use schema_version table

### DIFF
--- a/pipeline/id_minter/src/main/scala/weco/pipeline/id_minter/database/TableProvisioner.scala
+++ b/pipeline/id_minter/src/main/scala/weco/pipeline/id_minter/database/TableProvisioner.scala
@@ -15,7 +15,9 @@ class TableProvisioner(rdsClientConfig: RDSClientConfig) {
         rdsClientConfig.username,
         rdsClientConfig.password
       )
-      .table("schema_version") // Name of the table Flyway uses to track migrations
+      .table(
+        "schema_version"
+      ) // Name of the table Flyway uses to track migrations
       .placeholders(
         Map("database" -> database, "tableName" -> tableName).asJava
       )

--- a/pipeline/id_minter/src/main/scala/weco/pipeline/id_minter/database/TableProvisioner.scala
+++ b/pipeline/id_minter/src/main/scala/weco/pipeline/id_minter/database/TableProvisioner.scala
@@ -15,6 +15,7 @@ class TableProvisioner(rdsClientConfig: RDSClientConfig) {
         rdsClientConfig.username,
         rdsClientConfig.password
       )
+      .table("schema_version") // Name of the table Flyway uses to track migrations
       .placeholders(
         Map("database" -> database, "tableName" -> tableName).asJava
       )

--- a/tei_adapter/tei_id_extractor/src/main/scala/weco/catalogue/tei/id_extractor/database/TableProvisioner.scala
+++ b/tei_adapter/tei_id_extractor/src/main/scala/weco/catalogue/tei/id_extractor/database/TableProvisioner.scala
@@ -17,6 +17,7 @@ class TableProvisioner(
         rdsClientConfig.username,
         rdsClientConfig.password
       )
+      .table("schema_version") // Name of the table Flyway uses to track migrations
       .placeholders(
         Map(
           "database" -> pathIdConfig.database,

--- a/tei_adapter/tei_id_extractor/src/main/scala/weco/catalogue/tei/id_extractor/database/TableProvisioner.scala
+++ b/tei_adapter/tei_id_extractor/src/main/scala/weco/catalogue/tei/id_extractor/database/TableProvisioner.scala
@@ -17,7 +17,9 @@ class TableProvisioner(
         rdsClientConfig.username,
         rdsClientConfig.password
       )
-      .table("schema_version") // Name of the table Flyway uses to track migrations
+      .table(
+        "schema_version"
+      ) // Name of the table Flyway uses to track migrations
       .placeholders(
         Map(
           "database" -> pathIdConfig.database,


### PR DESCRIPTION
## What does this change?

Flyway stores its own table in the database for tracking schema changes. In version 4, the default name for this table was `schema_version`. However, in version 5, the default changed to `flyway_schema_history`.

We recently updated to Flyway 7, which resulted in Flyway not being able to find this table (because it was looking for the new default name). This reconfigures Flyway to instead look for the table with the old name. 

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

`id_minter` starts without errors.

## Have we considered potential risks?

This is a low-risk fix to an already broken service (id_minter). The fix does not involve any changes to the database itself. 
