### PR TITLE
Reduce catalogue graph map load concurrency

### DIFF
--- a/catalogue_graph/terraform/state_machine_ingestor.tf
+++ b/catalogue_graph/terraform/state_machine_ingestor.tf
@@ -50,7 +50,7 @@ resource "aws_sfn_state_machine" "catalogue_graph_ingestor" {
       # the next step is a state map that takes the json list output of the ingestor_trigger_lambda and maps it to a list of ingestor tasks
       "Map load to s3" = {
         Type           = "Map",
-        MaxConcurrency = 50
+        MaxConcurrency = 1
         ItemProcessor = {
           ProcessorConfig = {
             Mode          = "DISTRIBUTED",


### PR DESCRIPTION
## What does this change?

We reduce the map load concurrency for the catalogue graph ingestor step to 1 after seeing failures at higher concurrency. The nature of this query has changed and seems to have increased the load on neptune.

## How to test

- [ ] Run the ingestor pipeline, does it succeed

## How can we measure success?

- [ ] Consistently succeeding graph ingestion pipeline.

## Have we considered potential risks?

Risks should be minimal, it is likely to increase the amount of time the pipeline runs for, but this is likely to be a surmountable problem.
