### PR TITLE
Fix mesh altern labels

### DIFF
--- a/catalogue_graph/src/transformers/mesh/raw_concept.py
+++ b/catalogue_graph/src/transformers/mesh/raw_concept.py
@@ -30,9 +30,12 @@ class RawMeSHConcept:
     @property
     def alternative_labels(self) -> list[str]:
         """Returns a list of alternative labels for the concept, if available."""
-        altern_labels = [assert_get_text(altern_label) for altern_label in self.raw_concept.findall(
-            "ConceptList//Concept//TermList//Term//String"
-        )]
+        altern_labels = [
+            assert_get_text(altern_label)
+            for altern_label in self.raw_concept.findall(
+                "ConceptList//Concept//TermList//Term//String"
+            )
+        ]
         altern_labels.remove(self.label)
 
         return altern_labels

--- a/catalogue_graph/src/transformers/mesh/raw_concept.py
+++ b/catalogue_graph/src/transformers/mesh/raw_concept.py
@@ -30,16 +30,10 @@ class RawMeSHConcept:
     @property
     def alternative_labels(self) -> list[str]:
         """Returns a list of alternative labels for the concept, if available."""
-        altern_labels = []
-
-        for altern_concept in self.raw_concept.findall(
-            "ConceptList//TermList//Term[@ConceptPreferredTermYN='N']"
-        ):
-            altern_label_elem = altern_concept.find("String")
-            if isinstance(altern_label_elem, ET.Element):
-                altern_label = altern_label_elem.text
-                if isinstance(altern_label, str):
-                    altern_labels.append(altern_label)
+        altern_labels = [assert_get_text(altern_label) for altern_label in self.raw_concept.findall(
+            "ConceptList//Concept//TermList//Term//String"
+        )]
+        altern_labels.remove(self.label)
 
         return altern_labels
 

--- a/catalogue_graph/tests/transformers/test_mesh_concepts_transformer.py
+++ b/catalogue_graph/tests/transformers/test_mesh_concepts_transformer.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 from test_mocks import MockRequest
 from test_utils import load_fixture
 
@@ -39,7 +41,7 @@ def test_mesh_concepts_transformer() -> None:
         ],
         description="A broad class of substances containing carbon and its derivatives. Many of these chemicals will frequently contain hydrogen with or without oxygen, nitrogen, sulfur, phosphorus, and other elements. They exist in either carbon chain or carbon ring form.\n    ",
     )
-    assert len(nodes[2].alternative_labels) == 20
+    assert len(cast(SourceConcept, nodes[2]).alternative_labels) == 20
 
     edges = list(mesh_concepts_transformer._stream_edges())
 

--- a/catalogue_graph/tests/transformers/test_mesh_concepts_transformer.py
+++ b/catalogue_graph/tests/transformers/test_mesh_concepts_transformer.py
@@ -39,6 +39,7 @@ def test_mesh_concepts_transformer() -> None:
         ],
         description="A broad class of substances containing carbon and its derivatives. Many of these chemicals will frequently contain hydrogen with or without oxygen, nitrogen, sulfur, phosphorus, and other elements. They exist in either carbon chain or carbon ring form.\n    ",
     )
+    assert len(nodes[2].alternative_labels) == 20
 
     edges = list(mesh_concepts_transformer._stream_edges())
 


### PR DESCRIPTION
## What does this change?

There are some edge cases in the MeSH xml where a concept is not a preferred concept, but it has a preferred term, resulting in a small number of missing alternative labels. Fixed by minor changes to the MeSH transformer. https://github.com/wellcomecollection/platform/issues/5978

## How to test

Added a check for the number of alternative labels for a concept which was affected by the above issue.

## How can we measure success?

This has the potential for slightly more matches between label-derived concepts and MeSH.

## Have we considered potential risks?

Given this has the potential to increase the number of label-derived matches with MeSH, there is also a small risk of additional undesirable matches.
