### PR TITLE
Relation embedder empty climain

### DIFF
--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/CLIMain.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/CLIMain.scala
@@ -1,3 +1,5 @@
 package weco.pipeline.relation_embedder
 
-class CLIMain extends App {}
+class CLIMain extends App {
+  println("hello world")
+}

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/CLIMain.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/CLIMain.scala
@@ -1,0 +1,3 @@
+package weco.pipeline.relation_embedder
+
+class CLIMain extends App {}


### PR DESCRIPTION
## What does this change?

This adds a dummy CLIMain so that the build will create separate entrypoint scripts to match the entry point in task definition.

## How to test

* Run  `sbt "project batcher" ";stage"`, you should now see six entry point scripts (3 bash, 3 bat) in `pipeline/relation_embedder/relation_embedder/target/universal/scripts/bin` One should be called `main`

Revert the manually created task definition revisions, and once the result of this PR has been deployed to ECR, the relation embedder in the new pipeline should be able to start.

## How can we measure success?

Relation embedder works.  

## Have we considered potential risks?

Making the change this way, instead of changing the `/opt/docker/bin/main` line allows us to keep moving forward, as there is currently work in progress to create a proper CLIMain.  

Changing the application code and/or docker images is better than changing the terraform code, as the latter requires manual action to apply, and can have wider reaching consequences if anything is awry.
