### PR TITLE
Remove ECR login where broken and not needed

### DIFF
--- a/builds/publish_inferrer_image_to_ecr.sh
+++ b/builds/publish_inferrer_image_to_ecr.sh
@@ -29,8 +29,7 @@ else
 fi
 
 echo "*** Publishing Docker image to ECR"
-
-eval $(aws ecr get-login --no-include-email)
+# Login to ECR in the platform account is handled by the Buildkite runner
 
 docker tag "$PROJECT_NAME:$IMAGE_TAG" "$ECR_REGISTRY/$PROJECT_NAME:$IMAGE_TAG"
 docker push "$ECR_REGISTRY/$PROJECT_NAME:$IMAGE_TAG"

--- a/builds/publish_sbt_image_to_ecr.sh
+++ b/builds/publish_sbt_image_to_ecr.sh
@@ -33,8 +33,7 @@ else
 fi
 
 echo "*** Publishing Docker image to ECR"
-
-eval $(aws ecr get-login --no-include-email)
+# Login to ECR in the platform account is handled by the Buildkite runner
 
 docker tag "$PROJECT_NAME:$IMAGE_TAG" "$ECR_REGISTRY/$PROJECT_NAME:$IMAGE_TAG"
 docker push "$ECR_REGISTRY/$PROJECT_NAME:$IMAGE_TAG"


### PR DESCRIPTION
## What does this change?

The reference to logging in to ECR here is failing consistently in CI, but images are published anyway as buildkite runners are already logged into ECR, see [this hook](https://github.com/wellcomecollection/buildkite-infrastructure/blob/054c53fa48fc1fb26115849f80c081695432eaa3/buildkite_agent_hook.sh).

This removes the unnecessary login.

## How to test

- [ ] Deploy this change, ensure images are still published but no login error is visible.

## How can we measure success?

Less confusing errors in build logs.

## Have we considered potential risks?

The ECR login command is currently failing, so should not impact deployment.
