### PR TITLE
Turn off listen to reindexer in 2025-03-06

### DIFF
--- a/pipeline/terraform/2025-03-06/main.tf
+++ b/pipeline/terraform/2025-03-06/main.tf
@@ -2,7 +2,7 @@ module "pipeline" {
   source = "../modules/stack"
 
   reindexing_state = {
-    listen_to_reindexer      = true
+    listen_to_reindexer      = false
     scale_up_tasks           = false
     scale_up_elastic_cluster = false
     scale_up_id_minter_db    = false
@@ -45,4 +45,5 @@ moved {
   from = module.pipeline.module.pipeline_indices.module.concepts_indexed_index.elasticstack_elasticsearch_index.the_index
   to   = module.pipeline.module.pipeline_indices.module.concepts_indexed_indexes["2025-03-06"].elasticstack_elasticsearch_index.the_index
 }
+
 


### PR DESCRIPTION
> [!Note]
> The terraform in this PR has been applied.

## What does this change?

Before we create the new pipeline in https://github.com/wellcomecollection/catalogue-pipeline/pull/2875, we should turn off listening to the reindexer in the prod pipeline 

## How to test

- [ ] Apply the terraform, does it make the necessary updates?

## How can we measure success?

We are able to reindex in the new pipeline without it impacting the old one.

## Have we considered potential risks?

The risk should be minimal (this is turning _off_ the reindexer).
