### PR TITLE
Update new relation embedder submodule to apply cleanly

### DIFF
--- a/pipeline/terraform/modules/stack/relation_embedder/batcher.tf
+++ b/pipeline/terraform/modules/stack/relation_embedder/batcher.tf
@@ -16,7 +16,7 @@ locals {
   # This value should be higher than or equal to the lambda timeout, to avoid messages being reprocessed.
   lamda_q_vis_timeout_seconds = local.lambda_timeout_seconds
   # How long to wait to accumulate message: 5 minutes during reindexing, 1 minute otherwise
-  batching_window_seconds = var.reindexing_state.scale_up_tasks ? (60 * 5) : 60
+  batcher_batching_window_seconds = var.reindexing_state.scale_up_tasks ? (60 * 5) : 60
 }
 
 module "batcher_lambda_output_topic" {
@@ -30,7 +30,7 @@ module "batcher_lambda" {
   source = "../../pipeline_lambda"
 
   pipeline_date = var.pipeline_date
-  service_name  = "batcher"
+  service_name  = "${var.namespace}_batcher"
 
   environment_variables = {
     output_topic_arn = module.batcher_lambda_output_topic.arn
@@ -53,7 +53,7 @@ module "batcher_lambda" {
     batch_size          = 10000
 
     visibility_timeout_seconds = local.lamda_q_vis_timeout_seconds
-    batching_window_seconds    = local.batching_window_seconds
+    batching_window_seconds    = local.batcher_batching_window_seconds
   }
 
   ecr_repository_name = "uk.ac.wellcome/batcher"

--- a/pipeline/terraform/modules/stack/relation_embedder/embedder.tf
+++ b/pipeline/terraform/modules/stack/relation_embedder/embedder.tf
@@ -35,7 +35,7 @@ module "embedder_lambda" {
       module.batcher_lambda_output_topic.arn
     ]
 
-    batching_window_seconds = 60 # How long to wait to accumulate message: 1 minute
+    batching_window_seconds = 60                        # How long to wait to accumulate message: 1 minute
     maximum_concurrency     = local.maximum_concurrency # number of messages in flight is max_capacity x queue_parallelism
 
     visibility_timeout_seconds = 60 * 15 # same or higher than lambda timeout

--- a/pipeline/terraform/modules/stack/relation_embedder/embedder.tf
+++ b/pipeline/terraform/modules/stack/relation_embedder/embedder.tf
@@ -1,18 +1,22 @@
-module "relation_embedder_lambda_output_topic" {
-  source = "../../topic"
-
-  name       = "${var.namespace}_relation_embedder_lambda_output"
-  role_names = [module.relation_embedder_lambda.lambda_role_name]
+locals {
+  maximum_concurrency = var.reindexing_state.scale_up_tasks ? 10 : 3
 }
 
-module "relation_embedder_lambda" {
+module "embedder_lambda_output_topic" {
+  source = "../../topic"
+
+  name       = "${var.namespace}_embedder_lambda_output"
+  role_names = [module.embedder_lambda.lambda_role_name]
+}
+
+module "embedder_lambda" {
   source = "../../pipeline_lambda"
 
   pipeline_date = var.pipeline_date
-  service_name  = "relation_embedder"
+  service_name  = "${var.namespace}_embedder"
 
   environment_variables = {
-    output_topic_arn = module.relation_embedder_lambda_output_topic.arn
+    output_topic_arn = module.embedder_lambda_output_topic.arn
 
     es_merged_index       = var.es_works_merged_index
     es_denormalised_index = var.es_works_denormalised_index
@@ -31,8 +35,13 @@ module "relation_embedder_lambda" {
       module.batcher_lambda_output_topic.arn
     ]
 
-    maximum_concurrency        = 10      # could we go up to 30? ie. service's max_capacity x queue_parallelism
+    batching_window_seconds = 60 # How long to wait to accumulate message: 1 minute
+    maximum_concurrency     = local.maximum_concurrency # number of messages in flight is max_capacity x queue_parallelism
+
     visibility_timeout_seconds = 60 * 15 # same or higher than lambda timeout
+
+    max_receive_count = 3
+    batch_size        = 10
   }
 
   ecr_repository_name = "uk.ac.wellcome/relation_embedder"

--- a/pipeline/terraform/modules/stack/relation_embedder/path_concatenator.tf
+++ b/pipeline/terraform/modules/stack/relation_embedder/path_concatenator.tf
@@ -9,7 +9,7 @@ module "path_concatenator_output_topic" {
 module "path_concatenator" {
   source = "../../fargate_service"
 
-  name            = "path_concatenator"
+  name            = "${var.namespace}_path_concatenator"
   container_image = var.path_concatenator_image
 
   topic_arns = [

--- a/pipeline/terraform/modules/stack/relation_embedder/router.tf
+++ b/pipeline/terraform/modules/stack/relation_embedder/router.tf
@@ -22,7 +22,7 @@ module "router_work_output_topic" {
 module "router" {
   source = "../../fargate_service"
 
-  name            = "router"
+  name            = "${var.namespace}_router"
   container_image = var.router_image
 
   topic_arns = [

--- a/pipeline/terraform/modules/stack/subsystem_relation_embedder.tf
+++ b/pipeline/terraform/modules/stack/subsystem_relation_embedder.tf
@@ -1,7 +1,7 @@
 module "relation_embedder_sub" {
   source = "./relation_embedder"
 
-  namespace        = "relation_embedder_sub"
+  namespace        = "r_embed"
   pipeline_date    = var.pipeline_date
   reindexing_state = var.reindexing_state
 


### PR DESCRIPTION
> [!Note]
> This change has been applied.

## What does this change?

Follows https://github.com/wellcomecollection/catalogue-pipeline/issues/2770

Some tweaks to allow the terraform to apply cleanly.

## How to test

- [ ] Run `terraform apply` does it apply without error?

## How can we measure success?

New submodule with lambda batcher and embedder created!

## Have we considered potential risks?

This should only be applied to the `2024-11-18` pipeline which is not in production use!
