### PR TITLE
Add work reference numbers to catalogue graph

### DIFF
--- a/catalogue_graph/src/models/graph_node.py
+++ b/catalogue_graph/src/models/graph_node.py
@@ -1,7 +1,6 @@
 from typing import Annotated, Literal
 
 from pydantic import BaseModel, StringConstraints
-
 from shared.types import ConceptSource, WorkType
 
 # Matches a Wikidata date, such as 1976-01-01T00:00:00Z or -0005-12-12T00:00:00Z
@@ -48,6 +47,7 @@ class Concept(BaseNode):
 class Work(BaseNode):
     type: WorkType
     alternative_labels: list[str]
+    reference_number: str | None
 
 
 class PathIdentifier(BaseNode):

--- a/catalogue_graph/src/models/graph_node.py
+++ b/catalogue_graph/src/models/graph_node.py
@@ -1,6 +1,7 @@
 from typing import Annotated, Literal
 
 from pydantic import BaseModel, StringConstraints
+
 from shared.types import ConceptSource, WorkType
 
 # Matches a Wikidata date, such as 1976-01-01T00:00:00Z or -0005-12-12T00:00:00Z

--- a/catalogue_graph/src/transformers/catalogue/raw_work.py
+++ b/catalogue_graph/src/transformers/catalogue/raw_work.py
@@ -45,7 +45,7 @@ class RawCatalogueWork:
     @property
     def reference_number(self) -> str | None:
         reference_number: str | None = self.work_data.get("referenceNumber")
-        return reference_number 
+        return reference_number
 
     @property
     def concepts(self) -> list[WorkConcept]:

--- a/catalogue_graph/src/transformers/catalogue/raw_work.py
+++ b/catalogue_graph/src/transformers/catalogue/raw_work.py
@@ -43,6 +43,11 @@ class RawCatalogueWork:
         return alternative_titles
 
     @property
+    def reference_number(self) -> str | None:
+        reference_number: str | None = self.work_data.get("referenceNumber")
+        return reference_number 
+
+    @property
     def concepts(self) -> list[WorkConcept]:
         processed = set()
         work_concepts: list[WorkConcept] = []

--- a/catalogue_graph/src/transformers/catalogue/works_transformer.py
+++ b/catalogue_graph/src/transformers/catalogue/works_transformer.py
@@ -3,6 +3,7 @@ from collections.abc import Generator
 from models.graph_edge import WorkHasConcept, WorkHasConceptAttributes
 from models.graph_node import Work
 from sources.elasticsearch_source import ElasticsearchSource
+
 from transformers.base_transformer import BaseTransformer
 
 from .raw_work import RawCatalogueWork
@@ -18,6 +19,7 @@ ES_FIELDS = [
     "data.subjects",
     "data.contributors",
     "data.genres",
+    "data.referenceNumber",
 ]
 
 
@@ -32,6 +34,7 @@ class CatalogueWorksTransformer(BaseTransformer):
             label=raw_work.label,
             alternative_labels=raw_work.alternative_labels,
             type=raw_work.type,
+            reference_number=raw_work.reference_number,
         )
 
     def extract_edges(self, raw_node: dict) -> Generator[WorkHasConcept]:

--- a/catalogue_graph/src/transformers/catalogue/works_transformer.py
+++ b/catalogue_graph/src/transformers/catalogue/works_transformer.py
@@ -3,7 +3,6 @@ from collections.abc import Generator
 from models.graph_edge import WorkHasConcept, WorkHasConceptAttributes
 from models.graph_node import Work
 from sources.elasticsearch_source import ElasticsearchSource
-
 from transformers.base_transformer import BaseTransformer
 
 from .raw_work import RawCatalogueWork

--- a/catalogue_graph/tests/transformers/catalogue/test_catalogue_works_transformer.py
+++ b/catalogue_graph/tests/transformers/catalogue/test_catalogue_works_transformer.py
@@ -17,6 +17,7 @@ def test_catalogue_works_transformer_nodes() -> None:
         label="Human skull, seen from below, with details of the lower jaw bone. Etching by Martin after J. Gamelin, 1778/1779.",
         type="Work",
         alternative_labels=[],
+        reference_number=None,
     )
     assert any(node == expected_work for node in nodes)
 


### PR DESCRIPTION
## What does this change?

Add work reference numbers to `Work` nodes in the catalogue graph in preparation for https://github.com/wellcomecollection/platform/issues/6092. We need to store this information in the graph to reproduce the functionality of the relation embedder.


## Have we considered potential risks?

Risks are minimal.