### PR TITLE
Use correct topic env var name in relation embedder

### DIFF
--- a/pipeline/relation_embedder/relation_embedder/src/main/resources/application.conf
+++ b/pipeline/relation_embedder/relation_embedder/src/main/resources/application.conf
@@ -1,7 +1,7 @@
 aws.metrics.namespace=${?metrics_namespace}
 aws.sqs.queue.url=${?queue_url}
 aws.sqs.queue.parallelism=${?queue_parallelism}
-aws.sns.topic.arn=${?topic_arn}
+aws.sns.topic.arn=${?output_topic_arn}
 es.merged-works.index=${?es_merged_index}
 es.works.scroll.complete_tree=${?complete_tree_scroll_size}
 es.works.scroll.affected_works=${?affected_works_scroll_size}

--- a/pipeline/terraform/modules/stack/service_work_relation_embedder.tf
+++ b/pipeline/terraform/modules/stack/service_work_relation_embedder.tf
@@ -27,7 +27,7 @@ module "relation_embedder" {
   queue_visibility_timeout_seconds = 30 * 60
 
   env_vars = {
-    topic_arn = module.relation_embedder_output_topic.arn
+    output_topic_arn = module.relation_embedder_output_topic.arn
 
     es_merged_index       = local.es_works_merged_index
     es_denormalised_index = local.es_works_denormalised_index


### PR DESCRIPTION
## What does this change?

For https://github.com/wellcomecollection/platform/issues/5870

Use the correct env var name for topic arn in the relation embedder, there is a mismatch causing the lambda to fail. 

`output_topic_arn` is preferred to avoid confusion with `topic_arns` which is used to subscribe input topics.

## How to test

- [ ] Deploy the change, does the lambda run successfully?

## How can we measure success?

The relation embedder lambda can process events.

## Have we considered potential risks?

The 2024-11-18 pipeline is not the production pipeline yet, so a failure should not impact end users.

