### PR TITLE
Namespace relation embedder subsystem topics with pipeline date

### DIFF
--- a/pipeline/terraform/modules/stack/relation_embedder/batcher.tf
+++ b/pipeline/terraform/modules/stack/relation_embedder/batcher.tf
@@ -22,7 +22,7 @@ locals {
 module "batcher_lambda_output_topic" {
   source = "../../topic"
 
-  name       = "${var.namespace}_batcher_lambda_output"
+  name       = "${local.topic_namespace}_batcher_lambda_output"
   role_names = [module.batcher_lambda.lambda_role_name]
 }
 

--- a/pipeline/terraform/modules/stack/relation_embedder/embedder.tf
+++ b/pipeline/terraform/modules/stack/relation_embedder/embedder.tf
@@ -5,7 +5,7 @@ locals {
 module "embedder_lambda_output_topic" {
   source = "../../topic"
 
-  name       = "${var.namespace}_embedder_lambda_output"
+  name       = "${local.topic_namespace}_embedder_lambda_output"
   role_names = [module.embedder_lambda.lambda_role_name]
 }
 

--- a/pipeline/terraform/modules/stack/relation_embedder/path_concatenator.tf
+++ b/pipeline/terraform/modules/stack/relation_embedder/path_concatenator.tf
@@ -2,7 +2,7 @@
 module "path_concatenator_output_topic" {
   source = "../../topic"
 
-  name       = "${var.namespace}_path_concatenator_output_topic"
+  name       = "${local.topic_namespace}_path_concatenator_output_topic"
   role_names = [module.path_concatenator.task_role_name]
 }
 

--- a/pipeline/terraform/modules/stack/relation_embedder/router.tf
+++ b/pipeline/terraform/modules/stack/relation_embedder/router.tf
@@ -1,21 +1,21 @@
 module "router_path_output_topic" {
   source = "../../topic"
 
-  name       = "${var.namespace}_router_path_output"
+  name       = "${local.topic_namespace}_router_path_output"
   role_names = [module.router.task_role_name]
 }
 
 module "router_candidate_incomplete_paths_output_topic" {
   source = "../../topic"
 
-  name       = "${var.namespace}_router_candidate_incomplete_paths_output"
+  name       = "${local.topic_namespace}_router_candidate_incomplete_paths_output"
   role_names = [module.router.task_role_name]
 }
 
 module "router_work_output_topic" {
   source = "../../topic"
 
-  name       = "${var.namespace}_router_work_output"
+  name       = "${local.topic_namespace}_router_work_output"
   role_names = [module.router.task_role_name]
 }
 

--- a/pipeline/terraform/modules/stack/relation_embedder/variables.tf
+++ b/pipeline/terraform/modules/stack/relation_embedder/variables.tf
@@ -6,6 +6,9 @@ variable "pipeline_date" {
   type = string
 }
 
+locals {
+  topic_namespace = "catalogue-${var.pipeline_date}-${var.namespace}"
+}
 variable "reindexing_state" {
   type = object({
     listen_to_reindexer      = bool


### PR DESCRIPTION
> [!Note]
> This terraform change has been applied.

## What does this change?

This change includes the pipeline date in topic names in order that they are properly namespaced. Without the pipeline dates, pipelines can share topics resulting in accidental deletion and duplication of messages!

See: https://wellcome.slack.com/archives/C02ANCYL90E/p1737446762810389

## How to test

- [ ] Apply this change, redrive any messages impacted & observe changes properly flowing through the pipeline.

## How can we measure success?

The catalogue pipeline continues to publish changes to the public catalogue.

## Have we considered potential risks?

Applying this change to a production pipeline might cause some messages to be retried, but data should not be lost!
