### PR TITLE
serialise the handler response

### DIFF
--- a/catalogue_graph/src/ingestor_indexer.py
+++ b/catalogue_graph/src/ingestor_indexer.py
@@ -95,7 +95,7 @@ def handler(
 
 def lambda_handler(
     event: IngestorIndexerLambdaEvent, context: typing.Any
-) -> ReporterEvent:
+) -> dict[str, typing.Any]:
     return handler(
         IngestorIndexerLambdaEvent.model_validate(event), IngestorIndexerConfig()
     ).model_dump()


### PR DESCRIPTION
## What does this change?

Fixes failure of the ingestor-indexer following https://github.com/wellcomecollection/catalogue-pipeline/pull/2921 due to the Event not being serialised in the response 

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

The state machine completes successfully 

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? -->

