### PR TITLE
Fix ImagesIngestorFeatureTest by increasing timeout

### DIFF
--- a/pipeline/ingestor/ingestor_images/src/test/scala/weco/pipeline/ingestor/images/ImagesIngestorFeatureTest.scala
+++ b/pipeline/ingestor/ingestor_images/src/test/scala/weco/pipeline/ingestor/images/ImagesIngestorFeatureTest.scala
@@ -88,7 +88,7 @@ class ImagesIngestorFeatureTest
         withImagesIngestor(queue, existingImages = Nil) {
           index =>
             assertElasticsearchEmpty(index)
-            eventually(Timeout(Span(5, Seconds))) {
+            eventually(Timeout(Span(10, Seconds))) {
               assertQueueEmpty(queue)
               assertQueueHasSize(dlq, size = 1)
             }


### PR DESCRIPTION
## What does this change?

The `does not delete a message from the queue if it fails processing it` test in ImagesIngestorFeatureTest often fails randomly when asserting the size of the DLQ. This is because the timeout is not long enough. 

This increases the timeout from 5 seconds to 10 seconds to eliminate the random failures. 

## How to test

I ran the test locally 50 times both with the old timeout value and the new timeout value. With the old timeout, the test failed 18 times (36% failure rate). With the new increased timeout, the test failed 0 times.
