### PR TITLE
Update catalogue graph tests following update

### DIFF
--- a/catalogue_graph/terraform/state_machine_ingestor.tf
+++ b/catalogue_graph/terraform/state_machine_ingestor.tf
@@ -175,7 +175,7 @@ resource "aws_sfn_state_machine" "catalogue_graph_ingestor" {
         Output   = "{% $states.input %}",
         Arguments = {
           FunctionName = module.index_remover_lambda.lambda.arn,
-          Payload = "{% $states.input %}"
+          Payload      = "{% $states.input %}"
         },
         Retry = local.DefaultRetry,
         Next  = "Generate final report"

--- a/catalogue_graph/tests/fixtures/reporter/report.index_remover.json
+++ b/catalogue_graph/tests/fixtures/reporter/report.index_remover.json
@@ -1,6 +1,7 @@
 {
     "pipeline_date": "2025-10-01",
     "index_date": "2025-10-12",
+    "job_id": "20240103T1200",
     "deleted_count": 2,
     "date": "2023-08-01"
 }

--- a/catalogue_graph/tests/fixtures/reporter/report.indexer.json
+++ b/catalogue_graph/tests/fixtures/reporter/report.indexer.json
@@ -1,6 +1,7 @@
 {
   "pipeline_date": "2025-10-01",
   "job_id": "20240103T1200",
+  "index_date": "2025-10-12",
   "previous_job_id": "20240102T1200",
   "neptune_record_count": 1000,
   "previous_neptune_record_count": 950,

--- a/catalogue_graph/tests/test_concepts_pipeline_reporter.py
+++ b/catalogue_graph/tests/test_concepts_pipeline_reporter.py
@@ -102,10 +102,10 @@ def test_get_remover_report_success(
     )
 
     MockSmartOpen.mock_s3_file(
-        f"{s3_url}/report.index_remover.json",
+        f"{s3_url}/{job_id}/report.index_remover.json",
         load_fixture("reporter/report.index_remover.json"),
     )
-    MockSmartOpen.open(f"{s3_url}/report.index_remover.json", "r")
+    MockSmartOpen.open(f"{s3_url}/{job_id}/report.index_remover.json", "r")
 
     mock_deleted_ids_log_file()
 

--- a/catalogue_graph/tests/test_index_remover.py
+++ b/catalogue_graph/tests/test_index_remover.py
@@ -83,6 +83,7 @@ def test_index_remover_next_run() -> None:
             {
                 "pipeline_date": pipeline_date,
                 "index_date": index_date,
+                "job_id": "20240103T1200",
                 "deleted_count": 2,
                 "date": "2025-04-07",
             }


### PR DESCRIPTION
## What does this change?

Following https://github.com/wellcomecollection/catalogue-pipeline/pull/2931, this change performs formatting and test updates so CI/CD should pass.

## How to test

- [ ] Run the tests in catalogue-graph, do they pass?

## How can we measure success?

Deployment of reporter lambda.

## Have we considered potential risks?

Risks should be minimal, this is not a user facing change.
