### PR TITLE
Remove groupedWeightedWithin

### DIFF
--- a/pipeline/relation_embedder/relation_embedder/src/main/resources/application.conf
+++ b/pipeline/relation_embedder/relation_embedder/src/main/resources/application.conf
@@ -6,7 +6,6 @@ es.merged-works.index=${?es_merged_index}
 es.works.scroll.complete_tree=${?complete_tree_scroll_size}
 es.works.scroll.affected_works=${?affected_works_scroll_size}
 es.works.batch_size=${?index_batch_size}
-es.works.flush_interval_seconds=${?index_flush_interval_seconds}
 es.denormalised-works.index=${?es_denormalised_index}
 es.host=${?es_host}
 es.port=${?es_port}

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/BatchProcessor.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/BatchProcessor.scala
@@ -22,8 +22,6 @@ import scala.util.{Failure, Success}
 import weco.catalogue.internal_model.Implicits._
 import weco.typesafe.config.builders.EnrichConfig._
 
-import scala.concurrent.duration._
-
 class BatchProcessor(
   relationsService: RelationsService,
   bulkWriter: BulkWriter,
@@ -125,9 +123,7 @@ object BatchProcessor {
 
     val batchWriter = new BulkIndexWriter(
       workIndexer = workIndexer,
-      maxBatchWeight = config.requireInt("es.works.batch_size"),
-      maxBatchWait =
-        config.requireInt("es.works.flush_interval_seconds").seconds
+      maxBatchWeight = config.requireInt("es.works.batch_size")
     )
 
     new BatchProcessor(

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/BulkWriter.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/BulkWriter.scala
@@ -17,9 +17,8 @@ import io.circe.{Encoder, Printer}
   */
 trait BulkWriter {
   // Maximum size (number of average documents) of batch to write
-  val maxBatchWeight: Int = 100
-  // maximum time to wait for a batch to reach the maximum weight
-  val maxBatchWait: FiniteDuration = 20.seconds
+  protected val maxBatchWeight: Int = 100
+
   def writeWorksFlow
     : Flow[Work[Denormalised], Seq[Work[Denormalised]], NotUsed] =
     Flow[Work[Denormalised]]
@@ -30,9 +29,8 @@ trait BulkWriter {
 
   private def groupedFlow
     : Flow[Work[Denormalised], Seq[Work[Denormalised]], NotUsed] =
-    Flow[Work[Denormalised]].groupedWeightedWithin(
-      maxBatchWeight,
-      maxBatchWait
+    Flow[Work[Denormalised]].groupedWeighted(
+      maxBatchWeight
     )(workIndexable.weight)
 
   protected def writeWorks(
@@ -46,8 +44,7 @@ trait BulkWriter {
 
 class BulkIndexWriter(
   workIndexer: Indexer[Work[Denormalised]],
-  override val maxBatchWeight: Int,
-  override val maxBatchWait: FiniteDuration
+  override val maxBatchWeight: Int
 )(implicit ec: ExecutionContext)
     extends BulkWriter {
 
@@ -72,8 +69,7 @@ class BulkIndexWriter(
   */
 
 class BulkSTDOutWriter(
-  override val maxBatchWeight: Int,
-  override val maxBatchWait: FiniteDuration
+  override val maxBatchWeight: Int
 )(implicit encoder: Encoder[Work[Denormalised]])
     extends BulkWriter
     with Logging {

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/CLIMain.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/CLIMain.scala
@@ -32,7 +32,7 @@ object CLIMain extends App with StdInBatches {
       elasticClient = esClient,
       index = Index(config.requireString("es.merged-works.index"))
     ),
-    bulkWriter = new BulkSTDOutWriter(10, 1.second),
+    bulkWriter = new BulkSTDOutWriter(10),
     downstream = STDIODownstream
   )
 

--- a/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/BatchProcessorTest.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/BatchProcessorTest.scala
@@ -8,7 +8,6 @@ import weco.pipeline.relation_embedder.fixtures.{
   SampleWorkTree
 }
 import org.apache.pekko.stream.Materializer
-import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
 import weco.catalogue.internal_model.work.{Availability, Relations, Work}
 import weco.catalogue.internal_model.work.WorkState.{Denormalised, Merged}
 import weco.fixtures.TestWith
@@ -49,8 +48,7 @@ class BatchProcessorTest
 
     implicit val bulkWriter: BulkWriter = new BulkIndexWriter(
       workIndexer = new MemoryIndexer(denormalisedIndex),
-      maxBatchWeight = 10,
-      maxBatchWait = 1 milliseconds
+      maxBatchWeight = 10
     )
     withUpstreamIndex(workList) {
       mergedIndex =>

--- a/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/BulkIndexWriterTest.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/BulkIndexWriterTest.scala
@@ -2,7 +2,6 @@ package weco.pipeline.relation_embedder
 
 import com.sksamuel.elastic4s.Index
 import org.scalatest.funspec.AnyFunSpec
-import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
 import weco.catalogue.internal_model.fixtures.index.IndexFixtures
 import weco.catalogue.internal_model.work.Work
 import weco.catalogue.internal_model.work.WorkState.Denormalised
@@ -27,11 +26,7 @@ class BulkIndexWriterTest
         index = Index("this-index-does-not-exist")
       )
     val caught = intercept[RuntimeException] {
-      new BulkIndexWriter(
-        workIndexer = workIndexer,
-        maxBatchWeight = 1,
-        maxBatchWait = 1.second
-      )
+      new BulkIndexWriter(workIndexer = workIndexer, maxBatchWeight = 1)
     }
     caught.getMessage should include(
       "Indexer Initialisation error looking for index: this-index-does-not-exist"
@@ -44,8 +39,7 @@ class BulkIndexWriterTest
 
     implicit val bulkWriter: BulkWriter = new BulkIndexWriter(
       workIndexer = new MemoryIndexer(denormalisedIndex),
-      maxBatchWeight = 3,
-      maxBatchWait = 1 milliseconds
+      maxBatchWeight = 3
     )
     assertWhenWritingCompleted(works(5)) {
       result: Seq[Seq[Work[Denormalised]]] =>

--- a/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/RelationEmbedderWorkerServiceTest.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/RelationEmbedderWorkerServiceTest.scala
@@ -162,8 +162,7 @@ class RelationEmbedderWorkerServiceTest
                         )
                     val bulkWriter = new BulkIndexWriter(
                       workIndexer = new MemoryIndexer(denormalisedIndex),
-                      maxBatchWeight = 100,
-                      maxBatchWait = 1 milliseconds
+                      maxBatchWeight = 100
                     )
                     val processor = new BatchProcessor(
                       downstream = MemoryDownstream,

--- a/pipeline/terraform/modules/stack/service_work_relation_embedder.tf
+++ b/pipeline/terraform/modules/stack/service_work_relation_embedder.tf
@@ -1,7 +1,7 @@
 module "relation_embedder_output_topic" {
   source = "../topic"
 
-  name       = "${local.namespace}_relation_embedder_output"
+  name = "${local.namespace}_relation_embedder_output"
   role_names = [module.relation_embedder.task_role_name]
 }
 
@@ -32,16 +32,15 @@ module "relation_embedder" {
     es_merged_index       = local.es_works_merged_index
     es_denormalised_index = local.es_works_denormalised_index
 
-    queue_parallelism            = 3  // NOTE: limit to avoid memory errors
-    affected_works_scroll_size   = 50 // NOTE: limit to avoid memory errors
-    complete_tree_scroll_size    = 800
-    index_batch_size             = 100 // NOTE: too large results in 413 from ES
-    index_flush_interval_seconds = 60
+    queue_parallelism = 3  // NOTE: limit to avoid memory errors
+    affected_works_scroll_size = 50 // NOTE: limit to avoid memory errors
+    complete_tree_scroll_size = 800
+    index_batch_size          = 100 // NOTE: too large results in 413 from ES
   }
 
   secret_env_vars = local.pipeline_storage_es_service_secrets["relation_embedder"]
 
-  cpu    = 2048
+  cpu = 2048
   memory = 4096
 
   # NOTE: limit to avoid >500 concurrent scroll contexts

--- a/pipeline/terraform/modules/stack/service_work_relation_embedder.tf
+++ b/pipeline/terraform/modules/stack/service_work_relation_embedder.tf
@@ -1,7 +1,7 @@
 module "relation_embedder_output_topic" {
   source = "../topic"
 
-  name = "${local.namespace}_relation_embedder_output"
+  name       = "${local.namespace}_relation_embedder_output"
   role_names = [module.relation_embedder.task_role_name]
 }
 
@@ -32,15 +32,15 @@ module "relation_embedder" {
     es_merged_index       = local.es_works_merged_index
     es_denormalised_index = local.es_works_denormalised_index
 
-    queue_parallelism = 3  // NOTE: limit to avoid memory errors
+    queue_parallelism          = 3  // NOTE: limit to avoid memory errors
     affected_works_scroll_size = 50 // NOTE: limit to avoid memory errors
-    complete_tree_scroll_size = 800
-    index_batch_size          = 100 // NOTE: too large results in 413 from ES
+    complete_tree_scroll_size  = 800
+    index_batch_size           = 100 // NOTE: too large results in 413 from ES
   }
 
   secret_env_vars = local.pipeline_storage_es_service_secrets["relation_embedder"]
 
-  cpu = 2048
+  cpu    = 2048
   memory = 4096
 
   # NOTE: limit to avoid >500 concurrent scroll contexts


### PR DESCRIPTION
## What does this change?
Resolves https://github.com/wellcomecollection/catalogue-pipeline/issues/2779, see description there for rationale.

## How to test

Unit tests pass in reasonable time, as does running a command line invocation `cat pipeline/relation_embedder/relation_embedder/scripts/batches.txt | python pipeline/relation_embedder/relation_embedder/scripts/cli.py 2024-11-18 `

## How can we measure success?

This removes an unnecessary configuration parameter, marginally simplifying the code in the application, its tests, and the corresponding Terraform.

groupedWeightedWithin is provided by Pekko, and although groupedWeighted is also a Pekko function, it is one that would be simpler to replace with plain Scala, if we find that the rest of this application can be implemented without Pekko.  This may result in a lighter application with a faster startup.

## Have we considered potential risks?

I don't believe this change carries any risk. The timeout was redundant, as far as I could tell.