### PR TITLE
Add permissions for concepts reporter

### DIFF
--- a/catalogue_graph/src/concepts_pipeline_reporter.py
+++ b/catalogue_graph/src/concepts_pipeline_reporter.py
@@ -128,7 +128,7 @@ def get_remover_report(
     graph_remover_deletions = {}
 
     for source, entity in product(graph_sources, graph_entities):
-        try: 
+        try:
             df = df_from_s3_parquet(
                 f"s3://wellcomecollection-catalogue-graph/graph_remover/deleted_ids/{source}__{entity}.parquet",
             )
@@ -136,7 +136,7 @@ def get_remover_report(
             # if file does not exist, ignore
             print(f"S3 file not found for {source}__{entity}: {e}")
             df = None
-            
+
         now = datetime.now()
         beginning_of_today = datetime(
             now.year, now.month, now.day

--- a/catalogue_graph/terraform/iam_policies.tf
+++ b/catalogue_graph/terraform/iam_policies.tf
@@ -66,7 +66,7 @@ data "aws_iam_policy_document" "neptune_delete" {
   }
 }
 
-# read from catalogue_graph_bucket s3 bucket
+# read from catalogue_graph_bucket s3 bucket with prefix /ingestor
 data "aws_iam_policy_document" "ingestor_s3_read" {
   statement {
     actions = [
@@ -76,6 +76,21 @@ data "aws_iam_policy_document" "ingestor_s3_read" {
 
     resources = [
       "${aws_s3_bucket.catalogue_graph_bucket.arn}/ingestor/*"
+    ]
+  }
+}
+
+# read from catalogue_graph_bucket s3 bucket with prefix /graph_remover
+data "aws_iam_policy_document" "graph_remover_s3_read" {
+  statement {
+    actions = [
+      "s3:ListBucket",
+      "s3:GetObject",
+      "s3:HeadObject",
+    ]
+
+    resources = [
+      "${aws_s3_bucket.catalogue_graph_bucket.arn}/graph_remover/*"
     ]
   }
 }

--- a/catalogue_graph/terraform/iam_state_machines.tf
+++ b/catalogue_graph/terraform/iam_state_machines.tf
@@ -61,6 +61,7 @@ resource "aws_iam_policy" "state_machine_policy" {
           module.index_remover_lambda.lambda.arn,
           module.graph_scaler_lambda.lambda.arn,
           module.graph_status_poller_lambda.lambda.arn,
+          module.concepts_pipeline_reporter_lambda.lambda.arn
         ]
       },
       {

--- a/catalogue_graph/terraform/lambda_reporter.tf
+++ b/catalogue_graph/terraform/lambda_reporter.tf
@@ -10,7 +10,7 @@ module "concepts_pipeline_reporter_lambda" {
   // To deploy manually, see `scripts/deploy_lambda_zip.sh`
   filename = data.archive_file.empty_zip.output_path
 
-  handler     = "ingestor_reporter.lambda_handler"
+  handler     = "concepts_pipeline_reporter.lambda_handler"
   memory_size = 128
   timeout     = 300
 
@@ -31,4 +31,9 @@ resource "aws_iam_role_policy" "reporter_lambda_read_slack_secret_policy" {
 resource "aws_iam_role_policy" "reporter_lambda_s3_read_policy" {
   role   = module.concepts_pipeline_reporter_lambda.lambda_role.name
   policy = data.aws_iam_policy_document.ingestor_s3_read.json
+}
+
+resource "aws_iam_role_policy" "reporter_lambda_graph_remover_s3_read_policy" {
+  role   = module.concepts_pipeline_reporter_lambda.lambda_role.name
+  policy = data.aws_iam_policy_document.graph_remover_s3_read.json
 }


### PR DESCRIPTION
## What does this change?

A few fixes to get the reporter to run:
- for simplicity we try to get every combinations of source__entity_type in the `wellcomecollection-catalogue-graph/graph_remover/deleted_ids` prefix. Some of them do not exist. We catch now the error and return None. 
- Add permission to read from `/graph_remover` prefix (applied)
- allow state machine to trigger the lambda (applied)
- point to the correct handler (applied)
 
## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

The reporter runs successfully 

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? -->

