### PR TITLE
Add config builder for DownstreamTarget to avoid ambiguity

### DIFF
--- a/common/lambda/src/main/scala/weco/lambda/Downstream.scala
+++ b/common/lambda/src/main/scala/weco/lambda/Downstream.scala
@@ -54,7 +54,7 @@ object DownstreamBuilder extends Logging {
 
   def buildDownstreamTarget(config: Config): DownstreamTarget = {
     config.getStringOption("downstream.target") match {
-      case Some("sns")   =>
+      case Some("sns") =>
         val snsConfig = buildSNSConfig(config)
         info(s"Building SNS downstream with config: $snsConfig")
         SNS(snsConfig)
@@ -62,7 +62,9 @@ object DownstreamBuilder extends Logging {
         info("Building StdOut downstream")
         StdOut
       case Some(unknownTarget) =>
-        throw new IllegalArgumentException(s"Invalid downstream target: $unknownTarget")
+        throw new IllegalArgumentException(
+          s"Invalid downstream target: $unknownTarget"
+        )
       case None =>
         warn("No downstream target specified, defaulting to StdOut")
         StdOut

--- a/common/lambda/src/test/scala/weco/lambda/DownstreamTest.scala
+++ b/common/lambda/src/test/scala/weco/lambda/DownstreamTest.scala
@@ -1,0 +1,55 @@
+package weco.lambda
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import weco.lambda.helpers.ConfigurationTestHelpers
+import weco.messaging.sns.SNSConfig
+
+class DownstreamTest extends AnyFunSpec
+  with ConfigurationTestHelpers
+  with Matchers {
+
+  describe("DownstreamBuilder") {
+    it("builds a StdOut downstream target") {
+      val config =
+        """
+          |downstream.target = "stdio"
+          |""".asConfig
+
+        DownstreamBuilder.buildDownstreamTarget(config) shouldBe StdOut
+    }
+
+    it("builds an SNS downstream target") {
+      val config =
+        """
+          |downstream.target = "sns"
+          |aws.sns.topic.arn = "arn:aws:sns:eu-west-1:123456789012:my-topic"
+          |""".asConfig
+
+        DownstreamBuilder.buildDownstreamTarget(config) shouldBe SNS(
+          config = SNSConfig(
+            topicArn = "arn:aws:sns:eu-west-1:123456789012:my-topic"
+          )
+        )
+    }
+
+    it("builds a StdOut downstream target if no downstream target is specified") {
+      val config =
+        """
+          |""".asConfig
+
+      DownstreamBuilder.buildDownstreamTarget(config) shouldBe StdOut
+    }
+
+    it("throws an exception if the downstream target is not recognised") {
+      val config =
+        """
+          |downstream.target = "invalid"
+          |""".asConfig
+
+      intercept[IllegalArgumentException] {
+        DownstreamBuilder.buildDownstreamTarget(config)
+      }
+    }
+  }
+}

--- a/pipeline/relation_embedder/batcher/src/main/resources/application.conf
+++ b/pipeline/relation_embedder/batcher/src/main/resources/application.conf
@@ -5,4 +5,5 @@ aws.sns.topic.arn=${?output_topic_arn}
 batcher.flush_interval_minutes=${?flush_interval_minutes}
 batcher.max_processed_paths=${?max_processed_paths}
 batcher.max_batch_size=${?max_batch_size}
+downstream.target=sns
 downstream.target=${?use_downstream}

--- a/pipeline/relation_embedder/batcher/src/main/resources/application.conf
+++ b/pipeline/relation_embedder/batcher/src/main/resources/application.conf
@@ -5,5 +5,4 @@ aws.sns.topic.arn=${?output_topic_arn}
 batcher.flush_interval_minutes=${?flush_interval_minutes}
 batcher.max_processed_paths=${?max_processed_paths}
 batcher.max_batch_size=${?max_batch_size}
-batcher.use_downstream=sns
-batcher.use_downstream=${?use_downstream}
+downstream.target=${?use_downstream}

--- a/pipeline/relation_embedder/batcher/src/main/scala/weco/pipeline/batcher/lib/BatcherConfig.scala
+++ b/pipeline/relation_embedder/batcher/src/main/scala/weco/pipeline/batcher/lib/BatcherConfig.scala
@@ -6,10 +6,7 @@ import weco.lambda.{
   ApplicationConfig,
   DownstreamTarget,
   LambdaConfigurable,
-  SNS,
-  StdOut
 }
-import weco.messaging.typesafe.SNSBuilder.buildSNSConfig
 
 case class BatcherConfig(
   maxBatchSize: Int,

--- a/pipeline/relation_embedder/batcher/src/main/scala/weco/pipeline/batcher/lib/BatcherConfig.scala
+++ b/pipeline/relation_embedder/batcher/src/main/scala/weco/pipeline/batcher/lib/BatcherConfig.scala
@@ -2,7 +2,13 @@ package weco.pipeline.batcher.lib
 
 import com.typesafe.config.Config
 import weco.lambda.DownstreamBuilder.buildDownstreamTarget
-import weco.lambda.{ApplicationConfig, DownstreamTarget, LambdaConfigurable, SNS, StdOut}
+import weco.lambda.{
+  ApplicationConfig,
+  DownstreamTarget,
+  LambdaConfigurable,
+  SNS,
+  StdOut
+}
 import weco.messaging.typesafe.SNSBuilder.buildSNSConfig
 
 case class BatcherConfig(

--- a/pipeline/relation_embedder/batcher/src/main/scala/weco/pipeline/batcher/lib/BatcherConfig.scala
+++ b/pipeline/relation_embedder/batcher/src/main/scala/weco/pipeline/batcher/lib/BatcherConfig.scala
@@ -1,13 +1,8 @@
 package weco.pipeline.batcher.lib
 
 import com.typesafe.config.Config
-import weco.lambda.{
-  ApplicationConfig,
-  DownstreamTarget,
-  LambdaConfigurable,
-  SNS,
-  StdOut
-}
+import weco.lambda.DownstreamBuilder.buildDownstreamTarget
+import weco.lambda.{ApplicationConfig, DownstreamTarget, LambdaConfigurable, SNS, StdOut}
 import weco.messaging.typesafe.SNSBuilder.buildSNSConfig
 
 case class BatcherConfig(
@@ -21,11 +16,6 @@ trait BatcherConfigurable extends LambdaConfigurable[BatcherConfig] {
   def build(rawConfig: Config): BatcherConfig =
     BatcherConfig(
       maxBatchSize = rawConfig.requireInt("batcher.max_batch_size"),
-      downstreamTarget = {
-        rawConfig.requireString("batcher.use_downstream") match {
-          case "sns"   => SNS(buildSNSConfig(rawConfig))
-          case "stdio" => StdOut
-        }
-      }
+      downstreamTarget = buildDownstreamTarget(rawConfig)
     )
 }

--- a/pipeline/relation_embedder/batcher/src/main/scala/weco/pipeline/batcher/lib/BatcherConfig.scala
+++ b/pipeline/relation_embedder/batcher/src/main/scala/weco/pipeline/batcher/lib/BatcherConfig.scala
@@ -2,11 +2,7 @@ package weco.pipeline.batcher.lib
 
 import com.typesafe.config.Config
 import weco.lambda.DownstreamBuilder.buildDownstreamTarget
-import weco.lambda.{
-  ApplicationConfig,
-  DownstreamTarget,
-  LambdaConfigurable,
-}
+import weco.lambda.{ApplicationConfig, DownstreamTarget, LambdaConfigurable}
 
 case class BatcherConfig(
   maxBatchSize: Int,

--- a/pipeline/relation_embedder/relation_embedder/src/main/resources/application.conf
+++ b/pipeline/relation_embedder/relation_embedder/src/main/resources/application.conf
@@ -11,4 +11,5 @@ es.host=${?es_host}
 es.port=${?es_port}
 es.protocol=${?es_protocol}
 es.apikey=${?es_apikey}
+downstream.target=sns
 downstream.target=${?use_downstream}

--- a/pipeline/relation_embedder/relation_embedder/src/main/resources/application.conf
+++ b/pipeline/relation_embedder/relation_embedder/src/main/resources/application.conf
@@ -11,4 +11,4 @@ es.host=${?es_host}
 es.port=${?es_port}
 es.protocol=${?es_protocol}
 es.apikey=${?es_apikey}
-relation_embedder.use_downstream=${?use_downstream}
+downstream.target=${?use_downstream}

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/lib/RelationEmbedderConfig.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/lib/RelationEmbedderConfig.scala
@@ -2,9 +2,9 @@ package weco.pipeline.relation_embedder.lib
 
 import com.typesafe.config.Config
 import weco.elasticsearch.typesafe.ElasticBuilder.buildElasticClientConfig
+import weco.lambda.DownstreamBuilder.buildDownstreamTarget
 import weco.elasticsearch.typesafe.ElasticConfig
 import weco.lambda._
-import weco.messaging.typesafe.SNSBuilder.buildSNSConfig
 
 case class RelationEmbedderConfig(
   mergedWorkIndex: String,
@@ -31,11 +31,6 @@ trait RelationEmbedderConfigurable
       affectedWorksScroll =
         rawConfig.requireInt("es.works.scroll.affected_works"),
       elasticConfig = buildElasticClientConfig(rawConfig),
-      downstreamTarget = {
-        rawConfig.requireString("relation_embedder.use_downstream") match {
-          case "sns"   => SNS(buildSNSConfig(rawConfig))
-          case "stdio" => StdOut
-        }
-      }
+      downstreamTarget = buildDownstreamTarget(rawConfig)
     )
 }


### PR DESCRIPTION
## What does this change?

For https://github.com/wellcomecollection/platform/issues/5870

This change adds a typesafe config builder for `DownstreamTarget` adds tests and applies it to the batcher and relation embedder. Currently deployment is failing in the 2024-11-18 pipeline because of missing configuration for `use_downstream`, this change is intended to remove any ambiguity of how this configuration behaves between services and add a consistent default.

## How to test

- [ ] Run the tests, do they pass?
- [ ] Once merged is the deployment successful?

## How can we measure success?

The new pipeline can be deployed to and a reindex can proceed.

## Have we considered potential risks?

The 2024-11-18 pipeline is not the production pipeline yet, so a failure should not impact end users.
