### PR TITLE
Fix monthly bulk loaders

### DIFF
--- a/catalogue_graph/terraform/state_machine_bulk_loaders.tf
+++ b/catalogue_graph/terraform/state_machine_bulk_loaders.tf
@@ -12,7 +12,12 @@ resource "aws_sfn_state_machine" "catalogue_graph_bulk_loaders_monthly" {
         Resource = "arn:aws:states:::states:startExecution.sync:2",
         Parameters = {
           StateMachineArn = aws_sfn_state_machine.catalogue_graph_bulk_loader.arn
-          Input           = jsonencode(task_input)
+          Input = {
+            "transformer_type" : task_input.transformer_type,
+            "entity_type" : task_input.entity_type,
+            "pipeline_date" : local.pipeline_date,
+            "insert_error_threshold" : try(task_input.insert_error_threshold, local.bulk_loader_default_insert_error_threshold),
+          }
         }
         Next = index == length(local.concepts_pipeline_inputs_monthly) - 1 ? "Success" : "Load ${local.concepts_pipeline_inputs_monthly[index + 1].label}"
       }


### PR DESCRIPTION
## What does this change?

Add the `pipeline_date` argument to bulk loader Lambda function executions. This argument is now needed since we categorise bulk load files into folders based on which pipeline they are in.

