### PR TITLE
Parameterise the catalogue-graph ingestor trigger with pipeline date

### DIFF
--- a/catalogue_graph/src/ingestor_indexer.py
+++ b/catalogue_graph/src/ingestor_indexer.py
@@ -106,14 +106,14 @@ def local_handler() -> None:
     parser.add_argument(
         "--pipeline-date",
         type=str,
-        help='The pipeline that is being ingested to, will default to None.',
+        help="The pipeline that is being ingested to, will default to None.",
         required=False,
     )
     args = parser.parse_args()
 
     event = IngestorIndexerLambdaEvent(
-        pipeline_date=args.pipeline_date, 
-        object_to_index=IngestorIndexerObject(s3_uri=args.s3_uri)
+        pipeline_date=args.pipeline_date,
+        object_to_index=IngestorIndexerObject(s3_uri=args.s3_uri),
     )
     config = IngestorIndexerConfig(is_local=True)
 

--- a/catalogue_graph/src/ingestor_indexer.py
+++ b/catalogue_graph/src/ingestor_indexer.py
@@ -17,12 +17,18 @@ from models.catalogue_concept import CatalogueConcept
 from models.indexable_concept import IndexableConcept
 
 
-class IngestorIndexerLambdaEvent(BaseModel):
+class IngestorIndexerObject(BaseModel):
     s3_uri: str
+    content_length: int | None = None
+    record_count: int | None = None
+
+
+class IngestorIndexerLambdaEvent(BaseModel):
+    pipeline_date: str | None = INGESTOR_PIPELINE_DATE
+    object_to_index: IngestorIndexerObject
 
 
 class IngestorIndexerConfig(BaseModel):
-    pipeline_date: str | None = INGESTOR_PIPELINE_DATE
     is_local: bool = False
 
 
@@ -70,11 +76,11 @@ def load_data(
 def handler(event: IngestorIndexerLambdaEvent, config: IngestorIndexerConfig) -> int:
     print(f"Received event: {event} with config {config}")
 
-    extracted_data = extract_data(event.s3_uri)
+    extracted_data = extract_data(event.object_to_index.s3_uri)
     transformed_data = transform_data(extracted_data)
     success_count = load_data(
         concepts=transformed_data,
-        pipeline_date=config.pipeline_date,
+        pipeline_date=event.pipeline_date,
         is_local=config.is_local,
     )
 
@@ -97,9 +103,18 @@ def local_handler() -> None:
         help="The location of the shard to process, e.g. s3://mybukkit/path/key.parquet",
         required=True,
     )
+    parser.add_argument(
+        "--pipeline-date",
+        type=str,
+        help='The pipeline that is being ingested to, will default to None.',
+        required=False,
+    )
     args = parser.parse_args()
 
-    event = IngestorIndexerLambdaEvent(**args.__dict__)
+    event = IngestorIndexerLambdaEvent(
+        pipeline_date=args.pipeline_date, 
+        object_to_index=IngestorIndexerObject(s3_uri=args.s3_uri)
+    )
     config = IngestorIndexerConfig(is_local=True)
 
     handler(event, config)

--- a/catalogue_graph/src/ingestor_loader.py
+++ b/catalogue_graph/src/ingestor_loader.py
@@ -69,7 +69,7 @@ def load_data(s3_uri: str, data: list[CatalogueConcept]) -> IngestorIndexerObjec
         df = pl.DataFrame([e.model_dump() for e in data])
         df.write_parquet(f)
 
-    boto_s3_object = f.to_boto3(boto3.resource('s3'))
+    boto_s3_object = f.to_boto3(boto3.resource("s3"))
     content_length = boto_s3_object.content_length
 
     print(f"Data loaded to {s3_uri} with content length {content_length}")

--- a/catalogue_graph/src/ingestor_trigger.py
+++ b/catalogue_graph/src/ingestor_trigger.py
@@ -59,10 +59,10 @@ def transform_data(
         end_index = min(start_offset + shard_size, record_count)
         shard_ranges.append(
             IngestorLoaderLambdaEvent(
-                job_id=job_id, 
-                start_offset=start_offset, 
-                end_index=end_index, 
-                pipeline_date=pipeline_date
+                job_id=job_id,
+                start_offset=start_offset,
+                end_index=end_index,
+                pipeline_date=pipeline_date,
             )
         )
 
@@ -78,10 +78,10 @@ def handler(
 
     extracted_data = extract_data(config.is_local)
     transformed_data = transform_data(
-        record_count=extracted_data, 
-        shard_size=config.shard_size, 
+        record_count=extracted_data,
+        shard_size=config.shard_size,
         job_id=event.job_id,
-        pipeline_date=event.pipeline_date
+        pipeline_date=event.pipeline_date,
     )
 
     print(f"Shard ranges ({len(transformed_data)}) generated successfully.")
@@ -92,9 +92,12 @@ def handler(
 def lambda_handler(
     event: IngestorTriggerLambdaEvent, context: typing.Any
 ) -> list[dict]:
-    return [e.model_dump() for e in handler(
-        IngestorTriggerLambdaEvent.model_validate(event), IngestorTriggerConfig()
-    )]
+    return [
+        e.model_dump()
+        for e in handler(
+            IngestorTriggerLambdaEvent.model_validate(event), IngestorTriggerConfig()
+        )
+    ]
 
 
 def local_handler() -> None:
@@ -112,7 +115,6 @@ def local_handler() -> None:
         required=False,
         default="dev",
     )
-
 
     args = parser.parse_args()
 

--- a/catalogue_graph/src/ingestor_trigger.py
+++ b/catalogue_graph/src/ingestor_trigger.py
@@ -14,6 +14,7 @@ from utils.aws import get_neptune_client
 
 class IngestorTriggerLambdaEvent(BaseModel):
     job_id: str | None = None
+    pipeline_date: str | None = None
 
 
 class IngestorTriggerConfig(BaseModel):
@@ -43,7 +44,7 @@ def extract_data(is_local: bool) -> int:
 
 
 def transform_data(
-    record_count: int, shard_size: int, job_id: str | None
+    record_count: int, shard_size: int, job_id: str | None, pipeline_date: str | None
 ) -> list[IngestorLoaderLambdaEvent]:
     print("Transforming record count to shard ranges ...")
 
@@ -58,7 +59,10 @@ def transform_data(
         end_index = min(start_offset + shard_size, record_count)
         shard_ranges.append(
             IngestorLoaderLambdaEvent(
-                job_id=job_id, start_offset=start_offset, end_index=end_index
+                job_id=job_id, 
+                start_offset=start_offset, 
+                end_index=end_index, 
+                pipeline_date=pipeline_date
             )
         )
 
@@ -69,26 +73,28 @@ def transform_data(
 
 def handler(
     event: IngestorTriggerLambdaEvent, config: IngestorTriggerConfig
-) -> list[dict]:
+) -> list[IngestorLoaderLambdaEvent]:
     print(f"Received event: {event} with config {config}")
 
     extracted_data = extract_data(config.is_local)
     transformed_data = transform_data(
-        record_count=extracted_data, shard_size=config.shard_size, job_id=event.job_id
+        record_count=extracted_data, 
+        shard_size=config.shard_size, 
+        job_id=event.job_id,
+        pipeline_date=event.pipeline_date
     )
-    result = [e.model_dump() for e in transformed_data]
 
-    print(f"Shard ranges ({len(result)}) generated successfully.")
+    print(f"Shard ranges ({len(transformed_data)}) generated successfully.")
 
-    return result
+    return transformed_data
 
 
 def lambda_handler(
     event: IngestorTriggerLambdaEvent, context: typing.Any
 ) -> list[dict]:
-    return handler(
+    return [e.model_dump() for e in handler(
         IngestorTriggerLambdaEvent.model_validate(event), IngestorTriggerConfig()
-    )
+    )]
 
 
 def local_handler() -> None:
@@ -99,6 +105,14 @@ def local_handler() -> None:
         help="The ID of the job to process, will use a default based on the current timestamp if not provided.",
         required=False,
     )
+    parser.add_argument(
+        "--pipeline-date",
+        type=str,
+        help='The pipeline that is being ingested to, will default to "dev".',
+        required=False,
+        default="dev",
+    )
+
 
     args = parser.parse_args()
 

--- a/catalogue_graph/tests/conftest.py
+++ b/catalogue_graph/tests/conftest.py
@@ -4,8 +4,8 @@ from typing import Any
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
 from test_mocks import (
-    MockBoto3Session,
     MockBoto3Resource,
+    MockBoto3Session,
     MockElasticsearchClient,
     MockRequest,
     MockSmartOpen,

--- a/catalogue_graph/tests/conftest.py
+++ b/catalogue_graph/tests/conftest.py
@@ -5,6 +5,7 @@ import pytest
 from _pytest.monkeypatch import MonkeyPatch
 from test_mocks import (
     MockBoto3Session,
+    MockBoto3Resource,
     MockElasticsearchClient,
     MockRequest,
     MockSmartOpen,
@@ -16,6 +17,7 @@ from test_mocks import (
 def test(monkeypatch: MonkeyPatch) -> Generator[Any, Any, Any]:
     # Replaces boto3 and Elasticsearch with fake clients
     monkeypatch.setattr("boto3.Session", MockBoto3Session)
+    monkeypatch.setattr("boto3.resource", MockBoto3Resource)
     monkeypatch.setattr("requests.request", MockRequest.request)
     monkeypatch.setattr("requests.get", MockRequest.get)
     monkeypatch.setattr("smart_open.open", MockSmartOpen.open)

--- a/catalogue_graph/tests/test_ingestor_indexer.py
+++ b/catalogue_graph/tests/test_ingestor_indexer.py
@@ -5,7 +5,12 @@ import pytest
 from test_mocks import MockElasticsearchClient, MockSmartOpen
 from test_utils import load_fixture
 
-from ingestor_indexer import IngestorIndexerConfig, IngestorIndexerLambdaEvent, IngestorIndexerObject, handler
+from ingestor_indexer import (
+    IngestorIndexerConfig,
+    IngestorIndexerLambdaEvent,
+    IngestorIndexerObject,
+    handler,
+)
 
 
 def test_ingestor_indexer_success() -> None:
@@ -132,7 +137,9 @@ def build_test_matrix() -> list[tuple]:
         (
             "the file at s3_uri doesn't exist",
             IngestorIndexerLambdaEvent(
-                object_to_index=IngestorIndexerObject(s3_uri="s3://test-catalogue-graph/ghost-file")
+                object_to_index=IngestorIndexerObject(
+                    s3_uri="s3://test-catalogue-graph/ghost-file"
+                )
             ),
             None,
             KeyError,
@@ -144,7 +151,7 @@ def build_test_matrix() -> list[tuple]:
                 pipeline_date="2021-07-01",
                 object_to_index=IngestorIndexerObject(
                     s3_uri="s3://test-catalogue-graph/catalogue_example.json"
-                )
+                ),
             ),
             "catalogue_example.json",
             polars.exceptions.ComputeError,
@@ -173,7 +180,9 @@ def test_ingestor_indexer_failure(
 
     with pytest.raises(expected_exception=expected_error, match=error_message):
         if description != "the file at s3_uri doesn't exist":
-            MockSmartOpen.mock_s3_file(event.object_to_index.s3_uri, load_fixture(fixture))
+            MockSmartOpen.mock_s3_file(
+                event.object_to_index.s3_uri, load_fixture(fixture)
+            )
         MockSmartOpen.open(event.object_to_index.s3_uri, "r")
 
         handler(event, config)

--- a/catalogue_graph/tests/test_ingestor_indexer.py
+++ b/catalogue_graph/tests/test_ingestor_indexer.py
@@ -5,19 +5,21 @@ import pytest
 from test_mocks import MockElasticsearchClient, MockSmartOpen
 from test_utils import load_fixture
 
-from ingestor_indexer import IngestorIndexerConfig, IngestorIndexerLambdaEvent, handler
+from ingestor_indexer import IngestorIndexerConfig, IngestorIndexerLambdaEvent, IngestorIndexerObject, handler
 
 
 def test_ingestor_indexer_success() -> None:
     config = IngestorIndexerConfig()
     event = IngestorIndexerLambdaEvent(
-        s3_uri="s3://test-catalogue-graph/00000000-00000004.parquet"
+        object_to_index=IngestorIndexerObject(
+            s3_uri="s3://test-catalogue-graph/00000000-00000004.parquet"
+        )
     )
     MockSmartOpen.mock_s3_file(
         "s3://test-catalogue-graph/00000000-00000004.parquet",
         load_fixture("00000000-00000004.parquet"),
     )
-    MockSmartOpen.open(event.s3_uri, "r")
+    MockSmartOpen.open(event.object_to_index.s3_uri, "r")
 
     result = handler(event, config)
 
@@ -129,7 +131,9 @@ def build_test_matrix() -> list[tuple]:
     return [
         (
             "the file at s3_uri doesn't exist",
-            IngestorIndexerLambdaEvent(s3_uri="s3://test-catalogue-graph/ghost-file"),
+            IngestorIndexerLambdaEvent(
+                object_to_index=IngestorIndexerObject(s3_uri="s3://test-catalogue-graph/ghost-file")
+            ),
             None,
             KeyError,
             "Mock S3 file s3://test-catalogue-graph/ghost-file does not exist.",
@@ -137,7 +141,10 @@ def build_test_matrix() -> list[tuple]:
         (
             "the S3 file doesn't contain valid data",
             IngestorIndexerLambdaEvent(
-                s3_uri="s3://test-catalogue-graph/catalogue_example.json"
+                pipeline_date="2021-07-01",
+                object_to_index=IngestorIndexerObject(
+                    s3_uri="s3://test-catalogue-graph/catalogue_example.json"
+                )
             ),
             "catalogue_example.json",
             polars.exceptions.ComputeError,
@@ -166,7 +173,7 @@ def test_ingestor_indexer_failure(
 
     with pytest.raises(expected_exception=expected_error, match=error_message):
         if description != "the file at s3_uri doesn't exist":
-            MockSmartOpen.mock_s3_file(event.s3_uri, load_fixture(fixture))
-        MockSmartOpen.open(event.s3_uri, "r")
+            MockSmartOpen.mock_s3_file(event.object_to_index.s3_uri, load_fixture(fixture))
+        MockSmartOpen.open(event.object_to_index.s3_uri, "r")
 
         handler(event, config)

--- a/catalogue_graph/tests/test_ingestor_loader.py
+++ b/catalogue_graph/tests/test_ingestor_loader.py
@@ -3,7 +3,7 @@ import pytest
 from test_mocks import MockRequest, MockSmartOpen
 
 from ingestor_indexer import IngestorIndexerLambdaEvent
-from ingestor_loader import IngestorLoaderConfig, IngestorLoaderLambdaEvent, handler
+from ingestor_loader import IngestorLoaderConfig, IngestorLoaderLambdaEvent, IngestorIndexerObject, handler
 from models.catalogue_concept import CatalogueConcept, CatalogueConceptIdentifier
 
 
@@ -12,6 +12,7 @@ def build_test_matrix() -> list[tuple]:
         (
             "happy path, with alternative labels",
             IngestorLoaderLambdaEvent(
+                pipeline_date="2021-07-01",
                 job_id="123",
                 start_offset=0,
                 end_index=1,
@@ -44,7 +45,12 @@ def build_test_matrix() -> list[tuple]:
                 ]
             },
             IngestorIndexerLambdaEvent(
-                s3_uri="s3://test-bucket/test-prefix/123/00000000-00000001.parquet",
+                pipeline_date="2021-07-01",
+                object_to_index=IngestorIndexerObject(
+                    s3_uri="s3://test-bucket/test-prefix/2021-07-01/123/00000000-00000001.parquet",
+                    content_length=1,
+                    record_count=1,
+                ),
             ),
             CatalogueConcept(
                 id="source_id",
@@ -62,6 +68,7 @@ def build_test_matrix() -> list[tuple]:
         (
             "happy path, with NO alternative labels",
             IngestorLoaderLambdaEvent(
+                pipeline_date="2021-07-01",
                 job_id="123",
                 start_offset=0,
                 end_index=1,
@@ -93,7 +100,12 @@ def build_test_matrix() -> list[tuple]:
                 ]
             },
             IngestorIndexerLambdaEvent(
-                s3_uri="s3://test-bucket/test-prefix/123/00000000-00000001.parquet",
+                pipeline_date="2021-07-01",
+                object_to_index=IngestorIndexerObject(
+                    s3_uri="s3://test-bucket/test-prefix/2021-07-01/123/00000000-00000001.parquet",
+                    content_length=1,
+                    record_count=1,
+                )
             ),
             CatalogueConcept(
                 id="source_id",
@@ -111,6 +123,7 @@ def build_test_matrix() -> list[tuple]:
         (
             "badly formed response",
             IngestorLoaderLambdaEvent(
+                pipeline_date="2021-07-01",
                 job_id="123",
                 start_offset=0,
                 end_index=1,
@@ -141,7 +154,7 @@ def get_test_id(argvalue: str) -> str:
     build_test_matrix(),
     ids=get_test_id,
 )
-def test_ingestor_trigger(
+def test_ingestor_loader(
     description: str,
     event: IngestorLoaderLambdaEvent,
     config: IngestorLoaderConfig,
@@ -149,9 +162,6 @@ def test_ingestor_trigger(
     expected_output: IngestorIndexerLambdaEvent,
     expected_concept: CatalogueConcept,
 ) -> None:
-    if expected_output is not None:
-        MockSmartOpen.mock_s3_file(expected_output.s3_uri, "")
-
     MockRequest.mock_responses(
         [
             {
@@ -176,7 +186,7 @@ def test_ingestor_trigger(
         assert request["method"] == "POST"
         assert request["url"] == "https://test-host.com:8182/openCypher"
 
-        with MockSmartOpen.open(expected_output.s3_uri, "r") as f:
+        with MockSmartOpen.open(expected_output.object_to_index.s3_uri, "r") as f:
             df = pl.read_parquet(f)
             assert len(df) == 1
 

--- a/catalogue_graph/tests/test_ingestor_loader.py
+++ b/catalogue_graph/tests/test_ingestor_loader.py
@@ -3,7 +3,12 @@ import pytest
 from test_mocks import MockRequest, MockSmartOpen
 
 from ingestor_indexer import IngestorIndexerLambdaEvent
-from ingestor_loader import IngestorLoaderConfig, IngestorLoaderLambdaEvent, IngestorIndexerObject, handler
+from ingestor_loader import (
+    IngestorIndexerObject,
+    IngestorLoaderConfig,
+    IngestorLoaderLambdaEvent,
+    handler,
+)
 from models.catalogue_concept import CatalogueConcept, CatalogueConceptIdentifier
 
 
@@ -105,7 +110,7 @@ def build_test_matrix() -> list[tuple]:
                     s3_uri="s3://test-bucket/test-prefix/2021-07-01/123/00000000-00000001.parquet",
                     content_length=1,
                     record_count=1,
-                )
+                ),
             ),
             CatalogueConcept(
                 id="source_id",

--- a/catalogue_graph/tests/test_ingestor_trigger.py
+++ b/catalogue_graph/tests/test_ingestor_trigger.py
@@ -2,8 +2,8 @@ import pytest
 from freezegun import freeze_time
 from test_mocks import MockRequest
 
-from ingestor_trigger import IngestorTriggerConfig, IngestorTriggerLambdaEvent, handler
 from ingestor_loader import IngestorLoaderLambdaEvent
+from ingestor_trigger import IngestorTriggerConfig, IngestorTriggerLambdaEvent, handler
 
 
 def build_test_matrix() -> list[tuple]:
@@ -15,9 +15,12 @@ def build_test_matrix() -> list[tuple]:
             {"results": [{"count": 1}]},
             [
                 IngestorLoaderLambdaEvent(
-                    pipeline_date="2025-01-01", job_id="123", start_offset=0, end_index=1
+                    pipeline_date="2025-01-01",
+                    job_id="123",
+                    start_offset=0,
+                    end_index=1,
                 )
-            ]
+            ],
         ),
         (
             "job_id set, shard_size < results count",
@@ -26,12 +29,18 @@ def build_test_matrix() -> list[tuple]:
             {"results": [{"count": 2}]},
             [
                 IngestorLoaderLambdaEvent(
-                    pipeline_date="2025-01-01", job_id="123", start_offset=0, end_index=1
+                    pipeline_date="2025-01-01",
+                    job_id="123",
+                    start_offset=0,
+                    end_index=1,
                 ),
                 IngestorLoaderLambdaEvent(
-                    pipeline_date="2025-01-01", job_id="123", start_offset=1, end_index=2
+                    pipeline_date="2025-01-01",
+                    job_id="123",
+                    start_offset=1,
+                    end_index=2,
                 ),
-            ]
+            ],
         ),
         (
             "job_id set, shard_size == results count",
@@ -40,9 +49,12 @@ def build_test_matrix() -> list[tuple]:
             {"results": [{"count": 1}]},
             [
                 IngestorLoaderLambdaEvent(
-                    pipeline_date="2025-01-01", job_id="123", start_offset=0, end_index=1
+                    pipeline_date="2025-01-01",
+                    job_id="123",
+                    start_offset=0,
+                    end_index=1,
                 )
-            ]
+            ],
         ),
         (
             "job_id set, results count == 0",
@@ -58,12 +70,18 @@ def build_test_matrix() -> list[tuple]:
             {"pipeline_date": "2025-01-01", "results": [{"count": 1001}]},
             [
                 IngestorLoaderLambdaEvent(
-                    pipeline_date="2025-01-01", job_id="123", start_offset=0, end_index=1000
+                    pipeline_date="2025-01-01",
+                    job_id="123",
+                    start_offset=0,
+                    end_index=1000,
                 ),
                 IngestorLoaderLambdaEvent(
-                    pipeline_date="2025-01-01", job_id="123", start_offset=1000, end_index=1001
-                )
-            ]
+                    pipeline_date="2025-01-01",
+                    job_id="123",
+                    start_offset=1000,
+                    end_index=1001,
+                ),
+            ],
         ),
         (
             "job_id not set, shard_size > results count",
@@ -72,9 +90,12 @@ def build_test_matrix() -> list[tuple]:
             {"results": [{"count": 1}]},
             [
                 IngestorLoaderLambdaEvent(
-                    pipeline_date="2025-01-01", job_id="20120101T0000", start_offset=0, end_index=1
+                    pipeline_date="2025-01-01",
+                    job_id="20120101T0000",
+                    start_offset=0,
+                    end_index=1,
                 )
-            ]
+            ],
         ),
     ]
 

--- a/catalogue_graph/tests/test_ingestor_trigger.py
+++ b/catalogue_graph/tests/test_ingestor_trigger.py
@@ -3,57 +3,78 @@ from freezegun import freeze_time
 from test_mocks import MockRequest
 
 from ingestor_trigger import IngestorTriggerConfig, IngestorTriggerLambdaEvent, handler
+from ingestor_loader import IngestorLoaderLambdaEvent
 
 
 def build_test_matrix() -> list[tuple]:
     return [
         (
             "job_id set, shard_size > results count",
-            IngestorTriggerLambdaEvent(job_id="123"),
+            IngestorTriggerLambdaEvent(pipeline_date="2025-01-01", job_id="123"),
             IngestorTriggerConfig(shard_size=100, is_local=False),
             {"results": [{"count": 1}]},
-            [{"job_id": "123", "start_offset": 0, "end_index": 1}],
+            [
+                IngestorLoaderLambdaEvent(
+                    pipeline_date="2025-01-01", job_id="123", start_offset=0, end_index=1
+                )
+            ]
         ),
         (
             "job_id set, shard_size < results count",
-            IngestorTriggerLambdaEvent(job_id="123"),
+            IngestorTriggerLambdaEvent(pipeline_date="2025-01-01", job_id="123"),
             IngestorTriggerConfig(shard_size=1, is_local=False),
             {"results": [{"count": 2}]},
             [
-                {"job_id": "123", "start_offset": 0, "end_index": 1},
-                {"job_id": "123", "start_offset": 1, "end_index": 2},
-            ],
+                IngestorLoaderLambdaEvent(
+                    pipeline_date="2025-01-01", job_id="123", start_offset=0, end_index=1
+                ),
+                IngestorLoaderLambdaEvent(
+                    pipeline_date="2025-01-01", job_id="123", start_offset=1, end_index=2
+                ),
+            ]
         ),
         (
             "job_id set, shard_size == results count",
-            IngestorTriggerLambdaEvent(job_id="123"),
+            IngestorTriggerLambdaEvent(pipeline_date="2025-01-01", job_id="123"),
             IngestorTriggerConfig(shard_size=1),
             {"results": [{"count": 1}]},
-            [{"job_id": "123", "start_offset": 0, "end_index": 1}],
+            [
+                IngestorLoaderLambdaEvent(
+                    pipeline_date="2025-01-01", job_id="123", start_offset=0, end_index=1
+                )
+            ]
         ),
         (
             "job_id set, results count == 0",
-            IngestorTriggerLambdaEvent(job_id="123"),
+            IngestorTriggerLambdaEvent(pipeline_date="2025-01-01", job_id="123"),
             IngestorTriggerConfig(shard_size=100),
-            {"results": [{"count": 0}]},
+            {"pipeline_date": "2025-01-01", "results": [{"count": 0}]},
             [],
         ),
         (
             "job_id set, shard_size unset (default 1k) > results count",
-            IngestorTriggerLambdaEvent(job_id="123"),
+            IngestorTriggerLambdaEvent(pipeline_date="2025-01-01", job_id="123"),
             IngestorTriggerConfig(),
-            {"results": [{"count": 1001}]},
+            {"pipeline_date": "2025-01-01", "results": [{"count": 1001}]},
             [
-                {"job_id": "123", "start_offset": 0, "end_index": 1000},
-                {"job_id": "123", "start_offset": 1000, "end_index": 1001},
-            ],
+                IngestorLoaderLambdaEvent(
+                    pipeline_date="2025-01-01", job_id="123", start_offset=0, end_index=1000
+                ),
+                IngestorLoaderLambdaEvent(
+                    pipeline_date="2025-01-01", job_id="123", start_offset=1000, end_index=1001
+                )
+            ]
         ),
         (
             "job_id not set, shard_size > results count",
-            IngestorTriggerLambdaEvent(job_id=None),
+            IngestorTriggerLambdaEvent(pipeline_date="2025-01-01", job_id=None),
             IngestorTriggerConfig(shard_size=100),
             {"results": [{"count": 1}]},
-            [{"job_id": "20120101T0000", "start_offset": 0, "end_index": 1}],
+            [
+                IngestorLoaderLambdaEvent(
+                    pipeline_date="2025-01-01", job_id="20120101T0000", start_offset=0, end_index=1
+                )
+            ]
         ),
     ]
 
@@ -73,7 +94,7 @@ def test_ingestor_trigger(
     event: IngestorTriggerLambdaEvent,
     config: IngestorTriggerConfig,
     neptune_response: dict,
-    expected_output: list[dict],
+    expected_output: list[IngestorLoaderLambdaEvent],
 ) -> None:
     MockRequest.mock_responses(
         [

--- a/catalogue_graph/tests/test_mocks.py
+++ b/catalogue_graph/tests/test_mocks.py
@@ -17,6 +17,9 @@ MOCK_CREDENTIALS = Credentials(
     token="test_token",
 )
 
+class MockBotoS3Object:
+    def __init__(self) -> None:
+        self.content_length = 1
 
 class MockSmartOpen:
     file_lookup: dict = {}
@@ -49,6 +52,10 @@ class MockSmartOpen:
             # We're ignoring "SIM115 Use a context manager for opening files" as we need to keep
             # the file around for the duration of the test, cleaning it up in reset_mocks.
             temp_file = tempfile.NamedTemporaryFile(delete=False)  # noqa: SIM115
+            # Insert the to_boto3 method to simulate the method provided by smart_open
+            # https://github.com/piskvorky/smart_open/blob/develop/howto.md#how-to-access-s3-object-properties
+            temp_file.to_boto3 = lambda _: MockBotoS3Object()  # type: ignore[attr-defined]
+
             cls.file_lookup[uri] = temp_file.name
             return temp_file
         elif mode == "r":
@@ -102,6 +109,10 @@ class MockSNSClient(MockAwsService):
                 "PublishBatchRequestEntries": PublishBatchRequestEntries,
             }
         )
+
+class MockBoto3Resource:
+    def __init__(self, resourceName: str) -> None:
+        return None
 
 
 class MockBoto3Session:

--- a/catalogue_graph/tests/test_mocks.py
+++ b/catalogue_graph/tests/test_mocks.py
@@ -17,9 +17,11 @@ MOCK_CREDENTIALS = Credentials(
     token="test_token",
 )
 
+
 class MockBotoS3Object:
     def __init__(self) -> None:
         self.content_length = 1
+
 
 class MockSmartOpen:
     file_lookup: dict = {}
@@ -109,6 +111,7 @@ class MockSNSClient(MockAwsService):
                 "PublishBatchRequestEntries": PublishBatchRequestEntries,
             }
         )
+
 
 class MockBoto3Resource:
     def __init__(self, resourceName: str) -> None:


### PR DESCRIPTION
## What does this change?

This change is in order to allow ingestion runs to be namespaced and monitored on a per pipeline basis, required for monitoring. We add some stats on file size and record count to the loader that will be used in reporting and monitoring in a later PR.

## How to test

- [ ] Run the tests, do they pass?

## How can we measure success?

Allow us to run multiple pipeline and monitor them seperately.

## Have we considered potential risks?

The catalogue graph is not quite in production use, so we should be able to catch errors before they are in public view, mitigating risk.
