### PR TITLE
Filter out loc children's subject headings

### DIFF
--- a/catalogue_graph/src/transformers/loc/raw_concept.py
+++ b/catalogue_graph/src/transformers/loc/raw_concept.py
@@ -5,7 +5,7 @@ ID_PREFIXES_TO_REMOVE = (
     "http://id.loc.gov/authorities/subjects/",
     "/authorities/names/",
     "http://id.loc.gov/authorities/names/",
-    'http://id.loc.gov/authorities/childrensSubjects/'
+    "http://id.loc.gov/authorities/childrensSubjects/",
 )
 
 
@@ -168,7 +168,11 @@ class RawLibraryOfCongressConcept:
 
 def _filter_irrelevant_ids(ids: list[str]) -> list[str]:
     # IDs starting with 'sj' are for Children's Subject Headings. We don't want to include those.
-    return [concept_id for concept_id in ids if not concept_id.startswith("_:n") and not concept_id.startswith("sj")]
+    return [
+        concept_id
+        for concept_id in ids
+        if not concept_id.startswith("_:n") and not concept_id.startswith("sj")
+    ]
 
 
 def _as_list(dict_or_list: dict | list[dict]) -> list[dict]:

--- a/catalogue_graph/src/transformers/loc/raw_concept.py
+++ b/catalogue_graph/src/transformers/loc/raw_concept.py
@@ -5,6 +5,7 @@ ID_PREFIXES_TO_REMOVE = (
     "http://id.loc.gov/authorities/subjects/",
     "/authorities/names/",
     "http://id.loc.gov/authorities/names/",
+    'http://id.loc.gov/authorities/childrensSubjects/'
 )
 
 
@@ -166,7 +167,8 @@ class RawLibraryOfCongressConcept:
 
 
 def _filter_irrelevant_ids(ids: list[str]) -> list[str]:
-    return [concept_id for concept_id in ids if not concept_id.startswith("_:n")]
+    # IDs starting with 'sj' are for Children's Subject Headings. We don't want to include those.
+    return [concept_id for concept_id in ids if not concept_id.startswith("_:n") and not concept_id.startswith("sj")]
 
 
 def _as_list(dict_or_list: dict | list[dict]) -> list[dict]:


### PR DESCRIPTION
## What does this change?

Filter out LoC Children's Subject Headings from LoC edges. See [here](https://wellcome.slack.com/archives/CQ720BG02/p1744035046268559) for more info.


