### PR TITLE
Graph add organisation connections

### DIFF
--- a/catalogue_graph/src/models/graph_edge.py
+++ b/catalogue_graph/src/models/graph_edge.py
@@ -99,17 +99,20 @@ class SourceConceptHasFieldOfWork(BaseEdge):
     relationship: str = "HAS_FIELD_OF_WORK"
     directed: bool = True
 
+
 class SourceConceptHasFounder(BaseEdge):
     from_type: str = "SourceConcept"
-    to_type: str = "SourceName" # ?? 
+    to_type: str = "SourceName"
     relationship: str = "HAS_FOUNDER"
     directed: bool = True
 
+
 class SourceConceptHasIndustry(BaseEdge):
     from_type: str = "SourceConcept"
-    to_type: str = "SourceConcept" # ?? 
+    to_type: str = "SourceConcept"
     relationship: str = "HAS_INDUSTRY"
     directed: bool = True
+
 
 class WorkHasConcept(BaseEdge):
     from_type: str = "Work"

--- a/catalogue_graph/src/models/graph_edge.py
+++ b/catalogue_graph/src/models/graph_edge.py
@@ -99,6 +99,17 @@ class SourceConceptHasFieldOfWork(BaseEdge):
     relationship: str = "HAS_FIELD_OF_WORK"
     directed: bool = True
 
+class SourceConceptHasFounder(BaseEdge):
+    from_type: str = "SourceConcept"
+    to_type: str = "SourceName" # ?? 
+    relationship: str = "HAS_FOUNDER"
+    directed: bool = True
+
+class SourceConceptHasIndustry(BaseEdge):
+    from_type: str = "SourceConcept"
+    to_type: str = "SourceConcept" # ?? 
+    relationship: str = "HAS_INDUSTRY"
+    directed: bool = True
 
 class WorkHasConcept(BaseEdge):
     from_type: str = "Work"

--- a/catalogue_graph/src/sources/wikidata/linked_ontology_source.py
+++ b/catalogue_graph/src/sources/wikidata/linked_ontology_source.py
@@ -148,6 +148,12 @@ class WikidataLinkedOntologySource(BaseSource):
         yield from self._stream_all_edges_by_type("instance_of")
         yield from self._stream_all_edges_by_type("subclass_of")
 
+    def _stream_all_has_founder_edges(self) -> Generator[dict]:
+        yield from self._stream_all_edges_by_type("has_founder")
+
+    def _stream_all_has_industry_edges(self) -> Generator[dict]:
+        yield from self._stream_all_edges_by_type("has_industry")
+
     def _stream_filtered_wikidata_ids(self) -> Generator[str]:
         """Streams all wikidata ids to be processed as nodes given the selected `node_type`."""
         seen = set()
@@ -202,6 +208,20 @@ class WikidataLinkedOntologySource(BaseSource):
             if edge["from_id"] in streamed_wikidata_ids:
                 streamed_wikidata_ids.add(edge["to_id"])
                 yield {**edge, "type": "HAS_PARENT"}
+        
+        print("Streaming HAS_FOUNDER edges...")
+        for edge in self._stream_all_has_founder_edges():
+            if edge["from_id"] in streamed_wikidata_ids and is_id_in_ontology(
+                    edge["to_id"], "wikidata"
+                ):
+                yield {**edge, "type": "HAS_FOUNDER"}
+
+        print("Streaming HAS_INDUSTRY edges...")
+        for edge in self._stream_all_has_industry_edges():
+            if edge["from_id"] in streamed_wikidata_ids and is_id_in_ontology(
+                    edge["to_id"], "wikidata"
+                ):
+                yield {**edge, "type": "HAS_INDUSTRY"}
 
         # The following edges only apply to people (SourceName) nodes
         if self.node_type == "names":

--- a/catalogue_graph/src/sources/wikidata/linked_ontology_source.py
+++ b/catalogue_graph/src/sources/wikidata/linked_ontology_source.py
@@ -208,19 +208,12 @@ class WikidataLinkedOntologySource(BaseSource):
             if edge["from_id"] in streamed_wikidata_ids:
                 streamed_wikidata_ids.add(edge["to_id"])
                 yield {**edge, "type": "HAS_PARENT"}
-        
-        print("Streaming HAS_FOUNDER edges...")
-        for edge in self._stream_all_has_founder_edges():
-            if edge["from_id"] in streamed_wikidata_ids and is_id_in_ontology(
-                    edge["to_id"], "wikidata"
-                ):
-                yield {**edge, "type": "HAS_FOUNDER"}
 
         print("Streaming HAS_INDUSTRY edges...")
         for edge in self._stream_all_has_industry_edges():
             if edge["from_id"] in streamed_wikidata_ids and is_id_in_ontology(
-                    edge["to_id"], "wikidata"
-                ):
+                edge["to_id"], "wikidata"
+            ):
                 yield {**edge, "type": "HAS_INDUSTRY"}
 
         # The following edges only apply to people (SourceName) nodes
@@ -245,6 +238,15 @@ class WikidataLinkedOntologySource(BaseSource):
                             "type": "RELATED_TO",
                             "subtype": relationship_type,
                         }
+
+        # The following edges only apply to concepts (SourceConcepts) nodes
+        if self.node_type == "concepts":
+            print("Streaming HAS_FOUNDER edges...")
+            for edge in self._stream_all_has_founder_edges():
+                if edge["from_id"] in streamed_wikidata_ids and is_id_in_ontology(
+                    edge["to_id"], "wikidata"
+                ):
+                    yield {**edge, "type": "HAS_FOUNDER"}
 
     def _stream_raw_nodes(self) -> Generator[dict]:
         """

--- a/catalogue_graph/src/sources/wikidata/sparql_query_builder.py
+++ b/catalogue_graph/src/sources/wikidata/sparql_query_builder.py
@@ -14,7 +14,7 @@ WikidataEdgeQueryType = Literal[
     "has_spouse",
     "has_child",
     "has_founder",
-    "has_industry"
+    "has_industry",
 ]
 
 

--- a/catalogue_graph/src/sources/wikidata/sparql_query_builder.py
+++ b/catalogue_graph/src/sources/wikidata/sparql_query_builder.py
@@ -13,6 +13,8 @@ WikidataEdgeQueryType = Literal[
     "has_sibling",
     "has_spouse",
     "has_child",
+    "has_founder",
+    "has_industry"
 ]
 
 
@@ -155,6 +157,10 @@ class SparqlQueryBuilder:
             property_path = "wdt:P279"
         elif edge_type == "has_field_of_work":
             property_path = "wdt:P101"
+        elif edge_type == "has_founder":
+            property_path = "wdt:P112"
+        elif edge_type == "has_industry":
+            property_path = "wdt:P452"
         elif edge_type == "has_father":
             property_path = "wdt:P22"
         elif edge_type == "has_mother":

--- a/catalogue_graph/src/transformers/wikidata/concepts_transformer.py
+++ b/catalogue_graph/src/transformers/wikidata/concepts_transformer.py
@@ -2,6 +2,8 @@ from collections.abc import Generator
 
 from models.graph_edge import (
     BaseEdge,
+    SourceConceptHasFounder,
+    SourceConceptHasIndustry,
     SourceConceptHasParent,
     SourceConceptSameAs,
     SourceConceptSameAsAttributes,
@@ -31,23 +33,33 @@ class WikidataConceptsTransformer(BaseTransformer):
             description=raw_concept.description,
         )
 
-    def extract_edges(self, raw_edge: dict) -> Generator[BaseEdge]:
-        if raw_edge["type"] == "SAME_AS":
+    def extract_edges(self, raw_node: dict) -> Generator[BaseEdge]:
+        if raw_node["type"] == "SAME_AS":
             edge_attributes = SourceConceptSameAsAttributes(source="wikidata")
             yield SourceConceptSameAs(
-                from_id=raw_edge["from_id"],
-                to_id=raw_edge["to_id"],
+                from_id=raw_node["from_id"],
+                to_id=raw_node["to_id"],
                 attributes=edge_attributes,
             )
             yield SourceConceptSameAs(
-                from_id=raw_edge["to_id"],
-                to_id=raw_edge["from_id"],
+                from_id=raw_node["to_id"],
+                to_id=raw_node["from_id"],
                 attributes=edge_attributes,
             )
-        elif raw_edge["type"] == "HAS_PARENT":
+        elif raw_node["type"] == "HAS_PARENT":
             yield SourceConceptHasParent(
-                from_id=raw_edge["from_id"],
-                to_id=raw_edge["to_id"],
+                from_id=raw_node["from_id"],
+                to_id=raw_node["to_id"],
+            )
+        elif raw_node["type"] == "HAS_FOUNDER":
+            yield SourceConceptHasFounder(
+                from_id=raw_node["from_id"],
+                to_id=raw_node["to_id"],
+            )
+        elif raw_node["type"] == "HAS_INDUSTRY":
+            yield SourceConceptHasIndustry(
+                from_id=raw_node["from_id"],
+                to_id=raw_node["to_id"],
             )
         else:
-            raise ValueError(f"Unknown edge type {raw_edge['type']}")
+            raise ValueError(f"Unknown edge type {raw_node['type']}")

--- a/catalogue_graph/src/transformers/wikidata/names_transformer.py
+++ b/catalogue_graph/src/transformers/wikidata/names_transformer.py
@@ -5,6 +5,10 @@ from models.graph_edge import (
     SourceConceptHasFieldOfWork,
     SourceNameRelatedTo,
     SourceNameRelatedToAttributes,
+    SourceConceptHasIndustry,
+    SourceConceptHasParent,
+    SourceConceptSameAs,
+    SourceConceptSameAsAttributes,
 )
 from models.graph_node import SourceName
 from sources.wikidata.linked_ontology_source import WikidataLinkedOntologySource
@@ -36,6 +40,28 @@ class WikidataNamesTransformer(WikidataConceptsTransformer):
         )
 
     def extract_edges(self, raw_node: dict) -> Generator[BaseEdge]:
+        if raw_node["type"] == "SAME_AS":
+            edge_attributes = SourceConceptSameAsAttributes(source="wikidata")
+            yield SourceConceptSameAs(
+                from_id=raw_node["from_id"],
+                to_id=raw_node["to_id"],
+                attributes=edge_attributes,
+            )
+            yield SourceConceptSameAs(
+                from_id=raw_node["to_id"],
+                to_id=raw_node["from_id"],
+                attributes=edge_attributes,
+            )
+        elif raw_node["type"] == "HAS_PARENT":
+            yield SourceConceptHasParent(
+                from_id=raw_node["from_id"],
+                to_id=raw_node["to_id"],
+            )
+        elif raw_node["type"] == "HAS_INDUSTRY":
+            yield SourceConceptHasIndustry(
+                from_id=raw_node["from_id"],
+                to_id=raw_node["to_id"],
+            )
         if raw_node["type"] == "HAS_FIELD_OF_WORK":
             yield SourceConceptHasFieldOfWork(
                 from_id=raw_node["from_id"],
@@ -51,4 +77,5 @@ class WikidataNamesTransformer(WikidataConceptsTransformer):
                 attributes=attributes,
             )
         else:
-            yield from super().extract_edges(raw_node)
+            raise ValueError(f"Unknown edge type {raw_node['type']}")
+

--- a/catalogue_graph/src/transformers/wikidata/names_transformer.py
+++ b/catalogue_graph/src/transformers/wikidata/names_transformer.py
@@ -35,20 +35,20 @@ class WikidataNamesTransformer(WikidataConceptsTransformer):
             place_of_birth=raw_concept.place_of_birth,
         )
 
-    def extract_edges(self, raw_edge: dict) -> Generator[BaseEdge]:
-        if raw_edge["type"] == "HAS_FIELD_OF_WORK":
+    def extract_edges(self, raw_node: dict) -> Generator[BaseEdge]:
+        if raw_node["type"] == "HAS_FIELD_OF_WORK":
             yield SourceConceptHasFieldOfWork(
-                from_id=raw_edge["from_id"],
-                to_id=raw_edge["to_id"],
+                from_id=raw_node["from_id"],
+                to_id=raw_node["to_id"],
             )
-        elif raw_edge["type"] == "RELATED_TO":
+        elif raw_node["type"] == "RELATED_TO":
             attributes = SourceNameRelatedToAttributes(
-                relationship_type=raw_edge["subtype"]
+                relationship_type=raw_node["subtype"]
             )
             yield SourceNameRelatedTo(
-                from_id=raw_edge["from_id"],
-                to_id=raw_edge["to_id"],
+                from_id=raw_node["from_id"],
+                to_id=raw_node["to_id"],
                 attributes=attributes,
             )
         else:
-            yield from super().extract_edges(raw_edge)
+            yield from super().extract_edges(raw_node)

--- a/catalogue_graph/tests/fixtures/wikidata_linked_loc/has_founder_query.json
+++ b/catalogue_graph/tests/fixtures/wikidata_linked_loc/has_founder_query.json
@@ -1,0 +1,4 @@
+{
+  "format": "json",
+  "query": "SELECT DISTINCT ?fromItem ?toItem WHERE { VALUES ?fromItem { wd:Q1 wd:Q100 wd:Q101 wd:Q2 } ?fromItem wdt:P112 ?toItem. FILTER (!wikibase:isSomeValue(?toItem)) }"
+}

--- a/catalogue_graph/tests/fixtures/wikidata_linked_loc/has_founder_response.json
+++ b/catalogue_graph/tests/fixtures/wikidata_linked_loc/has_founder_response.json
@@ -1,0 +1,16 @@
+{
+  "results": {
+    "bindings": [
+      {
+        "fromItem": {
+          "type": "uri",
+          "value": "http://www.wikidata.org/entity/Q101"
+        },
+        "toItem": {
+          "type": "uri",
+          "value": "http://www.wikidata.org/entity/Q100"
+        }
+      }
+    ]
+  }
+}

--- a/catalogue_graph/tests/fixtures/wikidata_linked_loc/has_industry_query.json
+++ b/catalogue_graph/tests/fixtures/wikidata_linked_loc/has_industry_query.json
@@ -1,0 +1,4 @@
+{
+  "format": "json",
+  "query": "SELECT DISTINCT ?fromItem ?toItem WHERE { VALUES ?fromItem { wd:Q1 wd:Q100 wd:Q101 wd:Q2 } ?fromItem wdt:P452 ?toItem. FILTER (!wikibase:isSomeValue(?toItem)) }"
+}

--- a/catalogue_graph/tests/fixtures/wikidata_linked_loc/has_industry_response.json
+++ b/catalogue_graph/tests/fixtures/wikidata_linked_loc/has_industry_response.json
@@ -1,0 +1,16 @@
+{
+  "results": {
+    "bindings": [
+      {
+        "fromItem": {
+          "type": "uri",
+          "value": "http://www.wikidata.org/entity/Q100"
+        },
+        "toItem": {
+          "type": "uri",
+          "value": "http://www.wikidata.org/entity/Q2"
+        }
+      }
+    ]
+  }
+}

--- a/catalogue_graph/tests/sources/test_wikidata_names_source.py
+++ b/catalogue_graph/tests/sources/test_wikidata_names_source.py
@@ -15,12 +15,13 @@ def test_wikidata_names_source_edges() -> None:
         node_type="names", linked_ontology="loc", entity_type="edges"
     )
     stream_result = list(mesh_concepts_source.stream_raw())
+    assert len(stream_result) == 6
 
-    assert len(stream_result) == 5
 
     same_as_edges = set()
     has_field_of_work_edges = set()
     related_to_edges = set()
+    has_industry_edges = set()
     for edge in stream_result:
         if edge["type"] == "SAME_AS":
             same_as_edges.add((edge["from_id"], edge["to_id"]))
@@ -28,6 +29,8 @@ def test_wikidata_names_source_edges() -> None:
             has_field_of_work_edges.add((edge["from_id"], edge["to_id"]))
         elif edge["type"] == "RELATED_TO":
             related_to_edges.add((edge["from_id"], edge["to_id"], edge["subtype"]))
+        elif edge["type"] == "HAS_INDUSTRY":
+            has_industry_edges.add((edge["from_id"], edge["to_id"]))
         else:
             raise ValueError(f"Unknown edge type {edge['type']}")
 
@@ -41,6 +44,9 @@ def test_wikidata_names_source_edges() -> None:
     assert len(related_to_edges) == 2
     assert ("Q100", "Q101", "has_mother") in related_to_edges
     assert ("Q101", "Q100", "has_child") in related_to_edges
+
+    assert len(has_industry_edges) == 1
+    assert ("Q100", "Q2") in has_industry_edges
 
 
 def test_wikidata_names_source_nodes() -> None:


### PR DESCRIPTION
## What does this change?

https://github.com/wellcomecollection/platform/issues/6137
- adds HAS_INDUSTRY edges to wikidata-linked-loc concepts and names 
- adds HAS_FOUNDER edges to wikidata-linked-loc  concepts 

## How to test

Run
```
AWS_PROFILE=platform-developer uv run extractor.py --transformer-type wikidata_linked_loc_concepts --entity-type edges --stream-destination local --pipeline-date 2025-08-14 --sample-size 90000 --is-local

AWS_PROFILE=platform-developer uv run extractor.py --transformer-type wikidata_linked_loc_names --entity-type edges --stream-destination local --pipeline-date 2025-08-14 --sample-size 90000 --is-local
```
Expected
```
HAS_INDUSTRY:Q1770148-->Q11644505,Q1770148,Q11644505,HAS_INDUSTRY,,,,,,
HAS_FOUNDER:Q719620-->Q353723,Q719620,Q353723,HAS_FOUNDER,,,,,, // only for wikidata_linked_loc_concepts
```

## How can we measure success?

Graph includes new edges, as described
Concepts ingestor can extract new edges and transform as
```
"relatedConcepts": {
   "relatedTo": [],
   "fieldsOfWork": [],
   "narrowerThan": [],
   "broaderThan": [],
   "people": [],
   "frequentCollaborators": [],
   "relatedTopics": [],
   "industry": [],   <- new property
   "foundedBy": []   <- new property
```

## Have we considered potential risks?

Graph part of the pipeline can be run before the ingestor changes go in: we can check the graph without affecting the index

