### PR TITLE
Deactiveate pipeline 2024-11-18 for the break

### DIFF
--- a/pipeline/terraform/2024-11-18/main.tf
+++ b/pipeline/terraform/2024-11-18/main.tf
@@ -1,32 +1,38 @@
-module "pipeline" {
-  source = "../modules/stack"
+# DEACTIVATED - 2024-12-16
+# This pipeline has been deactivated over the winter break,
+# to save costs and will be reactivated in the new year.
+# We need to keep this folder, so that new deploys don't go
+# to the production environment.
 
-  reindexing_state = {
-    listen_to_reindexer      = false
-    scale_up_tasks           = false
-    scale_up_elastic_cluster = false
-    scale_up_id_minter_db    = false
-    scale_up_matcher_db      = false
-  }
-
-  index_config = {
-    works = {
-      identified = "works_identified.2023-05-26"
-      merged     = "works_merged.2023-05-26"
-      indexed    = "works_indexed.2024-11-14"
-    }
-    images = {
-      indexed        = "images_indexed.2024-11-14"
-      works_analysis = "works_indexed.2024-11-06"
-    }
-  }
-
-  allow_delete_indices = false
-
-  pipeline_date = local.pipeline_date
-  release_label = local.pipeline_date
-
-  providers = {
-    aws.catalogue = aws.catalogue
-  }
-}
+# module "pipeline" {
+#   source = "../modules/stack"
+#
+#   reindexing_state = {
+#     listen_to_reindexer      = false
+#     scale_up_tasks           = false
+#     scale_up_elastic_cluster = false
+#     scale_up_id_minter_db    = false
+#     scale_up_matcher_db      = false
+#   }
+#
+#   index_config = {
+#     works = {
+#       identified = "works_identified.2023-05-26"
+#       merged     = "works_merged.2023-05-26"
+#       indexed    = "works_indexed.2024-11-14"
+#     }
+#     images = {
+#       indexed        = "images_indexed.2024-11-14"
+#       works_analysis = "works_indexed.2024-11-06"
+#     }
+#   }
+#
+#   allow_delete_indices = true
+#
+#   pipeline_date = local.pipeline_date
+#   release_label = local.pipeline_date
+#
+#   providers = {
+#     aws.catalogue = aws.catalogue
+#   }
+# }


### PR DESCRIPTION
## What does this change?

This change deactivates pipeline 2024-11-18 for the winter break to save costs. We keep the pipeline folder around to prevent any deployments in CI going out to the production pipeline.

## How to test

- [ ] Have all the resources and clusters been deleted?

## How can we measure success?

Less spendy break.

## Have we considered potential risks?

The current state of main is ahead of what's in production, so in  order to prevent accidental deployments we need to keep the folder for 2024-11-18 around [which is the flag for the build system to deploy new changes (https://github.com/wellcomecollection/catalogue-pipeline/blob/main/.buildkite/scripts/deploy_latest_pipeline.py#L31) there rather than into the production pipeline.

The [current catalogue api is pointed at 2024-11-05](https://github.com/wellcomecollection/catalogue-api/blob/74728ba749b0b6476bdbbc520fdf7c64154c5041/common/search/src/main/scala/weco/api/search/models/ElasticConfig.scala#L14) so will be unimpacted.
