### PR TITLE
Move back to ubuntu-latest

### DIFF
--- a/.github/workflows/catalogue-graph-autoformat-typecheck.yml
+++ b/.github/workflows/catalogue-graph-autoformat-typecheck.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   typecheck:
-    runs-on: default_x64_latest
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
@@ -28,7 +28,7 @@ jobs:
           ./catalogue_graph/scripts/typecheck.sh
 
   autoformat:
-    runs-on: default_x64_latest
+    runs-on: ubuntu-latest
     needs: typecheck
 
     steps:

--- a/.github/workflows/catalogue-graph-build.yml
+++ b/.github/workflows/catalogue-graph-build.yml
@@ -5,7 +5,7 @@ on: push
 
 jobs:
   build:
-    runs-on: default_x64_latest
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/catalogue-graph-ci.yml
+++ b/.github/workflows/catalogue-graph-ci.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   test: 
-    runs-on: default_x64_latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v5
@@ -26,7 +26,7 @@ jobs:
           ./catalogue_graph/scripts/test.sh
         
   build:
-    runs-on: default_x64_latest
+    runs-on: ubuntu-latest
     needs: test
     if: ${{ needs.test.result == 'success' }}
     steps:
@@ -42,7 +42,7 @@ jobs:
           ./catalogue_graph/scripts/build.sh --push
   
   deploy:
-    runs-on: default_x64_latest
+    runs-on: ubuntu-latest
     needs: build
     if: ${{ needs.build.result == 'success' }}
     strategy:

--- a/.github/workflows/catalogue-graph-test.yml
+++ b/.github/workflows/catalogue-graph-test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   test:
-    runs-on: default_x64_latest
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/inferrer-python-ci.yml
+++ b/.github/workflows/inferrer-python-ci.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   python-inferrers-checks:
-    runs-on: default_x64_latest
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         project: [ aspect_ratio_inferrer, feature_inferrer, palette_inferrer ]
@@ -23,7 +23,7 @@ jobs:
     # then we could see a situation where the overall build fails, (e.g. because feature inferrer is broken)
     # but the other inferrers have been deployed.
     needs: python-inferrers-checks
-    runs-on: default_x64_latest
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         project: [ aspect_ratio_inferrer, feature_inferrer, palette_inferrer ]


### PR DESCRIPTION
Following an issue using `ubuntu-latest` runners, this returns to using them and off the larger paid runners.