### PR TITLE
match env var passed to the container

### DIFF
--- a/pipeline/matcher_merger/merger/src/main/resources/application.conf
+++ b/pipeline/matcher_merger/merger/src/main/resources/application.conf
@@ -1,9 +1,9 @@
 aws.metrics.namespace=${?metrics_namespace}
 aws.sqs.queue.url=${?queue_url}
 aws.work-sender.sns.topic.arn=${?merger_works_topic_arn}
-aws.path-sender.sns.topic.arn=${?paths_topic_arn}
-aws.path-concatenator-sender.sns.topic.arn=${?path_concatenator_topic_arn}
-aws.image-sender.sns.topic.arn=${?merger_images_topic_arn}
+aws.path-sender.sns.topic.arn=${?merger_paths_topic_arn}
+aws.path-concatenator-sender.sns.topic.arn=${?merger_path_concatenator_topic_arn}
+aws.image-sender.sns.topic.arn=${?merger_images_topic_arnmatch }
 
 es.host=${?es_host}
 es.port=${?es_port}

--- a/pipeline/matcher_merger/merger/src/main/resources/application.conf
+++ b/pipeline/matcher_merger/merger/src/main/resources/application.conf
@@ -3,7 +3,7 @@ aws.sqs.queue.url=${?queue_url}
 aws.work-sender.sns.topic.arn=${?merger_works_topic_arn}
 aws.path-sender.sns.topic.arn=${?merger_paths_topic_arn}
 aws.path-concatenator-sender.sns.topic.arn=${?merger_path_concatenator_topic_arn}
-aws.image-sender.sns.topic.arn=${?merger_images_topic_arnmatch }
+aws.image-sender.sns.topic.arn=${?merger_images_topic_arn}
 
 es.host=${?es_host}
 es.port=${?es_port}


### PR DESCRIPTION
## What does this change?

Following https://github.com/wellcomecollection/catalogue-pipeline/pull/2875
The env var in the application.conf didn't match the ones passed to the container [here](https://github.com/wellcomecollection/catalogue-pipeline/blob/47cf5416970f900246784f253457b6d819c11154/pipeline/terraform/modules/stack/service_merger.tf#L44)

## How to test

Deploy and check that the task start successfully

## How can we measure success?

The task can start with all the defined environment variables

## Have we considered potential risks?



