### PR TITLE
Add tests for extracting paths from message in lambda batcher

### DIFF
--- a/pipeline/relation_embedder/batcher/src/main/scala/weco/pipeline/batcher/LambdaMain.scala
+++ b/pipeline/relation_embedder/batcher/src/main/scala/weco/pipeline/batcher/LambdaMain.scala
@@ -47,4 +47,3 @@ object LambdaMain extends RequestHandler[SQSEvent, String] with Logging {
     override def notify(batch: Batch): Try[Unit] = msgSender.sendT(batch)
   }
 }
-

--- a/pipeline/relation_embedder/batcher/src/main/scala/weco/pipeline/batcher/LambdaMain.scala
+++ b/pipeline/relation_embedder/batcher/src/main/scala/weco/pipeline/batcher/LambdaMain.scala
@@ -3,18 +3,18 @@ package weco.pipeline.batcher
 import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
 import grizzled.slf4j.Logging
 import com.amazonaws.services.lambda.runtime.events.SQSEvent
-import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage
 import org.apache.pekko.actor.ActorSystem
 import weco.messaging.typesafe.SNSBuilder
 import weco.json.JsonUtil._
 import com.typesafe.config.ConfigFactory
 import weco.typesafe.config.builders.EnrichConfig.RichConfig
 
-import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 import scala.util.Try
 
 object LambdaMain extends RequestHandler[SQSEvent, String] with Logging {
+  import weco.pipeline.batcher.lib.SQSEventOps._
+
   private val config = ConfigFactory.load("application")
 
   private val downstream = config.getString("batcher.use_downstream") match {
@@ -35,27 +35,11 @@ object LambdaMain extends RequestHandler[SQSEvent, String] with Logging {
 
     PathsProcessor(
       config.requireInt("batcher.max_batch_size"),
-      extractPathsFromEvent(event),
+      event.extractPaths,
       downstream
     )
     "Done"
   }
-
-  /** Messages consumed by this Lambda are taken from a queue populated by an
-    * SNS topic. The actual message we are interested in is a String containing
-    * the path. However, the matryoshka-like nature of these things means the
-    * lambda receives
-    *   - an event containing
-    *   - a `Records` list, each Record containing
-    *   - an SQS Message with a JSON body containing
-    *   - an SNS notification containing
-    *   - a `Message`, which is the actual content we want
-    */
-  private def extractPathsFromEvent(event: SQSEvent): List[String] =
-    event.getRecords.asScala.toList.flatMap(extractPathFromMessage)
-
-  private def extractPathFromMessage(message: SQSMessage): Option[String] =
-    ujson.read(message.getBody).obj.get("Message").map(_.toString)
 
   private object SNSDownstream extends Downstream {
     private val msgSender = SNSBuilder
@@ -63,3 +47,4 @@ object LambdaMain extends RequestHandler[SQSEvent, String] with Logging {
     override def notify(batch: Batch): Try[Unit] = msgSender.sendT(batch)
   }
 }
+

--- a/pipeline/relation_embedder/batcher/src/main/scala/weco/pipeline/batcher/lib/SQSEventOps.scala
+++ b/pipeline/relation_embedder/batcher/src/main/scala/weco/pipeline/batcher/lib/SQSEventOps.scala
@@ -1,0 +1,25 @@
+package weco.pipeline.batcher.lib
+
+import com.amazonaws.services.lambda.runtime.events.SQSEvent
+import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage
+import scala.collection.JavaConverters._
+
+object SQSEventOps {
+  /** Messages consumed by Lambda from SQS are taken from a queue populated by an
+   * SNS topic. The actual message we are interested in is a String containing
+   * the path. However, the matryoshka-like nature of these things means the
+   * lambda receives
+   *   - an event containing
+   *   - a `Records` list, each Record containing
+   *   - an SQS Message with a JSON body containing
+   *   - an SNS notification containing
+   *   - a `Message`, which is the actual content we want
+   */
+  implicit class ExtractPathFromSqsEvent(event: SQSEvent) {
+    def extractPaths: List[String] =
+      event.getRecords.asScala.toList.flatMap(extractPathFromMessage)
+
+    private def extractPathFromMessage(message: SQSMessage): Option[String] =
+      ujson.read(message.getBody).obj.get("Message").flatMap(_.strOpt)
+  }
+}

--- a/pipeline/relation_embedder/batcher/src/main/scala/weco/pipeline/batcher/lib/SQSEventOps.scala
+++ b/pipeline/relation_embedder/batcher/src/main/scala/weco/pipeline/batcher/lib/SQSEventOps.scala
@@ -5,16 +5,17 @@ import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage
 import scala.collection.JavaConverters._
 
 object SQSEventOps {
-  /** Messages consumed by Lambda from SQS are taken from a queue populated by an
-   * SNS topic. The actual message we are interested in is a String containing
-   * the path. However, the matryoshka-like nature of these things means the
-   * lambda receives
-   *   - an event containing
-   *   - a `Records` list, each Record containing
-   *   - an SQS Message with a JSON body containing
-   *   - an SNS notification containing
-   *   - a `Message`, which is the actual content we want
-   */
+
+  /** Messages consumed by Lambda from SQS are taken from a queue populated by
+    * an SNS topic. The actual message we are interested in is a String
+    * containing the path. However, the matryoshka-like nature of these things
+    * means the lambda receives
+    *   - an event containing
+    *   - a `Records` list, each Record containing
+    *   - an SQS Message with a JSON body containing
+    *   - an SNS notification containing
+    *   - a `Message`, which is the actual content we want
+    */
   implicit class ExtractPathFromSqsEvent(event: SQSEvent) {
     def extractPaths: List[String] =
       event.getRecords.asScala.toList.flatMap(extractPathFromMessage)

--- a/pipeline/relation_embedder/batcher/src/test/scala/weco/pipeline/batcher/SQSEventOpsTest.scala
+++ b/pipeline/relation_embedder/batcher/src/test/scala/weco/pipeline/batcher/SQSEventOpsTest.scala
@@ -1,0 +1,24 @@
+package weco.pipeline.batcher
+
+import com.amazonaws.services.lambda.runtime.events.SQSEvent
+import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import scala.collection.JavaConverters._
+
+class SQSEventOpsTest extends AnyFunSpec with Matchers {
+  import lib.SQSEventOps._
+
+  describe("Using the implicit class SQSEventOps") {
+    it("extracts paths from an SQSEvent") {
+      val fakeMessage = new SQSMessage()
+        fakeMessage.setBody("{\"Message\":\"A/C\"}")
+      val fakeSQSEvent = new SQSEvent()
+        fakeSQSEvent.setRecords(List(fakeMessage).asJava)
+
+      val paths = fakeSQSEvent.extractPaths
+
+      paths shouldBe List("A/C")
+    }
+  }
+}


### PR DESCRIPTION
## What does this change?

Follows https://github.com/wellcomecollection/catalogue-pipeline/pull/2754, https://github.com/wellcomecollection/catalogue-pipeline/pull/2758

Part of https://github.com/wellcomecollection/platform/issues/5794

This change makes sure that path strings are properly formatted as strings, given the unexpected behaviour of the `ujson` library parsing string values to `"quoted"` rather than `unquoted` string values.

We add tests here to ensure the behaviour is as expected.

## How to test

- [ ] Run the tests, do they pass?

## How can we measure success?

Paths are correctly parsed as unquoted strings, resulting in output from the service being correct.

## Have we considered potential risks?

This should have minimal impact as this is only used in the lambda version of the batcher, which is not yet in production use.
