### PR TITLE
Add queue config for pipeline lambda

### DIFF
--- a/pipeline/terraform/2024-11-05/main.tf
+++ b/pipeline/terraform/2024-11-05/main.tf
@@ -2,7 +2,7 @@ module "pipeline" {
   source = "../modules/stack"
 
   reindexing_state = {
-    listen_to_reindexer      = false
+    listen_to_reindexer      = true
     scale_up_tasks           = false
     scale_up_elastic_cluster = false
     scale_up_id_minter_db    = false

--- a/pipeline/terraform/modules/pipeline_lambda/outputs.tf
+++ b/pipeline/terraform/modules/pipeline_lambda/outputs.tf
@@ -1,3 +1,7 @@
 output "lambda_role_name" {
   value = module.pipeline_step.lambda_role.name
 }
+
+output "queue_url" {
+  value = module.input_queue.url
+}

--- a/pipeline/terraform/modules/pipeline_lambda/variables.tf
+++ b/pipeline/terraform/modules/pipeline_lambda/variables.tf
@@ -61,3 +61,4 @@ variable "event_source_enabled" {
   type    = bool
   default = true
 }
+

--- a/pipeline/terraform/modules/stack/service_work_batcher.tf
+++ b/pipeline/terraform/modules/stack/service_work_batcher.tf
@@ -52,7 +52,13 @@ module "batcher_lambda" {
     max_batch_size = 40
   }
 
-  queue_config = {}
+  queue_config = {
+    topic_arns = [
+      module.router_path_output_topic.arn,
+      module.path_concatenator_output_topic.arn,
+    ]
+    visibility_timeout_seconds = (local.wait_minutes + 5) * 60
+  }
 
   ecr_repository_name = "uk.ac.wellcome/batcher"
 }


### PR DESCRIPTION
> [!Note]
> This terraform change is applied.

## What does this change?

Part of https://github.com/wellcomecollection/platform/issues/5794

Subscribes the batcher lambda queue to the correct upstream topics so that it can start processing work

## How to test

- [ ] Apply this terraform, can we see the queues subscribed to the correct topics?

## How can we measure success?

- [ ] The batcher lambda can be seen to do work so we can test its performance.

## Have we considered potential risks?

The risks should be minimal as the batcher lambda is not influencing downstream services.
