### PR TITLE
Tweaks for image surpression script

### DIFF
--- a/scripts/miro_updates.py
+++ b/scripts/miro_updates.py
@@ -13,6 +13,8 @@ import os
 import boto3
 import httpx
 
+from botocore.exceptions import ClientError
+
 from _common import (
     git,
     get_api_es_client,
@@ -235,19 +237,26 @@ def _remove_image_from_dlcs(*, miro_id):
     resp = dlcs_api_client().delete(
         f"https://api.dlcs.io/customers/2/spaces/8/images/{miro_id}"
     )
-    assert resp.status_code == 204, resp
+    if resp.status_code == 404:
+        print(f"Failed to delete image {miro_id} from DLCS, image not found!", file=sys.stderr)
+        return
+    else:
+        assert resp.status_code == 204, resp
 
 
 def _remove_image_from_cloudfront(*, miro_id):
     cloudfront_client = SESSION.client("cloudfront")
 
-    cloudfront_client.create_invalidation(
-        DistributionId="E1KKXGJWOADM2A",  # IIIF APIs prod
-        InvalidationBatch={
-            "Paths": {"Quantity": 1, "Items": [f"/image/{miro_id}*"]},
-            "CallerReference": f"{__file__} invalidating {miro_id}",
-        },
-    )
+    try:
+        cloudfront_client.create_invalidation(
+            DistributionId="E1KKXGJWOADM2A",  # IIIF APIs prod
+            InvalidationBatch={
+                "Paths": {"Quantity": 1, "Items": [f"/image/{miro_id}*"]},
+                "CallerReference": f"{__file__} invalidating {miro_id}",
+            },
+        )
+    except ClientError:
+        print(f"Failed to invalidate {miro_id} from CloudFront", file=sys.stderr)
 
 
 def suppress_image(*, miro_id, message: str):

--- a/scripts/miro_updates.py
+++ b/scripts/miro_updates.py
@@ -238,7 +238,10 @@ def _remove_image_from_dlcs(*, miro_id):
         f"https://api.dlcs.io/customers/2/spaces/8/images/{miro_id}"
     )
     if resp.status_code == 404:
-        print(f"Failed to delete image {miro_id} from DLCS, image not found!", file=sys.stderr)
+        print(
+            f"Failed to delete image {miro_id} from DLCS, image not found!",
+            file=sys.stderr,
+        )
         return
     else:
         assert resp.status_code == 204, resp

--- a/scripts/suppress_miro.py
+++ b/scripts/suppress_miro.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import click
 import httpx
+import os
 import sys
 
 from miro_updates import (
@@ -34,9 +35,21 @@ def suppress_miro(id_source, message, dry_run):
     suppress = print_suppression_command if dry_run else suppress_image
     update = print_update_command if dry_run else update_miro_image_suppressions_doc
 
+    # Run some pre-flight checks
+    check_gh_cli_installed()
+
     for miro_id in valid_ids(id_source):
         suppress(miro_id=miro_id, message=message)
+
+    # Run the update command
     update()
+
+
+def check_gh_cli_installed():
+    if os.system("gh --version > /dev/null") != 0:
+        raise click.ClickException(
+            "gh CLI not installed. Please install from https://cli.github.com/"
+        )
 
 
 def valid_ids(id_source):


### PR DESCRIPTION
## What does this change?

This change allows failure in certain cases:
- The image is already missing from DLCS, in cases where some of a batch have already been deleted
- The CloudFront invalidation fails, this can happen when processing a large number of images and is arguably a non-critical error when invalidating a large batch. An error will appear in the output logs.

In addition it will quickly fail if the user does not have the GitHub CLI installed which is a pre-requisite for updating the surpression doc in the private repo.

## How to test

- [ ] Run locally, test using dry-run.

## How can we measure success?

Easier image supressions.

## Have we considered potential risks?

Removing the fail on CloudFront invalidation is potentially a risk in some cases depending on the urgency of take downs. The output logs should be reviewed as part of running the script in cases where immediate take downs are required.
