### PR TITLE
Migrate TEI database to 8.0.mysql_aurora.3.07.1

### DIFF
--- a/infrastructure/critical/modules/rds-serverless/main.tf
+++ b/infrastructure/critical/modules/rds-serverless/main.tf
@@ -23,13 +23,6 @@ resource "aws_rds_cluster" "serverless" {
   }
 }
 
-resource "aws_rds_cluster_instance" "t3_instance" {
-  cluster_identifier = aws_rds_cluster.serverless.id
-  instance_class     = "db.t3.medium"
-  engine             = aws_rds_cluster.serverless.engine
-  engine_version     = aws_rds_cluster.serverless.engine_version
-}
-
 resource "aws_rds_cluster_instance" "serverless_instance" {
   cluster_identifier = aws_rds_cluster.serverless.id
   instance_class     = "db.serverless"

--- a/infrastructure/critical/modules/rds-serverless/main.tf
+++ b/infrastructure/critical/modules/rds-serverless/main.tf
@@ -13,15 +13,21 @@ resource "aws_rds_cluster" "serverless" {
   db_subnet_group_name   = var.aws_db_subnet_group_name
   vpc_security_group_ids = [var.db_security_group_id]
 
-  storage_encrypted = false
-  // This needs to be false until migration is complete
-  enable_http_endpoint = true
-  deletion_protection  = true
+  storage_encrypted    = false
+  enable_http_endpoint = false
+  deletion_protection  = false
 
   serverlessv2_scaling_configuration {
     max_capacity = var.max_scaling_capacity
     min_capacity = var.min_scaling_capacity
   }
+}
+
+resource "aws_rds_cluster_instance" "t3_instance" {
+  cluster_identifier = aws_rds_cluster.serverless.id
+  instance_class     = "db.t3.medium"
+  engine             = aws_rds_cluster.serverless.engine
+  engine_version     = aws_rds_cluster.serverless.engine_version
 }
 
 resource "aws_rds_cluster_instance" "serverless_instance" {

--- a/infrastructure/critical/modules/rds-serverless/main.tf
+++ b/infrastructure/critical/modules/rds-serverless/main.tf
@@ -14,8 +14,8 @@ resource "aws_rds_cluster" "serverless" {
   vpc_security_group_ids = [var.db_security_group_id]
 
   storage_encrypted    = false
-  enable_http_endpoint = false
-  deletion_protection  = false
+  enable_http_endpoint = true
+  deletion_protection  = true
 
   serverlessv2_scaling_configuration {
     max_capacity = var.max_scaling_capacity

--- a/tei_adapter/terraform/provider.tf
+++ b/tei_adapter/terraform/provider.tf
@@ -2,6 +2,6 @@ provider "aws" {
   region = "eu-west-1"
 
   assume_role {
-    role_arn = "arn:aws:iam::760097843905:role/platform-admin"
+    role_arn = "arn:aws:iam::760097843905:role/platform-developer"
   }
 }

--- a/tei_adapter/terraform/provider.tf
+++ b/tei_adapter/terraform/provider.tf
@@ -2,6 +2,6 @@ provider "aws" {
   region = "eu-west-1"
 
   assume_role {
-    role_arn = "arn:aws:iam::760097843905:role/platform-developer"
+    role_arn = "arn:aws:iam::760097843905:role/platform-admin"
   }
 }

--- a/tei_adapter/terraform/rds_id_extractor.tf
+++ b/tei_adapter/terraform/rds_id_extractor.tf
@@ -71,7 +71,7 @@ module "tei_id_extractor_rds_serverless_cluster" {
   master_username    = local.rds_username
   master_password    = local.rds_password
 
-  db_security_group_id = aws_security_group.database_sg.id
+  db_security_group_id     = aws_security_group.database_sg.id
   aws_db_subnet_group_name = aws_db_subnet_group.default.name
 
   engine_version = "8.0.mysql_aurora.3.07.1"

--- a/tei_adapter/terraform/rds_id_extractor.tf
+++ b/tei_adapter/terraform/rds_id_extractor.tf
@@ -64,6 +64,22 @@ module "tei_id_extractor_rds_cluster" {
   db_parameter_group_name = aws_db_parameter_group.default.id
 }
 
+module "tei_id_extractor_rds_serverless_cluster" {
+  source             = "../../infrastructure/critical/modules/rds-serverless"
+  cluster_identifier = "tei-adapter-cluster-serverless"
+  database_name      = "pathid"
+  master_username    = local.rds_username
+  master_password    = local.rds_password
+
+  db_security_group_id = aws_security_group.database_sg.id
+  aws_db_subnet_group_name = aws_db_subnet_group.default.name
+
+  engine_version = "8.0.mysql_aurora.3.07.1"
+
+  snapshot_identifier = "aurora-mysql-v3-tei-pre-migration-24-15-08"
+}
+
+
 resource "aws_security_group" "rds_ingress_security_group" {
   name        = "tei_adapter_rds_ingress_security_group"
   description = "Allow traffic to rds database"

--- a/tei_adapter/terraform/rds_id_extractor.tf
+++ b/tei_adapter/terraform/rds_id_extractor.tf
@@ -58,7 +58,6 @@ module "tei_id_extractor_rds_cluster" {
   instance_class = "db.t3.small"
 
   db_security_group_id = aws_security_group.database_sg.id
-
   aws_db_subnet_group_name = aws_db_subnet_group.default.name
 
   engine                  = "aurora-mysql"

--- a/tei_adapter/terraform/rds_id_extractor.tf
+++ b/tei_adapter/terraform/rds_id_extractor.tf
@@ -57,7 +57,7 @@ module "tei_id_extractor_rds_cluster" {
   instance_count = 1
   instance_class = "db.t3.small"
 
-  db_security_group_id = aws_security_group.database_sg.id
+  db_security_group_id     = aws_security_group.database_sg.id
   aws_db_subnet_group_name = aws_db_subnet_group.default.name
 
   engine                  = "aurora-mysql"

--- a/tei_adapter/terraform/tei_id_extractor.tf
+++ b/tei_adapter/terraform/tei_id_extractor.tf
@@ -30,8 +30,11 @@ module "tei_id_extractor_w" {
 
   // The total number of connections to RDS across all tasks
   // must not exceed the maximum supported by the RDS instance.
-  min_capacity = local.min_capacity
-  max_capacity = min(floor(local.rds_max_connections / local.tei_id_extractor_max_connections), local.max_capacity)
+  # min_capacity = local.min_capacity
+  # max_capacity = min(floor(local.rds_max_connections / local.tei_id_extractor_max_connections), local.max_capacity)
+
+  min_capacity = 0
+  max_capacity = 0
 
   cpu    = 1024
   memory = 2048

--- a/tei_adapter/terraform/tei_id_extractor.tf
+++ b/tei_adapter/terraform/tei_id_extractor.tf
@@ -21,8 +21,10 @@ module "tei_id_extractor_w" {
   }
 
   secret_env_vars = {
-    db_host      = "rds/tei-adapter-cluster/endpoint"
-    db_port      = "rds/tei-adapter-cluster/port"
+    # db_host      = "rds/tei-adapter-cluster/endpoint"
+    # db_port      = "rds/tei-adapter-cluster/port"
+    db_host      = "rds/tei-adapter-cluster-serverless/endpoint"
+    db_port      = "rds/tei-adapter-cluster-serverless/port"
     db_username  = "catalogue/tei_id_extractor/rds_user"
     db_password  = "catalogue/tei_id_extractor/rds_password"
     github_token = "catalogue/tei_id_extractor/github_token"

--- a/tei_adapter/terraform/tei_id_extractor.tf
+++ b/tei_adapter/terraform/tei_id_extractor.tf
@@ -21,8 +21,6 @@ module "tei_id_extractor_w" {
   }
 
   secret_env_vars = {
-    # db_host      = "rds/tei-adapter-cluster/endpoint"
-    # db_port      = "rds/tei-adapter-cluster/port"
     db_host      = "rds/tei-adapter-cluster-serverless/endpoint"
     db_port      = "rds/tei-adapter-cluster-serverless/port"
     db_username  = "catalogue/tei_id_extractor/rds_user"
@@ -32,11 +30,8 @@ module "tei_id_extractor_w" {
 
   // The total number of connections to RDS across all tasks
   // must not exceed the maximum supported by the RDS instance.
-  # min_capacity = local.min_capacity
-  # max_capacity = min(floor(local.rds_max_connections / local.tei_id_extractor_max_connections), local.max_capacity)
-
-  min_capacity = 0
-  max_capacity = 0
+  min_capacity = local.min_capacity
+  max_capacity = min(floor(local.rds_max_connections / local.tei_id_extractor_max_connections), local.max_capacity)
 
   cpu    = 1024
   memory = 2048


### PR DESCRIPTION
## What does this change?

Follows https://github.com/wellcomecollection/catalogue-pipeline/pull/2726

Part of a required database upgrade.

## How to test

- [ ] Is the TEI adapter using the new database successfully?

## How can we measure success?

- [ ] No more database migration warnings in the AWS console.

## Have we considered potential risks?

We are following a successful pattern for the id_minter, and as long as the database is successfully snapshotted we should be able to roll back, both of these things mitigate risk.
