### PR TITLE
rename services for build correctly

### DIFF
--- a/builds/deploy_catalogue_pipeline.sh
+++ b/builds/deploy_catalogue_pipeline.sh
@@ -79,10 +79,8 @@ then
     merger \
     ingestor_images \
     ingestor_works \
-    router \
-    path_concatenator \
-    batcher \
-    relation_embedder \
+    r_embed_router \
+    r_embed_path_concatenator \
     transformer_calm \
     transformer_ebsco \
     transformer_mets \

--- a/builds/deploy_lambda_services.sh
+++ b/builds/deploy_lambda_services.sh
@@ -33,7 +33,6 @@ do
     --image-uri "${IMAGE_URI}" \
     --no-cli-pager
 
-
   echo "Updated lambda configuration, (waiting for update @ $(date)}):"
   aws lambda wait function-updated \
     --function-name "$FUNCTION_NAME" \


### PR DESCRIPTION
## What does this change?

Follows: https://github.com/wellcomecollection/catalogue-pipeline/pull/2811

This change correctly names the ECS services that need deploying following the explicit creation of the relation embedder subsystem module.

See: 
<img width="871" alt="Screenshot 2025-01-16 at 12 56 00" src="https://github.com/user-attachments/assets/920481cb-95d9-4880-894f-2c94a9b3fdcb" />

## How to test

- [ ] Deploy this change, does it deploy successfully?

## How can we measure success?

Working build for catalogue-pipeline.

## Have we considered potential risks?

This should not impact services in public view.
