### PR TITLE
Use SearchIterator instead of ElasticSource and fromGraph

### DIFF
--- a/pipeline/relation_embedder/relation_embedder/docker-compose.yml
+++ b/pipeline/relation_embedder/relation_embedder/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     ports:
       - "4566:4566"
   elasticsearch:
-    image: "docker.elastic.co/elasticsearch/elasticsearch:8.4.0"
+    image: "docker.elastic.co/elasticsearch/elasticsearch:8.8.2"
     ports:
       - "9200:9200"
       - "9300:9300"

--- a/pipeline/relation_embedder/relation_embedder/scripts/batches.txt
+++ b/pipeline/relation_embedder/relation_embedder/scripts/batches.txt
@@ -1,2 +1,2 @@
 {"rootPath":"GC103","selectors":[{"path":"GC103","type":"Tree"}]}
-
+{"rootPath":"MS7826","selectors":[{"path":"MS7826","type":"Tree"}]}

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/BatchProcessor.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/BatchProcessor.scala
@@ -3,7 +3,6 @@ package weco.pipeline.relation_embedder
 import com.sksamuel.elastic4s.Index
 import grizzled.slf4j.Logging
 import org.apache.pekko.NotUsed
-import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.stream.Materializer
 import org.apache.pekko.stream.scaladsl.{Sink, Source}
 import weco.catalogue.internal_model.work.Work
@@ -79,6 +78,7 @@ class BatchProcessor(
       .getAffectedWorks(batch)
       .map {
         work =>
+          info(s"transitioning ${work.id}")
           val relations = relationsCache(work)
           work.transition[Denormalised](relations)
       }
@@ -105,8 +105,7 @@ object BatchProcessor {
   def apply(
     config: RelationEmbedderConfig
   )(
-    implicit actorSystem: ActorSystem,
-    ec: ExecutionContext,
+    implicit ec: ExecutionContext,
     materializer: Materializer
   ): BatchProcessor = {
 

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/BatchProcessor.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/BatchProcessor.scala
@@ -78,7 +78,7 @@ class BatchProcessor(
       .getAffectedWorks(batch)
       .map {
         work =>
-          info(s"transitioning ${work.id}")
+          debug(s"transitioning ${work.id}")
           val relations = relationsCache(work)
           work.transition[Denormalised](relations)
       }

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/RelationsService.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/RelationsService.scala
@@ -38,7 +38,7 @@ class PathQueryRelationsService(
     )
     // Arbitrary timeout value, it has to exist for SearchIterator,
     // but it has not been derived either through experimentation or calculation,
-q    implicit val timeout: Duration = 5 minutes
+    implicit val timeout: Duration = 5 minutes
 
     Source.fromIterator(
       () =>

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/RelationsService.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/RelationsService.scala
@@ -36,8 +36,9 @@ class PathQueryRelationsService(
     debug(
       s"Querying affected works with ES request: ${elasticClient.show(request)}"
     )
-
-    implicit val timeout: Duration = 5 minutes
+    // Arbitrary timeout value, it has to exist for SearchIterator,
+    // but it has not been derived either through experimentation or calculation,
+q    implicit val timeout: Duration = 5 minutes
 
     Source.fromIterator(
       () =>

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/RelationsService.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/RelationsService.scala
@@ -1,7 +1,6 @@
 package weco.pipeline.relation_embedder
 
 import org.apache.pekko.NotUsed
-import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.stream.scaladsl.Source
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.circe._
@@ -9,10 +8,12 @@ import com.sksamuel.elastic4s.{ElasticClient, Index}
 import grizzled.slf4j.Logging
 import weco.json.JsonUtil._
 import weco.catalogue.internal_model.Implicits._
-import com.sksamuel.elastic4s.pekko.streams._
+import com.sksamuel.elastic4s.requests.searches.SearchIterator
 import weco.catalogue.internal_model.work.WorkState.Merged
 import weco.catalogue.internal_model.work.Work
 import weco.pipeline.relation_embedder.models.{Batch, RelationWork}
+
+import scala.concurrent.duration.{Duration, DurationInt}
 
 trait RelationsService {
   def getRelationTree(batch: Batch): Source[RelationWork, NotUsed]
@@ -25,8 +26,7 @@ class PathQueryRelationsService(
   index: Index,
   completeTreeScroll: Int = 1000,
   affectedWorksScroll: Int = 250
-)(implicit as: ActorSystem)
-    extends RelationsService
+) extends RelationsService
     with Logging {
 
   private val requestBuilder = RelationsRequestBuilder(index)
@@ -36,17 +36,16 @@ class PathQueryRelationsService(
     debug(
       s"Querying affected works with ES request: ${elasticClient.show(request)}"
     )
-    val sourceSettings = SourceSettings(
-      search = request,
-      maxItems = Long.MaxValue,
-      fetchThreshold = affectedWorksScroll,
-      warm = true
+
+    implicit val timeout: Duration = 5 minutes
+
+    Source.fromIterator(
+      () =>
+        SearchIterator.iterate[Work[Merged]](
+          elasticClient,
+          request
+        )
     )
-    Source
-      .fromGraph(
-        new ElasticSource(elasticClient, sourceSettings)(as.dispatcher)
-      )
-      .map(searchHit => searchHit.safeTo[Work[Merged]].get)
   }
 
   def getRelationTree(batch: Batch): Source[RelationWork, NotUsed] = {
@@ -54,16 +53,15 @@ class PathQueryRelationsService(
     debug(
       s"Querying complete tree with ES request: ${elasticClient.show(request)}"
     )
-    val sourceSettings = SourceSettings(
-      search = request,
-      maxItems = Long.MaxValue,
-      fetchThreshold = affectedWorksScroll,
-      warm = true
+
+    implicit val timeout: Duration = 5 minutes
+
+    Source.fromIterator(
+      () =>
+        SearchIterator.iterate[RelationWork](
+          elasticClient,
+          request
+        )
     )
-    Source
-      .fromGraph(
-        new ElasticSource(elasticClient, sourceSettings)(as.dispatcher)
-      )
-      .map(searchHit => searchHit.safeTo[RelationWork].get)
   }
 }

--- a/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/RelationsServiceTest.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/test/scala/weco/pipeline/relation_embedder/RelationsServiceTest.scala
@@ -25,7 +25,7 @@ class RelationsServiceTest
     index: Index,
     completeTreeScroll: Int = 20,
     affectedWorksScroll: Int = 20
-  )(implicit as: ActorSystem) =
+  ) =
     new PathQueryRelationsService(
       elasticClient = elasticClient,
       index = index,


### PR DESCRIPTION
## What does this change?
fixes https://github.com/wellcomecollection/platform/issues/5957

## How to test

- [x] Run tests - these are unchanged.
- [x] Run it locally - see that _all_ expected works are transitioned in denormaliseAll
- [ ] Run it for Real Life - see that the missing and malformed records are now happy. 

## How can we measure success?

As well as being more reliable, I thin this simplifies that part of the RelationEmbedder and might make it easier to transition it away from Akka/Pekko.

## Have we considered potential risks?

There's some stuff in the existing RelationsService about managing when to fetch the next batch, which I have simply discarded in favour of simply letting Elastic4S work it out.  I don't think they were important, but they may have been.

