### PR TITLE
Downstream test fixture

### DIFF
--- a/common/lambda/src/main/scala/weco/lambda/Downstream.scala
+++ b/common/lambda/src/main/scala/weco/lambda/Downstream.scala
@@ -16,11 +16,23 @@ trait Downstream {
   def notify[T](batch: T)(implicit encoder: Encoder[T]): Try[Unit]
 }
 
+object Downstream {
+  def apply(downstreamTarget: DownstreamTarget): Downstream = {
+    downstreamTarget match {
+      case SNS(config) => new SNSDownstream(config)
+      case StdOut      => STDIODownstream
+    }
+  }
+  def apply(): Downstream = STDIODownstream
+}
+
 class SNSDownstream(snsConfig: SNSConfig) extends Downstream {
   protected val msgSender: MessageSender[_] = new SNSMessageSender(
     snsClient = SnsClient.builder().build(),
     snsConfig = snsConfig,
-    subject = "Sent from relation_embedder"
+    // format the topicArn to keep the service name only
+    subject =
+      s"Sent from ${snsConfig.topicArn.split(":").last.split("_").drop(1).dropRight(1).mkString("-")}"
   )
 
   override def notify(workId: String): Try[Unit] = Try(msgSender.send(workId))
@@ -39,24 +51,17 @@ sealed trait DownstreamTarget
 case class SNS(config: SNSConfig) extends DownstreamTarget
 case object StdOut extends DownstreamTarget
 
-object Downstream {
-  def apply(downstreamTarget: DownstreamTarget): Downstream = {
-    downstreamTarget match {
-      case SNS(config) => new SNSDownstream(config)
-      case StdOut      => STDIODownstream
-    }
-  }
-  def apply(): Downstream = STDIODownstream
-}
-
 // Typesafe specific configuration builder
 object DownstreamBuilder extends Logging {
   import weco.typesafe.config.builders.EnrichConfig._
 
-  def buildDownstreamTarget(config: Config): DownstreamTarget = {
+  def buildDownstreamTarget(
+    config: Config,
+    namespace: String = ""
+  ): DownstreamTarget = {
     config.getStringOption("downstream.target") match {
       case Some("sns") =>
-        val snsConfig = buildSNSConfig(config)
+        val snsConfig = buildSNSConfig(config, namespace)
         info(s"Building SNS downstream with config: $snsConfig")
         SNS(snsConfig)
       case Some("stdio") =>

--- a/common/lambda/src/test/scala/weco/lambda/helpers/MemoryDownstream.scala
+++ b/common/lambda/src/test/scala/weco/lambda/helpers/MemoryDownstream.scala
@@ -6,7 +6,7 @@ import weco.messaging.memory.MemoryMessageSender
 
 import scala.util.Try
 
-trait MemorySNSDownstream {
+trait MemoryDownstream {
 
   class MemorySNSDownstream(sender: MemoryMessageSender = new MemoryMessageSender)
     extends Downstream {

--- a/common/lambda/src/test/scala/weco/lambda/helpers/MemoryDownstream.scala
+++ b/common/lambda/src/test/scala/weco/lambda/helpers/MemoryDownstream.scala
@@ -16,6 +16,24 @@ trait MemoryDownstream {
     override def notify(workId: String): Try[Unit] =
       Try(msgSender.send(workId))
     override def notify[T](batch: T)(implicit encoder: Encoder[T]): Try[Unit] =
-      Try(msgSender.send(encoder.apply(batch).toString()))
+      sender.sendT(batch)
   }
 }
+
+
+
+//class MemoryDownstream(messageSender: MessageSender) extends Downstream {
+//  override def notify(workId: String): Try[Unit] = ???
+//  override def notify[T](batch: T)(implicit encoder: Encoder[T]): Try[Unit] = messageSender.sendT(batch)
+//}
+
+//class MemorySNSDownstream(sender: MemoryMessageSender = new MemoryMessageSender)
+//  extends Downstream {
+//
+//  val msgSender: MemoryMessageSender = sender
+//
+//  override def notify(workId: String): Try[Unit] =
+//    Try(msgSender.send(workId))
+//  override def notify[T](batch: T)(implicit encoder: Encoder[T]): Try[Unit] =
+//    sender.sendT(batch)
+//}

--- a/common/lambda/src/test/scala/weco/lambda/helpers/MemoryDownstream.scala
+++ b/common/lambda/src/test/scala/weco/lambda/helpers/MemoryDownstream.scala
@@ -6,10 +6,12 @@ import weco.messaging.memory.MemoryMessageSender
 
 import scala.util.Try
 
-trait DownstreamHelper {
+trait MemorySNSDownstream {
 
-  class MemoryDownstream extends Downstream {
-    val msgSender = new MemoryMessageSender
+  class MemorySNSDownstream(sender: MemoryMessageSender = new MemoryMessageSender)
+    extends Downstream {
+
+    val msgSender: MemoryMessageSender = sender
 
     override def notify(workId: String): Try[Unit] =
       Try(msgSender.send(workId))

--- a/common/lambda/src/test/scala/weco/lambda/helpers/MemoryDownstream.scala
+++ b/common/lambda/src/test/scala/weco/lambda/helpers/MemoryDownstream.scala
@@ -19,21 +19,3 @@ trait MemoryDownstream {
       sender.sendT(batch)
   }
 }
-
-
-
-//class MemoryDownstream(messageSender: MessageSender) extends Downstream {
-//  override def notify(workId: String): Try[Unit] = ???
-//  override def notify[T](batch: T)(implicit encoder: Encoder[T]): Try[Unit] = messageSender.sendT(batch)
-//}
-
-//class MemorySNSDownstream(sender: MemoryMessageSender = new MemoryMessageSender)
-//  extends Downstream {
-//
-//  val msgSender: MemoryMessageSender = sender
-//
-//  override def notify(workId: String): Try[Unit] =
-//    Try(msgSender.send(workId))
-//  override def notify[T](batch: T)(implicit encoder: Encoder[T]): Try[Unit] =
-//    sender.sendT(batch)
-//}

--- a/pipeline/id_minter/src/test/scala/weco/pipeline/id_minter/utils/IdMinterSqsLambdaTestHelpers.scala
+++ b/pipeline/id_minter/src/test/scala/weco/pipeline/id_minter/utils/IdMinterSqsLambdaTestHelpers.scala
@@ -7,9 +7,8 @@ import weco.catalogue.internal_model.Implicits._
 import weco.catalogue.internal_model.work.Work
 import weco.catalogue.internal_model.work.WorkState.{Identified, Source}
 import weco.fixtures.TestWith
-import weco.lambda.{ApplicationConfig, SNSDownstream}
-import weco.messaging.memory.MemoryMessageSender
-import weco.messaging.sns.SNSConfig
+import weco.lambda.helpers.MemoryDownstream
+import weco.lambda.{ApplicationConfig, Downstream}
 import weco.pipeline.id_minter.config.models.IdentifiersTableConfig
 import weco.pipeline.id_minter.database.RDSIdentifierGenerator
 import weco.pipeline.id_minter.fixtures.IdentifiersDatabase
@@ -20,7 +19,8 @@ import scala.collection.mutable
 import scala.concurrent.ExecutionContext.Implicits.global
 
 trait IdMinterSqsLambdaTestHelpers
-  extends IdentifiersDatabase {
+  extends IdentifiersDatabase
+    with MemoryDownstream {
 
   case class DummyConfig() extends ApplicationConfig
 
@@ -45,21 +45,9 @@ trait IdMinterSqsLambdaTestHelpers
     testWith(new MemoryIndexer[Work[Identified]](index = identifiedIndex))
   }
 
-  class MemorySNSDownstream(sender: Option[MemoryMessageSender] = None) extends SNSDownstream(
-    SNSConfig("arn:aws:sns:eu-west-1:123456789012:topic")
-  ) {
-    override protected val msgSender = sender.getOrElse(new MemoryMessageSender())
-  }
-
-  def withDownstream[R](sender: Option[MemoryMessageSender] = None)(
-    testWith: TestWith[MemorySNSDownstream, R]
-  ): R = {
-    testWith(new MemorySNSDownstream(sender))
-  }
-
   def withIdMinterSQSLambda[R](
                                 identifiersTableConfig: IdentifiersTableConfig,
-                                msgSender: Option[MemoryMessageSender] = None,
+                                memoryDownstream: Downstream,
                                 mergedIndex: Map[String, Json] = Map.empty,
                                 identifiedIndex: mutable.Map[String, Work[Identified]]
                               )(
@@ -69,28 +57,25 @@ trait IdMinterSqsLambdaTestHelpers
       retriever =>
         withMemoryIndexer(identifiedIndex) {
           indexer =>
-            withDownstream(msgSender) {
-              memoryDownstream =>
-                testWith(new IdMinterSqsLambda[DummyConfig] {
-                  val idGenerator = RDSIdentifierGenerator(
-                    rdsClientConfig,
-                    identifiersTableConfig
-                  )
+            testWith(new IdMinterSqsLambda[DummyConfig] {
+              val idGenerator = RDSIdentifierGenerator(
+                rdsClientConfig,
+                identifiersTableConfig
+              )
 
-                  override def build(rawConfig: Config): DummyConfig =
-                    DummyConfig()
+              override def build(rawConfig: Config): DummyConfig =
+                DummyConfig()
 
-                  override protected val processor: MintingRequestProcessor =
-                    new MintingRequestProcessor(
-                      new MultiIdMinter(
-                        retriever,
-                        new SingleDocumentIdMinter(idGenerator)
-                      ),
-                      indexer
-                    )(global)
-                  override protected val downstream = memoryDownstream
-                })
-            }
+              override protected val processor: MintingRequestProcessor =
+                new MintingRequestProcessor(
+                  new MultiIdMinter(
+                    retriever,
+                    new SingleDocumentIdMinter(idGenerator)
+                  ),
+                  indexer
+                )(global)
+              override protected val downstream: Downstream = memoryDownstream
+            })
         }
     }
   }

--- a/pipeline/matcher_merger/matcher/src/test/scala/weco/pipeline/matcher/MatcherFeatureTest.scala
+++ b/pipeline/matcher_merger/matcher/src/test/scala/weco/pipeline/matcher/MatcherFeatureTest.scala
@@ -64,7 +64,7 @@ class MatcherFeatureTest
       SQSTestLambdaMessage(message = "baadcafe"),
       SQSTestLambdaMessage(message = "baadd00d")
     )
-    val downstream = new MemorySNSDownstream()
+    val downstream = new MemorySNSDownstream
     val sut = StubLambda(MatcherStub(Nil), downstream)
 
     whenReady(
@@ -91,7 +91,7 @@ class MatcherFeatureTest
       SQSTestLambdaMessage(message = "g00dcafe"),
       SQSTestLambdaMessage(message = "baadd00d")
     )
-    val downstream = new MemorySNSDownstream()
+    val downstream = new MemorySNSDownstream
     val sut = StubLambda(MatcherStub(Seq(Set(Set("g00dcafe")))), downstream)
 
     whenReady(
@@ -137,7 +137,7 @@ class MatcherFeatureTest
           )
         )
       )
-    val downstream = new MemorySNSDownstream()
+    val downstream = new MemorySNSDownstream
     val sut = StubLambda(matcher, downstream)
 
     whenReady(

--- a/pipeline/matcher_merger/matcher/src/test/scala/weco/pipeline/matcher/MatcherFeatureTest.scala
+++ b/pipeline/matcher_merger/matcher/src/test/scala/weco/pipeline/matcher/MatcherFeatureTest.scala
@@ -7,7 +7,7 @@ import org.scalatest.matchers.should.Matchers
 import weco.lambda.{Downstream, SQSLambdaMessage, SQSLambdaMessageFailedRetryable, SQSLambdaMessageResult}
 import weco.pipeline.matcher.config.{MatcherConfig, MatcherConfigurable}
 import weco.pipeline.matcher.matcher.WorksMatcher
-import weco.lambda.helpers.DownstreamHelper
+import weco.lambda.helpers.MemoryDownstream
 import weco.pipeline.matcher.fixtures.MatcherFixtures
 import weco.pipeline.matcher.models.MatcherResult
 
@@ -17,7 +17,7 @@ class MatcherFeatureTest
     with LoneElement
     with ScalaFutures
     with MatcherFixtures
-    with DownstreamHelper {
+    with MemoryDownstream {
 
   private object SQSTestLambdaMessage {
     def apply[T](message: T): SQSLambdaMessage[T] =
@@ -36,7 +36,7 @@ class MatcherFeatureTest
 
   describe("when everything is successful") {
     val matcher = MatcherStub(Seq(Set(Set("g00dcafe"), Set("g00dd00d"))))
-    val downstream = new MemoryDownstream
+    val downstream = new MemorySNSDownstream
     val sut = StubLambda(matcher, downstream)
     whenReady(
       sut.processMessages(messages =
@@ -64,7 +64,7 @@ class MatcherFeatureTest
       SQSTestLambdaMessage(message = "baadcafe"),
       SQSTestLambdaMessage(message = "baadd00d")
     )
-    val downstream = new MemoryDownstream
+    val downstream = new MemorySNSDownstream()
     val sut = StubLambda(MatcherStub(Nil), downstream)
 
     whenReady(
@@ -91,7 +91,7 @@ class MatcherFeatureTest
       SQSTestLambdaMessage(message = "g00dcafe"),
       SQSTestLambdaMessage(message = "baadd00d")
     )
-    val downstream = new MemoryDownstream
+    val downstream = new MemorySNSDownstream()
     val sut = StubLambda(MatcherStub(Seq(Set(Set("g00dcafe")))), downstream)
 
     whenReady(
@@ -137,7 +137,7 @@ class MatcherFeatureTest
           )
         )
       )
-    val downstream = new MemoryDownstream
+    val downstream = new MemorySNSDownstream()
     val sut = StubLambda(matcher, downstream)
 
     whenReady(


### PR DESCRIPTION
## What does this change?

Firebreak
Improve tests around pipeline lambdas.
This generalises the use of MemorySNSDownstream in id_minter, matcher, batcher and relation_embedder tests


## How to test

Run the test! :) 

## How can we measure success?

Less duplication of test fixtures, less test code to write 

## Have we considered potential risks?

This doesn't affect the application logic 

