### PR TITLE
Reinstate curl in the inferrers

### DIFF
--- a/pipeline/inferrer/Dockerfile
+++ b/pipeline/inferrer/Dockerfile
@@ -52,6 +52,7 @@ RUN --mount=type=cache,target=/root/.cache/uv  \
 
 FROM  public.ecr.aws/docker/library/python:${pythonversion}-slim  AS base
 
+# curl is used by the Container HEALTHCHECK on AWS
 RUN apt-get -y install curl
 
 ENV PYTHONPATH=/app

--- a/pipeline/inferrer/Dockerfile
+++ b/pipeline/inferrer/Dockerfile
@@ -53,7 +53,7 @@ RUN --mount=type=cache,target=/root/.cache/uv  \
 FROM  public.ecr.aws/docker/library/python:${pythonversion}-slim  AS base
 
 # curl is used by the Container HEALTHCHECK on AWS
-RUN apt-get -y install curl
+RUN apt-get update && apt-get -y install curl
 
 ENV PYTHONPATH=/app
 ENV PATH="/venv/bin:$PATH"

--- a/pipeline/inferrer/Dockerfile
+++ b/pipeline/inferrer/Dockerfile
@@ -7,7 +7,7 @@
 ARG pythonversion=A_VERSION_THAT_DOES_NOT_EXIST
 FROM public.ecr.aws/docker/library/python:${pythonversion}-slim  AS builder
 
-RUN apt-get update && apt-get -y install gcc g++ libffi-dev curl
+RUN apt-get update && apt-get -y install gcc g++ libffi-dev
 
 COPY --from=ghcr.io/astral-sh/uv:0.6.17 /uv /uvx /bin/
 
@@ -51,6 +51,8 @@ RUN --mount=type=cache,target=/root/.cache/uv  \
     uv sync --frozen --no-dev
 
 FROM  public.ecr.aws/docker/library/python:${pythonversion}-slim  AS base
+
+RUN apt-get -y install curl
 
 ENV PYTHONPATH=/app
 ENV PATH="/venv/bin:$PATH"


### PR DESCRIPTION
## What does this change?

The inferrer containers need curl in order to run their health checks.  When I changed the multi-stage builds to exclude the build requirements (gcc etc.) from the final images, curl was also lost

## How to test
## How can we measure success?

The inferrer tasks should now start and work as expected

## Have we considered potential risks?

I have commented the reason for CURL in the Dockerfile, so that it doesn't inadvertently get discarded again.