### PR TITLE
Modify bulk load poller permissions

### DIFF
--- a/catalogue_graph/terraform/lambda_bulk_load_poller.tf
+++ b/catalogue_graph/terraform/lambda_bulk_load_poller.tf
@@ -31,3 +31,14 @@ resource "aws_iam_role_policy" "bulk_load_poller_lambda_neptune_policy" {
   role   = module.bulk_load_poller_lambda.lambda_role.name
   policy = data.aws_iam_policy_document.neptune_load_poll.json
 }
+
+resource "aws_iam_role_policy" "bulk_load_poller_s3_write" {
+  role   = module.bulk_load_poller_lambda.lambda_role.name
+  policy = data.aws_iam_policy_document.s3_bulk_load_write.json
+}
+
+resource "aws_iam_role_policy" "bulk_load_poller_s3_red" {
+  role   = module.bulk_load_poller_lambda.lambda_role.name
+  policy = data.aws_iam_policy_document.s3_bulk_load_read.json
+}
+


### PR DESCRIPTION
## What does this change?

Follow-up on https://github.com/wellcomecollection/catalogue-pipeline/pull/2870 giving the bulk load poller Lambda function the necessary permissions to read/write report files from the Neptune bulk load S3 bucket.
