### PR TITLE
don't try to deploy the id minter ecs as part of Deploy pipeline

### DIFF
--- a/builds/deploy_catalogue_pipeline.sh
+++ b/builds/deploy_catalogue_pipeline.sh
@@ -49,7 +49,6 @@ then
 fi
 
 ENV_TAG="env.$PIPELINE_DATE" "$ROOT/builds/update_ecr_image_tag.sh" \
-  uk.ac.wellcome/id_minter \
   uk.ac.wellcome/inference_manager \
   uk.ac.wellcome/feature_inferrer \
   uk.ac.wellcome/palette_inferrer \
@@ -73,7 +72,6 @@ if [[ "$TASK" == "tag_images_and_deploy_services" ]]
 then
   echo "Deploying ECS pipeline services to catalogue-$PIPELINE_DATE"
   CLUSTER="catalogue-$PIPELINE_DATE" "$ROOT/builds/deploy_ecs_services.sh" \
-    id_minter \
     image_inferrer \
     matcher \
     merger \


### PR DESCRIPTION
## What does this change?
Currently, the [automated deployment on merge](https://buildkite.com/wellcomecollection/catalogue-pipeline-deploy-pipeline) is [failing](https://buildkite.com/wellcomecollection/catalogue-pipeline-deploy-pipeline/builds/719).  I believe it's because it is trying to deploy the ID Minter ECS, which no longer exists. 

## How to test

merge it to main, watch the deployment, see it succeed

## How can we measure success?

New versions of the pipeline can find their way into production

## Have we considered potential risks?

Maybe this isn't why it's failing.  Even so, it doesn't exist, so it should not be deployed.

The deployment failure was not alerted, we should probably make it more obvious when it fails.