### PR TITLE
relation_embedder subscribes to batcher_lambda_output_topic

### DIFF
--- a/pipeline/terraform/modules/stack/service_work_relation_embedder.tf
+++ b/pipeline/terraform/modules/stack/service_work_relation_embedder.tf
@@ -12,7 +12,7 @@ module "relation_embedder" {
   container_image = local.relation_embedder_image
 
   topic_arns = [
-    module.batcher_output_topic.arn,
+    module.batcher_lambda_output_topic.arn
   ]
 
   # We know that 10 minutes is too short; some big archives can't be


### PR DESCRIPTION
## What does this change?

The relation_embedder will get its input from the `batcher_lambda_output` topic instead of the `batcher_output` topic following the [deployment of the batcher lambda](https://github.com/wellcomecollection/platform/issues/5794)

## How to test

Once applied, the `catalogue-2024-11-05_relation_embedder_input` will have only one subscription, to `arn:aws:sns:eu-west-1:760097843905:catalogue-2024-11-05_batcher_lambda_output` 

## How can we measure success?

The `relation_embedder` gets messages from the lambda batcher and does its thing just like before

## Have we considered potential risks?

Monitor the `relation_embedder` for any funny business. The real test will be next time we do a reindex of the `2024-11-05` pipeline, right now risk is low as only a few messages trickle through daily

### terraform plan output

```
Terraform will perform the following actions:

  # module.pipeline.module.batcher_lambda.aws_lambda_event_source_mapping.event_source_mapping will be updated in-place
  ~ resource "aws_lambda_event_source_mapping" "event_source_mapping" {
      ~ batch_size                         = 10000 -> 2500
        id                                 = "fd22f3ce-3873-4f3c-94c0-babfa58c5d34"
      ~ maximum_batching_window_in_seconds = 300 -> 60
        tags                               = {}
        # (22 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

  # module.pipeline.module.relation_embedder.module.scaling_service.aws_iam_role_policy.read_from_q will be updated in-place
  ~ resource "aws_iam_role_policy" "read_from_q" {
        id          = "catalogue-2024-11-05_relation_embedder_task_role:terraform-20241105164012274700000033"
        name        = "terraform-20241105164012274700000033"
      ~ policy      = jsonencode(
            {
              - Statement = [
                  - {
                      - Action   = [
                          - "sqs:ReceiveMessage",
                          - "sqs:DeleteMessage",
                          - "sqs:ChangeMessageVisibilityBatch",
                          - "sqs:ChangeMessageVisibility",
                        ]
                      - Effect   = "Allow"
                      - Resource = "arn:aws:sqs:eu-west-1:760097843905:catalogue-2024-11-05_relation_embedder_input"
                    },
                ]
              - Version   = "2012-10-17"
            }
        ) -> (known after apply)
        # (2 unchanged attributes hidden)
    }

  # module.pipeline.module.relation_embedder.module.scaling_service.module.input_queue.data.aws_iam_policy_document.read_from_queue will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "aws_iam_policy_document" "read_from_queue" {
      + id            = (known after apply)
      + json          = (known after apply)
      + minified_json = (known after apply)

      + statement {
          + actions   = [
              + "sqs:ChangeMessageVisibility",
              + "sqs:ChangeMessageVisibilityBatch",
              + "sqs:DeleteMessage",
              + "sqs:ReceiveMessage",
            ]
          + resources = [
              + "arn:aws:sqs:eu-west-1:760097843905:catalogue-2024-11-05_relation_embedder_input",
            ]
        }
    }

  # module.pipeline.module.relation_embedder.module.scaling_service.module.input_queue.aws_sns_topic_subscription.sns_topic[0] must be replaced
-/+ resource "aws_sns_topic_subscription" "sns_topic" {
      ~ arn                             = "arn:aws:sns:eu-west-1:760097843905:catalogue-2024-11-05_batcher_output:0b2fb2a0-a1f5-4802-ae95-3cc216ee079e" -> (known after apply)
      ~ confirmation_was_authenticated  = true -> (known after apply)
      + filter_policy_scope             = (known after apply)
      ~ id                              = "arn:aws:sns:eu-west-1:760097843905:catalogue-2024-11-05_batcher_output:0b2fb2a0-a1f5-4802-ae95-3cc216ee079e" -> (known after apply)
      ~ owner_id                        = "760097843905" -> (known after apply)
      ~ pending_confirmation            = false -> (known after apply)
      ~ topic_arn                       = "arn:aws:sns:eu-west-1:760097843905:catalogue-2024-11-05_batcher_output" -> "arn:aws:sns:eu-west-1:760097843905:catalogue-2024-11-05_batcher_lambda_output" # forces replacement
        # (10 unchanged attributes hidden)
    }

  # module.pipeline.module.relation_embedder.module.scaling_service.module.input_queue.aws_sqs_queue.q will be updated in-place
  ~ resource "aws_sqs_queue" "q" {
        id                                = "https://sqs.eu-west-1.amazonaws.com/760097843905/catalogue-2024-11-05_relation_embedder_input"
        name                              = "catalogue-2024-11-05_relation_embedder_input"
      ~ policy                            = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Condition = {
                          ~ ArnEquals = {
                              ~ "aws:SourceArn" = "arn:aws:sns:eu-west-1:760097843905:catalogue-2024-11-05_batcher_output" -> "arn:aws:sns:eu-west-1:760097843905:catalogue-2024-11-05_batcher_lambda_output"
                            }
                        }
                        # (5 unchanged attributes hidden)
                    },
                ]
                # (1 unchanged attribute hidden)
            }
        )
        tags                              = {}
        # (18 unchanged attributes hidden)
    }

Plan: 1 to add, 3 to change, 1 to destroy.
```
