### PR TITLE
Target main not batcher script in Dockerfile

### DIFF
--- a/pipeline/relation_embedder/batcher/Dockerfile
+++ b/pipeline/relation_embedder/batcher/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /opt/docker
 
 FROM base AS ecs
 
-ENTRYPOINT ["/opt/docker/bin/batcher"]
+ENTRYPOINT ["/opt/docker/bin/main"]
 
 FROM base AS lambda_rie
 ADD https://github.com/aws/aws-lambda-runtime-interface-emulator/releases/download/v1.22/aws-lambda-rie /aws-lambda/aws-lambda-rie

--- a/pipeline/terraform/modules/stack/service_work_batcher.tf
+++ b/pipeline/terraform/modules/stack/service_work_batcher.tf
@@ -66,7 +66,7 @@ module "batcher" {
   // Override entrypoint & command to dual use lambda container image
   // This should be removed once we have a dedicated batcher_lambda image
   entrypoint = [
-    "/opt/docker/bin/batcher"
+    "/opt/docker/bin/main"
   ]
   command = null
 


### PR DESCRIPTION
## What does this change?

Follows: https://github.com/wellcomecollection/catalogue-pipeline/pull/2735

This change updates the Dockerfile, and terraform for the batcher service to target the `main` script rather than the `batcher` script generated by native packager in order to specify the appropriate entrypoint now there are multiple objects that extend `App`.

See[ this thread ](https://wellcome.slack.com/archives/CQ720BG02/p1730936600708739) for the issue currently being caused.

The terraform change here will also need to be applied.

## How to test

- [x] Build the container locally and override the entrypoint.

## How can we measure success?

The Batcher service starts as expected when deployed

## Have we considered potential risks?

The terraform change also updates the production pipeline, but as that image is the same in both pipelines should not impact running.
