### PR TITLE
Make error handling easier to reason about

### DIFF
--- a/pipeline/relation_embedder/batcher/src/main/scala/weco/pipeline/batcher/CLIMain.scala
+++ b/pipeline/relation_embedder/batcher/src/main/scala/weco/pipeline/batcher/CLIMain.scala
@@ -31,9 +31,12 @@ object CLIMain extends App {
   val toStringFlow: Flow[ByteString, String, NotUsed] =
     Flow[ByteString].map(_.utf8String)
 
-  val pathsProcessorFlow: Flow[Seq[String], Future[Seq[Long]], NotUsed] =
-    Flow[Seq[String]].map {
-      paths: Seq[String] =>
+  val toPathFlow: Flow[String, Path, NotUsed] =
+    Flow[String].map(PathFromString)
+
+  val pathsProcessorFlow: Flow[Seq[Path], Future[Seq[Path]], NotUsed] =
+    Flow[Seq[Path]].map {
+      paths: Seq[Path] =>
         PathsProcessor(
           40, // TODO: 40 is the number in the config used by Main, do this properly later
           paths.toList,
@@ -44,6 +47,7 @@ object CLIMain extends App {
   stdinSource
     .via(lineDelimiter)
     .via(toStringFlow)
+    .via(toPathFlow)
     // this number is pretty arbitrary, but grouping of some kind is needed in order to
     // provide a list to the next step, rather than individual paths
     .grouped(10000)

--- a/pipeline/relation_embedder/batcher/src/main/scala/weco/pipeline/batcher/LambdaMain.scala
+++ b/pipeline/relation_embedder/batcher/src/main/scala/weco/pipeline/batcher/LambdaMain.scala
@@ -46,7 +46,7 @@ object LambdaMain extends RequestHandler[SQSEvent, String] with Logging {
 
     val f = PathsProcessor(
       config.requireInt("batcher.max_batch_size"),
-      event.extractPaths,
+      event.extractPaths.map(PathFromString),
       downstream
     )
 

--- a/pipeline/relation_embedder/batcher/src/main/scala/weco/pipeline/batcher/Selector.scala
+++ b/pipeline/relation_embedder/batcher/src/main/scala/weco/pipeline/batcher/Selector.scala
@@ -34,7 +34,7 @@ sealed trait Selector {
     }
   }
 
-  def shouldSuppress(otherSelectors: Set[Selector]): Boolean =
+  protected def shouldSuppress(otherSelectors: Set[Selector]): Boolean =
     superSelectors.exists(otherSelectors.contains)
 }
 

--- a/pipeline/relation_embedder/batcher/src/main/scala/weco/pipeline/batcher/Selector.scala
+++ b/pipeline/relation_embedder/batcher/src/main/scala/weco/pipeline/batcher/Selector.scala
@@ -18,7 +18,7 @@ sealed trait Selector {
     * use these to filter out any unnecessary selectors when another broader one
     * already exists.
     */
-  def superSelectors: List[Selector] = {
+  private def superSelectors: List[Selector] = {
     import Selector._
     val ancestorPaths = ancestors(path)
     val ancestorDescendents = ancestorPaths.map(Descendents(_))
@@ -34,21 +34,50 @@ sealed trait Selector {
     }
   }
 
-  def shouldSupress(otherSelectors: Set[Selector]): Boolean =
+  def shouldSuppress(otherSelectors: Set[Selector]): Boolean =
     superSelectors.exists(otherSelectors.contains)
 }
 
 object Selector {
 
-  type Path = String
+  private type SelectorPath = String
 
-  case class Tree(path: Path) extends Selector
+  case class Tree(path: SelectorPath) extends Selector
 
-  case class Node(path: Path) extends Selector
+  case class Node(path: SelectorPath) extends Selector
 
-  case class Children(path: Path) extends Selector
+  case class Children(path: SelectorPath) extends Selector
 
-  case class Descendents(path: Path) extends Selector
+  case class Descendents(path: SelectorPath) extends Selector
+
+  /** Given a list of input paths, return a list of selectors representing the
+    * nodes which should be sent to the `relation_embedder` for denormalisation.
+    * The output also includes the original path, as when sending a SNS
+    * notification we need to map this back to the original input path in case
+    * of failure.
+    *
+    * The generation of selectors uses the logic documented in `forPath`,
+    * followed by filtering of any selectors which are already accounted for by
+    * other broader selectors.
+    *
+    * For example, given the following tree:
+    * {{{
+    * A
+    * |
+    * |----------
+    * | |       |
+    * B C       E
+    * | |----   |------
+    * | | | |   | | | |
+    * D X Y Z   1 2 3 4
+    * }}}
+    * We would not need to include selectors for `Node(X)` or `Children(Y)` if
+    * for example either the selectors `Tree(A)` or `Descendents(C)` also
+    * existed.
+    */
+  def forPaths(paths: Seq[Path]): List[(Selector, Path)] = {
+    discardRedundantSelectors(mapSelectorsToPaths(paths)).toList
+  }
 
   /** Given an input path, return a list of selectors representing the nodes
     * which should be sent to the `relation_embedder` for denormalisation.
@@ -60,8 +89,16 @@ object Selector {
     *
     * To see why this is the case, consider the following tree:
     *
-    * A \| \|------------- \| | | B C E \| |------ |--------- \| | | | | | | | D
-    * X Y Z 1 2 3 4
+    * {{{
+    * A
+    * |
+    * |-------------
+    * |  |         |
+    * B  C         E
+    * |  |------   |---------
+    * |  |  |  |   |  |  |  |
+    * D  X  Y  Z   1  2  3  4
+    * }}}
     *
     * Given node `C` as an input, we need to denormalise the parent `A` as it
     * contains `C` as a child relation. We need to denormalise the input `C`
@@ -75,7 +112,7 @@ object Selector {
     * parent downwards this would result in the siblings descendents being
     * denormalised unnecessarily.
     */
-  def forPath(path: Path): List[Selector] =
+  private def forPath(path: SelectorPath): List[Selector] =
     parent(path)
       .map {
         parent =>
@@ -83,48 +120,31 @@ object Selector {
       }
       .getOrElse(List(Tree(path)))
 
-  /** Given a list of input paths, return a list of selectors representing the
-    * nodes which should be sent to the `relation_embedder` for denormalisation.
-    * The output also includes the index of the original path in the list, as
-    * when sending a SNS notification we need to map this back to the original
-    * input path in case of failure.
-    *
-    * The generation of selectors uses the logic documented in `forPath`,
-    * followed by filtering of any selectors which are already accounted for by
-    * other broader selectors.
-    *
-    * For example, given the following tree:
-    *
-    * A \| \|------------- \| | | B C E \| |------ |--------- \| | | | | | | | D
-    * X Y Z 1 2 3 4
-    *
-    * We would not need to include selectors for `Node(X)` or `Children(Y)` if
-    * for example either the selectors `Tree(A)` or `Descendents(C)` also
-    * existed.
-    */
-  def forPaths(paths: List[Path]): List[(Selector, Long)] = {
-    val selectors = paths.zipWithIndex
-      .flatMap {
-        case (path, idx) =>
-          Selector.forPath(path).map(selector => (selector, idx.toLong))
-      }
+  private def mapSelectorsToPaths(paths: Seq[Path]): Map[Selector, Path] =
+    paths
+      .flatMap(
+        path => Selector.forPath(path.path).map(selector => (selector, path))
+      )
       .groupBy(_._1)
       .map(_._2.head)
 
-    val selectorSet = selectors.keySet
-    selectors.collect {
-      case (selector, idx) if !selector.shouldSupress(selectorSet) =>
-        (selector, idx)
-    }.toList
+  private def discardRedundantSelectors(
+    selectorMap: Map[Selector, Path]
+  ): Map[Selector, Path] = {
+    val selectorSet = selectorMap.keySet
+    selectorMap.collect {
+      case (selector, path) if !selector.shouldSuppress(selectorSet) =>
+        (selector, path)
+    }
   }
 
-  private def parent(path: Path): Option[Path] =
+  private def parent(path: SelectorPath): Option[SelectorPath] =
     tokenize(path).dropRight(1) match {
       case Nil    => None
       case tokens => Some(join(tokens))
     }
 
-  private def ancestors(path: Path): List[Path] = {
+  private def ancestors(path: SelectorPath): List[SelectorPath] = {
     val tokens = tokenize(path).dropRight(1)
     (1 to tokens.length).map {
       i =>
@@ -132,9 +152,9 @@ object Selector {
     }.toList
   }
 
-  private def tokenize(path: Path): List[String] =
+  private def tokenize(path: SelectorPath): List[String] =
     path.split("/").toList
 
-  private def join(tokens: List[String]): Path =
+  private def join(tokens: List[String]): String =
     tokens.mkString("/")
 }

--- a/pipeline/relation_embedder/batcher/src/test/scala/weco/pipeline/batcher/BatcherWorkerServiceTest.scala
+++ b/pipeline/relation_embedder/batcher/src/test/scala/weco/pipeline/batcher/BatcherWorkerServiceTest.scala
@@ -28,9 +28,16 @@ class BatcherWorkerServiceTest
   import Selector._
 
   /** The following tests use paths representing this tree:
-    *
-    * A \| \|------------- \| | | B C E \| |------ |--------- \| | | | | | | | D
-    * X Y Z 1 2 3 4
+    * {{{
+    * A
+    * |
+    * |-------------
+    * |  |         |
+    * B  C         E
+    * |  |------   |---------
+    * |  |  |  |   |  |  |  |
+    * D  X  Y  Z   1  2  3  4
+    * }}}
     */
   it("processes incoming paths into batches") {
     withWorkerService(visibilityTimeout = 2 seconds) {

--- a/pipeline/relation_embedder/batcher/src/test/scala/weco/pipeline/batcher/SelectorTest.scala
+++ b/pipeline/relation_embedder/batcher/src/test/scala/weco/pipeline/batcher/SelectorTest.scala
@@ -1,5 +1,6 @@
 package weco.pipeline.batcher
 
+import org.scalatest.Assertion
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -8,62 +9,98 @@ class SelectorTest extends AnyFunSpec with Matchers {
   import Selector._
 
   /** The following tests use paths representing this tree:
-    *
-    * A \| \|------------- \| | | B C E \| |------ |--------- \| | | | | | | | D
-    * X Y Z 1 2 3 4
+    * {{{
+    * A
+    * |
+    * |-------------
+    * |  |         |
+    * B  C         E
+    * |  |------   |---------
+    * |  |  |  |   |  |  |  |
+    * D  X  Y  Z   1  2  3  4
+    * }}}
     */
-  it("generates selectors for a single path") {
-    Selector.forPath("A/C") should contain theSameElementsAs List(
-      Node("A"),
-      Children("A"),
-      Descendents("A/C")
-    )
+  describe("generating selectors for individual paths") {
+    it(
+      "generates selectors for the parent, siblings, and descendants of a single path"
+    ) {
+      val path = PathFromString("A/C")
+      Selector.forPaths(List(path)) should contain theSameElementsAs List(
+        Node("A") -> path,
+        Children("A") -> path,
+        Descendents("A/C") -> path
+      )
+    }
+
+    it("generates the whole tree selector for the root path") {
+      val rootPath = PathFromString("A")
+      Selector.forPaths(List(rootPath)) should contain theSameElementsAs List(
+        Tree("A") -> rootPath
+      )
+    }
   }
 
-  it("generates the whole tree selector for the root path") {
-    Selector.forPath("A") should contain theSameElementsAs List(
-      Tree("A")
-    )
-  }
+  describe("generating selectors for multiple paths") {
+    def assertSelectorsForPaths(
+      pathStrings: List[String],
+      expected: List[(Selector, Int)]
+    ): Assertion = {
+      val stringsAsPaths = pathStrings.map(PathFromString)
+      val expectedPaths = expected.map {
+        case (selector, index) => (selector, stringsAsPaths(index))
+      }
+      Selector.forPaths(
+        stringsAsPaths
+      ) should contain theSameElementsAs expectedPaths
+    }
 
-  it("generates selectors for multiple paths without duplicates") {
-    Selector.forPaths(List("A/C", "A/E")) should contain theSameElementsAs List(
-      Node("A") -> 0,
-      Children("A") -> 0,
-      Descendents("A/C") -> 0,
-      Descendents("A/E") -> 1
-    )
-  }
+    it("generates selectors where there are no duplicates") {
+      assertSelectorsForPaths(
+        List("A/C", "A/E"),
+        List(
+          Node("A") -> 0,
+          Children("A") -> 0,
+          Descendents("A/C") -> 0,
+          Descendents("A/E") -> 1
+        )
+      )
+    }
 
-  it("generates selectors for multiple paths filtering any unnecessary") {
-    Selector.forPaths(
-      List("A/C", "A/C/X", "A/C/Y", "A/E", "A/E/3")
-    ) should contain theSameElementsAs List(
-      Node("A") -> 0,
-      Children("A") -> 0,
-      Descendents("A/C") -> 0,
-      Descendents("A/E") -> 3
-    )
-  }
+    it(
+      "generates selectors for multiple paths filtering any unnecessary selectors"
+    ) {
+      assertSelectorsForPaths(
+        List("A/C", "A/C/X", "A/C/Y", "A/E", "A/E/3"),
+        List(
+          Node("A") -> 0,
+          Children("A") -> 0,
+          Descendents("A/C") -> 0,
+          Descendents("A/E") -> 3
+        )
+      )
+    }
 
-  it("generates selector for whole tree when root is in the path") {
-    Selector.forPaths(
-      List("A/E/1", "A/B", "A", "A/B/D")
-    ) should contain theSameElementsAs List(
-      Tree("A") -> 2
-    )
-  }
+    it("generates selector for whole tree when root is in the path") {
+      assertSelectorsForPaths(
+        List("A/E/1", "A/B", "A", "A/B/D"),
+        List(
+          Tree("A") -> 2
+        )
+      )
+    }
 
-  it("generates selector for multiple disjoint trees") {
-    Selector.forPaths(
-      List("A/E", "A/E/2", "Other/Tree")
-    ) should contain theSameElementsAs List(
-      Node("A") -> 0,
-      Children("A") -> 0,
-      Descendents("A/E") -> 0,
-      Node("Other") -> 2,
-      Children("Other") -> 2,
-      Descendents("Other/Tree") -> 2
-    )
+    it("generates selector for multiple disjoint trees") {
+      assertSelectorsForPaths(
+        List("A/E", "A/E/2", "Other/Tree"),
+        List(
+          Node("A") -> 0,
+          Children("A") -> 0,
+          Descendents("A/E") -> 0,
+          Node("Other") -> 2,
+          Children("Other") -> 2,
+          Descendents("Other/Tree") -> 2
+        )
+      )
+    }
   }
 }


### PR DESCRIPTION
## What does this change?

This simplifies error handling in the Batcher by hiding the SQS Message inside a generic that gets passed around internally, rather than all that list index business.

## How to test

Externally, this is a straight refactor, so nothing should change.

I have tried to ensure that the pertinent tests look the same as before, to make it easier to verify that I have not changed the behaviour.

## How can we measure success?

It should be easier to implement error handling in the lambda and CLI versions of this application.

## Have we considered potential risks?

As this should not result in a change in behaviour, I don't think there are any notable risks associated with this change