### PR TITLE
Catalogue graph terraform tweaks

### DIFF
--- a/catalogue_graph/terraform/.terraform.lock.hcl
+++ b/catalogue_graph/terraform/.terraform.lock.hcl
@@ -1,6 +1,25 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.7.0"
+  hashes = [
+    "h1:1niS9AcwxN8CrWemnJS2Xf6vM72+48Xh3xFSS3DFWQo=",
+    "zh:04e23bebca7f665a19a032343aeecd230028a3822e546e6f618f24c47ff87f67",
+    "zh:5bb38114238e25c45bf85f5c9f627a2d0c4b98fe44a0837e37d48574385f8dad",
+    "zh:64584bc1db4c390abd81c76de438d93acf967c8a33e9b923d68da6ed749d55bd",
+    "zh:697695ab9cce351adf91a1823bdd72ce6f0d219138f5124ef7645cedf8f59a1f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7edefb1d1e2fead8fd155f7b50a2cb49f2f3fed154ac3ef5f991ccaff93d6120",
+    "zh:807fb15b75910bf14795f2ad1a2d41b069f9ef52c242131b2964c8527312e235",
+    "zh:821d9148d261df1d1a8e5a4812df2a6a3ffaf0d2070dad3c785382e489069239",
+    "zh:a7d92251118fb723048c482154a6ac6368aad583d28d15fffc6f5dafd9507463",
+    "zh:b627d4cef192b3c12ddaf9cb2c4f98c10d0129883c8c2a9c0049983f9de7030d",
+    "zh:dfb70306fcc0ad1d512ab7c24765703783cc286062d4849de4fbe23526f5dc8e",
+    "zh:f21de276f857b7e51fa2593d8fef05a7faafb0a7b62db14ac58a03ce1be7d881",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version = "5.80.0"
   hashes = [

--- a/catalogue_graph/terraform/extractor_ecs_task.tf
+++ b/catalogue_graph/terraform/extractor_ecs_task.tf
@@ -15,7 +15,7 @@ module "extractor_ecs_task" {
   }
 
   cpu    = 2048
-  memory = 4096
+  memory = 8192
 }
 
 resource "aws_iam_role_policy" "ecs_stream_to_sns_policy" {

--- a/catalogue_graph/terraform/extractor_ecs_task.tf
+++ b/catalogue_graph/terraform/extractor_ecs_task.tf
@@ -15,7 +15,7 @@ module "extractor_ecs_task" {
   }
 
   cpu    = 2048
-  memory = 8192
+  memory = 4096
 }
 
 resource "aws_iam_role_policy" "ecs_stream_to_sns_policy" {

--- a/catalogue_graph/terraform/lambda_bulk_load_poller.tf
+++ b/catalogue_graph/terraform/lambda_bulk_load_poller.tf
@@ -6,8 +6,9 @@ module "bulk_load_poller_lambda" {
   runtime     = "python3.13"
   publish     = true
 
-  filename         = "../target/build.zip"
-  source_code_hash = filesha256("../target/build.zip")
+  // New versions are automatically deployed through a GitHub action.
+  // To deploy manually, see `scripts/deploy_lambda_zip.sh`
+  filename    = data.archive_file.empty_zip.output_path
 
   handler     = "bulk_load_poller.lambda_handler"
   memory_size = 128

--- a/catalogue_graph/terraform/lambda_bulk_load_poller.tf
+++ b/catalogue_graph/terraform/lambda_bulk_load_poller.tf
@@ -8,7 +8,7 @@ module "bulk_load_poller_lambda" {
 
   // New versions are automatically deployed through a GitHub action.
   // To deploy manually, see `scripts/deploy_lambda_zip.sh`
-  filename    = data.archive_file.empty_zip.output_path
+  filename = data.archive_file.empty_zip.output_path
 
   handler     = "bulk_load_poller.lambda_handler"
   memory_size = 128

--- a/catalogue_graph/terraform/lambda_bulk_loader.tf
+++ b/catalogue_graph/terraform/lambda_bulk_loader.tf
@@ -8,7 +8,7 @@ module "bulk_loader_lambda" {
 
   // New versions are automatically deployed through a GitHub action.
   // To deploy manually, see `scripts/deploy_lambda_zip.sh`
-  filename    = data.archive_file.empty_zip.output_path
+  filename = data.archive_file.empty_zip.output_path
 
   handler     = "bulk_loader.lambda_handler"
   memory_size = 128

--- a/catalogue_graph/terraform/lambda_bulk_loader.tf
+++ b/catalogue_graph/terraform/lambda_bulk_loader.tf
@@ -6,8 +6,9 @@ module "bulk_loader_lambda" {
   runtime     = "python3.13"
   publish     = true
 
-  filename         = "../target/build.zip"
-  source_code_hash = filesha256("../target/build.zip")
+  // New versions are automatically deployed through a GitHub action.
+  // To deploy manually, see `scripts/deploy_lambda_zip.sh`
+  filename    = data.archive_file.empty_zip.output_path
 
   handler     = "bulk_loader.lambda_handler"
   memory_size = 128

--- a/catalogue_graph/terraform/lambda_indexer.tf
+++ b/catalogue_graph/terraform/lambda_indexer.tf
@@ -6,8 +6,9 @@ module "indexer_lambda" {
   runtime     = "python3.13"
   publish     = true
 
-  filename         = "../target/build.zip"
-  source_code_hash = filesha256("../target/build.zip")
+  // New versions are automatically deployed through a GitHub action.
+  // To deploy manually, see `scripts/deploy_lambda_zip.sh`
+  filename    = data.archive_file.empty_zip.output_path
 
   handler     = "indexer.lambda_handler"
   memory_size = 128

--- a/catalogue_graph/terraform/lambda_indexer.tf
+++ b/catalogue_graph/terraform/lambda_indexer.tf
@@ -8,7 +8,7 @@ module "indexer_lambda" {
 
   // New versions are automatically deployed through a GitHub action.
   // To deploy manually, see `scripts/deploy_lambda_zip.sh`
-  filename    = data.archive_file.empty_zip.output_path
+  filename = data.archive_file.empty_zip.output_path
 
   handler     = "indexer.lambda_handler"
   memory_size = 128

--- a/catalogue_graph/terraform/locals.tf
+++ b/catalogue_graph/terraform/locals.tf
@@ -19,3 +19,12 @@ locals {
 data "aws_vpc" "vpc" {
   id = local.vpc_id
 }
+
+data "archive_file" "empty_zip" {
+  output_path = "data/empty.zip"
+  type        = "zip"
+  source {
+    content  = "// This file is intentionally left empty"
+    filename = "lambda.py"
+  }
+}


### PR DESCRIPTION
## What does this change?

Update catalogue graph Terraform code to stop deploying new Lambda function versions from local ZIP files. This process has now been superseded by a new deployment process via a GitHub action. 

The Lambda function module requires a `filename` parameter, so I replaced the build.zip file with an empty archive, mirroring the approach implemented in the [EBSCO adapter](https://github.com/wellcomecollection/catalogue-pipeline/blob/4ff4f8a64b515addadd6d699edf2df4cc9fb7578/ebsco_adapter/terraform/indexer_lambda.tf). 

## How to test

Run `terraform plan`. The output should not include any Lambda function changes associated with the build.zip file.

## How can we measure success?

Terraform apply decoupled from Lambda deployments. 

## Have we considered potential risks?

There should be no risks associated with this change.

