### PR TITLE
More debug logs in lambda batcher

### DIFF
--- a/pipeline/relation_embedder/batcher/src/main/scala/weco/pipeline/batcher/PathsProcessor.scala
+++ b/pipeline/relation_embedder/batcher/src/main/scala/weco/pipeline/batcher/PathsProcessor.scala
@@ -53,19 +53,19 @@ object PathsProcessor extends Logging {
   ): Source[(Batch, List[Long]), NotUsed] = {
     val selectors = Selector.forPaths(paths)
     val groupedSelectors = selectors.groupBy(_._1.rootPath)
-    info(
+    debug(
       s"Generated ${selectors.size} selectors spanning ${groupedSelectors.size} trees from ${paths.size} paths."
     )
     paths.sorted.grouped(1000).toList.zipWithIndex.foreach {
       case (paths, idx) =>
         val startIdx = idx * 1000 + 1
-        info(
+        debug(
           s"Input paths ($startIdx-${startIdx + paths.length - 1}): ${paths.mkString(", ")}"
         )
     }
     groupedSelectors.foreach {
       case (rootPath, selectors) =>
-        info(
+        debug(
           s"Selectors for root path $rootPath: ${selectors.map(_._1).mkString(", ")}"
         )
     }


### PR DESCRIPTION
## What does this change?

Follows https://github.com/wellcomecollection/catalogue-pipeline/pull/2759

Quietens the batcher a bit more!

## How to test

- [ ] Is less logs, good!?

## How can we measure success?

Less logs please.

## Have we considered potential risks?

MInimal, only a logging change.
