### PR TITLE
make lambda name consistent with the others

### DIFF
--- a/catalogue_graph/terraform/lambda_reporter.tf
+++ b/catalogue_graph/terraform/lambda_reporter.tf
@@ -1,7 +1,7 @@
 module "concepts_pipeline_reporter_lambda" {
   source = "git@github.com:wellcomecollection/terraform-aws-lambda?ref=v1.2.0"
 
-  name        = "catalogue-graph-pipeline_reporter"
+  name        = "catalogue-graph-pipeline-reporter"
   description = "Generates a report on the latest pipeline run and posts it to #wc-search-alerts"
   runtime     = "python3.13"
   publish     = true

--- a/catalogue_graph/terraform/lambda_reporter.tf
+++ b/catalogue_graph/terraform/lambda_reporter.tf
@@ -18,13 +18,13 @@ module "concepts_pipeline_reporter_lambda" {
     variables = {
       INGESTOR_S3_BUCKET = aws_s3_bucket.catalogue_graph_bucket.bucket
       INGESTOR_S3_PREFIX = "ingestor"
-      SLACK_SECRET_ID = local.slack_webhook
+      SLACK_SECRET_ID    = local.slack_webhook
     }
   }
 }
 
 resource "aws_iam_role_policy" "reporter_lambda_read_slack_secret_policy" {
-  role = module.concepts_pipeline_reporter_lambda.lambda_role.name
+  role   = module.concepts_pipeline_reporter_lambda.lambda_role.name
   policy = data.aws_iam_policy_document.allow_slack_secret_read.json
 }
 

--- a/catalogue_graph/terraform/state_machine_ingestor.tf
+++ b/catalogue_graph/terraform/state_machine_ingestor.tf
@@ -188,7 +188,7 @@ resource "aws_sfn_state_machine" "catalogue_graph_ingestor" {
         Resource = "arn:aws:states:::lambda:invoke",
         Arguments = {
           FunctionName = module.concepts_pipeline_reporter_lambda.lambda.arn,
-          Payload = "{% $states.input %}"
+          Payload      = "{% $states.input %}"
         },
         Next = "Success"
       },


### PR DESCRIPTION
## What does this change?

Following https://github.com/wellcomecollection/catalogue-pipeline/pull/2921 the deploy uncovered an inconsistency in lambda naming
This fixes it
Applied

## How to test

N/A

## How can we measure success?

All landas are deployed successfully and named consistently

## Have we considered potential risks?

none
