### PR TITLE
Increase concepts extractor concurrency

### DIFF
--- a/catalogue_graph/terraform/lambda_catalogue_ingestor.tf
+++ b/catalogue_graph/terraform/lambda_catalogue_ingestor.tf
@@ -105,7 +105,7 @@ module "ingestor_loader_lambda" {
 
   handler     = "ingestor_loader.lambda_handler"
   memory_size = 1024
-  timeout     = 300
+  timeout     = 600
 
   vpc_config = {
     subnet_ids = local.private_subnets

--- a/catalogue_graph/terraform/neptune.tf
+++ b/catalogue_graph/terraform/neptune.tf
@@ -1,7 +1,7 @@
 resource "aws_neptune_cluster" "catalogue_graph_cluster" {
   cluster_identifier                   = "catalogue-graph"
   engine                               = "neptune"
-  engine_version                       = "1.4.2.0"
+  engine_version                       = "1.4.5.0"
   neptune_cluster_parameter_group_name = "default.neptune1.4"
   iam_database_authentication_enabled  = true
   apply_immediately                    = true

--- a/catalogue_graph/terraform/state_machine_ingestor.tf
+++ b/catalogue_graph/terraform/state_machine_ingestor.tf
@@ -52,7 +52,7 @@ resource "aws_sfn_state_machine" "catalogue_graph_ingestor" {
       # the next step is a state map that takes the json list output of the ingestor_trigger_lambda and maps it to a list of ingestor tasks
       "Map load to s3" = {
         Type           = "Map",
-        MaxConcurrency = 1
+        MaxConcurrency = 6
         ItemProcessor = {
           ProcessorConfig = {
             Mode          = "DISTRIBUTED",


### PR DESCRIPTION
## What does this change?

Increase the concurrency of the concepts extractor S3 load step to speed up the pipeline. In practice, this results in a 2.5x speed-up.

