### PR TITLE
Id minter lambda deploy

### DIFF
--- a/builds/deploy_catalogue_pipeline.sh
+++ b/builds/deploy_catalogue_pipeline.sh
@@ -49,7 +49,6 @@ then
 fi
 
 ENV_TAG="env.$PIPELINE_DATE" "$ROOT/builds/update_ecr_image_tag.sh" \
-  uk.ac.wellcome/id_minter \
   uk.ac.wellcome/inference_manager \
   uk.ac.wellcome/feature_inferrer \
   uk.ac.wellcome/palette_inferrer \
@@ -73,7 +72,6 @@ if [[ "$TASK" == "tag_images_and_deploy_services" ]]
 then
   echo "Deploying ECS pipeline services to catalogue-$PIPELINE_DATE"
   CLUSTER="catalogue-$PIPELINE_DATE" "$ROOT/builds/deploy_ecs_services.sh" \
-    id_minter \
     image_inferrer \
     matcher \
     merger \

--- a/builds/deploy_catalogue_pipeline.sh
+++ b/builds/deploy_catalogue_pipeline.sh
@@ -90,6 +90,6 @@ then
   "$ROOT/builds/deploy_lambda_services.sh" \
     batcher:r_embed_batcher \
     relation_embedder:r_embed_embedder \
-    id_minter:id_minter_lambda
+    id_minter:id_minter
 fi
 


### PR DESCRIPTION
## What does this change?

The id_minter_lambda was renamed id_minter following the removal of the ECS version. 

I fixed the now-incorrect deployment of the minter to a non-existent ECS here: https://github.com/wellcomecollection/catalogue-pipeline/pull/2843

This PR fixes the name of the id_minter_lambda

## How to test

merge it to main, watch the deployment, see it succeed


## How can we measure success?

New versions of the pipeline can find their way into production

## Have we considered potential risks?

This fixes one of the risks from https://github.com/wellcomecollection/catalogue-pipeline/pull/2843 - that that was not the only problem.
