### PR TITLE
Only add first genre item into the graph

### DIFF
--- a/catalogue_graph/src/sources/catalogue/concepts_source.py
+++ b/catalogue_graph/src/sources/catalogue/concepts_source.py
@@ -1,9 +1,8 @@
 from collections.abc import Generator
 
-from utils.types import WorkConceptKey
-
 from sources.base_source import BaseSource
 from sources.gzip_source import GZipSource
+from utils.types import WorkConceptKey
 
 
 def extract_concepts_from_work(
@@ -26,7 +25,7 @@ def extract_concepts_from_work(
         for concept in genre.get("concepts", []):
             yield concept, "genres"
             # Only extract the first item from each genre. Subsequent items are not associated with the work in
-            # catalogue API filters and the resulting theme pages would be empty. 
+            # catalogue API filters and the resulting theme pages would be empty.
             break
 
 


### PR DESCRIPTION
## What does this change?

This is a follow-up on https://github.com/wellcomecollection/catalogue-pipeline/pull/2946, applied to genres instead of subjects for the same reason.

This will result in the removal of another 126 empty theme pages. Here is a full list:
[removed_genres.txt](https://github.com/user-attachments/files/21237347/removed_genres.txt)
