### PR TITLE
Force old EBSCO adapter to look only in "ftp/" prefix

### DIFF
--- a/ebsco_adapter/ebsco_adapter/run_local.sh
+++ b/ebsco_adapter/ebsco_adapter/run_local.sh
@@ -21,6 +21,6 @@ S3_PREFIX=prod
 export FTP_PASSWORD FTP_SERVER FTP_USERNAME CUSTOMER_ID FTP_REMOTE_DIR S3_BUCKET S3_PREFIX OUTPUT_TOPIC_ARN REINDEX_TOPIC_ARN
 
 # Ensure the docker image is up to date
-docker-compose --log-level ERROR build dev
+docker compose build dev
 
-docker-compose run dev "$@"
+docker compose run dev "$@"

--- a/ebsco_adapter/ebsco_adapter/src/main.py
+++ b/ebsco_adapter/ebsco_adapter/src/main.py
@@ -25,7 +25,7 @@ reindex_topic_arn = os.environ.get("REINDEX_TOPIC_ARN")
 s3_bucket = os.environ.get("S3_BUCKET", "wellcomecollection-platform-ebsco-adapter")
 s3_prefix = os.environ.get("S3_PREFIX", "dev")
 
-ftp_s3_prefix = os.path.join(s3_prefix, "ftp")
+ftp_s3_prefix = os.path.join(s3_prefix, "ftp/")
 xml_s3_prefix = os.path.join(s3_prefix, "xml")
 
 


### PR DESCRIPTION
## What does this change?

This change updates the prefix that the old EBSCO adapter looks in, in S3 for synced files from FTP.

Currently the old adapter reads files from the new adapter which is using the prefix ftp_v2/

We also make some changes to the old run local script in order to ensure it continues working.

## How to test

- [ ] Make this change and run locally.

## How can we measure success?

The EBSCO adapter continues to sync changes.

## Have we considered potential risks?

Risks should be minimal, we are returning things to a working state.
