### PR TITLE
Add adapter deploy permissions

### DIFF
--- a/builds/terraform/github/gha_role_catalogue_graph.tf
+++ b/builds/terraform/github/gha_role_catalogue_graph.tf
@@ -52,6 +52,7 @@ data "aws_iam_policy_document" "gha_catalogue_graph_ci" {
     ]
     resources = [
       "arn:aws:lambda:eu-west-1:760097843905:function:catalogue-*",
+      "arn:aws:lambda:eu-west-1:760097843905:function:ebsco-adapter-*",
     ]
   }
 }


### PR DESCRIPTION
## What does this change?

This change allow the the Catalogue Graph GHA role to deploy the ebsco-adapter lambdas.

## How to test

- [x] [Run a deployment](https://github.com/wellcomecollection/catalogue-pipeline/actions/runs/18466325355/job/52678635594), does it succeed?

## How can we measure success?

Deployments can proceed via GHA.

## Have we considered potential risks?

This widens the permissions of the GHA role, but keeps them within the scope of lambdas prefixed for the ebsco-adapter.
