### PR TITLE
use more specific concept Type is id same as subject

### DIFF
--- a/catalogue_graph/src/sources/catalogue/concepts_source.py
+++ b/catalogue_graph/src/sources/catalogue/concepts_source.py
@@ -14,7 +14,19 @@ def extract_concepts_from_work(
     # extracting these component concepts, since the frontend does not make use of them and the resulting
     # theme pages would be empty.
     for subject in raw_work.get("subjects", []):
-        yield subject, "subjects"
+        # caveat concerning the above comment:
+        # for non-composite concepts, identified as having the same id as the top-level subject,
+        # the nested "Type" is more specific than the top-level "Type"
+        # in that case, we copy the nested concept's "Type" onto the subject
+        # Check if the first concept in the concepts list has the same id as the subject
+        concepts = subject.get("concepts", [])
+        if concepts and concepts[0].get("id") == subject.get("id"):
+            # Replace the subject's type with the concept's type
+            subject_copy = subject.copy()
+            subject_copy["type"] = concepts[0].get("type", subject.get("type"))
+            yield subject_copy, "subjects"
+        else:
+            yield subject, "subjects"
 
     # Return all contributors
     for contributor in raw_work.get("contributors", []):


### PR DESCRIPTION
## What does this change?

[#6094](https://github.com/wellcomecollection/platform/issues/6094)
See also https://wellcome.slack.com/archives/C02ANCYL90E/p1755769402477639

## How to test

Will add tests in upcoming PR
Still looking into local testing, which is made difficult by the fact that we can't transform specifc concepts by id

## How can we measure success?

Concepts 
eg. `bjzcsb9x` work's subject "19th century" will be of type "period" as opposed to "subject" currently

## Have we considered potential risks?

Given the strict conditions under which the logic is applied, there may be cases where we still keep the more generic "subject" type

