### PR TITLE
Create new concepts index, reference new pipeline

### DIFF
--- a/catalogue_graph/terraform/locals.tf
+++ b/catalogue_graph/terraform/locals.tf
@@ -16,8 +16,8 @@ locals {
   catalogue_graph_nlb_url = "catalogue-graph.wellcomecollection.org"
 
   # This is a hint that the ingestors might need to be in the pipeline stack!
-  pipeline_date       = "2025-03-06"
-  concepts_index_date = "2025-04-24"
+  pipeline_date       = "2025-05-01"
+  concepts_index_date = "2025-05-15"
 
   concepts_pipeline_inputs_monthly = [
     {

--- a/pipeline/terraform/2025-05-01/main.tf
+++ b/pipeline/terraform/2025-05-01/main.tf
@@ -2,7 +2,7 @@ module "pipeline" {
   source = "../modules/stack"
 
   reindexing_state = {
-    listen_to_reindexer      = true
+    listen_to_reindexer      = false
     scale_up_tasks           = false
     scale_up_elastic_cluster = false
     scale_up_id_minter_db    = false
@@ -24,6 +24,7 @@ module "pipeline" {
       indexed = {
         "2025-03-06" = "concepts_indexed.2025-03-10"
         "2025-04-24" = "concepts_indexed.2025-03-10"
+        "2025-05-15" = "concepts_indexed.2025-03-10"
       }
     }
   }


### PR DESCRIPTION
## What does this change?

This change updates the graph pipeline to use the new pipeline 2025-05-01, and creates a new concepts index 2025-05-15 to index into.

We also turn the reindexer off and ensure 2025-05-01 is scaled down.

For https://github.com/wellcomecollection/platform/issues/6027

## How to test

- [ ] Apply this change, index catalogue graph into the new index & pipeline.

## How can we measure success?

We can switch to the new catalogue pipeline.

## Have we considered potential risks?

If this change is applied it will run with the daily concepts state machine - unless that's desirable we should un-apply these changes after testing.
