### PR TITLE
EBSCO transformer: structured manifests & error capture (platform#6141)

### DIFF
--- a/ebsco_adapter/ebsco_adapter_iceberg/src/config.py
+++ b/ebsco_adapter/ebsco_adapter_iceberg/src/config.py
@@ -16,7 +16,6 @@ LOCAL_TABLE_NAME = os.getenv("LOCAL_TABLE_NAME", "mytable")
 LOCAL_NAMESPACE = os.getenv("LOCAL_NAMESPACE", "default")
 LOCAL_DB_NAME = os.getenv("LOCAL_DB_NAME", "catalog")
 
-
 # Local Elasticsearch Configuration
 ES_LOCAL_HOST = os.environ.get("ES_LOCAL_HOST", "localhost")
 ES_LOCAL_PORT = int(os.environ.get("ES_LOCAL_PORT", "9200"))

--- a/ebsco_adapter/ebsco_adapter_iceberg/src/manifests.py
+++ b/ebsco_adapter/ebsco_adapter_iceberg/src/manifests.py
@@ -1,0 +1,85 @@
+"""Utilities for writing transformer output manifests (success & failure)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import PurePosixPath
+from typing import Any, Iterable, Callable
+
+import smart_open
+
+from models.manifests import S3Location, SuccessManifest, FailureManifest, TransformerManifest
+
+
+def _success_lines(batches_ids: list[list[str]], source_id_template: str) -> Iterable[str]:
+    for ids in batches_ids:
+        wrapped_ids = [source_id_template.format(i) for i in ids]
+        yield json.dumps({"ids": wrapped_ids})
+
+
+def _failure_lines(errors: list[dict[str, Any]]) -> Iterable[str]:
+    for err in errors:
+        yield json.dumps(err)
+
+
+class ManifestWriter:
+    """Write success & failure manifests for the transformer.
+
+    Success manifest: <changeset|reindex>.<job>.ids.ndjson
+    Failure manifest: <changeset|reindex>.<job>.ids.failures.ndjson (only if failures)
+    """
+
+    def __init__(
+        self,
+        job_id: str,
+        changeset_id: str | None,
+        *,
+        bucket: str,
+        prefix: str,
+        source_id_template: str,
+    ) -> None:
+        base = f"{changeset_id or 'reindex'}.{job_id}.ids"
+        self.success_filename = f"{base}.ndjson"
+        self.failure_filename = f"{base}.failures.ndjson"
+        self.prefix = prefix
+        self.bucket = bucket
+        self.source_id_template = source_id_template
+
+    def write_success(self, batches_ids: list[list[str]]) -> S3Location:
+        key = PurePosixPath(self.prefix) / self.success_filename
+        uri = f"s3://{self.bucket}/{key.as_posix()}"
+        with smart_open.open(uri, "w", encoding="utf-8") as f:
+            for line in _success_lines(batches_ids, self.source_id_template):
+                f.write(line + "\n")
+        return S3Location(bucket=self.bucket, key=key.as_posix())
+
+    def write_failures(self, errors: list[dict[str, Any]]) -> S3Location:
+        key = PurePosixPath(self.prefix) / self.failure_filename
+        uri = f"s3://{self.bucket}/{key.as_posix()}"
+        with smart_open.open(uri, "w", encoding="utf-8") as f:
+            for line in _failure_lines(errors):
+                f.write(line + "\n")
+        return S3Location(bucket=self.bucket, key=key.as_posix())
+
+    def build_manifest(
+        self,
+        *,
+        job_id: str,
+        batches_ids: list[list[str]],
+        errors: list[dict[str, Any]],
+        success_count: int,
+    ) -> TransformerManifest:
+        success_loc = self.write_success(batches_ids)
+        failures_section: FailureManifest | None = None
+        if errors:
+            failure_loc = self.write_failures(errors)
+            failures_section = FailureManifest(
+                count=len(errors), error_file_location=failure_loc
+            )
+        return TransformerManifest(
+            job_id=job_id,
+            successes=SuccessManifest(
+                count=success_count, batch_file_location=success_loc
+            ),
+            failures=failures_section,
+        )

--- a/ebsco_adapter/ebsco_adapter_iceberg/src/models/manifests.py
+++ b/ebsco_adapter/ebsco_adapter_iceberg/src/models/manifests.py
@@ -21,5 +21,18 @@ class FailureManifest(BaseModel):
 
 
 class TransformerManifest(BaseModel):
+    job_id: str
     successes: SuccessManifest
     failures: FailureManifest | None = None
+
+
+# These are consumed by a Scala service, so for convenience
+# we keep the field names in camelCase
+class SuccessBatchLine(BaseModel):
+    sourceIdentifiers: list[str]
+    jobId: str
+
+
+class ErrorLine(BaseModel):
+    id: str
+    message: str

--- a/ebsco_adapter/ebsco_adapter_iceberg/src/models/manifests.py
+++ b/ebsco_adapter/ebsco_adapter_iceberg/src/models/manifests.py
@@ -1,0 +1,25 @@
+"""Manifest-related pydantic models shared by transformer & other steps."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class S3Location(BaseModel):
+    bucket: str
+    key: str
+
+
+class SuccessManifest(BaseModel):
+    count: int
+    batch_file_location: S3Location
+
+
+class FailureManifest(BaseModel):
+    count: int
+    error_file_location: S3Location
+
+
+class TransformerManifest(BaseModel):
+    successes: SuccessManifest
+    failures: FailureManifest | None = None

--- a/ebsco_adapter/ebsco_adapter_iceberg/src/models/step_events.py
+++ b/ebsco_adapter/ebsco_adapter_iceberg/src/models/step_events.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 from pydantic import BaseModel
 
+from models.manifests import TransformerManifest
+
 
 class EbscoAdapterEvent(BaseModel):
     """Base event for all EBSCO adapter steps.
@@ -27,15 +29,3 @@ class EbscoAdapterLoaderEvent(EbscoAdapterEvent):
 
 class EbscoAdapterTransformerEvent(EbscoAdapterEvent):
     changeset_id: str | None = None
-
-
-class EbscoAdapterTransformerResult(EbscoAdapterEvent):
-    """Result of transformer execution passed to the next step.
-
-    Large lists of batch ids are written to S3 (one JSON line per batch).
-    """
-
-    batch_file_bucket: str | None = None
-    batch_file_key: str | None = None
-    success_count: int = 0
-    failure_count: int = 0

--- a/ebsco_adapter/ebsco_adapter_iceberg/src/models/step_events.py
+++ b/ebsco_adapter/ebsco_adapter_iceberg/src/models/step_events.py
@@ -26,9 +26,6 @@ class EbscoAdapterLoaderEvent(EbscoAdapterEvent):
 
 
 class EbscoAdapterTransformerEvent(EbscoAdapterEvent):
-    # Propagate original source file location so transformer can record tracking.
-    # Optional to allow full re-transform runs that aren't tied to a single source file.
-    file_location: str | None = None
     changeset_id: str | None = None
 
 

--- a/ebsco_adapter/ebsco_adapter_iceberg/src/models/step_events.py
+++ b/ebsco_adapter/ebsco_adapter_iceberg/src/models/step_events.py
@@ -8,8 +8,6 @@ from __future__ import annotations
 
 from pydantic import BaseModel
 
-from models.manifests import TransformerManifest
-
 
 class EbscoAdapterEvent(BaseModel):
     """Base event for all EBSCO adapter steps.

--- a/ebsco_adapter/ebsco_adapter_iceberg/src/models/step_events.py
+++ b/ebsco_adapter/ebsco_adapter_iceberg/src/models/step_events.py
@@ -1,7 +1,7 @@
 """Shared event models passed between EBSCO adapter pipeline steps.
 
 This centralises the pydantic definitions so we can evolve them safely &
-consistently (e.g. adding common attributes such as index_date).
+consistently.
 """
 
 from __future__ import annotations
@@ -11,12 +11,9 @@ from pydantic import BaseModel
 
 class EbscoAdapterEvent(BaseModel):
     """Base event for all EBSCO adapter steps.
-
-    index_date: Allows a prior step to override the index name date component
-    used by downstream indexing (falls back to pipeline date when omitted).
+    job_id is a unique identifier for the overall pipeline run.
     """
 
-    index_date: str | None = None
     job_id: str
 
 
@@ -38,18 +35,9 @@ class EbscoAdapterTransformerEvent(EbscoAdapterEvent):
 class EbscoAdapterTransformerResult(EbscoAdapterEvent):
     """Result of transformer execution passed to the next step.
 
-    Instead of embedding potentially large batch id lists directly in the
-    state machine event, we persist them to S3 and return the location.
-
-    batch_file_location: S3 URI (s3://bucket/prefix/<job_id>.ndjson) containing
-    NDJSON (one JSON object per line) where each line is {"ids": [ ... ]} for a
-    processed RecordBatch. ``None`` when no work was performed (e.g. idempotent
-    skip).
-
-    batch_file_bucket / batch_file_key: Explicit S3 components provided to make
-    it easy for Step Functions Distributed Map ItemReader to reference the
-    manifest without parsing the URI. Optional for backward compatibility.
-    success_count / failure_count: indexing outcome totals.
+    Large lists of batch ids are written to S3 (one JSON line per batch) and
+    we return the S3 location + explicit bucket/key to simplify downstream
+    ItemReader configuration.
     """
 
     batch_file_location: str | None = None

--- a/ebsco_adapter/ebsco_adapter_iceberg/src/models/step_events.py
+++ b/ebsco_adapter/ebsco_adapter_iceberg/src/models/step_events.py
@@ -35,12 +35,9 @@ class EbscoAdapterTransformerEvent(EbscoAdapterEvent):
 class EbscoAdapterTransformerResult(EbscoAdapterEvent):
     """Result of transformer execution passed to the next step.
 
-    Large lists of batch ids are written to S3 (one JSON line per batch) and
-    we return the S3 location + explicit bucket/key to simplify downstream
-    ItemReader configuration.
+    Large lists of batch ids are written to S3 (one JSON line per batch).
     """
 
-    batch_file_location: str | None = None
     batch_file_bucket: str | None = None
     batch_file_key: str | None = None
     success_count: int = 0

--- a/ebsco_adapter/ebsco_adapter_iceberg/src/steps/loader.py
+++ b/ebsco_adapter/ebsco_adapter_iceberg/src/steps/loader.py
@@ -81,7 +81,6 @@ def handler(
         return EbscoAdapterTransformerEvent(
             changeset_id=prior_changeset,
             job_id=event.job_id,
-            file_location=event.file_location,
         )
 
     table = get_iceberg_table(config_obj.use_rest_api_table)
@@ -96,14 +95,12 @@ def handler(
         payload_obj=EbscoAdapterTransformerEvent(
             changeset_id=changeset_id,
             job_id=event.job_id,
-            file_location=event.file_location,
         ),
     )
 
     return EbscoAdapterTransformerEvent(
         changeset_id=changeset_id,
         job_id=event.job_id,
-        file_location=event.file_location,
     )
 
 

--- a/ebsco_adapter/ebsco_adapter_iceberg/src/steps/loader.py
+++ b/ebsco_adapter/ebsco_adapter_iceberg/src/steps/loader.py
@@ -81,7 +81,6 @@ def handler(
         return EbscoAdapterTransformerEvent(
             changeset_id=prior_changeset,
             job_id=event.job_id,
-            index_date=event.index_date,
             file_location=event.file_location,
         )
 
@@ -97,7 +96,6 @@ def handler(
         payload_obj=EbscoAdapterTransformerEvent(
             changeset_id=changeset_id,
             job_id=event.job_id,
-            index_date=event.index_date,
             file_location=event.file_location,
         ),
     )
@@ -105,7 +103,6 @@ def handler(
     return EbscoAdapterTransformerEvent(
         changeset_id=changeset_id,
         job_id=event.job_id,
-        index_date=event.index_date,
         file_location=event.file_location,
     )
 

--- a/ebsco_adapter/ebsco_adapter_iceberg/src/steps/transformer.py
+++ b/ebsco_adapter/ebsco_adapter_iceberg/src/steps/transformer.py
@@ -172,8 +172,6 @@ def _process_batch(
     return success, failed, ids
 
 
-
-
 def process_batches(
     pa_table: pa.Table,
     es_client: Elasticsearch,
@@ -309,7 +307,7 @@ def local_handler() -> EbscoAdapterTransformerResult:
     args = parser.parse_args()
 
     event = EbscoAdapterTransformerEvent(
-        changeset_id=args.changeset_id, job_id=args.job_id, file_location=None
+        changeset_id=args.changeset_id, job_id=args.job_id
     )
     use_rest_api = args.use_rest_api_table
     config_obj = EbscoAdapterTransformerConfig(

--- a/ebsco_adapter/ebsco_adapter_iceberg/tests/test_loader.py
+++ b/ebsco_adapter/ebsco_adapter_iceberg/tests/test_loader.py
@@ -20,7 +20,6 @@ class TestLoaderHandler:
         tracking_uri = f"{file_uri}.loaded.json"
         prior_event = EbscoAdapterTransformerEvent(
             job_id="20250101T1200",
-            file_location=file_uri,
             changeset_id="prev-change-123",
         )
         tracking_record = ProcessedFileRecord(

--- a/ebsco_adapter/ebsco_adapter_iceberg/tests/test_manifests.py
+++ b/ebsco_adapter/ebsco_adapter_iceberg/tests/test_manifests.py
@@ -1,0 +1,157 @@
+import json
+
+import pytest
+
+import config as adapter_config
+from manifests import ManifestWriter
+from models.manifests import ErrorLine
+
+from .test_mocks import MockSmartOpen
+
+
+def _read_ndjson(uri: str) -> list[dict]:
+    path = MockSmartOpen.file_lookup[uri]
+    with open(path, encoding="utf-8") as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+def test_manifest_writer_writes_success_only() -> None:
+    writer = ManifestWriter(
+        job_id="job123",
+        changeset_id="chgABC",
+        bucket=adapter_config.S3_BUCKET,
+        prefix=adapter_config.BATCH_S3_PREFIX,
+        source_id_template="Work[ebsco-alt-lookup/{}]",
+    )
+    batches_ids = [["id1", "id2"], ["id3"]]
+    manifest = writer.build_manifest(
+        job_id="job123", batches_ids=batches_ids, errors=[], success_count=3
+    )
+
+    assert manifest.failures is None
+    assert manifest.successes.count == 3
+    expected_key = f"{adapter_config.BATCH_S3_PREFIX}/chgABC.job123.ids.ndjson"
+    assert manifest.successes.batch_file_location.key == expected_key
+    uri = (
+        f"s3://{manifest.successes.batch_file_location.bucket}/"  # bucket
+        f"{manifest.successes.batch_file_location.key}"
+    )
+    lines = _read_ndjson(uri)
+    assert len(lines) == 2  # two batch lines
+    assert lines[0]["jobId"] == "job123"
+    assert lines[0]["sourceIdentifiers"] == [
+        "Work[ebsco-alt-lookup/id1]",
+        "Work[ebsco-alt-lookup/id2]",
+    ]
+    assert lines[1]["sourceIdentifiers"] == ["Work[ebsco-alt-lookup/id3]"]
+
+
+def test_manifest_writer_writes_failures() -> None:
+    writer = ManifestWriter(
+        job_id="job999",
+        changeset_id=None,  # triggers 'reindex' naming
+        bucket=adapter_config.S3_BUCKET,
+        prefix=adapter_config.BATCH_S3_PREFIX,
+        source_id_template="Work[ebsco-alt-lookup/{}]",
+    )
+
+    error_lines = [
+        ErrorLine(id="e1", message="stage=transform; reason=parse_error"),
+        ErrorLine(
+            id="e2",
+            message="stage=index; status=400; error_type=mapper_parsing_exception",
+        ),
+    ]
+
+    manifest = writer.build_manifest(
+        job_id="job999", batches_ids=[["idA"]], errors=error_lines, success_count=1
+    )
+    assert manifest.failures is not None
+    assert manifest.failures.count == 2
+    # Check success file still written
+    success_uri = (
+        f"s3://{manifest.successes.batch_file_location.bucket}/"
+        f"{manifest.successes.batch_file_location.key}"
+    )
+    success_lines = _read_ndjson(success_uri)
+    assert success_lines[0]["sourceIdentifiers"] == ["Work[ebsco-alt-lookup/idA]"]
+
+    # Check failure file contents
+    failure_uri = (
+        f"s3://{manifest.failures.error_file_location.bucket}/"
+        f"{manifest.failures.error_file_location.key}"
+    )
+    failure_lines = _read_ndjson(failure_uri)
+    assert {line["id"] for line in failure_lines} == {"e1", "e2"}
+    messages = {line["id"]: line["message"] for line in failure_lines}
+    assert "reason=parse_error" in messages["e1"]
+    assert "error_type=mapper_parsing_exception" in messages["e2"]
+    # Naming pattern for reindex without changeset
+    assert manifest.successes.batch_file_location.key.startswith(
+        f"{adapter_config.BATCH_S3_PREFIX}/reindex.job999.ids"
+    )
+
+
+def test_manifest_writer_handles_empty_batches() -> None:
+    writer = ManifestWriter(
+        job_id="jobEmpty",
+        changeset_id="chgEmpty",
+        bucket=adapter_config.S3_BUCKET,
+        prefix=adapter_config.BATCH_S3_PREFIX,
+        source_id_template="Work[ebsco-alt-lookup/{}]",
+    )
+    # Even with zero success_count we still write an (empty) success manifest file with 0 count
+    manifest = writer.build_manifest(
+        job_id="jobEmpty", batches_ids=[], errors=[], success_count=0
+    )
+    assert manifest.successes.count == 0
+    assert manifest.failures is None
+    uri = (
+        f"s3://{manifest.successes.batch_file_location.bucket}/"
+        f"{manifest.successes.batch_file_location.key}"
+    )
+    lines = _read_ndjson(uri)
+    assert lines == []  # no batch lines written
+
+
+@pytest.mark.parametrize(
+    "changeset_id, job_id, expected_success, expected_failure_prefix",
+    [
+        (
+            "chgXYZ",
+            "job777",
+            "chgXYZ.job777.ids.ndjson",
+            "chgXYZ.job777.ids.failures.ndjson",
+        ),
+        (
+            None,
+            "job555",
+            "reindex.job555.ids.ndjson",
+            "reindex.job555.ids.failures.ndjson",
+        ),
+    ],
+)
+def test_manifest_file_naming_patterns(
+    changeset_id: str | None,
+    job_id: str,
+    expected_success: str,
+    expected_failure_prefix: str,
+) -> None:
+    """Ensure naming patterns match spec for both changeset & reindex cases."""
+    writer = ManifestWriter(
+        job_id=job_id,
+        changeset_id=changeset_id,
+        bucket=adapter_config.S3_BUCKET,
+        prefix=adapter_config.BATCH_S3_PREFIX,
+        source_id_template="Work[ebsco-alt-lookup/{}]",
+    )
+    # include an error to force failure file creation
+    manifest = writer.build_manifest(
+        job_id=job_id,
+        batches_ids=[["only1"]],
+        errors=[ErrorLine(id="x", message="stage=transform; reason=parse_error")],
+        success_count=1,
+    )
+    assert manifest.successes.batch_file_location.key.endswith(expected_success)
+    assert manifest.failures is not None
+    assert manifest.failures.error_file_location.key.endswith(expected_failure_prefix)

--- a/ebsco_adapter/ebsco_adapter_iceberg/tests/test_mocks.py
+++ b/ebsco_adapter/ebsco_adapter_iceberg/tests/test_mocks.py
@@ -46,9 +46,7 @@ class MockSmartOpen:
             # Create a temporary file, return a handle and save the location in the file lookup
             # We're ignoring "SIM115 Use a context manager for opening files" as we need to keep
             # the file around for the duration of the test, cleaning it up in reset_mocks.
-            temp_file = tempfile.NamedTemporaryFile(
-                delete=False, mode=mode
-            )  # noqa: SIM115
+            temp_file = tempfile.NamedTemporaryFile(delete=False, mode=mode)  # noqa: SIM115
             # Insert the to_boto3 method to simulate the method provided by smart_open
             # https://github.com/piskvorky/smart_open/blob/develop/howto.md#how-to-access-s3-object-properties
             temp_file.to_boto3 = lambda _: MockBotoS3Object()  # type: ignore[attr-defined]

--- a/ebsco_adapter/ebsco_adapter_iceberg/tests/test_mocks.py
+++ b/ebsco_adapter/ebsco_adapter_iceberg/tests/test_mocks.py
@@ -46,7 +46,9 @@ class MockSmartOpen:
             # Create a temporary file, return a handle and save the location in the file lookup
             # We're ignoring "SIM115 Use a context manager for opening files" as we need to keep
             # the file around for the duration of the test, cleaning it up in reset_mocks.
-            temp_file = tempfile.NamedTemporaryFile(delete=False, mode=mode)  # noqa: SIM115
+            temp_file = tempfile.NamedTemporaryFile(
+                delete=False, mode=mode
+            )  # noqa: SIM115
             # Insert the to_boto3 method to simulate the method provided by smart_open
             # https://github.com/piskvorky/smart_open/blob/develop/howto.md#how-to-access-s3-object-properties
             temp_file.to_boto3 = lambda _: MockBotoS3Object()  # type: ignore[attr-defined]

--- a/ebsco_adapter/ebsco_adapter_iceberg/tests/test_tracking.py
+++ b/ebsco_adapter/ebsco_adapter_iceberg/tests/test_tracking.py
@@ -54,9 +54,7 @@ class TestIsFileAlreadyProcessed:
     def test_file_already_processed(self) -> None:
         file_location = "s3://test-bucket/dev/ftp_v2/existing-file.xml"
 
-        prior_event = EbscoAdapterTransformerEvent(
-            job_id="jid", changeset_id="cid"
-        )
+        prior_event = EbscoAdapterTransformerEvent(job_id="jid", changeset_id="cid")
         stored = ProcessedFileRecord(
             job_id="jid", step="loaded", payload=prior_event.model_dump()
         )

--- a/ebsco_adapter/ebsco_adapter_iceberg/tests/test_tracking.py
+++ b/ebsco_adapter/ebsco_adapter_iceberg/tests/test_tracking.py
@@ -24,7 +24,7 @@ class TestRecordProcessedFile:
         job_id = "test-job-id"
         file_location = "s3://s3-bucket/is-a/file.xml"
         event = EbscoAdapterTransformerEvent(
-            changeset_id="I have changed", job_id=job_id, file_location=file_location
+            changeset_id="I have changed", job_id=job_id
         )
         record = record_processed_file(
             job_id=job_id, file_location=file_location, step="loaded", payload_obj=event
@@ -55,7 +55,7 @@ class TestIsFileAlreadyProcessed:
         file_location = "s3://test-bucket/dev/ftp_v2/existing-file.xml"
 
         prior_event = EbscoAdapterTransformerEvent(
-            job_id="jid", file_location=file_location, changeset_id="cid"
+            job_id="jid", changeset_id="cid"
         )
         stored = ProcessedFileRecord(
             job_id="jid", step="loaded", payload=prior_event.model_dump()

--- a/ebsco_adapter/ebsco_adapter_iceberg/tests/test_transformer.py
+++ b/ebsco_adapter/ebsco_adapter_iceberg/tests/test_transformer.py
@@ -155,7 +155,7 @@ def test_transformer_end_to_end_with_local_table(
     batch_contents_path = MockSmartOpen.file_lookup[result.batch_file_location]
     with open(batch_contents_path, encoding="utf-8") as f:
         lines = [json.loads(line) for line in f if line.strip()]
-    assert lines == [{"ids": list(records_by_id.keys())}]
+    assert lines == [{"ids": [f"Work[ebsco-alt-lookup/{i}]" for i in records_by_id]}]
     titles = {op["_source"].get("title") for op in MockElasticsearchClient.inputs}
     assert titles == {"How to Avoid Huge Ships", "Parasites, hosts and diseases"}
 
@@ -178,7 +178,14 @@ def test_transformer_creates_deletedwork_for_empty_content(
     batch_contents_path = MockSmartOpen.file_lookup[result.batch_file_location]
     with open(batch_contents_path, encoding="utf-8") as f:
         lines = [json.loads(line) for line in f if line.strip()]
-    assert lines == [{"ids": ["ebsDel001", "ebsDel002"]}]
+    assert lines == [
+        {
+            "ids": [
+                "Work[ebsco-alt-lookup/ebsDel001]",
+                "Work[ebsco-alt-lookup/ebsDel002]",
+            ]
+        }
+    ]
     deleted_docs = [
         op for op in MockElasticsearchClient.inputs if op["_id"] == "ebsDel001"
     ]
@@ -220,7 +227,14 @@ def test_transformer_full_retransform_when_no_changeset(
     batch_contents_path = MockSmartOpen.file_lookup[result.batch_file_location]
     with open(batch_contents_path, encoding="utf-8") as f:
         lines = [json.loads(line) for line in f if line.strip()]
-    assert lines == [{"ids": ["ebsFull001", "ebsFull002"]}]
+    assert lines == [
+        {
+            "ids": [
+                "Work[ebsco-alt-lookup/ebsFull001]",
+                "Work[ebsco-alt-lookup/ebsFull002]",
+            ]
+        }
+    ]
 
 
 def test_transformer_batch_file_location_with_changeset(

--- a/ebsco_adapter/ebsco_adapter_iceberg/tests/test_transformer.py
+++ b/ebsco_adapter/ebsco_adapter_iceberg/tests/test_transformer.py
@@ -94,65 +94,8 @@ def _add_pipeline_secrets(pipeline_date: str) -> None:
 
 
 # --------------------------------------------------------------------------------------
-# Tests (existing end-to-end & integration)
+# Tests
 # --------------------------------------------------------------------------------------
-
-
-def test_transformer_reprocesses_even_if_prior_processed_detected(
-    monkeypatch: pytest.MonkeyPatch, temporary_table: pa.Table
-) -> None:
-    """Transformer should reprocess even if a prior tracking JSON exists.
-
-    Previously we short-circuited; now we expect a full re-run producing a NEW batch file.
-    """
-    file_uri = "s3://bucket/path/file.xml"
-    tracking_uri = f"{file_uri}.transformed.json"
-    prior_result = EbscoAdapterTransformerResult(
-        job_id="20250101T1200",
-        batch_file_bucket="bucket",
-        batch_file_key="path/20250101T1200.json",
-        success_count=10,
-        failure_count=0,
-    )
-    tracking_record = ProcessedFileRecord(
-        job_id="20250101T1200", step="transformed", payload=prior_result.model_dump()
-    )
-    MockSmartOpen.mock_s3_file(tracking_uri, json.dumps(tracking_record.model_dump()))
-
-    # Create a new changeset so the handler does real work
-    records_by_id = {
-        "ebsAgain001": "<record><leader>00000nam a2200000   4500</leader><controlfield tag='001'>ebsAgain001</controlfield><datafield tag='245' ind1='0' ind2='0'><subfield code='a'>Replay Title</subfield></datafield></record>",
-    }
-    rows = [
-        {"id": rid, "content": record_xml} for rid, record_xml in records_by_id.items()
-    ]
-    pa_table_initial = data_to_namespaced_table(rows)
-    client = IcebergTableClient(temporary_table)
-    changeset_id = client.update(pa_table_initial, "ebsco")
-
-    # Ensure transformer uses our temporary table
-    monkeypatch.setattr(
-        "utils.iceberg.get_local_table", lambda **kwargs: temporary_table
-    )
-
-    event = EbscoAdapterTransformerEvent(
-        changeset_id=changeset_id, job_id="20250101T1200", file_location=file_uri
-    )
-    config = EbscoAdapterTransformerConfig(
-        is_local=True, use_rest_api_table=False, pipeline_date="dev"
-    )
-
-    result = handler(event=event, config_obj=config)
-
-    # We expect NOT to reuse prior batch file bucket/key; a new batch file is written
-    assert result.batch_file_bucket == adapter_config.S3_BUCKET
-    assert result.batch_file_key != prior_result.batch_file_key
-    assert result.success_count == 1
-    assert result.failure_count == 0
-    # Elasticsearch inputs should include the replayed record
-    ids = {op["_id"] for op in MockElasticsearchClient.inputs}
-    assert "ebsAgain001" in ids
-
 
 def test_transformer_end_to_end_with_local_table(
     temporary_table: pa.Table, monkeypatch: pytest.MonkeyPatch
@@ -260,7 +203,7 @@ def test_transformer_full_retransform_when_no_changeset(
 def test_transformer_batch_file_key_with_changeset(
     temporary_table: pa.Table, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """When a changeset exists the batch file path uses the changeset pattern under the batches prefix (file_location irrelevant)."""
+    """When a changeset exists the batch file path uses the changeset pattern under the batches prefix."""
     job_id = "20250101T1200"
     records_by_id = {
         "ebsReIdx001": "<record><leader>00000nam a2200000   4500</leader><controlfield tag='001'>X</controlfield><datafield tag='245' ind1='0' ind2='0'><subfield code='a'>Title</subfield></datafield></record>",


### PR DESCRIPTION
## What does this change?

Implements structured success & failure manifests for the EBSCO adapter transformer (part of platform#6141), replacing the previous flat result and ad‑hoc batch ID file.

Key points:
- Introduces `TransformerManifest` with nested `successes` and optional `failures`.
- Adds strongly-typed manifest line models: `SuccessBatchLine { sourceIdentifiers, jobId }`, `ErrorLine { id, message }`.
- Writes success manifest: `<changeset|reindex>.<job>.ids.ndjson`.
- Writes failure manifest only when errors occur: `<changeset|reindex>.<job>.ids.failures.ndjson`.
- Captures transform errors (`empty_content`, `parse_error`, `no_valid_title`) & indexing errors (status + error_type) and normalises them into deterministic `ErrorLine` messages.
- Refactors manifest writing into a reusable `ManifestWriter` (parameterised: bucket, prefix, source ID template, job_id).
- Removes legacy result class; transformer now returns a `TransformerManifest`.
- Updates all tests to the new schemas; adds isolated manifest tests & naming pattern parameterised test.
- Does NOT yet update the adapter state machine orchestration (will follow in a later PR).
- Follows earlier groundwork in #3009 and #3017.

Breaking change for downstream consumers: success lines changed from `{ "ids": [...] }` to `{ "sourceIdentifiers": [...], "jobId": "..." }`, and failure lines changed from structured dicts to `{ "id": "...", "message": "key=value; ..." }`.

## How to test

1. Run tests locally:
   ```
   uv run pytest -q
   uv run mypy .
   uv run ruff check
   ```
   All should pass (expected: 54 tests green).

2. (Optional) Manually invoke the transformer locally:
   ```
   uv run python -m steps.transformer --changeset-id <some_changeset> --job-id testJob
   ```
   Inspect S3 (or mocked paths in tests) for:
   - Success file: `batches/<changeset|reindex>.<job>.ids.ndjson`
   - Failure file only if errors encountered.

3. Verify manifest line formats:
   - Success line example:
     ```json
     {"sourceIdentifiers": ["Work[ebsco-alt-lookup/ebs123]"], "jobId": "testJob"}
     ```
   - Failure line example:
     ```json
     {"id": "ebs123", "message": "stage=transform; reason=parse_error; detail=..."}
     ```

## How can we measure success?

- Clearer downstream contract: consumers can rely on counts + explicit failure presence.
- Deterministic, parseable error messages (consistent ordering).
- Easier future extension (metrics, replay, auditing) via typed manifest components.
- Reduced ambiguity for batch completeness vs partial error cases.

Potential measurable signals (future):
- Number of failure lines per job over time (should trend low).
- Presence of parse or indexing error types for monitoring quality or ES mapping issues.

## Have we considered potential risks?

| Risk | Mitigation |
|------|------------|
| Downstream code still expecting old `ids` field | Coordinate deployment; update consumers before/with this change; failure is obvious (missing key). |
| Loss of structured error fields (now in `message`) | Message includes all prior fields; can be parsed if needed; could add structured JSON later if required. |
| Large error volumes produce big failure files | Failure file only written if errors; can add metrics & size monitoring later. |
| State machine still referencing old result shape | Deferred intentionally; next PR updates orchestration. |
| Accidental schema drift | Typed Pydantic models + dedicated tests (`test_manifests.py`) lock format. |

Alarms & Monitoring (future PR):
- Add CloudWatch metric emission for `success_count` / `failure_count`.
- Add alert on non-zero failure count threshold.

## Related
- Issue: https://github.com/wellcomecollection/platform/issues/6141
- Previous PRs: #3009, #3017

## Follow-up work (future PRs)
1. Update adapter state machine to consume `TransformerManifest`.
2. Emit metrics (CloudWatch) for success/failure counts.
3. Update downstream consumers / documentation referencing old `ids` schema.
4. (Optional) Provide structured error JSON alongside message if richer programmatic handling needed.

## Notes for reviewers
Focus areas:
- `manifests.py` (naming logic & line formats)
- `_to_error_line` in `steps/transformer.py` (deterministic message ordering)
- New tests in `tests/test_manifests.py` (coverage & edge cases)
- Removal of deprecated result class

---

Let me know if you would like a shorter version or additional migration guidance added before merge.
