### PR TITLE
refactor transition trigger to loader

### DIFF
--- a/ebsco_adapter/ebsco_adapter_iceberg/src/utils/tracking.py
+++ b/ebsco_adapter/ebsco_adapter_iceberg/src/utils/tracking.py
@@ -1,86 +1,49 @@
+import json
+
 import boto3
 
 
-def _get_tracking_info(s3_uri: str) -> dict[str, str]:
+def record_processed_file(
+    job_id: str, file_location: str, changeset_id: str | None
+) -> dict:
     """
-    Get the S3 bucket and key for the tracking file based on the original file's S3 URI.
-    Returns:
-        Dict with 'bucket', 'key' and 'filename' entries
-    """
-    path_parts = s3_uri.split("/")
-    bucket_name = path_parts[2]
-    # Get the prefix (everything between bucket and filename) and add tracking file
-    prefix = "/".join(path_parts[3:-1])
-    tracking_key = f"{prefix}/processed_files.txt"
-
-    return {
-        "bucket": bucket_name,
-        "key": tracking_key,
-        "filename": s3_uri.split("/")[-1],
-    }
-
-
-def _get_tracking_file_content(file_location: str) -> tuple[dict[str, str], str | None]:
-    """
-    Helper function to get tracking info and existing content.
-
-    Returns:
-        Tuple of (tracking_info, existing_content or None if file doesn't exist)
-    """
-    s3_client = boto3.client("s3")
-    tracking_info = _get_tracking_info(file_location)
-
-    bucket_name = tracking_info["bucket"]
-    tracking_key = tracking_info["key"]
-
-    try:
-        response = s3_client.get_object(Bucket=bucket_name, Key=tracking_key)
-        existing_content = response["Body"].read().decode("utf-8")
-        return tracking_info, existing_content
-    except s3_client.exceptions.NoSuchKey:
-        return tracking_info, None
-
-
-def record_processed_file(file_location: str) -> None:
-    """
-    Record the filename to an S3 tracking file
+    Record the file as processed
     Args:
+        job_id: state machine execution id
         file_location: S3 path of the processed file
+        changeset_id: identifies items added or updated in the current execution
     """
     s3_client = boto3.client("s3")
-    tracking_info, existing_content = _get_tracking_file_content(file_location)
 
-    bucket_name = tracking_info["bucket"]
-    tracking_key = tracking_info["key"]
-    file_name = tracking_info["filename"]
+    path_parts = file_location.split("/")
+    bucket_name = path_parts[2]
+    key = f"{'/'.join(path_parts[3:])}.loaded.json"
 
-    if existing_content is not None:
-        new_content = existing_content.rstrip() + f"\n{file_name}"
-    else:
-        new_content = file_name
+    record = {"job_id": job_id, "changeset_id": changeset_id}
 
     s3_client.put_object(
         Bucket=bucket_name,
-        Key=tracking_key,
-        Body=new_content.encode("utf-8"),
-        ContentType="text/plain",
+        Key=key,
+        Body=json.dumps(record),
+        ContentType="application/json",
     )
 
+    return record
 
-def is_file_already_processed(file_location: str) -> bool:
+
+def is_file_already_processed(bucket: str, key: str) -> bool:
     """
-    Check if a file has already been processed.
+    Check if a file has already been processed, ie. has a corresponding .loaded.json file
     Args:
-        file_location: S3 path of the file to check
+        bucket: s3 bucket name
+        key: s3 object key
     Returns:
         True if the file has already been processed, False otherwise
     """
-    tracking_info, existing_content = _get_tracking_file_content(file_location)
+    s3_client = boto3.client("s3")
 
-    if existing_content is None:
-        # File doesn't exist, so nothing has been processed yet
+    try:
+        s3_client.head_object(Bucket=bucket, Key=f"{key}.loaded.json")
+        return True
+    except Exception:
         return False
-
-    file_name = tracking_info["filename"]
-    processed_files = existing_content.strip().split("\n")
-    return file_name in processed_files

--- a/ebsco_adapter/ebsco_adapter_iceberg/tests/test_tracking.py
+++ b/ebsco_adapter/ebsco_adapter_iceberg/tests/test_tracking.py
@@ -10,29 +10,31 @@ from utils.tracking import (
 class TestRecordProcessedFile:
     def setup_method(self) -> None:
         """Setup method run before each test."""
-        self.mock_boto3_client = patch("utils.tracking.boto3.client").start()
-        self.mock_s3 = Mock()
-        self.mock_boto3_client.return_value = self.mock_s3
+        self.mock_smart_open = patch("utils.tracking.smart_open.open").start()
+        self.mock_file = Mock()
+        self.mock_smart_open.return_value.__enter__.return_value = self.mock_file
 
     def teardown_method(self) -> None:
         """Teardown method run after each test."""
-        patch("utils.tracking.boto3.client").stop()
+        patch("utils.tracking.smart_open.open").stop()
 
     def test_record_processed_file(self) -> None:
         job_id = "test-job-id"
-        file_location = "right/there-in-the/s3-bucket/is-a/file.xml"
+        file_location = "s3://s3-bucket/is-a/file.xml"
         changeset_id = "I have changed"
 
         record = record_processed_file(job_id, file_location, changeset_id)
 
         assert record == {"job_id": job_id, "changeset_id": changeset_id}
 
-        self.mock_s3.put_object.assert_called_once_with(
-            Bucket="s3-bucket",
-            Key="is-a/file.xml.loaded.json",
-            Body=json.dumps(record),
-            ContentType="application/json",
+        # Verify smart_open was called with the correct S3 URI
+        self.mock_smart_open.assert_called_once_with(
+            "s3://s3-bucket/is-a/file.xml.loaded.json", "w", encoding="utf-8"
         )
+
+        # Verify the JSON was written correctly
+        expected_json = json.dumps({"job_id": job_id, "changeset_id": changeset_id})
+        self.mock_file.write.assert_called_once_with(expected_json)
 
 
 class TestIsFileAlreadyProcessed:
@@ -51,15 +53,14 @@ class TestIsFileAlreadyProcessed:
         key = "dev/ftp_v2/existing-file.xml.loaded.json"
 
         self.mock_s3.head_object.return_value = {}
-        is_it = is_file_already_processed(bucket, key)
 
-        assert is_it is True
+        assert is_file_already_processed(bucket, key)
 
     def test_file_not_yet_processed(self) -> None:
         bucket = "test-bucket"
         key = "dev/ftp_v2/non-existent-file.xml.loaded.json"
 
-        self.mock_s3.head_object.side_effect = Exception("NoSuchKey")
-        is_it = is_file_already_processed(bucket, key)
+        # if head_object throws for whatever reason, we consider the file not processed
+        self.mock_s3.head_object.side_effect = Exception()
 
-        assert is_it is False
+        assert not is_file_already_processed(bucket, key)

--- a/ebsco_adapter/ebsco_adapter_iceberg/tests/test_tracking.py
+++ b/ebsco_adapter/ebsco_adapter_iceberg/tests/test_tracking.py
@@ -1,189 +1,65 @@
+import json
 from unittest.mock import Mock, patch
 
-from botocore.exceptions import ClientError  # type: ignore
-
 from utils.tracking import (
-    _get_tracking_file_content,
-    _get_tracking_info,
     is_file_already_processed,
     record_processed_file,
 )
-
-
-class TestGetTrackingInfo:
-    def test_get_tracking_info(self) -> None:
-        s3_uri = "s3://test-bucket/dev/ftp_v2/ebz-s7451719-20240322-1.xml"
-        result = _get_tracking_info(s3_uri)
-
-        expected = {
-            "bucket": "test-bucket",
-            "key": "dev/ftp_v2/processed_files.txt",
-            "filename": "ebz-s7451719-20240322-1.xml",
-        }
-        assert result == expected
-
-    def test_get_tracking_info_nested_prefix(self) -> None:
-        s3_uri = "s3://test-bucket/very/deep/nested/path/ebz-s7451719-20240322-1.xml"
-        result = _get_tracking_info(s3_uri)
-
-        expected = {
-            "bucket": "test-bucket",
-            "key": "very/deep/nested/path/processed_files.txt",
-            "filename": "ebz-s7451719-20240322-1.xml",
-        }
-        assert result == expected
-
-
-class TestGetTrackingFileContent:
-    @patch("utils.tracking.boto3.client")
-    def test_get_tracking_file_content_file_exists(self, mock_boto3_client) -> None:  # type: ignore
-        mock_s3 = Mock()
-        mock_boto3_client.return_value = mock_s3
-
-        mock_response = {"Body": Mock()}
-        mock_response["Body"].read.return_value = b"file1.xml\nfile2.xml\nfile3.xml"
-        mock_s3.get_object.return_value = mock_response
-
-        s3_uri = "s3://test-bucket/dev/ftp_v2/test-file.xml"
-
-        tracking_info, content = _get_tracking_file_content(s3_uri)
-
-        assert content == "file1.xml\nfile2.xml\nfile3.xml"
-        assert tracking_info["bucket"] == "test-bucket"
-        assert tracking_info["key"] == "dev/ftp_v2/processed_files.txt"
-        assert tracking_info["filename"] == "test-file.xml"
-        mock_s3.get_object.assert_called_once_with(
-            Bucket="test-bucket", Key="dev/ftp_v2/processed_files.txt"
-        )
-
-    @patch("utils.tracking.boto3.client")
-    def test_get_tracking_file_content_file_not_exists(self, mock_boto3_client) -> None:  # type: ignore
-        mock_s3 = Mock()
-        mock_boto3_client.return_value = mock_s3
-
-        # Simulate NoSuchKey exception
-        mock_s3.exceptions.NoSuchKey = ClientError
-        mock_s3.get_object.side_effect = ClientError(
-            error_response={"Error": {"Code": "NoSuchKey"}}, operation_name="GetObject"
-        )
-
-        s3_uri = "s3://test-bucket/dev/ftp_v2/test-file.xml"
-
-        tracking_info, content = _get_tracking_file_content(s3_uri)
-
-        assert content is None
-        assert tracking_info["bucket"] == "test-bucket"
-        assert tracking_info["key"] == "dev/ftp_v2/processed_files.txt"
-        assert tracking_info["filename"] == "test-file.xml"
 
 
 class TestRecordProcessedFile:
     def setup_method(self) -> None:
         """Setup method run before each test."""
         self.mock_boto3_client = patch("utils.tracking.boto3.client").start()
-        self.mock_get_content = patch(
-            "utils.tracking._get_tracking_file_content"
-        ).start()
         self.mock_s3 = Mock()
         self.mock_boto3_client.return_value = self.mock_s3
 
     def teardown_method(self) -> None:
         """Teardown method run after each test."""
         patch("utils.tracking.boto3.client").stop()
-        patch("utils.tracking._get_tracking_file_content").stop()
 
-    def test_record_processed_file_new_tracking_file(self) -> None:
-        tracking_info = {
-            "bucket": "test-bucket",
-            "key": "dev/ftp_v2/processed_files.txt",
-            "filename": "new-file.xml",
-        }
-        self.mock_get_content.return_value = (tracking_info, None)
+    def test_record_processed_file(self) -> None:
+        job_id = "test-job-id"
+        file_location = "right/there-in-the/s3-bucket/is-a/file.xml"
+        changeset_id = "I have changed"
 
-        s3_uri = "s3://test-bucket/dev/ftp_v2/new-file.xml"
+        record = record_processed_file(job_id, file_location, changeset_id)
 
-        record_processed_file(s3_uri)
+        assert record == {"job_id": job_id, "changeset_id": changeset_id}
 
         self.mock_s3.put_object.assert_called_once_with(
-            Bucket="test-bucket",
-            Key="dev/ftp_v2/processed_files.txt",
-            Body=b"new-file.xml",
-            ContentType="text/plain",
-        )
-
-    def test_record_processed_file_append_to_existing(self) -> None:
-        tracking_info = {
-            "bucket": "test-bucket",
-            "key": "dev/ftp_v2/processed_files.txt",
-            "filename": "new-file.xml",
-        }
-        existing_content = "file1.xml\nfile2.xml"
-        self.mock_get_content.return_value = (tracking_info, existing_content)
-
-        s3_uri = "s3://test-bucket/dev/ftp_v2/new-file.xml"
-
-        record_processed_file(s3_uri)
-
-        expected_content = "file1.xml\nfile2.xml\nnew-file.xml"
-        self.mock_s3.put_object.assert_called_once_with(
-            Bucket="test-bucket",
-            Key="dev/ftp_v2/processed_files.txt",
-            Body=expected_content.encode("utf-8"),
-            ContentType="text/plain",
+            Bucket="s3-bucket",
+            Key="is-a/file.xml.loaded.json",
+            Body=json.dumps(record),
+            ContentType="application/json",
         )
 
 
 class TestIsFileAlreadyProcessed:
     def setup_method(self) -> None:
         """Setup method run before each test."""
-        self.mock_get_content = patch(
-            "utils.tracking._get_tracking_file_content"
-        ).start()
+        self.mock_boto3_client = patch("utils.tracking.boto3.client").start()
+        self.mock_s3 = Mock()
+        self.mock_boto3_client.return_value = self.mock_s3
 
     def teardown_method(self) -> None:
         """Teardown method run after each test."""
-        patch("utils.tracking._get_tracking_file_content").stop()
+        patch("utils.tracking.boto3.client").stop()
 
-    def test_is_file_already_processed_file_found(self) -> None:
-        tracking_info = {
-            "bucket": "test-bucket",
-            "key": "dev/ftp_v2/processed_files.txt",
-            "filename": "existing-file.xml",
-        }
-        existing_content = "file1.xml\nexisting-file.xml\nfile3.xml"
-        self.mock_get_content.return_value = (tracking_info, existing_content)
+    def test_file_already_processed(self) -> None:
+        bucket = "test-bucket"
+        key = "dev/ftp_v2/existing-file.xml.loaded.json"
 
-        s3_uri = "s3://test-bucket/dev/ftp_v2/existing-file.xml"
+        self.mock_s3.head_object.return_value = {}
+        is_it = is_file_already_processed(bucket, key)
 
-        result = is_file_already_processed(s3_uri)
+        assert is_it is True
 
-        assert result is True
+    def test_file_not_yet_processed(self) -> None:
+        bucket = "test-bucket"
+        key = "dev/ftp_v2/non-existent-file.xml.loaded.json"
 
-    def test_is_file_already_processed_file_not_found(self) -> None:
-        tracking_info = {
-            "bucket": "test-bucket",
-            "key": "dev/ftp_v2/processed_files.txt",
-            "filename": "missing-file.xml",
-        }
-        existing_content = "file1.xml\nfile2.xml\nfile3.xml"
-        self.mock_get_content.return_value = (tracking_info, existing_content)
+        self.mock_s3.head_object.side_effect = Exception("NoSuchKey")
+        is_it = is_file_already_processed(bucket, key)
 
-        s3_uri = "s3://test-bucket/dev/ftp_v2/missing-file.xml"
-
-        result = is_file_already_processed(s3_uri)
-
-        assert result is False
-
-    def test_is_file_already_processed_no_tracking_file(self) -> None:
-        tracking_info = {
-            "bucket": "test-bucket",
-            "key": "dev/ftp_v2/processed_files.txt",
-            "filename": "any-file.xml",
-        }
-        self.mock_get_content.return_value = (tracking_info, None)
-
-        s3_uri = "s3://test-bucket/dev/ftp_v2/any-file.xml"
-
-        result = is_file_already_processed(s3_uri)
-
-        assert result is False
+        assert is_it is False

--- a/ebsco_adapter/ebsco_adapter_iceberg/tests/test_trigger.py
+++ b/ebsco_adapter/ebsco_adapter_iceberg/tests/test_trigger.py
@@ -107,7 +107,6 @@ class TestSyncFiles:
             s3_bucket=self.s3_bucket,
             s3_prefix=self.s3_prefix,
         )
-        print(f"RESULT!!!!!!!!!!!!!! {result}")
 
         self.mock_ebsco_ftp.list_files.assert_called_once()
         self.mock_ebsco_ftp.download_file.assert_called_once_with(

--- a/ebsco_adapter/ebsco_adapter_iceberg/tests/test_trigger.py
+++ b/ebsco_adapter/ebsco_adapter_iceberg/tests/test_trigger.py
@@ -67,6 +67,7 @@ class TestSyncFiles:
         self.s3_bucket = "test-bucket"
         self.s3_prefix = "test-prefix"
         self.mock_list_s3_keys = patch("steps.trigger.list_s3_keys").start()
+        # self.mock_is_file_processed = patch("steps.trigger.is_file_already_processed").start()
 
         # Mock boto3 for the S3 client used in sync_files
         self.mock_boto3 = patch("steps.trigger.boto3").start()
@@ -76,11 +77,11 @@ class TestSyncFiles:
     def teardown_method(self) -> None:
         """Clean up patches"""
         self.mock_list_s3_keys.stop()
+        # self.mock_is_file_processed.stop()
         self.mock_boto3.stop()
 
     def test_successful_download_and_upload(self) -> None:
         """Test successful download of *most recent* file from FTP and upload to S3"""
-        # Setup FTP mock
         ftp_files = [
             "ebz-s7451719-20240315-1.xml",
             "ebz-s7451719-20240320-1.xml",
@@ -106,8 +107,8 @@ class TestSyncFiles:
             s3_bucket=self.s3_bucket,
             s3_prefix=self.s3_prefix,
         )
+        print(f"RESULT!!!!!!!!!!!!!! {result}")
 
-        # Verify calls
         self.mock_ebsco_ftp.list_files.assert_called_once()
         self.mock_ebsco_ftp.download_file.assert_called_once_with(
             "ebz-s7451719-20240325-1.xml", self.target_directory
@@ -116,9 +117,9 @@ class TestSyncFiles:
             download_path, self.s3_bucket, "test-prefix/ebz-s7451719-20240325-1.xml"
         )
 
-        # Verify result
         expected_result = (
-            f"s3://{self.s3_bucket}/test-prefix/ebz-s7451719-20240325-1.xml"
+            f"s3://{self.s3_bucket}/test-prefix/ebz-s7451719-20240325-1.xml",
+            False,
         )
         assert result == expected_result
 
@@ -136,7 +137,6 @@ class TestSyncFiles:
 
     def test_file_already_exists_in_s3(self) -> None:
         """Test early return when file already exists in S3"""
-        # Setup FTP mock
         ftp_files = [
             "ebz-s7451719-20240320-1.xml",
             "ebz-s7451719-20240322-1.xml",
@@ -145,7 +145,7 @@ class TestSyncFiles:
         self.mock_ebsco_ftp.list_files.return_value = ftp_files
 
         # Setup S3 mock - file exists
-        self.mock_s3_client.head_object.return_value = {}  # File exists
+        self.mock_s3_client.head_object.return_value = {}
 
         self.mock_list_s3_keys.return_value = [
             "test-prefix/ebz-s7451719-20240322-1.xml"
@@ -160,7 +160,45 @@ class TestSyncFiles:
 
         # Should return S3 URL without downloading or uploading
         expected_result = (
-            f"s3://{self.s3_bucket}/test-prefix/ebz-s7451719-20240322-1.xml"
+            f"s3://{self.s3_bucket}/test-prefix/ebz-s7451719-20240322-1.xml",
+            False,
+        )
+        assert result == expected_result
+        self.mock_ebsco_ftp.download_file.assert_not_called()
+        self.mock_s3_client.upload_file.assert_not_called()
+
+    @patch("steps.trigger.is_file_already_processed")
+    def test_file_already_exists_in_s3_and_processed(  # type: ignore
+        self, mock_is_file_processed
+    ) -> None:
+        """Test early return with is_processed: True when files exist in S3"""
+        ftp_files = [
+            "ebz-s7451719-20240320-1.xml",
+            "ebz-s7451719-20240322-1.xml",
+            "ebz-s7451719-20240321-1.xml",
+        ]
+        self.mock_ebsco_ftp.list_files.return_value = ftp_files
+
+        # Setup S3 mock - file exists
+        self.mock_s3_client.head_object.return_value = {}
+
+        self.mock_list_s3_keys.return_value = [
+            "test-prefix/ebz-s7451719-20240322-1.xml"
+        ]
+
+        mock_is_file_processed.return_value = True
+
+        result = sync_files(
+            ebsco_ftp=self.mock_ebsco_ftp,
+            target_directory=self.target_directory,
+            s3_bucket=self.s3_bucket,
+            s3_prefix=self.s3_prefix,
+        )
+
+        # Should return S3 URL without downloading or uploading
+        expected_result = (
+            f"s3://{self.s3_bucket}/test-prefix/ebz-s7451719-20240322-1.xml",
+            True,
         )
         assert result == expected_result
         self.mock_ebsco_ftp.download_file.assert_not_called()
@@ -241,7 +279,8 @@ class TestSyncFiles:
 
         # Should select the newest file in s3 (20240428)
         expected_result = (
-            f"s3://{self.s3_bucket}/test-prefix/ebz-s7451719-20240428-1.xml"
+            f"s3://{self.s3_bucket}/test-prefix/ebz-s7451719-20240428-1.xml",
+            False,
         )
         assert result == expected_result
 
@@ -274,6 +313,7 @@ class TestSyncFiles:
         self.mock_list_s3_keys.assert_called_once()
 
         expected_result = (
-            f"s3://{self.s3_bucket}/test-prefix/ebz-s7451719-20240322-1.xml"
+            f"s3://{self.s3_bucket}/test-prefix/ebz-s7451719-20240322-1.xml",
+            False,
         )
         assert result == expected_result

--- a/ebsco_adapter/terraform/iceberg_adapter/state_machine.tf
+++ b/ebsco_adapter/terraform/iceberg_adapter/state_machine.tf
@@ -18,12 +18,12 @@ locals {
         ]
       }
       TransitionStep = {
-        Type     = "Choice"
-        Choices  = [
+        Type = "Choice"
+        Choices = [
           {
-            Variable = "$.is_processed"
+            Variable      = "$.is_processed"
             BooleanEquals = true
-            Next         = "Success"
+            Next          = "Success"
           }
         ]
         Default = "LoaderStep"

--- a/ebsco_adapter/terraform/iceberg_adapter/state_machine.tf
+++ b/ebsco_adapter/terraform/iceberg_adapter/state_machine.tf
@@ -21,14 +21,12 @@ locals {
         Type     = "Choice"
         Choices  = [
           {
-            Condition =  "{% $states.input.is_processed = true %}"
+            Variable = "$.is_processed"
+            BooleanEquals = true
             Next         = "Success"
-          },
-          {
-            Condition =  "{% $states.input.is_processed = false %}"
-            Next         = "LoaderStep"
           }
-        ],
+        ]
+        Default = "LoaderStep"
       }
       LoaderStep = {
         Type     = "Task"

--- a/ebsco_adapter/terraform/iceberg_adapter/state_machine.tf
+++ b/ebsco_adapter/terraform/iceberg_adapter/state_machine.tf
@@ -17,6 +17,19 @@ locals {
           }
         ]
       }
+      TransitionStep = {
+        Type     = "Choice"
+        Choices  = [
+          {
+            Condition =  "{% $states.input.is_processed = true %}"
+            Next         = "Success"
+          },
+          {
+            Condition =  "{% $states.input.is_processed = false %}"
+            Next         = "LoaderStep"
+          }
+        ],
+      }
       LoaderStep = {
         Type     = "Task"
         Resource = module.loader_lambda.lambda.arn
@@ -42,6 +55,9 @@ locals {
             BackoffRate     = 2.0
           }
         ]
+      }
+      Success = {
+        Type = "Succeed"
       }
     }
   })


### PR DESCRIPTION
## What does this change?

See https://github.com/wellcomecollection/platform/issues/6119
Move the checking if the file has been processed into the trigger. 
Based on the outcome of the check, the trigger outputs a boolean which is used in a Choice step to invoke the loader or not.
If the file has already been processed, terminate the state machine as Success

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? -->

