### PR TITLE
Fix labelling archive-digital

### DIFF
--- a/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/transformers/CalmFormat.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/transformers/CalmFormat.scala
@@ -7,8 +7,8 @@ import weco.pipeline.transformer.calm.models.CalmRecordOps
 object CalmFormat extends CalmRecordOps {
   def apply(record: CalmRecord): Format = {
     record.get("Material") match {
-      case Some("Born-digital archives") => Format.ArchivesDigital
-      case _                             => Format.ArchivesAndManuscripts
+      case Some("Archives - Digital") => Format.ArchivesDigital
+      case _                          => Format.ArchivesAndManuscripts
     }
   }
 }

--- a/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/transformers/CalmFormatTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/transformers/CalmFormatTest.scala
@@ -15,7 +15,7 @@ class CalmFormatTest
     "Correctly extracts the ArchivesDigital Format when the appropriate Material string is present"
   ) {
     val digitalRecord = createCalmRecordWith(
-      ("Material", "Born-digital archives")
+      ("Material", "Archives - Digital")
     )
 
     val digitalFormat = CalmFormat(digitalRecord)


### PR DESCRIPTION
## What does this change?

Follows https://github.com/wellcomecollection/catalogue-pipeline/pull/2743, https://github.com/wellcomecollection/catalogue-pipeline/pull/2758

Part of https://github.com/wellcomecollection/platform/issues/5794

Fixes matching on incorrect label.

## How to test

- [ ] Run the tests, do they pass?

## How can we measure success?

Correct label on born-digital format works.

## Have we considered potential risks?

Minimal. Needs to be incorporated as part of a reindex.
