### PR TITLE
remove actual markup, not strings that look like tags

### DIFF
--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiOps.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiOps.scala
@@ -20,7 +20,8 @@ object TeiOps {
         // some summary nodes can contain TEI specific xml tags, so we remove them
         Right(
           Some(
-            node.text.trim
+            node
+              .toString()
               // First, strip out any attributes in paragraph tags
               // This allows the next replacement to simply leave in
               // any paragraph tags without worrying about what to do
@@ -33,6 +34,7 @@ object TeiOps {
               // It also matches the poorly-formed </p/>, but we do not
               // expect to find anything like that.
               .replaceAll("""(?!</?p\s*/?>)<.*?>""", "")
+              .trim
           )
         )
       case Nil => Right(None)

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiXmlTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiXmlTest.scala
@@ -8,6 +8,7 @@ import weco.pipeline.transformer.generators.LabelDerivedIdentifiersGenerators
 import weco.pipeline.transformer.tei.generators.TeiGenerators
 import weco.sierra.generators.SierraIdentifierGenerators
 
+import java.time.Instant
 import scala.xml.Elem
 
 class TeiXmlTest
@@ -114,11 +115,14 @@ class TeiXmlTest
 
   describe("summary") {
     it("removes XML tags from the summary") {
-      val description = "a <note>manuscript</note> about stuff"
+      val summary =
+        <summary>
+        a <note>manuscript</note> about stuff
+        </summary>
 
       val xml = TeiXml(
         id,
-        teiXml(id = id, summary = Some(summary(description)))
+        teiXml(id = id, summary = Some(summary))
           .toString()
       ).flatMap(_.parse)
 
@@ -126,27 +130,33 @@ class TeiXmlTest
     }
 
     it("retains paragraph tags in the summary") {
-      val description =
-        """a <pppp/><note>delightful <p>manu<xp></xp>script</p></note> <p /><p/> about <p>stuff</p><pb />"""
-
+      val summary =
+        <summary>
+          a <pppp/><note>delightful <p>manu<xp></xp>script</p></note> <p /><p/> about <p>stuff</p>
+          <pb />
+        </summary>
       val xml = TeiXml(
         id,
-        teiXml(id = id, summary = Some(summary(description)))
+        teiXml(id = id, summary = Some(summary))
           .toString()
       ).flatMap(_.parse)
 
       xml.value.description shouldBe Some(
-        "a delightful <p>manuscript</p> <p /><p/> about <p>stuff</p>"
+        "a delightful <p>manuscript</p> <p/><p/> about <p>stuff</p>"
       )
+      val w: Work[WorkState.Source] = xml.value.toWork(Instant.now, 5)
+      println(w)
     }
 
     it("discards paragraph attributes from the summary") {
-      val description =
-        """a <note>delightful <p hand="reza_abbasi">manu<xp></xp>script</p></note> <p a="b" /> <p a="b" c="d"/> about stuff"""
+      val summary =
+        <summary>
+        a <note>delightful <p hand="reza_abbasi">manu<xp></xp>script</p></note> <p a="b" /> <p a="b" c="d"/> about stuff
+      </summary>
 
       val xml = TeiXml(
         id,
-        teiXml(id = id, summary = Some(summary(description)))
+        teiXml(id = id, summary = Some(summary))
           .toString()
       ).flatMap(_.parse)
 


### PR DESCRIPTION
## What does this change?

This fixes a problem overlooked in https://github.com/wellcomecollection/catalogue-pipeline/pull/2889, which meant that paragraph tags were still being dropped.

What was happening:
* An existing method purported to be removing unwanted XML tags from within the summary, using regex `replaceAll`
* It was actually removing unwanted XML tags by using `node.text`, which returns the concatenation of all descendent text nodes in document order
* the regex replacement was irrelevant.
* An existing test purported to exercise this, by creating a summary node containing a `<note>`. It actually contained `&lt;note&gt;`
* So the test exercised the regex part  of it, but nothing was testing that XML tags were being removed (they were)
* I modified the regex to ignore `p` tags, and copied the format of the existing test.  As a result, `&lt;p&gt;` was being retained, but this was not what was wanted.  `<p/>` was still being removed.


It now actually removes unwanted markup by first serialising to an XML string and then doing the replacement.


## How to test

MS_Sinhalese_326 - https://wellcomecollection.org/works/axqp36b6 should have paragraphs.

## How can we measure success?

Paragraph breaks get displayed, making TEI records more readable on the website.

## Have we considered potential risks?

Perhaps the behaviour of the existing test was also correct, and that we need to remove escaped markup as well.  I doubt it, as that would not tally with the commentary or description of the test.

