### PR TITLE
Add VPC config for matcher lambda

### DIFF
--- a/pipeline/terraform/modules/stack/service_matcher.tf
+++ b/pipeline/terraform/modules/stack/service_matcher.tf
@@ -47,6 +47,14 @@ module "matcher_lambda" {
 
   service_name = "matcher"
 
+  vpc_config = {
+    subnet_ids = local.network_config.subnets
+    security_group_ids = [
+      aws_security_group.egress.id,
+      local.network_config.ec_privatelink_security_group_id,
+    ]
+  }
+
   environment_variables = {
     topic_arn = module.matcher_output_topic.arn
 


### PR DESCRIPTION
## What does this change?

Follows: https://github.com/wellcomecollection/catalogue-pipeline/pull/2914

Adds VPC configuration for the matcher lambda required for it to talk to the Elastic cluster.

## How to test

- [ ] Send a test message, does the lambda successfully start and process the message?

## How can we measure success?

An unblocked catalogue pipeline.

## Have we considered potential risks?

Risks should be minimal, the old matcher had this access.
