### PR TITLE
Add VPC config for lambdas

### DIFF
--- a/pipeline/terraform/modules/pipeline_lambda/main.tf
+++ b/pipeline/terraform/modules/pipeline_lambda/main.tf
@@ -8,6 +8,8 @@ module "pipeline_step" {
   memory_size  = var.memory_size
   description  = var.description
 
+  vpc_config = var.vpc_config
+
   environment = {
     variables = local.environment_variables_with_secrets
   }

--- a/pipeline/terraform/modules/pipeline_lambda/variables.tf
+++ b/pipeline/terraform/modules/pipeline_lambda/variables.tf
@@ -31,6 +31,14 @@ variable "environment_variables" {
   default     = {}
 }
 
+variable vpc_config {
+  type = object({
+    subnet_ids         = list(string)
+    security_group_ids = list(string)
+  })
+  default = null
+}
+
 variable "timeout" {
   default     = 30
   description = "lambda function timeout"

--- a/pipeline/terraform/modules/pipeline_lambda/variables.tf
+++ b/pipeline/terraform/modules/pipeline_lambda/variables.tf
@@ -31,7 +31,7 @@ variable "environment_variables" {
   default     = {}
 }
 
-variable vpc_config {
+variable "vpc_config" {
   type = object({
     subnet_ids         = list(string)
     security_group_ids = list(string)

--- a/pipeline/terraform/modules/stack/locals.tf
+++ b/pipeline/terraform/modules/stack/locals.tf
@@ -200,6 +200,14 @@ locals {
     security_group_id = local.infra_critical.rds_access_security_group_id
   }
 
+  lambda_vpc_config = {
+    subnet_ids         = local.network_config.subnets
+    security_group_ids = [
+      aws_security_group.egress.id,
+      local.network_config.ec_privatelink_security_group_id,
+    ]
+  }
+
   fargate_service_boilerplate = {
     egress_security_group_id             = aws_security_group.egress.id
     elastic_cloud_vpce_security_group_id = local.network_config.ec_privatelink_security_group_id

--- a/pipeline/terraform/modules/stack/locals.tf
+++ b/pipeline/terraform/modules/stack/locals.tf
@@ -201,7 +201,7 @@ locals {
   }
 
   lambda_vpc_config = {
-    subnet_ids         = local.network_config.subnets
+    subnet_ids = local.network_config.subnets
     security_group_ids = [
       aws_security_group.egress.id,
       local.network_config.ec_privatelink_security_group_id,

--- a/pipeline/terraform/modules/stack/relation_embedder/embedder.tf
+++ b/pipeline/terraform/modules/stack/relation_embedder/embedder.tf
@@ -15,6 +15,8 @@ module "embedder_lambda" {
   pipeline_date = var.pipeline_date
   service_name  = "${var.namespace}_embedder"
 
+  vpc_config = var.lambda_vpc_config
+
   environment_variables = {
     output_topic_arn = module.embedder_lambda_output_topic.arn
 

--- a/pipeline/terraform/modules/stack/relation_embedder/variables.tf
+++ b/pipeline/terraform/modules/stack/relation_embedder/variables.tf
@@ -33,6 +33,14 @@ variable "pipeline_storage_es_service_secrets" {
   }))
 }
 
+variable lambda_vpc_config {
+  type = object({
+    subnet_ids         = list(string)
+    security_group_ids = list(string)
+  })
+  default = null
+}
+
 variable "path_concatenator_image" {
   type = string
 }

--- a/pipeline/terraform/modules/stack/relation_embedder/variables.tf
+++ b/pipeline/terraform/modules/stack/relation_embedder/variables.tf
@@ -33,7 +33,7 @@ variable "pipeline_storage_es_service_secrets" {
   }))
 }
 
-variable lambda_vpc_config {
+variable "lambda_vpc_config" {
   type = object({
     subnet_ids         = list(string)
     security_group_ids = list(string)

--- a/pipeline/terraform/modules/stack/subsystem_relation_embedder.tf
+++ b/pipeline/terraform/modules/stack/subsystem_relation_embedder.tf
@@ -20,4 +20,5 @@ module "relation_embedder_sub" {
   min_capacity                = var.min_capacity
   max_capacity                = var.reindexing_state.scale_up_tasks ? var.max_capacity : min(1, var.max_capacity)
   fargate_service_boilerplate = local.fargate_service_boilerplate
+  lambda_vpc_config           = local.lambda_vpc_config
 }


### PR DESCRIPTION
## What does this change?

This change adds VPC config for pipeline lambdas, and enables that for the relation embedder so that it can talk to elasticsearch over the internal VPC endpoint.

## How to test

- [ ] Apply the terraform change to the 2024-11-18 pipeline
- [ ] Test run the relation_embedder lambda in AWS, does it succeed?

## How can we measure success?

Lambdas can write to elastic search, the pipeline works!

## Have we considered potential risks?

The 2024-11-19 pipeline is not in production use, so this change should not impact users.
