### PR TITLE
Debug level log event in lambda batcher

### DIFF
--- a/pipeline/relation_embedder/batcher/src/main/scala/weco/pipeline/batcher/LambdaMain.scala
+++ b/pipeline/relation_embedder/batcher/src/main/scala/weco/pipeline/batcher/LambdaMain.scala
@@ -26,7 +26,7 @@ object LambdaMain extends RequestHandler[SQSEvent, String] with Logging {
     event: SQSEvent,
     context: Context
   ): String = {
-    info(s"running batcher lambda, got event: $event")
+    debug(s"Running batcher lambda, got event: $event")
 
     implicit val actorSystem: ActorSystem =
       ActorSystem("main-actor-system")
@@ -38,6 +38,7 @@ object LambdaMain extends RequestHandler[SQSEvent, String] with Logging {
       extractPathsFromEvent(event),
       downstream
     )
+
     "Done"
   }
 


### PR DESCRIPTION
## What does this change?

Part of https://github.com/wellcomecollection/platform/issues/5794

Follows https://github.com/wellcomecollection/catalogue-pipeline/pull/2758

Don't log event at info level in production, or it will be quite expensive as we use CloudWatch logs for lambdas!

## How to test

- [ ] Deploy this change, run a test event, can you see it in the logs?

## How can we measure success?

Cheaper logging!

## Have we considered potential risks?

This is only a change to logging, so the risk should be minimal.
