### PR TITLE
Increase memory for router

### DIFF
--- a/pipeline/terraform/modules/stack/relation_embedder/router.tf
+++ b/pipeline/terraform/modules/stack/relation_embedder/router.tf
@@ -49,8 +49,8 @@ module "router" {
 
   secret_env_vars = var.pipeline_storage_es_service_secrets["router"]
 
-  cpu    = 1024
-  memory = 2048
+  cpu    = 2048
+  memory = 8192
 
   min_capacity = var.min_capacity
   max_capacity = var.max_capacity


### PR DESCRIPTION
## What does this change?

Following some recent repeated failures of the router it looks like it might need more memory.

<img width="1560" alt="Screenshot 2025-03-28 at 08 45 15" src="https://github.com/user-attachments/assets/8492a0e6-9d1a-4cc0-b090-789d7c65be40" />

This change increases the CPU and memory to 1vCPU & 8GB to ensure it has enough resources. This service is likely to be [subsumed into the merger soon](https://github.com/wellcomecollection/platform/issues/5985) so i'm not too worried about rightsizing, and want to guarantee the resource increase will be imapctful.

## How to test

- [ ] Apply the change, redrive the messages, does that solve the problem?

<img width="605" alt="Screenshot 2025-03-28 at 08 47 54" src="https://github.com/user-attachments/assets/c658cf0f-e33d-4ee0-8856-dd7dbddfd155" />

## How can we measure success?

The router does not fail processing messages.

## Have we considered potential risks?

Risks should be minimal as this is not a change that will impact output.
