### PR TITLE
relations merging now respects ids

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Relations.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Relations.scala
@@ -66,38 +66,19 @@ object RelationSet {
     existingRelations: List[Relation],
     newRelations: List[Relation]
   ): List[Relation] = {
-    def relationsMatch(oldRelation: Relation, newRelation: Relation): Boolean =
-      sameId(
-        oldRelation,
-        newRelation
-      ) || oldRelation.id.isEmpty && sameTitle(oldRelation, newRelation)
-
-    def sameId(oldRelation: Relation, newRelation: Relation): Boolean =
-      oldRelation.id.isDefined && oldRelation.id == newRelation.id
-
-    def sameTitle(oldRelation: Relation, newRelation: Relation): Boolean =
-      removeTerminalPunctuation(
-        newRelation.title
-      ) == removeTerminalPunctuation(oldRelation.title)
-
-    val (replacementRelations, relationsToAppend) = newRelations partition {
-      newRelation =>
-        existingRelations.exists(
-          oldRelation => relationsMatch(oldRelation, newRelation)
+    val retainedRelations = existingRelations filter {
+      oldRelation =>
+        oldRelation.id.isEmpty && !newRelations.exists(
+          newRelation => sameTitle(oldRelation, newRelation)
         )
     }
-    val updatedRelations = existingRelations map {
-      oldRelation: Relation =>
-        replacementRelations.find(
-          newRelation => relationsMatch(oldRelation, newRelation)
-        ) match {
-          case Some(replacement) => replacement
-          case None              => oldRelation
-        }
-    }
-
-    updatedRelations ++ relationsToAppend
+    retainedRelations ++ newRelations
   }
+
+  private def sameTitle(oldRelation: Relation, newRelation: Relation): Boolean =
+    removeTerminalPunctuation(
+      newRelation.title
+    ) == removeTerminalPunctuation(oldRelation.title)
 
   /** The title used in a relation may come from one of two places:
     *   1. The title of the related document 2. The title of the link to the

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Relations.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Relations.scala
@@ -66,6 +66,7 @@ object RelationSet {
     existingRelations: List[Relation],
     newRelations: List[Relation]
   ): List[Relation] = {
+    // Retain any unidentified relations that do not have a replacement in the new list.
     val retainedRelations = existingRelations filter {
       oldRelation =>
         oldRelation.id.isEmpty && !newRelations.exists(

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/RelationsTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/RelationsTest.scala
@@ -82,7 +82,7 @@ class RelationsTest
     (r1 + r2).ancestors.loneElement shouldBe newGranny
   }
 
-  it("replaces relations when they match by identifier") {
+  it("replaces identified relations") {
     val granny = SeriesRelation("Granny").copy(id = Some(createCanonicalId))
     val newGranny = granny.copy(title = Some("Grandma"))
 
@@ -101,25 +101,33 @@ class RelationsTest
     (r1 + r2).ancestors.loneElement shouldBe newGranny
   }
 
-  it("preserves the order of relations when they are replaced") {
-    val granny = SeriesRelation("Granny").copy(id = Some(createCanonicalId))
-    val newGranny = granny.copy(title = Some("Grandma"))
+  it(
+    "replaces all relations other than unidentified ones that do not have a replacement in the new set"
+  ) {
+    val grandma = SeriesRelation("Grandma").copy(id = Some(createCanonicalId))
+    val newGranny = grandma.copy(title = Some("Granny"))
     val mum = SeriesRelation("Mum")
-    val great = SeriesRelation("Great Grandma")
+    val newMum = mum.copy(id = Some(createCanonicalId))
+    val greatGrandma =
+      SeriesRelation("Great Grandma").copy(id = Some(createCanonicalId))
     val eve = SeriesRelation("Mitochondrial Eve")
     val r1 = Relations(
-      ancestors = List(mum, granny, great),
+      ancestors = List(mum, grandma, greatGrandma, eve),
       children = Nil,
       siblingsPreceding = Nil,
       siblingsSucceeding = Nil
     )
     val r2 = Relations(
-      ancestors = List(newGranny, eve),
+      ancestors = List(newMum, newGranny),
       children = Nil,
       siblingsPreceding = Nil,
       siblingsSucceeding = Nil
     )
-    (r1 + r2).ancestors shouldBe List(mum, newGranny, great, eve)
+    (r1 + r2).ancestors shouldBe List(
+      eve, // Eve is the only unidentified non-matching entry
+      newMum, // mum is replaced by newMum, matching on title
+      newGranny
+    )
   }
 
   it("replaces matching relations, even when title and id are the same") {

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/RelationsTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/RelationsTest.scala
@@ -127,6 +127,7 @@ class RelationsTest
       eve, // Eve is the only unidentified non-matching entry
       newMum, // mum is replaced by newMum, matching on title
       newGranny
+      // great grandma is removed, because it has an id in the old list, but is not in the new list.
     )
   }
 

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/RelationsTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/RelationsTest.scala
@@ -1,10 +1,16 @@
 package weco.catalogue.internal_model.work
 
+import org.scalatest.LoneElement
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+import weco.catalogue.internal_model.generators.IdentifiersGenerators
 import weco.catalogue.internal_model.work.generators.WorkGenerators
 
-class RelationsTest extends AnyFunSpec with Matchers {
+class RelationsTest
+    extends AnyFunSpec
+    with Matchers
+    with LoneElement
+    with IdentifiersGenerators {
   it("has zero size when empty") {
     Relations.none.size shouldBe 0
   }
@@ -55,6 +61,87 @@ class RelationsTest extends AnyFunSpec with Matchers {
       siblingsSucceeding =
         List(SeriesRelation("Little Sister"), SeriesRelation("Little Brother"))
     )
+  }
+
+  it("replaces unidentified relations when they match by title") {
+    val granny = SeriesRelation("Granny")
+    val newGranny = granny.copy(id = Some(createCanonicalId))
+
+    val r1 = Relations(
+      ancestors = List(granny),
+      children = Nil,
+      siblingsPreceding = Nil,
+      siblingsSucceeding = Nil
+    )
+    val r2 = Relations(
+      ancestors = List(newGranny),
+      children = Nil,
+      siblingsPreceding = Nil,
+      siblingsSucceeding = Nil
+    )
+    (r1 + r2).ancestors.loneElement shouldBe newGranny
+  }
+
+  it("replaces relations when they match by identifier") {
+    val granny = SeriesRelation("Granny").copy(id = Some(createCanonicalId))
+    val newGranny = granny.copy(title = Some("Grandma"))
+
+    val r1 = Relations(
+      ancestors = List(granny),
+      children = Nil,
+      siblingsPreceding = Nil,
+      siblingsSucceeding = Nil
+    )
+    val r2 = Relations(
+      ancestors = List(newGranny),
+      children = Nil,
+      siblingsPreceding = Nil,
+      siblingsSucceeding = Nil
+    )
+    (r1 + r2).ancestors.loneElement shouldBe newGranny
+  }
+
+  it("preserves the order of relations when they are replaced") {
+    val granny = SeriesRelation("Granny").copy(id = Some(createCanonicalId))
+    val newGranny = granny.copy(title = Some("Grandma"))
+    val mum = SeriesRelation("Mum")
+    val great = SeriesRelation("Great Grandma")
+    val eve = SeriesRelation("Mitochondrial Eve")
+    val r1 = Relations(
+      ancestors = List(mum, granny, great),
+      children = Nil,
+      siblingsPreceding = Nil,
+      siblingsSucceeding = Nil
+    )
+    val r2 = Relations(
+      ancestors = List(newGranny, eve),
+      children = Nil,
+      siblingsPreceding = Nil,
+      siblingsSucceeding = Nil
+    )
+    (r1 + r2).ancestors shouldBe List(mum, newGranny, great, eve)
+  }
+
+  it("replaces matching relations, even when title and id are the same") {
+    val granny = SeriesRelation("Granny").copy(
+      id = Some(createCanonicalId),
+      numDescendents = 1
+    )
+    val newGranny = granny.copy(numDescendents = 99)
+
+    val r1 = Relations(
+      ancestors = List(granny),
+      children = Nil,
+      siblingsPreceding = Nil,
+      siblingsSucceeding = Nil
+    )
+    val r2 = Relations(
+      ancestors = List(newGranny),
+      children = Nil,
+      siblingsPreceding = Nil,
+      siblingsSucceeding = Nil
+    )
+    (r1 + r2).ancestors.loneElement.numDescendents shouldBe 99
   }
 }
 

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/StateTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/StateTest.scala
@@ -129,78 +129,7 @@ class StateTest
         granny
       )
     }
-
-    it("Only overwrites unidentified relations from a previous stage.") {
-      val mum1 = new Relation(
-        id = Some(CanonicalId("cafef00d")),
-        title = Some("Mum"),
-        collectionPath = Some(CollectionPath("cafef00d")),
-        workType = WorkType.Standard,
-        depth = 0,
-        numChildren = 1,
-        numDescendents = 1
-      )
-      val merged = Work.Visible[Merged](
-        version = 0,
-        state = Merged(
-          sourceIdentifier = sourceIdentifier,
-          canonicalId = canonicalId,
-          sourceModifiedTime = Instant.MIN,
-          mergedTime = Instant.MIN,
-          availabilities = Set(),
-          relations = Relations(
-            ancestors =
-              List(SeriesRelation("Granny"), SeriesRelation("Dad"), mum1)
-          )
-        ),
-        data = WorkData(title = Some("My Title"))
-      )
-
-      val mum2 = new Relation(
-        id = Some(CanonicalId("f00dcafe")),
-        title = Some("Mum"),
-        collectionPath = Some(CollectionPath("f00dcafe")),
-        workType = WorkType.Standard,
-        depth = 0,
-        numChildren = 1,
-        numDescendents = 1
-      )
-
-      val mumsMum = new Relation(
-        id = Some(CanonicalId("deadbeef")),
-        title = Some("Granny"),
-        collectionPath = Some(CollectionPath("cafed00d/deadbeef")),
-        workType = WorkType.Standard,
-        depth = 0,
-        numChildren = 1,
-        numDescendents = 1
-      )
-
-      val dadsMum = new Relation(
-        id = Some(CanonicalId("baadf00d")),
-        title = Some("Granny"),
-        collectionPath = Some(CollectionPath("cafed00d/baadf00d")),
-        workType = WorkType.Standard,
-        depth = 0,
-        numChildren = 1,
-        numDescendents = 1
-      )
-
-      val denormalised = merged.transition[Denormalised](
-        Relations(
-          // Mum is already in the list, granny is new
-          ancestors = List(mumsMum, dadsMum, mum2)
-        )
-      )
-      denormalised.state.relations.ancestors shouldBe List(
-        SeriesRelation("Dad"),
-        mum1,
-        mumsMum,
-        dadsMum,
-        mum2
-      )
-    }
-
+    
     it("matches relations ignoring trailing terminal punctuation") {
       val merged = Work.Visible[Merged](
         version = 0,


### PR DESCRIPTION
## What does this change?

When we add together relations lists, we want a set-like behaviour.  Prior to this change, the logic was that an entry would be replaced on the condition that the title matched, and that it had no id.  Following this change, that condition still stands, but entries are also discarded if the id is defined.  It accepts the list provided by the denormaliser as The Truth, with the caveat that entries yet to be identified should be left to represent a Series.

This worked for Sierra Series/Collection definitions when we had separate merged/denormalised indexes. An existing entry in the ancestors list would either have no id, or it would not need to be replaced.

Having collapsed the merged/denormalised indices together, it is now possible to have entries in relations lists that need to be replaced, but that also are already identified.  This happens as the denormalisation discovers more indirect relations and therefore has to increase the counters on numDescendents etc.

## How to test

I think the new tests added to cover this are comprehensive enough.  When we next reindex, this should fix the "big tree" problem we have seen.

## How can we measure success?

The reindex will succeed without taking up too much space in the database

## Have we considered potential risks?

This may still be more complex than it needs to be. I don't know if it's possible for a record to be both in a Series and in a different Collection for real life.  It may be the case that we could just overwrite the whole list in the embedder.