### PR TITLE
Make ingestor-images tests more reliable

### DIFF
--- a/pipeline/ingestor/ingestor_images/src/test/scala/weco/pipeline/ingestor/images/ImagesIngestorFeatureTest.scala
+++ b/pipeline/ingestor/ingestor_images/src/test/scala/weco/pipeline/ingestor/images/ImagesIngestorFeatureTest.scala
@@ -88,7 +88,12 @@ class ImagesIngestorFeatureTest
         withImagesIngestor(queue, existingImages = Nil) {
           index =>
             assertElasticsearchEmpty(index)
-            eventually(timeout(Span(10, Seconds)), interval(Span(1, Seconds))) {
+            eventually(
+              timeout(Span(10, Seconds)),
+              // The message does not expire until a second has elapsed, so don't bother
+              // looking until at least then.
+              interval(Span(1, Seconds))
+            ) {
               assertQueueEmpty(queue)
               assertQueueHasSize(dlq, size = 1)
             }

--- a/pipeline/ingestor/ingestor_images/src/test/scala/weco/pipeline/ingestor/images/ImagesIngestorFeatureTest.scala
+++ b/pipeline/ingestor/ingestor_images/src/test/scala/weco/pipeline/ingestor/images/ImagesIngestorFeatureTest.scala
@@ -32,7 +32,8 @@ class ImagesIngestorFeatureTest
     extends AnyFunSpec
     with ImageGenerators
     with IndexFixtures
-    with IngestorFixtures {
+    with IngestorFixtures
+     {
 
   it("reads an image from the queue, ingests it and deletes the message") {
     val image = createImageData.toAugmentedImage
@@ -88,7 +89,7 @@ class ImagesIngestorFeatureTest
         withImagesIngestor(queue, existingImages = Nil) {
           index =>
             assertElasticsearchEmpty(index)
-            eventually(Timeout(Span(10, Seconds))) {
+            eventually(timeout(Span(10, Seconds)), interval(Span(1, Seconds))) {
               assertQueueEmpty(queue)
               assertQueueHasSize(dlq, size = 1)
             }

--- a/pipeline/ingestor/ingestor_images/src/test/scala/weco/pipeline/ingestor/images/ImagesIngestorFeatureTest.scala
+++ b/pipeline/ingestor/ingestor_images/src/test/scala/weco/pipeline/ingestor/images/ImagesIngestorFeatureTest.scala
@@ -3,7 +3,6 @@ package weco.pipeline.ingestor.images
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.requests.get.GetResponse
 import com.sksamuel.elastic4s.{Index, Response}
-import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.time.{Seconds, Span}
 import weco.catalogue.display_model.image.DisplayImage


### PR DESCRIPTION
## What does this change?

Fixes https://github.com/wellcomecollection/platform/issues/5793

The test for whether a failed ingest leaves the message on the queue is unreliable.  Sometimes the message is still in flight when the test declares it a failure.

The call to `eventually` was unexpectedly quitting after about five seconds, rather than the requested ten.  I did not get to the bottom of why this happened, but one part of the problem here was that the test was frantically examining the queue every 15 milliseconds even when we know that it won't pass until it has done about 66 of them (minus whatever for the minuscule gap between running the ingestor and entering the eventually loop.

I suspect that, in line with the eventually correct nature of real SQS API requests, localstack is not always telling the exact truth about in-flight messages.  It may be that, by continually asking it at a high frequency, we are preventing it from getting round to updating the queue states.

## How to test

This is tricky.  The problem is intermittent.  I think we just need to keep running and retrying the tests.  If we get a bunch of greens in a row, then I guess the problem is solved.

## How can we measure success?

We should see fewer bogus ephemeral test failures on Buildkite.

## Have we considered potential risks?
When flaky tests get solved by fiddling with timeouts and intervals, then there is always a chance that this is just kicking the problem down the road.  Waiting longer can also make the test runs take longer, a perennial problem in UI test suites.

However, (IMO) It is certainly correct that we shouldn't start looking at the queue until the message is expected to timeout, so this is a valid solution for this specific scenario.