### PR TITLE
terraform tweaks for batcher lambda

### DIFF
--- a/pipeline/relation_embedder/batcher/src/main/scala/weco/pipeline/batcher/LambdaMain.scala
+++ b/pipeline/relation_embedder/batcher/src/main/scala/weco/pipeline/batcher/LambdaMain.scala
@@ -45,7 +45,11 @@ object LambdaMain extends RequestHandler[SQSEvent, String] with Logging {
       event.extractPaths,
       downstream
     )
+
+    // Wait here so that lambda can finish executing correctly.
+    // 15 minutes is the maximum time allowed for a lambda to run.
     Await.result(f, 15.minutes)
+
     "Done"
   }
 }


### PR DESCRIPTION
## What does this change?

Follows https://github.com/wellcomecollection/catalogue-pipeline/pull/2763

This change makes the lambda timeout the same as the message visibility timeout, reasoning that the lambda should not hang onto a message longer than its maximum runtime. We also set some environment variables to indicate they are unused.

## How to test

- [ ] Apply the terraform, does the lambda update and behave as expected?

## How can we measure success?

Easier to understand code.

## Have we considered potential risks?

Should be minimal as the batch lambda isn't wired into anything yet.
