### PR TITLE
Add concept ids for archive subject concepts

### DIFF
--- a/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/CalmTransformer.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/CalmTransformer.scala
@@ -2,14 +2,21 @@ package weco.pipeline.transformer.calm
 
 import grizzled.slf4j.Logging
 import weco.catalogue.internal_model.identifiers._
-import weco.catalogue.internal_model.work.DeletedReason.{DeletedFromSource, SuppressedFromSource}
+import weco.catalogue.internal_model.work.DeletedReason.{
+  DeletedFromSource,
+  SuppressedFromSource
+}
 import weco.catalogue.internal_model.work.InvisibilityReason._
 import weco.catalogue.internal_model.work.WorkState.Source
 import weco.catalogue.internal_model.work._
 import weco.catalogue.source_model.calm.CalmRecord
 import weco.pipeline.transformer.Transformer
 import weco.pipeline.transformer.calm.models.CalmTransformerException._
-import weco.pipeline.transformer.calm.models.{CalmRecordOps, CalmSourceData, CalmTransformerException}
+import weco.pipeline.transformer.calm.models.{
+  CalmRecordOps,
+  CalmSourceData,
+  CalmTransformerException
+}
 import weco.pipeline.transformer.calm.transformers._
 import weco.pipeline.transformer.result.Result
 import weco.pipeline.transformer.transformers.ParsedPeriod

--- a/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/CalmTransformer.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/CalmTransformer.scala
@@ -2,21 +2,14 @@ package weco.pipeline.transformer.calm
 
 import grizzled.slf4j.Logging
 import weco.catalogue.internal_model.identifiers._
-import weco.catalogue.internal_model.work.DeletedReason.{
-  DeletedFromSource,
-  SuppressedFromSource
-}
+import weco.catalogue.internal_model.work.DeletedReason.{DeletedFromSource, SuppressedFromSource}
 import weco.catalogue.internal_model.work.InvisibilityReason._
 import weco.catalogue.internal_model.work.WorkState.Source
 import weco.catalogue.internal_model.work._
 import weco.catalogue.source_model.calm.CalmRecord
 import weco.pipeline.transformer.Transformer
 import weco.pipeline.transformer.calm.models.CalmTransformerException._
-import weco.pipeline.transformer.calm.models.{
-  CalmRecordOps,
-  CalmSourceData,
-  CalmTransformerException
-}
+import weco.pipeline.transformer.calm.models.{CalmRecordOps, CalmSourceData, CalmTransformerException}
 import weco.pipeline.transformer.calm.transformers._
 import weco.pipeline.transformer.result.Result
 import weco.pipeline.transformer.transformers.ParsedPeriod
@@ -154,7 +147,7 @@ object CalmTransformer
       format = Some(CalmFormat(record)),
       collectionPath = Some(collectionPath),
       referenceNumber = collectionPath.label.map(ReferenceNumber(_)),
-      subjects = subjects(record),
+      subjects = CalmSubjects(record),
       languages = languages,
       items = CalmItems(record),
       contributors = CalmContributors(record),
@@ -259,17 +252,4 @@ object CalmTransformer
         )
     }
   }
-
-  def subjects(record: CalmRecord): List[Subject[IdState.Unminted]] =
-    record
-      .getList("Subject")
-      .map {
-        label =>
-          val normalisedLabel =
-            NormaliseText(label, whitelist = NormaliseText.none)
-          Subject(
-            label = normalisedLabel,
-            concepts = List(Concept(normalisedLabel))
-          )
-      }
 }

--- a/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/transformers/CalmSubjects.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/transformers/CalmSubjects.scala
@@ -7,7 +7,6 @@ import weco.pipeline.transformer.calm.NormaliseText
 import weco.pipeline.transformer.calm.models.CalmRecordOps
 import weco.pipeline.transformer.identifiers.LabelDerivedIdentifiers
 
-
 object CalmSubjects extends CalmRecordOps with LabelDerivedIdentifiers {
   def apply(record: CalmRecord): List[Subject[IdState.Unminted]] =
     record.getList("Subject").map {

--- a/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/transformers/CalmSubjects.scala
+++ b/pipeline/transformer/transformer_calm/src/main/scala/weco/pipeline/transformer/calm/transformers/CalmSubjects.scala
@@ -1,0 +1,34 @@
+package weco.pipeline.transformer.calm.transformers
+
+import weco.catalogue.internal_model.identifiers.IdState
+import weco.catalogue.internal_model.work.{Concept, Subject}
+import weco.catalogue.source_model.calm.CalmRecord
+import weco.pipeline.transformer.calm.NormaliseText
+import weco.pipeline.transformer.calm.models.CalmRecordOps
+import weco.pipeline.transformer.identifiers.LabelDerivedIdentifiers
+
+
+object CalmSubjects extends CalmRecordOps with LabelDerivedIdentifiers {
+  def apply(record: CalmRecord): List[Subject[IdState.Unminted]] =
+    record.getList("Subject").map {
+      label =>
+        val normalisedLabel =
+          NormaliseText(label, whitelist = NormaliseText.none)
+
+        val labelDerivedId = identifierFromText(
+          label = normalisedLabel,
+          ontologyType = "Concept"
+        )
+
+        Subject(
+          label = normalisedLabel,
+          concepts = List(
+            Concept(
+              id = labelDerivedId,
+              label = normalisedLabel
+            )
+          ),
+          id = labelDerivedId
+        )
+    }
+}

--- a/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/CalmTransformerTest.scala
+++ b/pipeline/transformer/transformer_calm/src/test/scala/weco/pipeline/transformer/calm/CalmTransformerTest.scala
@@ -253,13 +253,19 @@ class CalmTransformerTest
       "Subject" -> "<i>anatomy</i>",
       "CatalogueStatus" -> "Catalogued"
     )
+
     CalmTransformer(
       record,
       version
     ).right.get.data.subjects should contain theSameElementsAs List(
-      Subject("anatomy", List(Concept("anatomy"))),
-      Subject("botany", List(Concept("botany")))
-    )
+      "anatomy",
+      "botany"
+    ).map((strippedSubject: String) => {
+      val id = labelDerivedConceptIdentifier(strippedSubject)
+      val concepts = List(Concept(id, strippedSubject))
+
+      Subject(id, strippedSubject, concepts)
+    })
   }
 
   it("finds a single language") {


### PR DESCRIPTION
## What does this change?

Part of https://github.com/wellcomecollection/platform/issues/5654

This change adds label derived identifiers for subject concepts from Calm (the archive), in order that subjects on Calm sourced works link to concept pages and not pre-filtered catalogue searches. 

The aim is to make works pages behave consistently and to allow us to move forward with filtering searches for concepts (contributors, subjects, genres) by ID rather than label which would create further inconsistencies in behaviour if we keep label filtering on archive concepts.

Needed for: https://github.com/wellcomecollection/platform/issues/5825

See for more context: https://wellcome.slack.com/archives/C07PUCL8TR8/p1730295691080569

> [!Note]
> - Releasing this work requires a re-index for full completion, if we have a new non-prod pipeline in place this can be released without impacting the production catalogue-api.
> - There is code in [wellcomecollection.org that specifically accounts for archive subjects](https://github.com/wellcomecollection/wellcomecollection.org/blob/main/content/webapp/components/WorkDetails/index.tsx#L407) that can be removed when this has been released. After this change **all subjects** should be identified (shout if you think this won't be true!).

This change will introduce a number of new label-derived concept IDs some of which will overlap with others that already exist. Looking at the data in the reporting cluster it looks like there are ~1000 distinct subjects.

https://github.com/user-attachments/assets/26b85857-6154-40c9-a39c-c468098f6efc

https://reporting.wellcomecollection.org/s/calm/app/r/s/w4NUy

## How to test

- [ ] Run the tests, do they pass?
- [ ] Deploy this change, do archive-sourced works start getting subject concept ids in the new pipeline?

## How can we measure success?

Improved consistency on works pages, and an improved experience of navigating concepts pages.

## Have we considered potential risks?

This change should be deployed to the new pipeline `[2024-11-18](https://cloud.elastic.co/open-kibana/deployment/fdc3f3e52d9a020ed5a2a9e69ce3072c)`, not to the production pipeline in use by the catalogue API mitigating risk and allowing us to test before switching over.
