### PR TITLE
Update reindex scripts

### DIFF
--- a/reindexer/scripts/get_reindex_status.py
+++ b/reindexer/scripts/get_reindex_status.py
@@ -111,7 +111,6 @@ def get_works_index_stats(*, reindex_date):
     indexes = [
         "works-source",
         "works-identified",
-        "works-merged",
         "works-denormalised",
         "works-indexed",
     ]

--- a/reindexer/scripts/pipeline_inject_messages.py
+++ b/reindexer/scripts/pipeline_inject_messages.py
@@ -7,16 +7,46 @@ See the section of the README "fixing leaks" for more info.
 """
 import click
 from tqdm import tqdm
+from uuid import uuid4
 from get_reindex_status import get_session_with_role
+from concurrent.futures import ThreadPoolExecutor
 
+
+def build_sns_batch(messages):
+    for m in messages:
+        yield {
+            "Id": str(uuid4()),
+            "Message": m,
+            "MessageStructure": "string"
+        }
+
+def publish_batch_to_sns(sns, topic_arn, messages):
+    batch_messages = build_sns_batch(messages)
+    response = sns.publish_batch(
+        TopicArn=topic_arn,
+        PublishBatchRequestEntries=list(batch_messages)
+    )
+    return response
+
+def publish_to_sns_threaded(sns, topic_arn, doc_ids, sns_batch_size = 10):
+    with ThreadPoolExecutor(max_workers=10) as executor:
+        batched_messages  = [doc_ids[i:i + sns_batch_size] for i in range(0, len(doc_ids), sns_batch_size)]
+        results = list(executor.map(lambda batch: publish_batch_to_sns(sns, topic_arn, batch), batched_messages))
+    return results
 
 def inject_id_messages(session, *, destination_name, reindex_date, ids):
     sns = session.client("sns")
-    for id in tqdm(ids):
-        sns.publish(
-            TopicArn=f"arn:aws:sns:eu-west-1:760097843905:catalogue-{reindex_date}_{destination_name}",
-            Message=id,
-        )
+
+    topic_arn = f"arn:aws:sns:eu-west-1:760097843905:catalogue-{reindex_date}_{destination_name}"
+
+    chunk_size = 10000
+    chunks = [ids[i:i + chunk_size] for i in range(0, len(ids), chunk_size)]
+
+    for chunk in tqdm(chunks):
+        results = publish_to_sns_threaded(sns, topic_arn, chunk)
+        for result in results:
+            if result['ResponseMetadata']['HTTPStatusCode'] != 200:
+                print(f"Failed to publish!")
 
 
 @click.command()


### PR DESCRIPTION
## What does this change?

This change removes the merged index which no longer exists, and updates the `./pipeline_inject_messages.py` script to work much faster.

## How to test

Verify the `./get_reindex_status.py` and `./pipeline_inject_messages.py` scripts behave as expected.

## How can we measure success?

Only reference indices that exist and faster fixing of borked pipeline.

## Have we considered potential risks?

Risks should be minimal, this is used during reindexes only and changes are minor.
