### PR TITLE
truncate the message subject when building missing windows

### DIFF
--- a/sierra_adapter/build_missing_windows.py
+++ b/sierra_adapter/build_missing_windows.py
@@ -72,5 +72,5 @@ if __name__ == "__main__":
             client.publish(
                 TopicArn=f"arn:aws:sns:eu-west-1:760097843905:sierra_{resource_type}_windows",
                 Message=json.dumps(missing_window),
-                Subject="Window sender: missing windows script"
+                Subject="Window sender: missing windows script",
             )


### PR DESCRIPTION
## What does this change?

SNS Message Subjects have a limit of 100 characters.  Depending on where you store this repository in your local filesystem, this could easily be exceeded - the path to this file from repository root is 59 characters, add in the "Window sender " prefix, and it's up to 73, so you only have 27 characters of path to reach filesystem root.

If you attempt to run this script from a location with a long leading path, you will see an error message:

> botocore.errorfactory.InvalidParameterException: An error occurred (InvalidParameter) when calling the Publish operation: Invalid parameter: Subject

## How to test

Clone the repository into a deeply nested location (with roughly 30 or more characters in the path)
run ` python sierra_adapter/build_missing_windows.py`

You will not see the Invalid Parameter message.
## How can we measure success?

The error does not get in the way of building missing windows

## Have we considered potential risks?

I have set this to truncate from the left, on the assumption that the most pertinent information is on the right of the path.
If someone stores it in their home directory, the most important thing we need to know if we look at the message, is that it came from the missing window generator, rather than the regular window generator, and maybe which repository it is in (if the user is currently in the process of moving it)

 e.g. `/home/myveryverylongusernamewhichistoolongforsns/my_work/my_github_repositories/catalogue_pipeline/sierra_adapter/build_missing_windows.py`

`/home/myveryverylongusernamewhichistoolongforsns/my_work/my_github_repositories/source_adapters/sierra_adapter/build_missing_windows.py`

Maybe the leftmost content is useful?  Probably not. In fact, I don't really believe we care about the whole path at all.

