### PR TITLE
Clean input in id_minter

### DIFF
--- a/pipeline/id_minter/src/main/scala/weco/pipeline/id_minter/MultiIdMinter.scala
+++ b/pipeline/id_minter/src/main/scala/weco/pipeline/id_minter/MultiIdMinter.scala
@@ -36,8 +36,11 @@ class MultiIdMinter(
     implicit ec: ExecutionContext
   ): Future[Iterable[Either[String, Work[Identified]]]] = {
 
+    // clean up the identifiers
+    val cleanIdentifiers = identifiers.map(_.strip())
+
     // run through the happy path (logging, but otherwise ignoring exceptions as we go)
-    val futureSuccesses = jsonRetriever(identifiers.map(_.strip()))
+    val futureSuccesses = jsonRetriever(cleanIdentifiers)
       .map {
         result: RetrieverMultiResult[Json] =>
           // At this point, it would be possible to collect the failed identifiers,
@@ -65,7 +68,7 @@ class MultiIdMinter(
         val successfulIds =
           seqWorks.map(_.right.get.sourceIdentifier.toString)
         // populate a Seq of Lefts with any input identifier that is not in the successful set
-        val failedIds = identifiers.toSet -- successfulIds
+        val failedIds = cleanIdentifiers.toSet -- successfulIds
         // bang together the Rights and the Lefts and return the lot.
         seqWorks ++ failedIds.map(Left(_))
     }

--- a/pipeline/id_minter/src/test/scala/weco/pipeline/id_minter/MultiIdMinterTest.scala
+++ b/pipeline/id_minter/src/test/scala/weco/pipeline/id_minter/MultiIdMinterTest.scala
@@ -62,6 +62,20 @@ class MultiIdMinterTest
           ) should contain theSameElementsAs idMap.keys
       }
     }
+
+    it("ignores spaces in identifiers passed to processSourceIds") {
+      val idsWithSpaces = allUpstreamIds.map(" " + _ + " ")
+
+      whenReady(
+        multiMinter(jsonRetriever, idMap).processSourceIds(idsWithSpaces)
+      ) {
+        result =>
+          val r = result.toSeq
+          r.map(
+            _.right.get.sourceIdentifier
+          ) should contain theSameElementsAs idMap.keys
+      }
+    }
   }
 
   describe(


### PR DESCRIPTION
## What does this change?

This change remove spaces in identifiers handed to processSourceIds in id_minter, in order to prevent issues when input is not properly cleaned. This can happen now that the lambda can be triggered from local input rather than directly from another lambda, but this is also good practise as input "cleaning" was not uniformly applied.

Replaces: https://github.com/wellcomecollection/catalogue-pipeline/pull/2838

## How to test

- [ ] Run the tests, do they pass?

## How can we measure success?

Less confused developers when running locally.

## Have we considered potential risks?

This should not be change behaviour in production, so risk is minimal.
