### PR TITLE
Retain paragraph tags in TEI summaries

### DIFF
--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiOps.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiOps.scala
@@ -19,7 +19,11 @@ object TeiOps {
       case List(node) =>
         // some summary nodes can contain TEI specific xml tags, so we remove them
         Right(
-          Some(node.text.trim.replaceAll("(?!<\\/?p\\ ?\\/?>)<.*?>", ""))
+          Some(
+            node.text.trim
+              .replaceAll("""<p(\s+\S+=".+?")+\s*(/)?>""", "<p$2>")
+              .replaceAll("""(?!</?p\s*/?>)<.*?>""", "")
+          )
         )
       case Nil => Right(None)
       case _   => Left(new RuntimeException("More than one summary node!"))

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiOps.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiOps.scala
@@ -21,7 +21,17 @@ object TeiOps {
         Right(
           Some(
             node.text.trim
+              // First, strip out any attributes in paragraph tags
+              // This allows the next replacement to simply leave in
+              // any paragraph tags without worrying about what to do
+              // about attributes that we don't want to show.
               .replaceAll("""<p(\s+\S+=".+?")+\s*(/)?>""", "<p$2>")
+              // Then, strip out any XML other than paragraph tags
+              // The initial negative lookahead matches
+              // opening, closing, and self-closing paragraph tags.
+              // <p> </p> <p /> <p/>
+              // It also matches the poorly-formed </p/>, but we do not
+              // expect to find anything like that.
               .replaceAll("""(?!</?p\s*/?>)<.*?>""", "")
           )
         )

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiOps.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiOps.scala
@@ -18,7 +18,9 @@ object TeiOps {
     (nodeSeq \ "msContents" \ "summary").toList match {
       case List(node) =>
         // some summary nodes can contain TEI specific xml tags, so we remove them
-        Right(Some(node.text.trim.replaceAll("<.*?>", "")))
+        Right(
+          Some(node.text.trim.replaceAll("(?!<\\/?p\\ ?\\/?>)<.*?>", ""))
+        )
       case Nil => Right(None)
       case _   => Left(new RuntimeException("More than one summary node!"))
     }

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiXmlTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiXmlTest.scala
@@ -125,6 +125,21 @@ class TeiXmlTest
       xml.value.description shouldBe Some("a manuscript about stuff")
     }
 
+    it("retains paragraph tags in the summary") {
+      val description =
+        "a <note>delightful <p>manuscript</p></note> <p /><p/> about <p>stuff</p>"
+
+      val xml = TeiXml(
+        id,
+        teiXml(id = id, summary = Some(summary(description)))
+          .toString()
+      ).flatMap(_.parse)
+
+      xml.value.description shouldBe Some(
+        "a delightful <p>manuscript</p> <p /><p/> about <p>stuff</p>"
+      )
+    }
+
     it("fails parsing if there's more than one summary node") {
       val bnumber = createSierraBibNumber.withCheckDigit
 

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiXmlTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiXmlTest.scala
@@ -127,7 +127,7 @@ class TeiXmlTest
 
     it("retains paragraph tags in the summary") {
       val description =
-        "a <note>delightful <p>manuscript</p></note> <p /><p/> about <p>stuff</p>"
+        """a <pppp/><note>delightful <p>manu<xp></xp>script</p></note> <p /><p/> about <p>stuff</p><pb />"""
 
       val xml = TeiXml(
         id,
@@ -137,6 +137,21 @@ class TeiXmlTest
 
       xml.value.description shouldBe Some(
         "a delightful <p>manuscript</p> <p /><p/> about <p>stuff</p>"
+      )
+    }
+
+    it("discards paragraph attributes from the summary") {
+      val description =
+        """a <note>delightful <p hand="reza_abbasi">manu<xp></xp>script</p></note> <p a="b" /> <p a="b" c="d"/> about stuff"""
+
+      val xml = TeiXml(
+        id,
+        teiXml(id = id, summary = Some(summary(description)))
+          .toString()
+      ).flatMap(_.parse)
+
+      xml.value.description shouldBe Some(
+        "a delightful <p>manuscript</p> <p/> <p/> about stuff"
       )
     }
 


### PR DESCRIPTION
## What does this change?

Fixes https://github.com/wellcomecollection/platform/issues/5996

## How to test

Once deployed, reindex the MS_Sinhalese_326 TEI document. Once complete, https://wellcomecollection.org/works/axqp36b6 will have paragraphs
 
## How can we measure success?

Works derived from TEI summaries will contain paragraphs from now on.  It will not contain any other unexpected markup.

## Have we considered potential risks?

I have taken care to ensure that the corresponding regular expression does not overmatch or do anything unexpected, but there is always a chance it might do something I haven't tested for.

