### PR TITLE
Born digital archives format

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Format.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Format.scala
@@ -106,7 +106,7 @@ object Format extends Enum[Format] {
     // for all CALM sourced works, hence the id here is prefixed
     // with a "h" to namespace it within "ArchivesAndManuscripts".
     override val id: String = "hdig"
-    override val label: String = "Archives - Digital"
+    override val label: String = "Born-digital archives"
   }
 
   case object Film extends Unlinked with Audiovisual {

--- a/pipeline/ingestor/test_documents/works.every-format.13.json
+++ b/pipeline/ingestor/test_documents/works.every-format.13.json
@@ -30,7 +30,7 @@
       ],
       "workType" : {
         "id" : "hdig",
-        "label" : "Archives - Digital",
+        "label" : "Born-digital archives",
         "type" : "Format"
       },
       "contributors" : [
@@ -121,7 +121,7 @@
     },
     "aggregatableValues" : {
       "workType" : [
-        "{\"id\":\"hdig\",\"label\":\"Archives - Digital\",\"type\":\"Format\"}"
+        "{\"id\":\"hdig\",\"label\":\"Born-digital archives\",\"type\":\"Format\"}"
       ],
       "genres.label" : [
       ],

--- a/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.13.json
+++ b/pipeline/ingestor/test_documents/works.examples.aggregation-with-filters-tests.13.json
@@ -30,7 +30,7 @@
       ],
       "workType" : {
         "id" : "hdig",
-        "label" : "Archives - Digital",
+        "label" : "Born-digital archives",
         "type" : "Format"
       },
       "contributors" : [
@@ -142,7 +142,7 @@
     },
     "aggregatableValues" : {
       "workType" : [
-        "{\"id\":\"hdig\",\"label\":\"Archives - Digital\",\"type\":\"Format\"}"
+        "{\"id\":\"hdig\",\"label\":\"Born-digital archives\",\"type\":\"Format\"}"
       ],
       "genres.label" : [
       ],

--- a/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/transformers/CalmFormat.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/transformers/CalmFormat.scala
@@ -8,7 +8,7 @@ object CalmFormat extends CalmRecordOps {
   def apply(record: CalmRecord): Format = {
     record.get("Material") match {
       case Some("Born-digital archives") => Format.ArchivesDigital
-      case _                          => Format.ArchivesAndManuscripts
+      case _                             => Format.ArchivesAndManuscripts
     }
   }
 }

--- a/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/transformers/CalmFormat.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/transformers/CalmFormat.scala
@@ -7,7 +7,7 @@ import weco.pipeline.transformer.calm.models.CalmRecordOps
 object CalmFormat extends CalmRecordOps {
   def apply(record: CalmRecord): Format = {
     record.get("Material") match {
-      case Some("Archives - Digital") => Format.ArchivesDigital
+      case Some("Born-digital archives") => Format.ArchivesDigital
       case _                          => Format.ArchivesAndManuscripts
     }
   }

--- a/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/transformers/CalmFormatTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/transformers/CalmFormatTest.scala
@@ -15,15 +15,15 @@ class CalmFormatTest
     "Correctly extracts the ArchivesDigital Format when the appropriate Material string is present"
   ) {
     val digitalRecord = createCalmRecordWith(
-      ("Material", "Archives - Digital")
+      ("Material", "Born-digital archives")
     )
 
     val digitalFormat = CalmFormat(digitalRecord)
 
     digitalFormat shouldBe Format.ArchivesDigital
 
-    // Check that the label is "Archives - Digital"
-    Format.ArchivesDigital.label shouldBe ("Archives - Digital")
+    // Check that the label is "Born-digital archives"
+    Format.ArchivesDigital.label shouldBe ("Born-digital archives")
   }
 
   it("Defaults to ArchivesAndManuscripts for all other contents of Material") {


### PR DESCRIPTION
## What does this change?

https://github.com/wellcomecollection/catalogue-pipeline/issues/2742
Born-digital archives currently have a format label of `Archives - Digital`
We want it to be `Born-digital archives` 
see https://wellcome.slack.com/archives/C3TQSF63C/p1730476730751429

## How to test

[This](https://github.com/wellcomecollection/catalogue-pipeline/blob/main/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/transformers/CalmFormatTest.scala) is probably test enough 

## How can we measure success?

After the next reindex, all Born-digital archives (and the corresponding Format filter) should be labelled as such

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? -->

None that I can think of, simple string replacement

![image](https://github.com/user-attachments/assets/6a04b6cb-636d-435a-9007-3af4383ab3db)

