### PR TITLE
Increase relation embedder memory

### DIFF
--- a/pipeline/terraform/2024-11-18/pipeline_config.tf
+++ b/pipeline/terraform/2024-11-18/pipeline_config.tf
@@ -8,7 +8,9 @@ locals {
 
 terraform {
   backend "s3" {
-    role_arn = "arn:aws:iam::760097843905:role/platform-developer"
+    assume_role = {
+      role_arn = "arn:aws:iam::760097843905:role/platform-developer"
+    }
 
     bucket         = "wellcomecollection-platform-infra"
     key            = "terraform/catalogue-pipeline/pipeline/2024-11-18.tfstate"

--- a/pipeline/terraform/modules/stack/relation_embedder/embedder.tf
+++ b/pipeline/terraform/modules/stack/relation_embedder/embedder.tf
@@ -33,7 +33,7 @@ module "embedder_lambda" {
 
   # see comment on fargate service's queue_visibility_timeout_seconds
   # 15 minutes is the max for lambda, is it going to be enough?
-  timeout = 60 * 15 # 15 Minutes
+  timeout     = 60 * 15 # 15 Minutes
   memory_size = 2048
 
   queue_config = {

--- a/pipeline/terraform/modules/stack/relation_embedder/embedder.tf
+++ b/pipeline/terraform/modules/stack/relation_embedder/embedder.tf
@@ -34,6 +34,7 @@ module "embedder_lambda" {
   # see comment on fargate service's queue_visibility_timeout_seconds
   # 15 minutes is the max for lambda, is it going to be enough?
   timeout = 60 * 15 # 15 Minutes
+  memory_size = 2048
 
   queue_config = {
     topic_arns = [

--- a/pipeline/terraform/modules/stack/terraform.tf
+++ b/pipeline/terraform/modules/stack/terraform.tf
@@ -5,9 +5,9 @@ data "terraform_remote_state" "catalogue_infra_critical" {
     assume_role = {
       role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
     }
-    bucket   = "wellcomecollection-platform-infra"
-    key      = "terraform/catalogue/infrastructure/critical.tfstate"
-    region   = "eu-west-1"
+    bucket = "wellcomecollection-platform-infra"
+    key    = "terraform/catalogue/infrastructure/critical.tfstate"
+    region = "eu-west-1"
   }
 }
 
@@ -18,9 +18,9 @@ data "terraform_remote_state" "shared_infra" {
     assume_role = {
       role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
     }
-    bucket   = "wellcomecollection-platform-infra"
-    key      = "terraform/platform-infrastructure/shared.tfstate"
-    region   = "eu-west-1"
+    bucket = "wellcomecollection-platform-infra"
+    key    = "terraform/platform-infrastructure/shared.tfstate"
+    region = "eu-west-1"
   }
 }
 
@@ -61,9 +61,9 @@ data "terraform_remote_state" "sierra_adapter" {
     assume_role = {
       role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
     }
-    bucket   = "wellcomecollection-platform-infra"
-    key      = "terraform/sierra_adapter.tfstate"
-    region   = "eu-west-1"
+    bucket = "wellcomecollection-platform-infra"
+    key    = "terraform/sierra_adapter.tfstate"
+    region = "eu-west-1"
   }
 }
 
@@ -74,9 +74,9 @@ data "terraform_remote_state" "mets_adapter" {
     assume_role = {
       role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
     }
-    bucket   = "wellcomecollection-platform-infra"
-    key      = "terraform/catalogue/mets_adapter.tfstate"
-    region   = "eu-west-1"
+    bucket = "wellcomecollection-platform-infra"
+    key    = "terraform/catalogue/mets_adapter.tfstate"
+    region = "eu-west-1"
   }
 }
 
@@ -87,9 +87,9 @@ data "terraform_remote_state" "tei_adapter" {
     assume_role = {
       role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
     }
-    bucket   = "wellcomecollection-platform-infra"
-    key      = "terraform/tei_adapter.tfstate"
-    region   = "eu-west-1"
+    bucket = "wellcomecollection-platform-infra"
+    key    = "terraform/tei_adapter.tfstate"
+    region = "eu-west-1"
   }
 }
 
@@ -100,9 +100,9 @@ data "terraform_remote_state" "ebsco_adapter" {
     assume_role = {
       role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
     }
-    bucket   = "wellcomecollection-platform-infra"
-    key      = "terraform/ebsco_adapter.tfstate"
-    region   = "eu-west-1"
+    bucket = "wellcomecollection-platform-infra"
+    key    = "terraform/ebsco_adapter.tfstate"
+    region = "eu-west-1"
   }
 }
 
@@ -114,9 +114,9 @@ data "terraform_remote_state" "calm_adapter" {
     assume_role = {
       role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
     }
-    bucket   = "wellcomecollection-platform-infra"
-    key      = "terraform/calm_adapter.tfstate"
-    region   = "eu-west-1"
+    bucket = "wellcomecollection-platform-infra"
+    key    = "terraform/calm_adapter.tfstate"
+    region = "eu-west-1"
   }
 }
 
@@ -127,9 +127,9 @@ data "terraform_remote_state" "reindexer" {
     assume_role = {
       role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
     }
-    bucket   = "wellcomecollection-platform-infra"
-    key      = "terraform/catalogue/reindexer.tfstate"
-    region   = "eu-west-1"
+    bucket = "wellcomecollection-platform-infra"
+    key    = "terraform/catalogue/reindexer.tfstate"
+    region = "eu-west-1"
   }
 }
 
@@ -140,9 +140,9 @@ data "terraform_remote_state" "inferrer" {
     assume_role = {
       role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
     }
-    bucket   = "wellcomecollection-platform-infra"
-    key      = "terraform/catalogue-pipeline/pipeline/inferrer.tfstate"
-    region   = "eu-west-1"
+    bucket = "wellcomecollection-platform-infra"
+    key    = "terraform/catalogue-pipeline/pipeline/inferrer.tfstate"
+    region = "eu-west-1"
   }
 }
 

--- a/pipeline/terraform/modules/stack/terraform.tf
+++ b/pipeline/terraform/modules/stack/terraform.tf
@@ -2,7 +2,9 @@ data "terraform_remote_state" "catalogue_infra_critical" {
   backend = "s3"
 
   config = {
-    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    assume_role = {
+      role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    }
     bucket   = "wellcomecollection-platform-infra"
     key      = "terraform/catalogue/infrastructure/critical.tfstate"
     region   = "eu-west-1"
@@ -13,7 +15,9 @@ data "terraform_remote_state" "shared_infra" {
   backend = "s3"
 
   config = {
-    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    assume_role = {
+      role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    }
     bucket   = "wellcomecollection-platform-infra"
     key      = "terraform/platform-infrastructure/shared.tfstate"
     region   = "eu-west-1"
@@ -24,8 +28,9 @@ data "terraform_remote_state" "monitoring" {
   backend = "s3"
 
   config = {
-    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
-
+    assume_role = {
+      role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    }
     bucket = "wellcomecollection-platform-infra"
     key    = "terraform/monitoring.tfstate"
     region = "eu-west-1"
@@ -36,8 +41,9 @@ data "terraform_remote_state" "accounts_catalogue" {
   backend = "s3"
 
   config = {
-    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
-
+    assume_role = {
+      role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    }
     bucket = "wellcomecollection-platform-infra"
     key    = "terraform/aws-account-infrastructure/catalogue.tfstate"
     region = "eu-west-1"
@@ -52,7 +58,9 @@ data "terraform_remote_state" "sierra_adapter" {
   backend = "s3"
 
   config = {
-    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    assume_role = {
+      role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    }
     bucket   = "wellcomecollection-platform-infra"
     key      = "terraform/sierra_adapter.tfstate"
     region   = "eu-west-1"
@@ -63,7 +71,9 @@ data "terraform_remote_state" "mets_adapter" {
   backend = "s3"
 
   config = {
-    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    assume_role = {
+      role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    }
     bucket   = "wellcomecollection-platform-infra"
     key      = "terraform/catalogue/mets_adapter.tfstate"
     region   = "eu-west-1"
@@ -74,7 +84,9 @@ data "terraform_remote_state" "tei_adapter" {
   backend = "s3"
 
   config = {
-    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    assume_role = {
+      role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    }
     bucket   = "wellcomecollection-platform-infra"
     key      = "terraform/tei_adapter.tfstate"
     region   = "eu-west-1"
@@ -85,7 +97,9 @@ data "terraform_remote_state" "ebsco_adapter" {
   backend = "s3"
 
   config = {
-    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    assume_role = {
+      role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    }
     bucket   = "wellcomecollection-platform-infra"
     key      = "terraform/ebsco_adapter.tfstate"
     region   = "eu-west-1"
@@ -97,7 +111,9 @@ data "terraform_remote_state" "calm_adapter" {
   backend = "s3"
 
   config = {
-    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    assume_role = {
+      role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    }
     bucket   = "wellcomecollection-platform-infra"
     key      = "terraform/calm_adapter.tfstate"
     region   = "eu-west-1"
@@ -108,7 +124,9 @@ data "terraform_remote_state" "reindexer" {
   backend = "s3"
 
   config = {
-    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    assume_role = {
+      role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    }
     bucket   = "wellcomecollection-platform-infra"
     key      = "terraform/catalogue/reindexer.tfstate"
     region   = "eu-west-1"
@@ -119,7 +137,9 @@ data "terraform_remote_state" "inferrer" {
   backend = "s3"
 
   config = {
-    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    assume_role = {
+      role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    }
     bucket   = "wellcomecollection-platform-infra"
     key      = "terraform/catalogue-pipeline/pipeline/inferrer.tfstate"
     region   = "eu-west-1"

--- a/pipeline/terraform/scripts/create_terraform_config_file.sh
+++ b/pipeline/terraform/scripts/create_terraform_config_file.sh
@@ -28,7 +28,9 @@ locals {
 
 terraform {
   backend "s3" {
-    role_arn = "arn:aws:iam::760097843905:role/platform-developer"
+    assume_role = {
+      role_arn = "arn:aws:iam::760097843905:role/platform-developer"
+    }
 
     bucket         = "wellcomecollection-platform-infra"
     key            = "terraform/catalogue-pipeline/pipeline/$PIPELINE_DATE.tfstate"


### PR DESCRIPTION
## What does this change?

Increased memory_size for relation_embedder lambda (from the default 1024) to help it handle large archive trees
This has been applied 

## How to test

Re drive the DLQ messages to the main queue and see whether they get processed faster

## How can we measure success?

The lambda can process large archive trees without timing out

## Have we considered potential risks?

Worst case scenario, it doesn't help 🤷‍♂️

