### PR TITLE
Reinstate info logs in path processor

### DIFF
--- a/pipeline/relation_embedder/batcher/src/main/scala/weco/pipeline/batcher/PathsProcessor.scala
+++ b/pipeline/relation_embedder/batcher/src/main/scala/weco/pipeline/batcher/PathsProcessor.scala
@@ -53,19 +53,19 @@ object PathsProcessor extends Logging {
   ): Source[(Batch, List[Long]), NotUsed] = {
     val selectors = Selector.forPaths(paths)
     val groupedSelectors = selectors.groupBy(_._1.rootPath)
-    debug(
+    info(
       s"Generated ${selectors.size} selectors spanning ${groupedSelectors.size} trees from ${paths.size} paths."
     )
     paths.sorted.grouped(1000).toList.zipWithIndex.foreach {
       case (paths, idx) =>
         val startIdx = idx * 1000 + 1
-        debug(
+        info(
           s"Input paths ($startIdx-${startIdx + paths.length - 1}): ${paths.mkString(", ")}"
         )
     }
     groupedSelectors.foreach {
       case (rootPath, selectors) =>
-        debug(
+        info(
           s"Selectors for root path $rootPath: ${selectors.map(_._1).mkString(", ")}"
         )
     }


### PR DESCRIPTION
## What does this change?

This change reinstates the logs removed by https://github.com/wellcomecollection/catalogue-pipeline/pull/2760, as they are not considerable expense during a reindex after reviewing recent costs.

Follows https://github.com/wellcomecollection/catalogue-pipeline/pull/2760

## How to test

- [ ] Deploy the changes, can you see the logs appearing?

## How can we measure success?

Better view of what's going on in a service.

## Have we considered potential risks?

We only stopped the logs after processing a portion of the reindex, that could be masking unexpected costs, but the billing data makes it look like we don't need to worry it will be exorbitant.
