### PR TITLE
Do not add nested concepts into the catalogue graph

### DIFF
--- a/catalogue_graph/src/sources/catalogue/concepts_source.py
+++ b/catalogue_graph/src/sources/catalogue/concepts_source.py
@@ -1,19 +1,20 @@
 from collections.abc import Generator
 
+from utils.types import WorkConceptKey
+
 from sources.base_source import BaseSource
 from sources.gzip_source import GZipSource
-from utils.types import WorkConceptKey
 
 
 def extract_concepts_from_work(
     raw_work: dict,
 ) -> Generator[tuple[dict, WorkConceptKey]]:
     """Returns all concepts associated with the given work. Does not deduplicate."""
-    # We need to return all concepts stored in each subject, and also the subject itself.
-    # This will sometimes result in duplicates being returned.
+    # Some subjects contain nested component concepts. For example, the subject 'Milk - Quality' consists
+    # of concepts 'Milk' and 'Quality' (each with its own Wellcome ID). For now, we are not interested in 
+    # extracting these component concepts, since the frontend does not make use of them and the resulting 
+    # theme pages would be empty. 
     for subject in raw_work.get("subjects", []):
-        for concept in subject.get("concepts", []):
-            yield concept, "subjects"
         yield subject, "subjects"
 
     # Return all contributors

--- a/catalogue_graph/src/sources/catalogue/concepts_source.py
+++ b/catalogue_graph/src/sources/catalogue/concepts_source.py
@@ -1,9 +1,8 @@
 from collections.abc import Generator
 
-from utils.types import WorkConceptKey
-
 from sources.base_source import BaseSource
 from sources.gzip_source import GZipSource
+from utils.types import WorkConceptKey
 
 
 def extract_concepts_from_work(
@@ -11,9 +10,9 @@ def extract_concepts_from_work(
 ) -> Generator[tuple[dict, WorkConceptKey]]:
     """Returns all concepts associated with the given work. Does not deduplicate."""
     # Some subjects contain nested component concepts. For example, the subject 'Milk - Quality' consists
-    # of concepts 'Milk' and 'Quality' (each with its own Wellcome ID). For now, we are not interested in 
-    # extracting these component concepts, since the frontend does not make use of them and the resulting 
-    # theme pages would be empty. 
+    # of concepts 'Milk' and 'Quality' (each with its own Wellcome ID). For now, we are not interested in
+    # extracting these component concepts, since the frontend does not make use of them and the resulting
+    # theme pages would be empty.
     for subject in raw_work.get("subjects", []):
         yield subject, "subjects"
 


### PR DESCRIPTION
## What does this change?

See https://wellcome.slack.com/archives/C02ANCYL90E/p1752144782764929

## How to test

Run the catalogue concepts extractor locally and examine the outputted bulk load file.

## How can we measure success?

Concepts which are only referenced as component concepts of a subject should no longer be stored in the catalogue graph and in the concepts index. As a result, the number of empty theme pages should be reduced, and it should no longer be possible to arrive at an empty theme page via links from other theme pages.

## Have we considered potential risks?

This change will result in the removal of approximately 16,000 concepts from the concepts index. For a full list, see:
[removed_concepts.txt](https://github.com/user-attachments/files/21163452/removed_concepts.txt)

To mitigate the risk of accidentally removing non-empty theme pages, I verified that none of the concepts above are included among filterable subjects of any works by running this query and checking that it returns 0 results:

```
GET works-indexed-2025-05-01/_search
{
  "query": {
    "terms": {
      "filterableValues.subjects.concepts.id": [
          <all concept IDs from the list above>
      ]
    }
  }
}
```
