### PR TITLE
Concept ingestor tweaks

### DIFF
--- a/catalogue_graph/src/models/catalogue_concept.py
+++ b/catalogue_graph/src/models/catalogue_concept.py
@@ -1,5 +1,5 @@
 from dataclasses import field
-from typing import Any, Optional
+from typing import Optional
 
 from pydantic import BaseModel
 
@@ -52,31 +52,28 @@ def standardise_label(label: str | None) -> str | None:
     return capitalised.replace("--", " - ")
 
 
-def get_priority_source_concept_value(
-    concept_node: dict | None, source_concept_nodes: list[dict], key: str
-) -> tuple[Any, str | None]:
+def get_priority_label(
+    concept_node: dict, source_concept_nodes: list[dict]
+) -> tuple[str, str]:
     """
-    Given a concept, its source concepts, and a key (e.g. 'label' or 'description'), extract the corresponding
-    values (where available) and return the highest-priority one.
-
-    (For example, if a `description` field exists in both Wikidata and MeSH, we always prioritise the MeSH one.)
+    Given a concept and its source concepts, extract the corresponding labels and return the highest-priority one.
+    (For example, if a `label` field exists in both Wikidata and MeSH, we always prioritise the MeSH one.)
     """
-    values = {}
-
-    if concept_node is not None:
-        values["label-derived"] = concept_node["~properties"].get(key, "")
+    labels = {"label-derived": concept_node["~properties"].get("label")}
 
     for source_concept in source_concept_nodes:
         properties = source_concept["~properties"]
         source = properties["source"]
-        values[source] = standardise_label(properties.get(key))
+        labels[source] = standardise_label(properties.get("label"))
 
     # Sources sorted by priority
-    for source in ["nlm-mesh", "lc-subjects", "lc-names", "wikidata", "label-derived"]:
-        if (value := values.get(source)) is not None:
+    for source in ["nlm-mesh", "lc-subjects", "wikidata", "lc-names", "label-derived"]:
+        if (value := labels.get(source)) is not None:
             return value, source
 
-    return None, None
+    raise ValueError(
+        f"Concept {concept_node['properties']['id']} does not have a label."
+    )
 
 
 def transform_related_concepts(
@@ -89,8 +86,8 @@ def transform_related_concepts(
 
     for related_item in related_items:
         concept_id = related_item["concept_node"]["~properties"]["id"]
-        label, _ = get_priority_source_concept_value(
-            related_item["concept_node"], related_item["source_concept_nodes"], "label"
+        label, _ = get_priority_label(
+            related_item["concept_node"], related_item["source_concept_nodes"]
         )
 
         relationship_type = ""
@@ -168,23 +165,19 @@ class ConceptDescription(BaseModel):
 
 def get_concept_description(concept_data: dict) -> ConceptDescription | None:
     source_concept_nodes = concept_data["source_concepts"]
-    description_text, description_source = get_priority_source_concept_value(
-        None, source_concept_nodes, "description"
-    )
 
-    if description_text and description_source:
-        source_concept_id: str | None = None
-        for source_concept in source_concept_nodes:
-            if source_concept["~properties"]["source"] == description_source:
-                source_concept_id = source_concept["~properties"]["id"]
+    for source_concept in source_concept_nodes:
+        properties = source_concept["~properties"]
+        description_text = standardise_label(properties.get("description"))
+        description_source = properties["source"]
+        source_concept_id = properties["id"]
 
-        assert source_concept_id is not None
-
-        return ConceptDescription(
-            text=description_text,
-            sourceLabel=description_source,
-            sourceUrl=get_source_concept_url(source_concept_id, description_source),
-        )
+        if description_text is not None and description_source == "wikidata":
+            return ConceptDescription(
+                text=description_text,
+                sourceLabel=description_source,
+                sourceUrl=get_source_concept_url(source_concept_id, description_source),
+            )
 
     return None
 
@@ -217,10 +210,8 @@ class CatalogueConcept(BaseModel):
 
         concept_data: dict = data.concept
 
-        # For now, only extract labels from source concepts which are explicitly linked
-        # to the concept via HAS_SOURCE_CONCEPT edges
-        label, _ = get_priority_source_concept_value(
-            concept_data["concept"], concept_data["linked_source_concepts"], "label"
+        label, _ = get_priority_label(
+            concept_data["concept"], concept_data["source_concepts"]
         )
 
         for source_concept in concept_data["linked_source_concepts"]:

--- a/catalogue_graph/src/models/catalogue_concept.py
+++ b/catalogue_graph/src/models/catalogue_concept.py
@@ -66,7 +66,8 @@ def get_priority_label(
         source = properties["source"]
         labels[source] = standardise_label(properties.get("label"))
 
-    # Sources sorted by priority
+    # Sources sorted by priority. Wikidata is prioritised over Library of Congress Names since Wikidata person names
+    # work better as theme page titles (e.g. 'Florence Nightingale' vs 'Nightingale, Florence, 1820-1910').
     for source in ["nlm-mesh", "lc-subjects", "wikidata", "lc-names", "label-derived"]:
         if (value := labels.get(source)) is not None:
             return value, source
@@ -172,6 +173,7 @@ def get_concept_description(concept_data: dict) -> ConceptDescription | None:
         description_source = properties["source"]
         source_concept_id = properties["id"]
 
+        # Only extract descriptions from Wikidata (MeSH also stores descriptions, but we do not want to surface them).
         if description_text is not None and description_source == "wikidata":
             return ConceptDescription(
                 text=description_text,

--- a/catalogue_graph/tests/fixtures/neptune/concept_query_single.json
+++ b/catalogue_graph/tests/fixtures/neptune/concept_query_single.json
@@ -10,8 +10,14 @@
   "source_concepts": [
     {
       "~properties": {
+        "id": "123",
+        "source": "lc-names"
+      }
+    },
+    {
+      "~properties": {
         "id": "456",
-        "source": "lc-names",
+        "source": "wikidata",
         "description": "description"
       }
     },
@@ -26,9 +32,8 @@
   "linked_source_concepts": [
     {
       "~properties": {
-        "id": "456",
-        "source": "lc-names",
-        "description": "description"
+        "id": "123",
+        "source": "lc-names"
       }
     }
   ],

--- a/catalogue_graph/tests/fixtures/neptune/concept_query_single_alternative_labels.json
+++ b/catalogue_graph/tests/fixtures/neptune/concept_query_single_alternative_labels.json
@@ -10,10 +10,17 @@
   "source_concepts": [
     {
       "~properties": {
-        "id": "456",
+        "id": "123",
         "source": "lc-names",
         "description": "description",
         "alternative_labels": "alternative label||another alternative label"
+      }
+    },
+    {
+      "~properties": {
+        "id": "456",
+        "source": "wikidata",
+        "description": "description"
       }
     },
     {
@@ -28,7 +35,7 @@
   "linked_source_concepts": [
     {
       "~properties": {
-        "id": "456",
+        "id": "123",
         "source": "lc-names",
         "description": "description"
       }

--- a/catalogue_graph/tests/models/test_catalogue_concept.py
+++ b/catalogue_graph/tests/models/test_catalogue_concept.py
@@ -1,5 +1,3 @@
-from test_utils import load_json_fixture
-
 from models.catalogue_concept import (
     CatalogueConcept,
     CatalogueConceptIdentifier,
@@ -9,6 +7,7 @@ from models.catalogue_concept import (
     RelatedConcepts,
     get_most_specific_concept_type,
 )
+from test_utils import load_json_fixture
 
 
 def test_catalogue_concept_from_neptune_result() -> None:
@@ -31,7 +30,7 @@ def test_catalogue_concept_from_neptune_result() -> None:
     assert CatalogueConcept.from_neptune_result(neptune_result) == CatalogueConcept(
         id="id",
         identifiers=[
-            CatalogueConceptIdentifier(value="456", identifierType="lc-names")
+            CatalogueConceptIdentifier(value="123", identifierType="lc-names")
         ],
         label="label",
         alternativeLabels=[
@@ -40,9 +39,9 @@ def test_catalogue_concept_from_neptune_result() -> None:
             "MeSH alternative label",
         ],
         description=ConceptDescription(
-            text="Mesh description",
-            sourceLabel="nlm-mesh",
-            sourceUrl="https://meshb.nlm.nih.gov/record/ui?ui=789",
+            text="Description",
+            sourceLabel="wikidata",
+            sourceUrl="https://www.wikidata.org/wiki/456",
         ),
         type="Person",
         sameAs=[],
@@ -77,14 +76,14 @@ def test_catalogue_concept_from_neptune_result_without_alternative_labels() -> N
     assert CatalogueConcept.from_neptune_result(neptune_result) == CatalogueConcept(
         id="id",
         identifiers=[
-            CatalogueConceptIdentifier(value="456", identifierType="lc-names")
+            CatalogueConceptIdentifier(value="123", identifierType="lc-names")
         ],
         label="label",
         alternativeLabels=[],
         description=ConceptDescription(
-            text="Mesh description",
-            sourceLabel="nlm-mesh",
-            sourceUrl="https://meshb.nlm.nih.gov/record/ui?ui=789",
+            text="Description",
+            sourceLabel="wikidata",
+            sourceUrl="https://www.wikidata.org/wiki/456",
         ),
         type="Person",
         sameAs=[],

--- a/catalogue_graph/tests/models/test_catalogue_concept.py
+++ b/catalogue_graph/tests/models/test_catalogue_concept.py
@@ -1,3 +1,5 @@
+from test_utils import load_json_fixture
+
 from models.catalogue_concept import (
     CatalogueConcept,
     CatalogueConceptIdentifier,
@@ -7,7 +9,6 @@ from models.catalogue_concept import (
     RelatedConcepts,
     get_most_specific_concept_type,
 )
-from test_utils import load_json_fixture
 
 
 def test_catalogue_concept_from_neptune_result() -> None:

--- a/catalogue_graph/tests/test_ingestor_loader.py
+++ b/catalogue_graph/tests/test_ingestor_loader.py
@@ -3,6 +3,9 @@ from enum import Enum, auto
 
 import polars as pl
 import pytest
+from test_mocks import MockRequest, MockSmartOpen
+from test_utils import load_json_fixture
+
 from ingestor_indexer import IngestorIndexerLambdaEvent
 from ingestor_loader import (
     CONCEPT_QUERY,
@@ -20,8 +23,6 @@ from models.catalogue_concept import (
     ConceptDescription,
     RelatedConcepts,
 )
-from test_mocks import MockRequest, MockSmartOpen
-from test_utils import load_json_fixture
 
 MOCK_INGESTOR_LOADER_EVENT = IngestorLoaderLambdaEvent(
     pipeline_date="2021-07-01",

--- a/catalogue_graph/tests/test_ingestor_loader.py
+++ b/catalogue_graph/tests/test_ingestor_loader.py
@@ -3,9 +3,6 @@ from enum import Enum, auto
 
 import polars as pl
 import pytest
-from test_mocks import MockRequest, MockSmartOpen
-from test_utils import load_json_fixture
-
 from ingestor_indexer import IngestorIndexerLambdaEvent
 from ingestor_loader import (
     CONCEPT_QUERY,
@@ -23,6 +20,8 @@ from models.catalogue_concept import (
     ConceptDescription,
     RelatedConcepts,
 )
+from test_mocks import MockRequest, MockSmartOpen
+from test_utils import load_json_fixture
 
 MOCK_INGESTOR_LOADER_EVENT = IngestorLoaderLambdaEvent(
     pipeline_date="2021-07-01",
@@ -229,13 +228,13 @@ def get_catalogue_concept_mock(
         type="Person",
         alternativeLabels=alternative_labels,
         description=ConceptDescription(
-            text="Mesh description",
-            sourceLabel="nlm-mesh",
-            sourceUrl="https://meshb.nlm.nih.gov/record/ui?ui=789",
+            text="Description",
+            sourceLabel="wikidata",
+            sourceUrl="https://www.wikidata.org/wiki/456",
         ),
         identifiers=[
             CatalogueConceptIdentifier(
-                value="456",
+                value="123",
                 identifierType="lc-names",
             )
         ],


### PR DESCRIPTION
## What does this change?

* Prioritise Wikidata labels over those from LoC Names to increase the number of nicely formatted names. (https://github.com/wellcomecollection/platform/issues/6068). 
* Suppress all MeSH descriptions (https://github.com/wellcomecollection/wellcomecollection.org/issues/12042#issuecomment-3028425468).

## How to test

These changes can be tested by running the concepts ingestor locally. 

## How can we measure success?

The two issues listed above are addressed, allowing us to remove the 'New theme pages' toggle.

## Have we considered potential risks?

Risks are minimal.

