### PR TITLE
removing alarm that evaluates metrics across days

### DIFF
--- a/catalogue_graph/terraform/cloudwatch_alarms.tf
+++ b/catalogue_graph/terraform/cloudwatch_alarms.tf
@@ -49,25 +49,6 @@ resource "aws_cloudwatch_metric_alarm" "concepts_daily_run_timedout_alarm" {
   alarm_actions = [data.terraform_remote_state.platform_monitoring.outputs.chatbot_topic_arn]
 }
 
-resource "aws_cloudwatch_metric_alarm" "concepts_daily_run_no_success_alarm" {
-  alarm_name          = "concepts_daily_run_no_success_seen_alarm"
-  comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = 1176
-  metric_name         = "ExecutionsSucceeded"
-  namespace           = "AWS/States"
-  period              = 300
-  statistic           = "Sum"
-  threshold           = 0
-  actions_enabled     = true
-  # this accounts for the fact that the pipeline doesn't run FRI-SAT-SUN
-  alarm_description = "No successful run of the daily concept pipeline for 98 hours."
-  dimensions = {
-    StateMachineArn = "arn:aws:states:eu-west-1:760097843905:stateMachine:concepts-pipeline_daily"
-  }
-  treat_missing_data = "breaching"
-  alarm_actions      = [data.terraform_remote_state.platform_monitoring.outputs.chatbot_topic_arn]
-}
-
 resource "aws_cloudwatch_metric_alarm" "concepts_monthly_run_aborted_alarm" {
   alarm_name          = "concepts_monthly_run_aborted_alarm"
   comparison_operator = "GreaterThanThreshold"


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? -->

