### PR TITLE
Remove Akka from the Batcher Lambda

### DIFF
--- a/pipeline/relation_embedder/batcher/src/main/scala/weco/pipeline/batcher/BatcherWorkerService.scala
+++ b/pipeline/relation_embedder/batcher/src/main/scala/weco/pipeline/batcher/BatcherWorkerService.scala
@@ -5,7 +5,6 @@ import scala.concurrent.duration._
 import scala.util.Try
 import org.apache.pekko.{Done, NotUsed}
 import org.apache.pekko.stream.scaladsl._
-import org.apache.pekko.stream.Materializer
 import software.amazon.awssdk.services.sqs.model.{Message => SQSMessage}
 import grizzled.slf4j.Logging
 import weco.messaging.MessageSender
@@ -22,7 +21,7 @@ class BatcherWorkerService[MsgDestination](
   flushInterval: FiniteDuration,
   maxProcessedPaths: Int,
   maxBatchSize: Int
-)(implicit ec: ExecutionContext, materializer: Materializer)
+)(implicit ec: ExecutionContext)
     extends Runnable
     with Logging {
 

--- a/pipeline/relation_embedder/batcher/src/main/scala/weco/pipeline/batcher/LambdaMain.scala
+++ b/pipeline/relation_embedder/batcher/src/main/scala/weco/pipeline/batcher/LambdaMain.scala
@@ -38,7 +38,7 @@ object LambdaMain extends RequestHandler[SQSEvent, String] with Logging {
     context: Context
   ): String = {
     debug(s"Running batcher lambda, got event: $event")
-    
+
     val f = PathsProcessor(
       config.requireInt("batcher.max_batch_size"),
       event.extractPaths.map(PathFromString),


### PR DESCRIPTION
## What does this change?

This pushes Akka to the periphery of the Batcher, allowing the Lambda version to run without it.

## How to test

Build and run the lambda following the instructions in the [Readme](https://github.com/wellcomecollection/catalogue-pipeline/blob/main/pipeline/relation_embedder/batcher/README.md).  It should work as before.

The tests in [BatcherWorkerServiceTest](https://github.com/wellcomecollection/catalogue-pipeline/blob/main/pipeline/relation_embedder/batcher/src/test/scala/weco/pipeline/batcher/BatcherWorkerServiceTest.scala) demonstrate that it still works with Akka in the old way.

## How can we measure success?

Faster Lambdas.

In my (not very scientific) investigation, I ran the lambda-rie docker locally, both before and after this change.  I posted scripts/paths.txt to it twice each time.

Times with Akka:
> Init Duration: 0.04 ms	Duration: 2099.56 ms	Billed Duration: 2100 ms	Memory Size: 3008 MB	Max Memory Used: 3008 MB
> Duration: 51.45 ms	Billed Duration: 52 ms	Memory Size: 3008 MB	Max Memory Used: 3008 MB

Times without Akka:
> Init Duration: 0.03 ms	Duration: 1446.88 ms	Billed Duration: 1447 ms	Memory Size: 3008 MB	Max Memory Used: 3008 MB
> Duration: 15.07 ms	Billed Duration: 16 ms	Memory Size: 3008 MB	Max Memory Used: 3008 MB

This is an improvement of over half a second on a cold start. To my surprise, there was also a significant improvement in the second call.

We may be also able to dial back the memory size we assign to the lambda, saving even more cash.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? -->

