### PR TITLE
increase the search scroll keepAlive to 5 minutes

### DIFF
--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/RelationsRequestBuilder.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/RelationsRequestBuilder.scala
@@ -8,7 +8,7 @@ import weco.pipeline.relation_embedder.models._
 
 case class RelationsRequestBuilder(
   index: Index,
-  scrollKeepAlive: String = "2m"
+  scrollKeepAlive: String = "5m"
 ) {
 
   // To reduce response size and improve Elasticsearch performance we only


### PR DESCRIPTION
## What does this change?

The relation_embedder is throwing a lot of messages on the DLQ
[This](https://github.com/wellcomecollection/catalogue-pipeline/pull/2816) fixed the timeouts 
Here we're increasing the length of time we can scroll, hoping to fix the `search_context_missing_exception` 

## How to test

Redrive the DLQ message to the source queue, do we still see this error?

## How can we measure success?

The relation_embedder can scroll through all the ES search results to build large relation trees

## Have we considered potential risks?

None that I can think of 

