### PR TITLE
Add queue and event source for pipeline lambdas (specifically batcher)

### DIFF
--- a/pipeline/terraform/modules/pipeline_lambda/data.tf
+++ b/pipeline/terraform/modules/pipeline_lambda/data.tf
@@ -3,6 +3,8 @@ locals {
 
   name      = "${local.namespace}-${var.service_name}"
   image_tag = var.tag_override != "" ? var.tag_override : "env.${var.pipeline_date}"
+
+  queue_name = var.queue_config.name == null ? trim("${local.name}_lambda_input", "_") : var.queue_config.name
 }
 
 data "aws_ecr_repository" "repository" {

--- a/pipeline/terraform/modules/pipeline_lambda/main.tf
+++ b/pipeline/terraform/modules/pipeline_lambda/main.tf
@@ -12,3 +12,37 @@ module "pipeline_step" {
     variables = var.environment_variables
   }
 }
+
+module "input_queue" {
+  source = "github.com/wellcomecollection/terraform-aws-sqs.git//queue?ref=v1.4.0"
+
+  queue_name = local.queue_name
+
+  topic_arns                 = var.queue_config.topic_arns
+  visibility_timeout_seconds = var.queue_config.visibility_timeout_seconds
+  max_receive_count          = var.queue_config.max_receive_count
+  message_retention_seconds  = var.queue_config.message_retention_seconds
+  alarm_topic_arn            = var.queue_config.dlq_alarm_arn
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_sqs_role_policy" {
+  role       = module.pipeline_step.lambda_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaSQSQueueExecutionRole"
+}
+
+resource "aws_lambda_event_source_mapping" "event_source_mapping" {
+  event_source_arn = module.input_queue.arn
+  enabled          = var.event_source_enabled
+  function_name    = module.pipeline_step.lambda.function_name
+
+  # Scaling configuration
+  # See: https://docs.aws.amazon.com/lambda/latest/dg/services-sqs-scaling.html
+  scaling_config {
+    maximum_concurrency = var.queue_config.maximum_concurrency
+  }
+
+  # Batching configuration
+  # See: https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#sqs-polling-behavior
+  batch_size                         = var.queue_config.batch_size
+  maximum_batching_window_in_seconds = var.queue_config.batching_window_seconds
+}

--- a/pipeline/terraform/modules/pipeline_lambda/variables.tf
+++ b/pipeline/terraform/modules/pipeline_lambda/variables.tf
@@ -39,17 +39,17 @@ variable "memory_size" {
 
 variable "queue_config" {
   type = object({
-    name                       = optional(string, null)
-    topic_arns                 = optional(list(string),[])
+    name       = optional(string, null)
+    topic_arns = optional(list(string), [])
     // Note this must be greater than or equal to the lambda timeout
     visibility_timeout_seconds = optional(number, 30)
     // 4 days, to allow message retention if something goes wrong over a weekend
-    message_retention_seconds  = optional(number, 345600)
-    max_receive_count          = optional(number, 4)
-    dlq_alarm_arn              = optional(string, null)
+    message_retention_seconds = optional(number, 345600)
+    max_receive_count         = optional(number, 4)
+    dlq_alarm_arn             = optional(string, null)
 
     # Batching configuration
-    batch_size      = optional(number, 1)
+    batch_size              = optional(number, 1)
     batching_window_seconds = optional(number, null)
 
     # Scaling configuration

--- a/pipeline/terraform/modules/pipeline_lambda/variables.tf
+++ b/pipeline/terraform/modules/pipeline_lambda/variables.tf
@@ -28,11 +28,36 @@ variable "environment_variables" {
 }
 
 variable "timeout" {
-  default     = 600
+  default     = 30
   description = "lambda function timeout"
 }
 
 variable "memory_size" {
   default     = 1024
   description = "lambda function memory size"
+}
+
+variable "queue_config" {
+  type = object({
+    name                       = optional(string, null)
+    topic_arns                 = optional(list(string),[])
+    // Note this must be greater than or equal to the lambda timeout
+    visibility_timeout_seconds = optional(number, 30)
+    // 4 days, to allow message retention if something goes wrong over a weekend
+    message_retention_seconds  = optional(number, 345600)
+    max_receive_count          = optional(number, 4)
+    dlq_alarm_arn              = optional(string, null)
+
+    # Batching configuration
+    batch_size      = optional(number, 1)
+    batching_window_seconds = optional(number, null)
+
+    # Scaling configuration
+    maximum_concurrency = optional(number, 2)
+  })
+}
+
+variable "event_source_enabled" {
+  type    = bool
+  default = true
 }

--- a/pipeline/terraform/modules/stack/service_work_batcher.tf
+++ b/pipeline/terraform/modules/stack/service_work_batcher.tf
@@ -35,7 +35,8 @@ module "batcher_lambda" {
 
   pipeline_date = var.pipeline_date
   service_name  = "batcher"
-  tag_override  = "dev"
+
+  queue_config = {}
 
   ecr_repository_name = "uk.ac.wellcome/batcher"
 }


### PR DESCRIPTION
## What does this change?

> [!Note]
> This change is applied!

Adds a queue and an event source for pipeline lambdas, allowing invocation from SQS queue with various queue and invocation options including batching & concurrency.

This follows: https://github.com/wellcomecollection/catalogue-pipeline/pull/2728

Part of https://github.com/wellcomecollection/catalogue-pipeline/issues/2721

## How to test

- [x] Can you manually publish messages to the queue, do they invoke the lambda? 

## How can we measure success?

Smooth migration to lambda implementation of pipeline services.

## Have we considered potential risks?

This should avoid changing any exisiting infra, and run in tandem with existing services reducing risk.
