### PR TITLE
Switch catalogue-graph ingest pipeline to new index

### DIFF
--- a/catalogue_graph/terraform/locals.tf
+++ b/catalogue_graph/terraform/locals.tf
@@ -16,7 +16,7 @@ locals {
   catalogue_graph_nlb_url = "catalogue-graph.wellcomecollection.org"
 
   # This is a hint that the ingestors might need to be in the pipeline stack!
-  pipeline_date = "2024-11-18"
+  pipeline_date = "2025-03-06"
 
   concepts_pipeline_inputs_monthly = [
     {


### PR DESCRIPTION
## What does this change?

This change uses the latest pipeline as the target for the catalogue-graph ingestor state machine.

## How to test

- [ ] Run the ingestor state machine, does it succeed?

## How can we measure success?

Latest pipeline can be regularly, safely updated.

## Have we considered potential risks?

This will change what gets indexed into the production pipeline, it should not happen automatically until the start of next week (24th March).
