### PR TITLE
Use the Concept ontology type in TEI

### DIFF
--- a/pipeline/transformer/transformer_common/src/test/scala/weco/pipeline/transformer/generators/LabelDerivedIdentifiersGenerators.scala
+++ b/pipeline/transformer/transformer_common/src/test/scala/weco/pipeline/transformer/generators/LabelDerivedIdentifiersGenerators.scala
@@ -26,12 +26,12 @@ trait LabelDerivedIdentifiersGenerators {
       )
     )
 
-  def labelDerivedSubjectIdentifier(value: String): Identifiable =
+  def labelDerivedConceptIdentifier(value: String): Identifiable =
     IdState.Identifiable(
       sourceIdentifier = SourceIdentifier(
         identifierType = IdentifierType.LabelDerived,
         value = value,
-        ontologyType = "Subject"
+        ontologyType = "Concept"
       )
     )
 }

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiSubjects.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiSubjects.scala
@@ -56,12 +56,12 @@ object TeiSubjects extends LabelDerivedIdentifiers {
         IdState.Identifiable(
           sourceIdentifier = SourceIdentifier(
             identifierType = identifierType,
-            ontologyType = "Subject",
+            ontologyType = "Concept",
             value = value
           )
         )
       case _ =>
-        identifierFromText(label, ontologyType = "Subject")
+        identifierFromText(label, ontologyType = "Concept")
     }
   }
 

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiTransformerTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiTransformerTest.scala
@@ -82,7 +82,7 @@ class TeiTransformerTest
               id = Identifiable(
                 SourceIdentifier(
                   IdentifierType.LCSubjects,
-                  "Subject",
+                  "Concept",
                   "sh85083116"
                 )
               ),

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiXmlTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiXmlTest.scala
@@ -248,7 +248,7 @@ class TeiXmlTest
 
     result.value.subjects shouldBe List(
       Subject(
-        id = labelDerivedSubjectIdentifier("botany"),
+        id = labelDerivedConceptIdentifier("botany"),
         label = "Botany",
         concepts = List(Concept(label = "Botany"))
       )

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/transformers/TeiSubjectsTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/transformers/TeiSubjectsTest.scala
@@ -31,7 +31,7 @@ class TeiSubjectsTest
 
     result shouldBe List(
       Subject(
-        id = labelDerivedSubjectIdentifier("botany"),
+        id = labelDerivedConceptIdentifier("botany"),
         label = "Botany",
         concepts = List(Concept("Botany"))
       )
@@ -56,17 +56,17 @@ class TeiSubjectsTest
 
     result shouldBe List(
       Subject(
-        id = labelDerivedSubjectIdentifier("botany"),
+        id = labelDerivedConceptIdentifier("botany"),
         label = "Botany",
         concepts = List(Concept("Botany"))
       ),
       Subject(
-        id = labelDerivedSubjectIdentifier("computers"),
+        id = labelDerivedConceptIdentifier("computers"),
         label = "Computers",
         concepts = List(Concept("Computers"))
       ),
       Subject(
-        id = labelDerivedSubjectIdentifier("aliens"),
+        id = labelDerivedConceptIdentifier("aliens"),
         label = "Aliens",
         concepts = List(Concept("Aliens"))
       )
@@ -99,7 +99,7 @@ class TeiSubjectsTest
 
     result shouldBe List(
       Subject(
-        id = labelDerivedSubjectIdentifier("very fast cars"),
+        id = labelDerivedConceptIdentifier("very fast cars"),
         label = "Very fast cars",
         concepts = List(Concept("Very fast cars"))
       )
@@ -126,7 +126,7 @@ class TeiSubjectsTest
     result shouldBe List(
       Subject(
         id = Identifiable(
-          SourceIdentifier(IdentifierType.LCSubjects, "Subject", "sh12345")
+          SourceIdentifier(IdentifierType.LCSubjects, "Concept", "sh12345")
         ),
         label = "Botany",
         concepts = List(Concept(label = "Botany"))
@@ -156,7 +156,7 @@ class TeiSubjectsTest
     result shouldBe List(
       Subject(
         id = Identifiable(
-          SourceIdentifier(IdentifierType.LCSubjects, "Subject", "sh12345")
+          SourceIdentifier(IdentifierType.LCSubjects, "Concept", "sh12345")
         ),
         label = "Botany",
         concepts = List(Concept(label = "Botany"))
@@ -186,7 +186,7 @@ class TeiSubjectsTest
     result shouldBe List(
       Subject(
         id = Identifiable(
-          SourceIdentifier(IdentifierType.LCSubjects, "Subject", "sh12345")
+          SourceIdentifier(IdentifierType.LCSubjects, "Concept", "sh12345")
         ),
         label = "Botany",
         concepts = List(Concept(label = "Botany"))
@@ -215,7 +215,7 @@ class TeiSubjectsTest
     result shouldBe List(
       Subject(
         id = Identifiable(
-          SourceIdentifier(IdentifierType.LCSubjects, "Subject", "sh12345")
+          SourceIdentifier(IdentifierType.LCSubjects, "Concept", "sh12345")
         ),
         label = "Botany",
         concepts = List(Concept(label = "Botany"))
@@ -250,7 +250,7 @@ class TeiSubjectsTest
     result shouldBe List(
       Subject(
         id = Identifiable(
-          SourceIdentifier(IdentifierType.LCSubjects, "Subject", "sh85136100")
+          SourceIdentifier(IdentifierType.LCSubjects, "Concept", "sh85136100")
         ),
         label = "Torah scrolls",
         concepts = List(Concept(label = "Torah scrolls"))
@@ -279,7 +279,7 @@ class TeiSubjectsTest
     result shouldBe List(
       Subject(
         id = Identifiable(
-          SourceIdentifier(IdentifierType.MESH, "Subject", "D001901")
+          SourceIdentifier(IdentifierType.MESH, "Concept", "D001901")
         ),
         label = "Botany",
         concepts = List(Concept(label = "Botany"))
@@ -307,7 +307,7 @@ class TeiSubjectsTest
 
     result shouldBe List(
       Subject(
-        id = labelDerivedSubjectIdentifier("botany"),
+        id = labelDerivedConceptIdentifier("botany"),
         label = "Botany",
         concepts = List(Concept(label = "Botany"))
       )
@@ -333,7 +333,7 @@ class TeiSubjectsTest
 
     result shouldBe List(
       Subject(
-        id = labelDerivedSubjectIdentifier("botany"),
+        id = labelDerivedConceptIdentifier("botany"),
         label = "Botany",
         concepts = List(Concept(label = "Botany"))
       )
@@ -357,17 +357,17 @@ class TeiSubjectsTest
 
     result shouldBe List(
       Subject(
-        id = labelDerivedSubjectIdentifier("botany"),
+        id = labelDerivedConceptIdentifier("botany"),
         label = "Botany",
         concepts = List(Concept("Botany"))
       ),
       Subject(
-        id = labelDerivedSubjectIdentifier("computers"),
+        id = labelDerivedConceptIdentifier("computers"),
         label = "Computers",
         concepts = List(Concept("Computers"))
       ),
       Subject(
-        id = labelDerivedSubjectIdentifier("aliens"),
+        id = labelDerivedConceptIdentifier("aliens"),
         label = "Aliens",
         concepts = List(Concept("Aliens"))
       )


### PR DESCRIPTION
## What does this change?

This replaces the old Subject ontology type with Concept, to harmonise the data from TEI with the data from Sierra.

Resolves https://github.com/wellcomecollection/catalogue-pipeline/issues/2744

This fixes a problem where multiple canonical ids are minted for apparently identical concepts, where the subject of a Sierra record results in a Concept, but the subject of a TEI document results in a Subject, despite them both having the same source identifier and scheme (e.g. [LCSH:sh85008893](https://id.loc.gov/authorities/sh85008893)) 

The ID Minter distinguishes between identifiers based on three values - the value and scheme and also (inappropriately, IMO) the type.  

## How to test

This is a pretty well isolated and tested area, so the unit tests provide a good level of confidence.

The next step would be to run the TEI content through the transformer and see that no Subjects appear.

## How can we measure success?

When we next run a full refresh of the Concept Store, the number of records will fall, and there will be fewer records with identifiers in their sameAs lists.

## Have we considered potential risks?

This will result in the `Subject` canonical ids disappearing from the ConceptStore, so the corresponding Concept pages will cease to exist.  This violates the [Cool URIs](https://www.w3.org/Provider/Style/URI) principle, but arguably, those URIs should not have existed in the first place, as IMO they were created in error.

However, someone may have bookmarked these URLs, and will now be displeased that the page has vanished.  I think this is a very unlikely scenario, given the research we have recently done on concept page usage.
