### PR TITLE
Increase default message retention for scaling services 

### DIFF
--- a/pipeline/terraform/modules/fargate_service/variables.tf
+++ b/pipeline/terraform/modules/fargate_service/variables.tf
@@ -47,13 +47,8 @@ variable "queue_visibility_timeout_seconds" {
 variable "message_retention_seconds" {
   type = number
   # The actual default on SQS is four whole days.
-  #   default = 345600
   # This is sufficient to cope with normal bank holiday weekends.
-
-  # However, if a message is sitting on any main queue for more than a day,
-  # then something has gone rather awry, and it should be moved to a DLQ,
-  # rather than cluttering a main queue.
-  default = 86400
+  default = 345600
 }
 
 variable "max_receive_count" {


### PR DESCRIPTION
## What does this change?

Following a recent change where the catalogue pipeline stopped publishing changes we noticed that some messages were being lost as they were being deleted from scaling services "main queues" when they reached the maximum set retention period.

See: https://github.com/wellcomecollection/docs/blob/main/incident_retros/2024-10-07_updates_not_getting_through_to_works.md

This change increases the maximum retention period to avoid a similar situation in the future, and addresses an action from that incident retrospective.

Note that the comment being deleted in this change:

```
  # However, if a message is sitting on any main queue for more than a day,
  # then something has gone rather awry, and it should be moved to a DLQ,
  # rather than cluttering a main queue.
```

Doesn't seem to be correct, messages that exceed the retention period are deleted, not moved to the DLQ. See https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/welcome.html

> Amazon SQS automatically deletes messages that have been in a queue for more than the maximum message retention period.

## How to test

 - [ ] Apply this change, has the message retention period increased?

## How can we measure success?

Less chance of messages being lost.

## Have we considered potential risks?

This should have minimal risk, but should be made in conjunction with an action to provide visbility on queues that have old messages on them.

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? -->

