### PR TITLE
keep lambda warm to allow pekko to publish

### DIFF
--- a/pipeline/relation_embedder/batcher/src/main/scala/weco/pipeline/batcher/LambdaMain.scala
+++ b/pipeline/relation_embedder/batcher/src/main/scala/weco/pipeline/batcher/LambdaMain.scala
@@ -8,7 +8,8 @@ import weco.messaging.typesafe.SNSBuilder
 import weco.json.JsonUtil._
 import com.typesafe.config.ConfigFactory
 import weco.typesafe.config.builders.EnrichConfig.RichConfig
-
+import scala.concurrent.Await
+import scala.concurrent.duration.DurationInt
 import scala.concurrent.ExecutionContext
 import scala.util.Try
 
@@ -16,11 +17,6 @@ object LambdaMain extends RequestHandler[SQSEvent, String] with Logging {
   import weco.pipeline.batcher.lib.SQSEventOps._
 
   private val config = ConfigFactory.load("application")
-
-  private val downstream = config.getString("batcher.use_downstream") match {
-    case "sns"   => SNSDownstream
-    case "stdio" => STDIODownstream
-  }
 
   override def handleRequest(
     event: SQSEvent,
@@ -33,18 +29,23 @@ object LambdaMain extends RequestHandler[SQSEvent, String] with Logging {
     implicit val ec: ExecutionContext =
       actorSystem.dispatcher
 
-    PathsProcessor(
+    object SNSDownstream extends Downstream {
+      private val msgSender = SNSBuilder
+        .buildSNSMessageSender(config, subject = "Sent from batcher")
+      override def notify(batch: Batch): Try[Unit] = msgSender.sendT(batch)
+    }
+
+    val downstream = config.getString("batcher.use_downstream") match {
+      case "sns"   => SNSDownstream
+      case "stdio" => STDIODownstream
+    }
+
+    val f = PathsProcessor(
       config.requireInt("batcher.max_batch_size"),
       event.extractPaths,
       downstream
     )
-
+    Await.result(f, 15.minutes)
     "Done"
-  }
-
-  private object SNSDownstream extends Downstream {
-    private val msgSender = SNSBuilder
-      .buildSNSMessageSender(config, subject = "Sent from batcher")
-    override def notify(batch: Batch): Try[Unit] = msgSender.sendT(batch)
   }
 }

--- a/pipeline/terraform/modules/stack/service_work_batcher.tf
+++ b/pipeline/terraform/modules/stack/service_work_batcher.tf
@@ -59,7 +59,7 @@ module "batcher_lambda" {
       module.router_path_output_topic.arn,
       module.path_concatenator_output_topic.arn,
     ]
-    visibility_timeout_seconds = (local.wait_minutes + 5) * 60
+    visibility_timeout_seconds = (local.wait_minutes + 9) * 60
 
     maximum_concurrency     = 20
     batch_size              = 2500


### PR DESCRIPTION
## What does this change?

Not waiting for the Future to complete caused failure to publish downstream notifications in some scenario 
https://wellcome.slack.com/archives/C02ANCYL90E/p1731662840990099
Also increased the `visibility_timeout_seconds` for the input queue. It was fine in reindexing mode (25 + 5) but scaled down, the `visibility_timeout_seconds` ended up being shorter (1 + 5) than the lambda timeout (10)

## How to test

The lambda batcher is still not wired to the relation embedder. We can deploy and test that it works in the live environment

## How can we measure success?

The lambda batcher is able to Do The Thing even when it's dealing with low volume of input 

## Have we considered potential risks?

The lambda batcher is still not wired to the relation embedder
