### PR TITLE
write indexer report in pipeline/index/job prefix

### DIFF
--- a/catalogue_graph/src/concepts_pipeline_reporter.py
+++ b/catalogue_graph/src/concepts_pipeline_reporter.py
@@ -137,7 +137,10 @@ def get_remover_report(
 
     # get deletions from the graph
     graph_remover_deletions = {}
-    last_index_remover_run_date = index_remover_report.date if index_remover_report is not None else datetime.now().date()
+    if index_remover_report is not None:
+        last_index_remover_run_date = datetime.strptime(index_remover_report.date, "%Y-%m-%d").date()
+    else:
+        last_index_remover_run_date = datetime.now().date()
 
     for source, entity in product(graph_sources, graph_entities):
         try:

--- a/catalogue_graph/src/concepts_pipeline_reporter.py
+++ b/catalogue_graph/src/concepts_pipeline_reporter.py
@@ -139,7 +139,9 @@ def get_remover_report(
     # get deletions from the graph
     graph_remover_deletions = {}
     if index_remover_report is not None:
-        last_index_remover_run_date = datetime.strptime(index_remover_report.date, "%Y-%m-%d").date()
+        last_index_remover_run_date = datetime.strptime(
+            index_remover_report.date, "%Y-%m-%d"
+        ).date()
     else:
         last_index_remover_run_date = datetime.now().date()
 
@@ -163,8 +165,6 @@ def get_remover_report(
             )
             if deletions_today > 0:
                 graph_remover_deletions[f"{source}__{entity}"] = deletions_today
-
-    
 
     # format the reports for Slack
 

--- a/catalogue_graph/src/concepts_pipeline_reporter.py
+++ b/catalogue_graph/src/concepts_pipeline_reporter.py
@@ -127,9 +127,10 @@ def get_remover_report(
     # get deletions from the index
     pipeline_date = event.pipeline_date or "dev"
     index_date = event.index_date
+    job_id = event.job_id
 
     report_name = "report.index_remover.json"
-    s3_url_index_remover_report = f"s3://{config.ingestor_s3_bucket}/{config.ingestor_s3_prefix}/{pipeline_date}/{index_date}/{report_name}"
+    s3_url_index_remover_report = f"s3://{config.ingestor_s3_bucket}/{config.ingestor_s3_prefix}/{pipeline_date}/{index_date}/{job_id}/{report_name}"
 
     index_remover_report = pydantic_from_s3_json(
         IndexRemoverReport, s3_url_index_remover_report, ignore_missing=True

--- a/catalogue_graph/src/index_remover.py
+++ b/catalogue_graph/src/index_remover.py
@@ -148,13 +148,12 @@ def handler(
 def lambda_handler(events: list[ReporterEvent], context: typing.Any) -> None:
     # we only want properties pertaining to the overall pipeline run, any event will do
     validated_event = [ReporterEvent.model_validate(event) for event in events][0]
-    override_safety_check = validated_event.force_pass if validated_event.force_pass is not None else False
     
     handler(
         validated_event.pipeline_date, 
         validated_event.index_date, 
         validated_event.job_id,
-        override_safety_check
+        bool(validated_event.force_pass)
     )
 
 

--- a/catalogue_graph/src/index_remover.py
+++ b/catalogue_graph/src/index_remover.py
@@ -137,8 +137,10 @@ def handler(
         deleted_count=deleted_count,
         date=datetime.today().strftime("%Y-%m-%d"),
     )
-
+    
+    # write the current report to s3 as latest
     update_index_remover_report(report, _get_last_index_remover_report_file_uri(pipeline_date, index_date))
+    # write the current report to s3 as job_id
     update_index_remover_report(report, _get_current_index_remover_report_file_uri(pipeline_date, index_date, job_id))
 
 

--- a/catalogue_graph/src/index_remover.py
+++ b/catalogue_graph/src/index_remover.py
@@ -134,10 +134,11 @@ def handler(
     report = IndexRemoverReport(
         pipeline_date=pipeline_date or "dev",
         index_date=index_date or "dev",
+        job_id=job_id or "dev",
         deleted_count=deleted_count,
         date=datetime.today().strftime("%Y-%m-%d"),
     )
-    
+
     # write the current report to s3 as latest
     update_index_remover_report(report, _get_last_index_remover_report_file_uri(pipeline_date, index_date))
     # write the current report to s3 as job_id

--- a/catalogue_graph/src/ingestor_loader_monitor.py
+++ b/catalogue_graph/src/ingestor_loader_monitor.py
@@ -1,4 +1,4 @@
-from pydantic import typing
+import typing
 
 from clients.metric_reporter import MetricReporter
 from config import INGESTOR_S3_BUCKET, INGESTOR_S3_PREFIX

--- a/catalogue_graph/src/models/step_events.py
+++ b/catalogue_graph/src/models/step_events.py
@@ -6,7 +6,7 @@ class IngestorMonitorStepEvent(BaseModel):
     report_results: bool = True
 
 
-class ReporterEvent(BaseModel):
+class ReporterEvent(IngestorMonitorStepEvent):
     pipeline_date: str | None = None
     index_date: str | None = None
     job_id: str | None = None

--- a/catalogue_graph/src/utils/slack_report.py
+++ b/catalogue_graph/src/utils/slack_report.py
@@ -44,7 +44,7 @@ def build_indexer_report(
     latest_report: TriggerReport | LoaderReport,
 ) -> None:
     report_name = "report.indexer.json"
-    s3_url_indexer_report = f"s3://{INGESTOR_S3_BUCKET}/{INGESTOR_S3_PREFIX}/{current_report.pipeline_date}/{current_report.job_id}/{report_name}"
+    s3_url_indexer_report = f"s3://{INGESTOR_S3_BUCKET}/{INGESTOR_S3_PREFIX}/{current_report.pipeline_date}/{current_report.index_date}/{current_report.job_id}/{report_name}"
 
     indexer_report = pydantic_from_s3_json(
         IndexerReport, s3_url_indexer_report, ignore_missing=True

--- a/catalogue_graph/src/utils/slack_report.py
+++ b/catalogue_graph/src/utils/slack_report.py
@@ -25,12 +25,14 @@ class LoaderReport(BaseModel):
 class IndexRemoverReport(BaseModel):
     pipeline_date: str
     index_date: str
+    job_id: str
     deleted_count: int | None
     date: str
 
 
 class IndexerReport(BaseModel):
     pipeline_date: str
+    index_date: str
     job_id: str
     previous_job_id: str
     neptune_record_count: int
@@ -54,6 +56,7 @@ def build_indexer_report(
     if indexer_report is None:
         indexer_report = IndexerReport(
             pipeline_date=current_report.pipeline_date,
+            index_date=current_report.index_date,
             job_id=current_report.job_id,
             previous_job_id=latest_report.job_id,
             neptune_record_count=current_report.record_count,
@@ -66,6 +69,7 @@ def build_indexer_report(
     else:
         updated_indexer_report = IndexerReport(
             pipeline_date=indexer_report.pipeline_date,
+            index_date=indexer_report.index_date,
             job_id=indexer_report.job_id,
             previous_job_id=indexer_report.previous_job_id,
             neptune_record_count=indexer_report.neptune_record_count,
@@ -73,7 +77,7 @@ def build_indexer_report(
             es_record_count=current_report.record_count,
             previous_es_record_count=latest_report.record_count,
         )
-        
+
         # write the final indexer report to s3 as latest
         pydantic_to_s3_json(updated_indexer_report, s3_url_latest_indexer_report)
         # write the final indexer report to s3 as job_id

--- a/catalogue_graph/src/utils/slack_report.py
+++ b/catalogue_graph/src/utils/slack_report.py
@@ -44,10 +44,11 @@ def build_indexer_report(
     latest_report: TriggerReport | LoaderReport,
 ) -> None:
     report_name = "report.indexer.json"
-    s3_url_indexer_report = f"s3://{INGESTOR_S3_BUCKET}/{INGESTOR_S3_PREFIX}/{current_report.pipeline_date}/{current_report.index_date}/{current_report.job_id}/{report_name}"
+    s3_url_current_indexer_report = f"s3://{INGESTOR_S3_BUCKET}/{INGESTOR_S3_PREFIX}/{current_report.pipeline_date}/{current_report.index_date}/{current_report.job_id}/{report_name}"
+    s3_url_latest_indexer_report = f"s3://{INGESTOR_S3_BUCKET}/{INGESTOR_S3_PREFIX}/{current_report.pipeline_date}/{current_report.index_date}/{report_name}"
 
     indexer_report = pydantic_from_s3_json(
-        IndexerReport, s3_url_indexer_report, ignore_missing=True
+        IndexerReport, s3_url_current_indexer_report, ignore_missing=True
     )
 
     if indexer_report is None:
@@ -60,7 +61,7 @@ def build_indexer_report(
             es_record_count=None,
             previous_es_record_count=None,
         )
-        pydantic_to_s3_json(indexer_report, s3_url_indexer_report)
+        pydantic_to_s3_json(indexer_report, s3_url_current_indexer_report)
 
     else:
         updated_indexer_report = IndexerReport(
@@ -72,8 +73,11 @@ def build_indexer_report(
             es_record_count=current_report.record_count,
             previous_es_record_count=latest_report.record_count,
         )
-        pydantic_to_s3_json(updated_indexer_report, s3_url_indexer_report)
-
+        
+        # write the final indexer report to s3 as latest
+        pydantic_to_s3_json(updated_indexer_report, s3_url_latest_indexer_report)
+        # write the final indexer report to s3 as job_id
+        pydantic_to_s3_json(updated_indexer_report, s3_url_current_indexer_report)
 
 def publish_report(report: list[typing.Any], slack_secret: str) -> None:
     slack_endpoint = get_secret(slack_secret)

--- a/catalogue_graph/src/utils/slack_report.py
+++ b/catalogue_graph/src/utils/slack_report.py
@@ -83,6 +83,7 @@ def build_indexer_report(
         # write the final indexer report to s3 as job_id
         pydantic_to_s3_json(updated_indexer_report, s3_url_current_indexer_report)
 
+
 def publish_report(report: list[typing.Any], slack_secret: str) -> None:
     slack_endpoint = get_secret(slack_secret)
 

--- a/catalogue_graph/terraform/state_machine_ingestor.tf
+++ b/catalogue_graph/terraform/state_machine_ingestor.tf
@@ -175,10 +175,7 @@ resource "aws_sfn_state_machine" "catalogue_graph_ingestor" {
         Output   = "{% $states.input %}",
         Arguments = {
           FunctionName = module.index_remover_lambda.lambda.arn,
-          Payload = {
-            pipeline_date = local.pipeline_date,
-            index_date    = local.concepts_index_date
-          }
+          Payload = "{% $states.input %}"
         },
         Retry = local.DefaultRetry,
         Next  = "Generate final report"

--- a/catalogue_graph/tests/test_index_remover.py
+++ b/catalogue_graph/tests/test_index_remover.py
@@ -2,12 +2,12 @@ import json
 
 import polars as pl
 import pytest
-from models.step_events import ReporterEvent
 from test_graph_remover import CATALOGUE_CONCEPTS_REMOVED_IDS_URI
 from test_mocks import MockElasticsearchClient, MockSecretsManagerClient, MockSmartOpen
 
 from graph_remover import IDS_LOG_SCHEMA
 from index_remover import lambda_handler
+from models.step_events import ReporterEvent
 
 
 def _mock_es_secrets() -> None:
@@ -52,11 +52,11 @@ def test_index_remover_first_run() -> None:
 
     # No index date specified, so the local 'concepts-indexed' index name should be used
     event = ReporterEvent(
-        pipeline_date = None,
-        index_date = None,
-        job_id = None,
-        success_count = 1000,
-        force_pass = True
+        pipeline_date=None,
+        index_date=None,
+        job_id=None,
+        success_count=1000,
+        force_pass=True,
     )
     lambda_handler([event], None)
 
@@ -101,7 +101,7 @@ def test_index_remover_next_run() -> None:
         index_date=index_date,
         job_id=job_id,
         success_count=1000,
-        force_pass=True
+        force_pass=True,
     )
     lambda_handler([event], None)
 
@@ -163,7 +163,7 @@ def test_index_remover_new_index_run() -> None:
         index_date=index_date,
         job_id=job_id,
         success_count=1000,
-        force_pass=True
+        force_pass=True,
     )
 
     lambda_handler([event], None)

--- a/catalogue_graph/tests/test_index_remover.py
+++ b/catalogue_graph/tests/test_index_remover.py
@@ -2,6 +2,7 @@ import json
 
 import polars as pl
 import pytest
+from models.step_events import ReporterEvent
 from test_graph_remover import CATALOGUE_CONCEPTS_REMOVED_IDS_URI
 from test_mocks import MockElasticsearchClient, MockSecretsManagerClient, MockSmartOpen
 
@@ -50,8 +51,14 @@ def test_index_remover_first_run() -> None:
     assert len(indexed_concepts) == 5
 
     # No index date specified, so the local 'concepts-indexed' index name should be used
-    event = {"pipeline_date": None, "index_date": None, "override_safety_check": True}
-    lambda_handler(event, None)
+    event = ReporterEvent(
+        pipeline_date = None,
+        index_date = None,
+        job_id = None,
+        success_count = 1000,
+        force_pass = True
+    )
+    lambda_handler([event], None)
 
     indexed_concepts = MockElasticsearchClient.indexed_documents["concepts-indexed"]
 
@@ -64,6 +71,7 @@ def test_index_remover_next_run() -> None:
 
     pipeline_date = "2025-01-01"
     index_date = "2025-02-02"
+    job_id = "test-job-id"
     index_name = f"concepts-indexed-{index_date}"
 
     _mock_es_secrets()
@@ -88,12 +96,14 @@ def test_index_remover_next_run() -> None:
     indexed_concepts = MockElasticsearchClient.indexed_documents[index_name]
     assert len(indexed_concepts) == 5
 
-    event = {
-        "pipeline_date": pipeline_date,
-        "index_date": index_date,
-        "override_safety_check": True,
-    }
-    lambda_handler(event, None)
+    event = ReporterEvent(
+        pipeline_date=pipeline_date,
+        index_date=index_date,
+        job_id=job_id,
+        success_count=1000,
+        force_pass=True
+    )
+    lambda_handler([event], None)
 
     indexed_concepts = MockElasticsearchClient.indexed_documents[index_name]
 
@@ -108,18 +118,28 @@ def test_index_remover_safety_check() -> None:
     mock_deleted_ids_log_file()
     index_concepts(["u6jve2vb", "amzfbrbz", "q5a7uqkz", "s8f6cxcf", "someid12"])
 
-    event = {"pipeline_date": None, "index_date": None}
+    event = ReporterEvent(
+        pipeline_date=None,
+        index_date=None,
+        job_id=None,
+        success_count=1000,
+    )
     with pytest.raises(ValueError):
-        lambda_handler(event, None)
+        lambda_handler([event], None)
 
 
 def test_index_remover_no_deleted_ids_file() -> None:
     index_concepts(["u6jve2vb", "amzfbrbz", "q5a7uqkz", "s8f6cxcf", "someid12"])
 
     # If the file storing deleted IDs does not exist, something went wrong and an exception should be thrown.
-    event = {"pipeline_date": None, "index_date": None}
+    event = ReporterEvent(
+        pipeline_date=None,
+        index_date=None,
+        job_id=None,
+        success_count=1000,
+    )
     with pytest.raises(KeyError):
-        lambda_handler(event, None)
+        lambda_handler([event], None)
 
 
 def test_index_remover_new_index_run() -> None:
@@ -128,6 +148,7 @@ def test_index_remover_new_index_run() -> None:
     # Mock an index which was created *after* some IDs were deleted from the graph
     pipeline_date = "2025-01-01"
     index_date = "2025-04-07"
+    job_id = "test-job-id"
     index_name = f"concepts-indexed-{index_date}"
 
     _mock_es_secrets()
@@ -137,12 +158,15 @@ def test_index_remover_new_index_run() -> None:
     indexed_concepts = MockElasticsearchClient.indexed_documents[index_name]
     assert len(indexed_concepts) == 4
 
-    event = {
-        "pipeline_date": pipeline_date,
-        "index_date": index_date,
-        "override_safety_check": True,
-    }
-    lambda_handler(event, None)
+    event = ReporterEvent(
+        pipeline_date=pipeline_date,
+        index_date=index_date,
+        job_id=job_id,
+        success_count=1000,
+        force_pass=True
+    )
+
+    lambda_handler([event], None)
 
     indexed_concepts = MockElasticsearchClient.indexed_documents[index_name]
 


### PR DESCRIPTION
## What does this change?

- write all reports in the job_id prefix as well as the root of the ingestor
- make sure reports are consistent, with pipeline_date, index_date and job_id
- report on graph deletions since last index_remover run, not just for today
- in order to be able to write the index_remover report in the job_id prefix, passes the ReportEvent to the "Remove documents" step of the state machine

## How to test

## How can we measure success?

Reports get published, easier to debug

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? -->

