### PR TITLE
Make Sierra reader more resilient

### DIFF
--- a/sierra_adapter/sierra_reader/client.py
+++ b/sierra_adapter/sierra_reader/client.py
@@ -17,7 +17,7 @@ class SierraClient:
     def __init__(self, *, api_url, oauth_key, oauth_secret):
         self.oauth_key = oauth_key
         self.oauth_secret = oauth_secret
-        
+
         # Set timeout to 10 seconds (instead of the default 5 seconds)
         self.client = httpx.Client(base_url=api_url, timeout=10)
 
@@ -88,13 +88,15 @@ class SierraClient:
             "Accept": "application/json",
             "Connection": "close",
         }
-    
-    # Try up to five times with an exponential backoff strategy (retries after 2s, 4s, 8s, and 16s) 
-    @retry(wait=wait_exponential(multiplier=2, min=2, max=60), stop=stop_after_attempt(5))
+
+    # Try up to five times with an exponential backoff strategy (retries after 2s, 4s, 8s, and 16s)
+    @retry(
+        wait=wait_exponential(multiplier=2, min=2, max=60), stop=stop_after_attempt(5)
+    )
     def _get_objects_from_id(self, path, id, params):
         id_param = {"id": f"[{id},]"}
         merged_params = {**id_param, **params}
-        
+
         resp = self.client.get(path, params=merged_params).json()
 
         # When requesting a set of objects that is empty


### PR DESCRIPTION
## What does this change?

We have been getting a lot of `ConnectTimeout` errors when making calls to Sierra from the adapter Lambdas. This PR implements a few tweaks to the client to make these errors less likely.

## How to test

Run the `sierra_reader` locally via `run_lambda.sh`. 

## How can we measure success?

Fewer timeout errors in the alerts channel.

## Have we considered potential risks?

Risks are minimal.
