### PR TITLE
try removing internal model from batcher

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -191,7 +191,7 @@ lazy val batcher = setupProject(
     // https://github.com/wellcomecollection/catalogue-pipeline/pull/2327
     //
     // But ultimately it wasn't a good use of time to keep debugging this.
-    internal_model
+    // internal_model
   ),
   externalDependencies = CatalogueDependencies.batcherDependencies
 )

--- a/build.sbt
+++ b/build.sbt
@@ -149,50 +149,7 @@ lazy val router = setupProject(
 lazy val batcher = setupProject(
   project,
   "pipeline/relation_embedder/batcher",
-  localDependencies = Seq(
-    // Strictly speaking, the batcher doesn't need any of the internal model code,
-    // but for some reason the batcher tests fail if we don't include it in the
-    // class path:
-    //
-    //        Cause: software.amazon.awssdk.core.exception.SdkClientException: Unable to execute HTTP request: The connection was closed during the request. The request will usually succeed on a retry, but if it does not: consider disabling any proxies you have configured, enabling debug logging, or performing a TCP dump to identify the root cause. If this is a streaming operation, validate that data is being read or written in a timely manner. Channel Information: ChannelDiagnostics(channel=[id: 0x49117641, L:0.0.0.0/0.0.0.0:38210], channelAge=PT0.000813S, requestCount=1)
-    //        at software.amazon.awssdk.core.exception.SdkClientException$BuilderImpl.build(SdkClientException.java:111)
-    //        at software.amazon.awssdk.core.exception.SdkClientException.create(SdkClientException.java:47)
-    //        at software.amazon.awssdk.core.internal.http.pipeline.stages.utils.RetryableStageHelper.setLastException(RetryableStageHelper.java:223)
-    //        at software.amazon.awssdk.core.internal.http.pipeline.stages.utils.RetryableStageHelper.setLastException(RetryableStageHelper.java:218)
-    //        at software.amazon.awssdk.core.internal.http.pipeline.stages.AsyncRetryableStage$RetryingExecutor.maybeRetryExecute(AsyncRetryableStage.java:182)
-    //        at software.amazon.awssdk.core.internal.http.pipeline.stages.AsyncRetryableStage$RetryingExecutor.lambda$attemptExecute$1(AsyncRetryableStage.java:159)
-    //        at java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(Unknown Source)
-    //        at java.base/java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(Unknown Source)
-    //        at java.base/java.util.concurrent.CompletableFuture.postComplete(Unknown Source)
-    //        at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(Unknown Source)
-    //        ...
-    //        Cause: java.io.IOException: The connection was closed during the request. The request will usually succeed on a retry, but if it does not: consider disabling any proxies you have configured, enabling debug logging, or performing a TCP dump to identify the root cause. If this is a streaming operation, validate that data is being read or written in a timely manner. Channel Information: ChannelDiagnostics(channel=[id: 0x49117641, L:0.0.0.0/0.0.0.0:38210], channelAge=PT0.000813S, requestCount=1)
-    //        at software.amazon.awssdk.http.nio.netty.internal.NettyRequestExecutor.configurePipeline(NettyRequestExecutor.java:233)
-    //        at software.amazon.awssdk.http.nio.netty.internal.NettyRequestExecutor.lambda$makeRequestListener$10(NettyRequestExecutor.java:181)
-    //        at io.netty.util.concurrent.PromiseTask.runTask(PromiseTask.java:98)
-    //        at io.netty.util.concurrent.PromiseTask.run(PromiseTask.java:106)
-    //        at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:174)
-    //        at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:167)
-    //        at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470)
-    //        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:566)
-    //        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
-    //        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
-    //        ...
-    //
-    // We started seeing these issues when we upgraded our Buildkite CI Stack
-    // from 5.7.2 to 5.16.1.
-    //
-    // This is presumably an issue of dependency resolution somewhere, and the batcher
-    // is getting a different version of a dependency to all our other apps -- but
-    // I can't work out exactly where it is.
-    //
-    // You can see some experiments trying to find it in this PR, where I created a new
-    // copy of internal_model and started cutting bits out:
-    // https://github.com/wellcomecollection/catalogue-pipeline/pull/2327
-    //
-    // But ultimately it wasn't a good use of time to keep debugging this.
-    // internal_model
-  ),
+  localDependencies = Nil,
   externalDependencies = CatalogueDependencies.batcherDependencies
 )
 


### PR DESCRIPTION
## What does this change?

Batcher does not need internal model, but there is a big comment about the fact that it fails to build on CI if we do not include it.  This removes it, because that failure no longer occurs.

I was looking at the dependencies as a prelude to creating a common library for some of the new Lambda and CLI changes, and I spotted this surprise dependency.

## How to test

CI should cover it. It was apparently in there to satisfy Buildkite.

## How can we measure success?
 
Unnecessary dependencies are reduced this 
- shrinks the built artefacts (the target/universal/stage folder is nearly 20MiB smaller).
- clarifies what the batcher does and needs.

## Have we considered potential risks?

If it works locally and on CI, then I doubt there is any reason to expect it won't work for real life.