### PR TITLE
Close the scroll context in the id_minter

### DIFF
--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/RelationsService.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/RelationsService.scala
@@ -4,17 +4,15 @@ import org.apache.pekko.NotUsed
 import org.apache.pekko.stream.scaladsl.Source
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.circe._
-import com.sksamuel.elastic4s.{ElasticClient, HitReader, Index, RequestFailure, RequestSuccess}
+import com.sksamuel.elastic4s.{ElasticClient, Index}
 import grizzled.slf4j.Logging
 import weco.json.JsonUtil._
 import weco.catalogue.internal_model.Implicits._
-import com.sksamuel.elastic4s.requests.searches.{SearchHit, SearchRequest}
 import weco.catalogue.internal_model.work.WorkState.Merged
 import weco.catalogue.internal_model.work.Work
 import weco.pipeline.relation_embedder.lib.SearchIterator
 import weco.pipeline.relation_embedder.models.{Batch, RelationWork}
 
-import scala.concurrent.Await
 import scala.concurrent.duration.{Duration, DurationInt}
 
 trait RelationsService {

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/RelationsService.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/RelationsService.scala
@@ -4,15 +4,17 @@ import org.apache.pekko.NotUsed
 import org.apache.pekko.stream.scaladsl.Source
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.circe._
-import com.sksamuel.elastic4s.{ElasticClient, Index}
+import com.sksamuel.elastic4s.{ElasticClient, HitReader, Index, RequestFailure, RequestSuccess}
 import grizzled.slf4j.Logging
 import weco.json.JsonUtil._
 import weco.catalogue.internal_model.Implicits._
-import com.sksamuel.elastic4s.requests.searches.SearchIterator
+import com.sksamuel.elastic4s.requests.searches.{SearchHit, SearchRequest}
 import weco.catalogue.internal_model.work.WorkState.Merged
 import weco.catalogue.internal_model.work.Work
+import weco.pipeline.relation_embedder.lib.SearchIterator
 import weco.pipeline.relation_embedder.models.{Batch, RelationWork}
 
+import scala.concurrent.Await
 import scala.concurrent.duration.{Duration, DurationInt}
 
 trait RelationsService {

--- a/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/lib/SearchIterator.scala
+++ b/pipeline/relation_embedder/relation_embedder/src/main/scala/weco/pipeline/relation_embedder/lib/SearchIterator.scala
@@ -1,0 +1,77 @@
+package weco.pipeline.relation_embedder.lib
+
+import com.sksamuel.elastic4s.{ElasticClient, HitReader, RequestFailure, RequestSuccess}
+import com.sksamuel.elastic4s.requests.searches.{SearchHit, SearchRequest}
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+// This object is copied from https://github.com/Philippus/elastic4s/blob/main/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/SearchIterator.scala#L4
+// It is modified to allow the scroll context to be closed when the iterator is exhausted
+object SearchIterator {
+
+  /**
+   * Creates a new Iterator for instances of SearchHit by wrapping the given HTTP client.
+   */
+  def hits(client: ElasticClient, searchreq: SearchRequest)(implicit timeout: Duration): Iterator[SearchHit] =
+    new Iterator[SearchHit] {
+      require(searchreq.keepAlive.isDefined, "Search request must define keep alive value")
+
+      import com.sksamuel.elastic4s.ElasticDsl._
+
+      private var internalIterator: Iterator[SearchHit] = Iterator.empty
+      private var scrollId: Option[String]      = None
+
+      override def hasNext: Boolean = {
+        val hasNext = internalIterator.hasNext || {
+          internalIterator = fetchNext()
+          internalIterator.hasNext
+        }
+
+        if (!hasNext) {
+          closeScroll()
+        }
+
+        hasNext
+      }
+
+      override def next(): SearchHit = internalIterator.next()
+
+      private def closeScroll(): Unit = {
+        scrollId.foreach { id =>
+          val f = client.execute(clearScroll(id))
+          Await.result(f, timeout)
+        }
+      }
+
+      def fetchNext(): Iterator[SearchHit] = {
+
+        // we're either advancing a scroll id or issuing the first query w/ the keep alive set
+        val f = scrollId match {
+          case Some(id) => client.execute(searchScroll(id, searchreq.keepAlive.get))
+          case None     => client.execute(searchreq)
+        }
+
+        val resp = Await.result(f, timeout)
+
+        // in a search scroll we must always use the last returned scrollId
+        val response = resp match {
+          case RequestSuccess(_, _, _, result) => result
+          case failure: RequestFailure         => sys.error(failure.toString)
+        }
+
+        scrollId = response.scrollId
+        response.hits.hits.iterator
+      }
+    }
+
+  /**
+   * Creates a new Iterator for type T by wrapping the given HTTP client.
+   * A typeclass HitReader[T] must be provided for marshalling of the search
+   * responses into instances of type T.
+   */
+  def iterate[T](client: ElasticClient, searchreq: SearchRequest)(implicit
+                                                                  reader: HitReader[T],
+                                                                  timeout: Duration): Iterator[T] =
+    hits(client, searchreq).map(_.to[T])
+}


### PR DESCRIPTION
## What does this change?

This change copies and modifies the search iterator class from Elastic4S in order to properly close the [scroll context](https://www.elastic.co/guide/en/elasticsearch/reference/current/scroll-api.html). Following https://github.com/wellcomecollection/catalogue-pipeline/pull/2842 we we're seeing an error pattern that looks like this: 

![image](https://github.com/user-attachments/assets/78de93af-f0e1-4665-b4b8-8fb96b0a52b2)

@StepanBrychta & @paul-butcher suggest this is happening:

```
1. In a short period of time, we open lots of scroll contexts and successfully process some messages.
2. The scroll contexts are not automatically cleared, so we quickly reach the maximum number of 500 open scroll contexts. 
3. Any further Lambda executions fail (explaining the 0% success rate between the spikes).
4. After 5 minutes, the scroll contexts opened in step 1. are automatically cleared. Back to step 1.
```

See: https://wellcome.slack.com/archives/C02ANCYL90E/p1741274178988389?thread_ts=1741260150.022259&cid=C02ANCYL90E

Here we modify the `hasNext` function to notice when we have reached the end of the iterator, and then close the associated scroll context.

This change is difficult to write tests for but has been tested under load in production and seems to behave without errors.

## How to test

- [ ] Build this locally, push it to a dev tag, update the deployed lambda to use it. Does it error in the same pattern when run?

## How can we measure success?

Reindexes that run in a timely manner without error.

## Have we considered potential risks?

This change couples us heavily to the current implementation of the elastic4s lib as it duplicates an internal implementation of `SearchIterator`. We should modify our usage to avoid use of the scroll API as recommended in the documentation.


