### PR TITLE
adds id_minter to list of ecr image tags to update

### DIFF
--- a/builds/deploy_catalogue_pipeline.sh
+++ b/builds/deploy_catalogue_pipeline.sh
@@ -53,6 +53,7 @@ ENV_TAG="env.$PIPELINE_DATE" "$ROOT/builds/update_ecr_image_tag.sh" \
   uk.ac.wellcome/feature_inferrer \
   uk.ac.wellcome/palette_inferrer \
   uk.ac.wellcome/aspect_ratio_inferrer \
+  uk.ac.wellcome/id_minter \
   uk.ac.wellcome/matcher \
   uk.ac.wellcome/merger \
   uk.ac.wellcome/ingestor_images \


### PR DESCRIPTION
## What does this change?

The catalogue pipeline [deployment](https://buildkite.com/wellcomecollection/catalogue-pipeline-deploy-pipeline) is broken :(
```
An error occurred (InvalidParameterValueException) when calling the UpdateFunctionCode operation: Source image 760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/id_minter:env.pipeline_date does not exist. Provide a valid source image.
```
The id_minter ecr was missing from the list of images whose tags needed updating
Adding it to the list

## How to test

Run the deployment pipeline 

## How can we measure success?

It run successfully

## Have we considered potential risks?



