### PR TITLE
Update rules for requesting (03/11/24)

### DIFF
--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala
@@ -72,6 +72,14 @@ object SierraRulesForRequesting {
       case i if i.fixedField("88").contains("g") =>
         NotRequestable.SafeguardedItem("Safeguarded item.")
 
+      // This line covers the case:
+      //
+      // q|i||88||=|j||Deny item request if catalogue record has data issues.
+      //
+      // This rule is intended to deny item requests if a catalogue record has data issues.
+      case i if i.fixedField("88").contains("j") =>
+        NotRequestable.ItemUnavailable()
+
       // These cases cover the lines:
       //
       //    v|i||88||=|b||

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequestingTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequestingTest.scala
@@ -19,6 +19,7 @@ class SierraRulesForRequestingTest
       ("s", NotRequestable.ItemOnSearch("This item is on search.")),
       ("x", NotRequestable.ItemWithdrawn("This item is withdrawn.")),
       ("r", NotRequestable.ItemUnavailable("This item is unavailable.")),
+      ("j", NotRequestable.ItemUnavailable("This item is unavailable.")),
       ("z", NotRequestable.NoPublicMessage("fixed field 88 = z")),
       ("v", NotRequestable.AtConservation("This item is with conservation.")),
       ("h", NotRequestable.ItemClosed("This item is closed.")),


### PR DESCRIPTION
## What does this change?

This change updates the [rules for requesting](https://github.com/wellcomecollection/docs/blob/main/rfcs/042-requesting-model/README.md?plain=1#L119) which need to match those in Sierra, following an update from LS in Collection Product Lines:

> q|i||88||=|j||Deny item request if catalogue record has data issues.

See [similar changes](https://github.com/search?q=org%3Awellcomecollection+%22rules+for+requesting%22&type=pullrequests).

Resolves: https://github.com/wellcomecollection/catalogue-api/issues/833

## How to test

- [x] Run the tests, do they pass?
- [ ] Deploy this change, are the items specified un-requestable?

## How can we measure success?

Folk can't request things matching this pattern

## Have we considered potential risks?

This change is self contained, and does not need a [corresponding catalogue-api update](https://github.com/wellcomecollection/catalogue-api/blob/main/common/stacks/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala) as these are permanently unrequestable.
