### PR TITLE
Move maxConnections into RDSClientConfig, move creation of RDSClientConfig 

### DIFF
--- a/pipeline/id_minter/src/main/scala/weco/pipeline/id_minter/Main.scala
+++ b/pipeline/id_minter/src/main/scala/weco/pipeline/id_minter/Main.scala
@@ -16,6 +16,7 @@ import weco.pipeline.id_minter.config.builders.{
   IdentifiersTableBuilder,
   RDSBuilder
 }
+import weco.pipeline.id_minter.config.models.RDSClientConfig
 import weco.pipeline.id_minter.database.IdentifiersDao
 import weco.pipeline.id_minter.models.IdentifiersTable
 import weco.pipeline.id_minter.services.IdMinterWorkerService
@@ -29,9 +30,9 @@ object Main extends WellcomeTypesafeApp {
     config: Config =>
       implicit val executionContext: ExecutionContext =
         ActorSystem("main-actor-system").dispatcher
-
+      val rdsConfig = RDSClientConfig(config)
       val identifiersTableConfig = IdentifiersTableBuilder.buildConfig(config)
-      RDSBuilder.buildDB(config)
+      RDSBuilder.buildDB(rdsConfig)
 
       val identifierGenerator = new IdentifierGenerator(
         identifiersDao = new IdentifiersDao(
@@ -66,7 +67,7 @@ object Main extends WellcomeTypesafeApp {
         identifierGenerator = identifierGenerator,
         jsonRetriever = jsonRetriever,
         pipelineStream = pipelineStream,
-        rdsClientConfig = RDSBuilder.buildRDSClientConfig(config),
+        rdsClientConfig = rdsConfig,
         identifiersTableConfig = identifiersTableConfig
       )
   }

--- a/pipeline/id_minter/src/main/scala/weco/pipeline/id_minter/config/builders/RDSBuilder.scala
+++ b/pipeline/id_minter/src/main/scala/weco/pipeline/id_minter/config/builders/RDSBuilder.scala
@@ -1,25 +1,13 @@
 package weco.pipeline.id_minter.config.builders
 
-import com.typesafe.config.Config
 import scalikejdbc.{ConnectionPool, ConnectionPoolSettings}
 import weco.pipeline.id_minter.config.models.RDSClientConfig
-import weco.typesafe.config.builders.EnrichConfig._
 
 object RDSBuilder {
-  def buildDB(config: Config): Unit = {
-    val maxConnections = config.requireInt("aws.rds.maxConnections")
 
-    val rdsClientConfig = buildRDSClientConfig(config)
-
-    buildDB(
-      maxConnections = maxConnections,
-      rdsClientConfig = rdsClientConfig
-    )
-  }
-
-  def buildDB(maxConnections: Int, rdsClientConfig: RDSClientConfig): Unit = {
+  def buildDB(rdsClientConfig: RDSClientConfig): Unit = {
     val connectionPoolSettings = ConnectionPoolSettings(
-      maxSize = maxConnections,
+      maxSize = rdsClientConfig.maxConnections,
       connectionTimeoutMillis = 120000L
     )
 
@@ -41,23 +29,4 @@ object RDSBuilder {
     )
   }
 
-  def buildRDSClientConfig(config: Config): RDSClientConfig = {
-    val primaryHost = config.requireString("aws.rds.primary_host")
-    val replicaHost = config.requireString("aws.rds.replica_host")
-
-    val port = config
-      .getIntOption("aws.rds.port")
-      .getOrElse(3306)
-
-    val username = config.requireString("aws.rds.username")
-    val password = config.requireString("aws.rds.password")
-
-    RDSClientConfig(
-      primaryHost = primaryHost,
-      replicaHost = replicaHost,
-      port = port,
-      username = username,
-      password = password
-    )
-  }
 }

--- a/pipeline/id_minter/src/main/scala/weco/pipeline/id_minter/config/models/RDSClientConfig.scala
+++ b/pipeline/id_minter/src/main/scala/weco/pipeline/id_minter/config/models/RDSClientConfig.scala
@@ -1,9 +1,36 @@
 package weco.pipeline.id_minter.config.models
 
+import com.typesafe.config.Config
+import weco.typesafe.config.builders.EnrichConfig._
+
 case class RDSClientConfig(
   primaryHost: String,
   replicaHost: String,
   port: Int,
   username: String,
-  password: String
+  password: String,
+  maxConnections: Int
 )
+
+object RDSClientConfig {
+  def apply(config: Config): RDSClientConfig = {
+    val primaryHost = config.requireString("aws.rds.primary_host")
+    val replicaHost = config.requireString("aws.rds.replica_host")
+
+    val port = config
+      .getIntOption("aws.rds.port")
+      .getOrElse(3306)
+
+    val username = config.requireString("aws.rds.username")
+    val password = config.requireString("aws.rds.password")
+
+    RDSClientConfig(
+      primaryHost = primaryHost,
+      replicaHost = replicaHost,
+      port = port,
+      username = username,
+      password = password,
+      maxConnections = config.requireInt("aws.rds.maxConnections")
+    )
+  }
+}

--- a/pipeline/id_minter/src/test/scala/weco/pipeline/id_minter/config/builders/RDSBuilderTest.scala
+++ b/pipeline/id_minter/src/test/scala/weco/pipeline/id_minter/config/builders/RDSBuilderTest.scala
@@ -1,0 +1,84 @@
+package weco.pipeline.id_minter.config.builders
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import scalikejdbc.ConnectionPool
+import weco.pipeline.id_minter.config.models.RDSClientConfig
+
+import scala.jdk.CollectionConverters._
+
+class RDSBuilderTest extends AnyFunSpec with Matchers {
+  describe("Building the database client connection pools") {
+    it("sets up a connection pool for the primary host") {
+      RDSBuilder.buildDB(
+        RDSClientConfig(
+          primaryHost = "realdeal.example.com",
+          replicaHost = "doppelganger.example.com",
+          port = 999,
+          username = "slartibartfast",
+          password = "ssh_its_a_secret",
+          maxConnections = 5
+        )
+      )
+      val p = ConnectionPool.get(name = 'primary)
+      p.url shouldBe "jdbc:mysql://realdeal.example.com:999"
+      p.user shouldBe "slartibartfast"
+      p.settings.maxSize shouldBe 5
+    }
+
+    it("sets up a connection pool for the replica host") {
+      RDSBuilder.buildDB(
+        RDSClientConfig(
+          primaryHost = "primary.example.com",
+          replicaHost = "doppelganger.example.com",
+          port = 1234,
+          username = "slartibartfast",
+          password = "ssh_its_a_secret",
+          maxConnections = 12
+        )
+      )
+      val p = ConnectionPool.get(name = 'replica)
+      p.url shouldBe "jdbc:mysql://doppelganger.example.com:1234"
+      p.user shouldBe "slartibartfast"
+      p.settings.maxSize shouldBe 12
+    }
+  }
+  describe("Extracting configuration values") {
+    val rawConfig = Map(
+      "aws.rds.primary_host" -> "numberone",
+      "aws.rds.replica_host" -> "numbertwo",
+      "aws.rds.username" -> "rincewind",
+      "aws.rds.password" -> "opensesame",
+      "aws.rds.maxConnections" -> "678"
+    )
+    val config = RDSClientConfig(
+      ConfigFactory.parseMap(rawConfig.asJava)
+    )
+    it("extracts the primary host") {
+      config.primaryHost shouldBe "numberone"
+    }
+    it("extracts the replica host") {
+      config.replicaHost shouldBe "numbertwo"
+    }
+    it("extracts the username") {
+      config.username shouldBe "rincewind"
+    }
+    it("extracts the password") {
+      config.password shouldBe "opensesame"
+    }
+    it("extracts the maxConnections") {
+      config.maxConnections shouldBe 678
+    }
+    it("defaults to port 3306") {
+      config.port shouldBe 3306
+    }
+    it("extracts the port value if specified") {
+      val configWithPort = RDSClientConfig(
+        ConfigFactory.parseMap((rawConfig + ("aws.rds.port" -> 1234)).asJava)
+      )
+      configWithPort.port shouldBe 1234
+
+    }
+  }
+}

--- a/pipeline/id_minter/src/test/scala/weco/pipeline/id_minter/fixtures/IdentifiersDatabase.scala
+++ b/pipeline/id_minter/src/test/scala/weco/pipeline/id_minter/fixtures/IdentifiersDatabase.scala
@@ -83,7 +83,8 @@ trait IdentifiersDatabase
     replicaHost = rdsHost,
     port = rdsPort,
     username = rdsUsername,
-    password = rdsPassword
+    password = rdsPassword,
+    maxConnections = rdsMaxPoolSize
   )
 
   def withIdentifiersTable[R](


### PR DESCRIPTION
## What does this change?

This is a straight refactor.

Previously, RDSBuilder.buildDB took a typespace Config, built an RDSClientConfig from it, then later on pulled out the maxConnections from the Config, and used that value alongside the RDSClientConfig.  Later still, Main also builds RDSClientConfig from the Config, to pass in to the Worker Service.

This change minimises that duplication, and also clarifies the buildDB interface, by removing the "here's a stringly-keyed dictionary which I hope has all the values you want" approach.

## How to test

As a straight refactor, everything should continue working as before.

## How can we measure success?

This is part of some refactoring other facilitate https://github.com/wellcomecollection/platform/issues/5888

There is a little inconsistency in the ID Minter about where certain things happen.  This is one step towards bringing the configuration aspect in line with the other services we have converted to Lambda.

## Have we considered potential risks?

The code in Main is a little undertested, but this is a fairly minimal change, and I've added comprehensive testing to RDSBuilder and RDSClientConfig.
