### PR TITLE
weco-authority sourceLabel for concepts with overridden description

### DIFF
--- a/catalogue_graph/src/ingestor/transformers/concept_override.py
+++ b/catalogue_graph/src/ingestor/transformers/concept_override.py
@@ -48,7 +48,9 @@ class ConceptTextOverrideProvider:
                 return None
             if override_description:
                 return ConceptDescription(
-                    text=override_description, sourceUrl=None, sourceLabel="weco-authority"
+                    text=override_description,
+                    sourceUrl=None,
+                    sourceLabel="weco-authority",
                 )
         return raw_concept.description
 

--- a/catalogue_graph/tests/ingestor/test_concept_override.py
+++ b/catalogue_graph/tests/ingestor/test_concept_override.py
@@ -47,7 +47,7 @@ def test_label_unchanged_if_unset(concept: RawNeptuneConcept) -> None:
     assert overrider.display_label_of(concept) == concept.display_label
     assert overrider.description_of(concept) == ConceptDescription(
         text="Pottery with a transparent jade green glaze",
-        sourceLabel=None,
+        sourceLabel="weco-authority",
         sourceUrl=None,
     )
 

--- a/catalogue_graph/tests/ingestor/test_concept_transformer.py
+++ b/catalogue_graph/tests/ingestor/test_concept_transformer.py
@@ -577,7 +577,7 @@ def test_catalogue_concept_from_neptune_result_with_overridden_label_description
             alternativeLabels=[],
             description=ConceptDescription(
                 text="Wellcome Description",
-                sourceLabel=None,
+                sourceLabel="weco-authority",
                 sourceUrl=None,
             ),
             type="Person",


### PR DESCRIPTION
## What does this change?

Implements https://github.com/wellcomecollection/platform/issues/6174

## How to test

Run the tests, do they pass?

- Create a new concept index manually in the Elastic console 
- Load new data
```
AWS_PROFILE=platform-developer uv run src/ingestor/steps/ingestor_loader.py --ingestor-type concepts --pipeline-date 2025-08-14 --index-date 2025-10-14 --es-mode public --load-destination s3 --load-format parquet --job-id agnes-concepts-override-sourceLabel
```
- Index it
```
AWS_PROFILE=platform-developer uv run src/ingestor/steps/ingestor_indexer.py --ingestor-type concepts --pipeline-date 2025-08-14 --index-date 2025-10-14 --job-id agnes-concepts-override-sourceLabel --es-mode public
```

## How can we measure success?

The concept API returns display description as 
```
"description": {
        "text": "Our South Asian collections include historical manuscripts in the region’s many languages, documents from the British Raj, and contemporary public health materials.",
        "sourceLabel": "weco-authority" <--- this added
      }
```
for concepts that have a description override. 

## Have we considered potential risks?

The change will be loaded into a new concepts index to protect the production index/API 

