### PR TITLE
Lambda batcher config tweaks

### DIFF
--- a/pipeline/terraform/modules/stack/service_work_batcher.tf
+++ b/pipeline/terraform/modules/stack/service_work_batcher.tf
@@ -22,7 +22,13 @@ locals {
   # See https://aws.amazon.com/sqs/faqs/ "Q: How large can Amazon SQS message queues be?"
   max_processed_paths = var.reindexing_state.scale_up_tasks ? 120000 : 5000
 
-  lambda_timeout = 60 * 10 # 10 Minutes
+  # Lambda specific settings
+  # ------------------------
+  lambda_timeout_seconds      = 60 * 10 # 10 Minutes
+  # This value should be higher than or equal to the lambda timeout, to avoid messages being reprocessed.
+  lamda_q_vis_timeout_seconds = local.lambda_timeout_seconds
+  # How long to wait to accumulate message: 5 minutes during reindexing, 1 minute otherwise
+  batching_window_seconds     = var.reindexing_state.scale_up_tasks ? (60 * 5) : 60
 }
 
 module "batcher_output_topic" {
@@ -54,18 +60,19 @@ module "batcher_lambda" {
     max_processed_paths    = 0
   }
 
-  timeout = local.lambda_timeout
+  timeout = local.lambda_timeout_seconds
 
   queue_config = {
     topic_arns = [
       module.router_path_output_topic.arn,
       module.path_concatenator_output_topic.arn,
     ]
-    visibility_timeout_seconds = local.lambda_timeout
+    max_receive_count   = 1
+    maximum_concurrency = 20
+    batch_size          = 2500
 
-    maximum_concurrency     = 20
-    batch_size              = 2500
-    batching_window_seconds = 60
+    visibility_timeout_seconds = local.lamda_q_vis_timeout_seconds
+    batching_window_seconds    = local.batching_window_seconds
   }
 
   ecr_repository_name = "uk.ac.wellcome/batcher"

--- a/pipeline/terraform/modules/stack/service_work_batcher.tf
+++ b/pipeline/terraform/modules/stack/service_work_batcher.tf
@@ -24,11 +24,11 @@ locals {
 
   # Lambda specific settings
   # ------------------------
-  lambda_timeout_seconds      = 60 * 10 # 10 Minutes
+  lambda_timeout_seconds = 60 * 10 # 10 Minutes
   # This value should be higher than or equal to the lambda timeout, to avoid messages being reprocessed.
   lamda_q_vis_timeout_seconds = local.lambda_timeout_seconds
   # How long to wait to accumulate message: 5 minutes during reindexing, 1 minute otherwise
-  batching_window_seconds     = var.reindexing_state.scale_up_tasks ? (60 * 5) : 60
+  batching_window_seconds = var.reindexing_state.scale_up_tasks ? (60 * 5) : 60
 }
 
 module "batcher_output_topic" {

--- a/pipeline/terraform/modules/stack/service_work_batcher.tf
+++ b/pipeline/terraform/modules/stack/service_work_batcher.tf
@@ -69,7 +69,7 @@ module "batcher_lambda" {
     ]
     max_receive_count   = 1
     maximum_concurrency = 20
-    batch_size          = 2500
+    batch_size          = 10000
 
     visibility_timeout_seconds = local.lamda_q_vis_timeout_seconds
     batching_window_seconds    = local.batching_window_seconds


### PR DESCRIPTION
> [!Note]
> This terraform change is applied.

## What does this change?

Resolves: https://github.com/wellcomecollection/platform/issues/5824

This change:
- Varies the amount of time taken to accumulate messages during a reindex vs normal operation (60 seconds normally, 5 minutes in a reindex), in order to allow better batching performance when we know there will be more messages and to allow messages to pass through quickly in normal operation.
- Reduces the number of retries that it takes for a message to end up on the DLQ to 1 - the batcher should (mostly) fail deterministically as it is not talking to a data store, in order to reduce the amount of time errors are hidden for.

### `terraform plan`

```
  # module.pipeline.module.batcher_lambda.aws_lambda_event_source_mapping.event_source_mapping will be updated in-place
  ~ resource "aws_lambda_event_source_mapping" "event_source_mapping" {
      ~ batch_size                         = 10000 -> 2500
        id                                 = "fd22f3ce-3873-4f3c-94c0-babfa58c5d34"
      ~ maximum_batching_window_in_seconds = 300 -> 60
        tags                               = {}
        # (22 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

  # module.pipeline.module.batcher_lambda.module.input_queue.data.aws_iam_policy_document.read_from_queue will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "aws_iam_policy_document" "read_from_queue" {
      + id            = (known after apply)
      + json          = (known after apply)
      + minified_json = (known after apply)

      + statement {
          + actions   = [
              + "sqs:ChangeMessageVisibility",
              + "sqs:ChangeMessageVisibilityBatch",
              + "sqs:DeleteMessage",
              + "sqs:ReceiveMessage",
            ]
          + resources = [
              + "arn:aws:sqs:eu-west-1:760097843905:catalogue-2024-11-05-batcher_lambda_input",
            ]
        }
    }

  # module.pipeline.module.batcher_lambda.module.input_queue.aws_sqs_queue.q will be updated in-place
  ~ resource "aws_sqs_queue" "q" {
        id                                = "https://sqs.eu-west-1.amazonaws.com/760097843905/catalogue-2024-11-05-batcher_lambda_input"
        name                              = "catalogue-2024-11-05-batcher_lambda_input"
      ~ redrive_policy                    = jsonencode(
          ~ {
              ~ maxReceiveCount     = 4 -> 1
                # (1 unchanged attribute hidden)
            }
        )
        tags                              = {}
        # (18 unchanged attributes hidden)
    }

Plan: 0 to add, 2 to change, 0 to destroy.
```

## How to test

- [ ] Deploy this change, does the batcher behave as expected?

## How can we measure success?

Better lambda performance.

## Have we considered potential risks?

Risks should be minimal as the service is not yet in use, and an outage even when it is does not cause an immediate user facing issue and should be made visible by existing mechanisms.
