### PR TITLE
Not necessary to output to /dev/tty, is forbidden in lambda env

### DIFF
--- a/pipeline/relation_embedder/relation_embedder/bash_secrets_extension.sh
+++ b/pipeline/relation_embedder/relation_embedder/bash_secrets_extension.sh
@@ -32,11 +32,11 @@ echo "[${LAMBDA_EXTENSION_NAME}] Initialization"
 get_secret() {
   local secret_name=$1
   local secret_value
-  echo "[${LAMBDA_EXTENSION_NAME}] Getting secret: $secret_name" > /dev/tty
+  echo "[${LAMBDA_EXTENSION_NAME}] Getting secret: $secret_name"
 
   secret_value=$(aws secretsmanager get-secret-value --secret-id "$secret_name" --query SecretString --output text)
   if [[ -z "$secret_value" ]]; then
-    echo "[${LAMBDA_EXTENSION_NAME}] Secret not found: $secret_name" > /dev/tty
+    echo "[${LAMBDA_EXTENSION_NAME}] Secret not found: $secret_name"
     exit 1
   fi
   echo "$secret_value"


### PR DESCRIPTION
## What does this change?

For https://github.com/wellcomecollection/platform/issues/5870

A tweak to ensure secret retrieval is logged correctly in the bash secrets lambda extensions.

<img width="650" alt="Screenshot 2025-01-09 at 13 58 30" src="https://github.com/user-attachments/assets/269cdf78-60c7-492c-b3e4-88d81c5a1227" />

This error appears in logs in a deployed lambda. I believe this is because /dev/tty is unavailable in the lambda environment, although the command to retrieve the secret is succeeding.

## How to test

- [ ] Deploy the change, does the error go away?

## How can we measure success?

Less confusing errors, better logs.

## Have we considered potential risks?

The 2024-11-18 pipeline is not the production pipeline yet, so a failure should not impact end users.
