### PR TITLE
Add concepts elasticsearch secrets to catalogue account

### DIFF
--- a/pipeline/terraform/modules/stack/elastic_pipeline.tf
+++ b/pipeline/terraform/modules/stack/elastic_pipeline.tf
@@ -207,7 +207,8 @@ locals {
 
   catalogue_account_services = toset([
     "catalogue_api",
-    "snapshot_generator"
+    "snapshot_generator",
+    "concepts_api"
   ])
 }
 


### PR DESCRIPTION
## What does this change?

A small terraform change to add the Elasticsearch `concepts_api/api_key` SecretsManager secret to the catalogue account so that the concepts API can access it.

