### PR TITLE
Rename identified_type to type on BaseIdentify

### DIFF
--- a/catalogue_graph/src/models/pipeline/identifier.py
+++ b/catalogue_graph/src/models/pipeline/identifier.py
@@ -19,7 +19,7 @@ IdentifyType = Literal["Identified", "Unidentifiable"]
 
 class BaseIdentify(ElasticsearchModel):
     canonical_id: str | None = None
-    identified_type: IdentifyType
+    type: IdentifyType
 
     def get_identifiers(self) -> Generator[SourceIdentifier]:
         raise NotImplementedError()
@@ -31,7 +31,7 @@ class BaseIdentify(ElasticsearchModel):
 class Identifiable(BaseIdentify):
     source_identifier: SourceIdentifier
     other_identifiers: list[SourceIdentifier] = []
-    identified_type: IdentifyType = "Identified"
+    type: IdentifyType = "Identified"
 
     def get_identifiers(self) -> Generator[SourceIdentifier]:
         yield self.source_identifier
@@ -52,7 +52,7 @@ class Identified(Identifiable):
 
 class Unidentifiable(BaseIdentify):
     canonical_id: None = None
-    identified_type: IdentifyType = "Unidentifiable"
+    type: IdentifyType = "Unidentifiable"
 
     def get_identifiers(self) -> Generator[SourceIdentifier]:
         yield from []

--- a/catalogue_graph/tests/fixtures/ingestor/single_merged.json
+++ b/catalogue_graph/tests/fixtures/ingestor/single_merged.json
@@ -56,7 +56,7 @@
         "dates": [
           {
             "id": {
-              "identifiedType": "Unidentifiable"
+              "type": "Unidentifiable"
             },
             "label": "1955-1978",
             "range": {
@@ -121,7 +121,7 @@
       {
         "id": {
           "canonicalId": "pawwq3yp",
-          "identifiedType": "Identified",
+          "type": "Identified",
           "sourceIdentifier": {
             "identifierType": {
               "id": "calm-ref-no"
@@ -138,7 +138,7 @@
   "redirectSources": [
     {
       "canonicalId": "ygwq7j69",
-      "identifiedType": "Identified",
+      "type": "Identified",
       "sourceIdentifier": {
         "identifierType": {
           "id": "sierra-system-number"

--- a/catalogue_graph/tests/fixtures/ingestor/works/mock_es_inputs.json
+++ b/catalogue_graph/tests/fixtures/ingestor/works/mock_es_inputs.json
@@ -372,7 +372,7 @@
           {
             "id": {
               "canonicalId": "jqd7k4sp",
-              "identifiedType": "Identified",
+              "type": "Identified",
               "sourceIdentifier": {
                 "identifierType": {
                   "id": "calm-ref-no"
@@ -388,7 +388,7 @@
         "redirectSources": [
           {
             "canonicalId": "w4bajds8",
-            "identifiedType": "Identified",
+            "type": "Identified",
             "sourceIdentifier": {
               "identifierType": {
                 "id": "sierra-system-number"
@@ -400,7 +400,7 @@
           },
           {
             "canonicalId": "dfcyrkxh",
-            "identifiedType": "Identified",
+            "type": "Identified",
             "sourceIdentifier": {
               "identifierType": {
                 "id": "mets"
@@ -1000,7 +1000,7 @@
           {
             "id": {
               "canonicalId": "hcqs6xp6",
-              "identifiedType": "Identified",
+              "type": "Identified",
               "sourceIdentifier": {
                 "identifierType": {
                   "id": "sierra-system-number"
@@ -1016,7 +1016,7 @@
         "redirectSources": [
           {
             "canonicalId": "jstyg2xn",
-            "identifiedType": "Identified",
+            "type": "Identified",
             "sourceIdentifier": {
               "identifierType": {
                 "id": "mets"
@@ -1028,7 +1028,7 @@
           },
           {
             "canonicalId": "hcqs6xp6",
-            "identifiedType": "Identified",
+            "type": "Identified",
             "sourceIdentifier": {
               "identifierType": {
                 "id": "sierra-system-number"
@@ -1633,7 +1633,7 @@
           {
             "id": {
               "canonicalId": "hmy2udbf",
-              "identifiedType": "Identified",
+              "type": "Identified",
               "sourceIdentifier": {
                 "identifierType": {
                   "id": "calm-ref-no"
@@ -1649,7 +1649,7 @@
         "redirectSources": [
           {
             "canonicalId": "adyxgsj4",
-            "identifiedType": "Identified",
+            "type": "Identified",
             "sourceIdentifier": {
               "identifierType": {
                 "id": "sierra-system-number"
@@ -1661,7 +1661,7 @@
           },
           {
             "canonicalId": "ugpnzjrn",
-            "identifiedType": "Identified",
+            "type": "Identified",
             "sourceIdentifier": {
               "identifierType": {
                 "id": "mets"
@@ -3485,7 +3485,7 @@
         "redirectSources": [
           {
             "canonicalId": "gqj73sk6",
-            "identifiedType": "Identified",
+            "type": "Identified",
             "sourceIdentifier": {
               "identifierType": {
                 "id": "mets"
@@ -3807,7 +3807,7 @@
           {
             "id": {
               "canonicalId": "zyphxyta",
-              "identifiedType": "Identified",
+              "type": "Identified",
               "sourceIdentifier": {
                 "identifierType": {
                   "id": "calm-ref-no"
@@ -3823,7 +3823,7 @@
         "redirectSources": [
           {
             "canonicalId": "cpmtamr5",
-            "identifiedType": "Identified",
+            "type": "Identified",
             "sourceIdentifier": {
               "identifierType": {
                 "id": "sierra-system-number"


### PR DESCRIPTION
## What does this change?

Following https://github.com/wellcomecollection/catalogue-pipeline/pull/3039 we matched the name of python classes mirroring the attribute on the `Identifiable` class: https://github.com/wellcomecollection/catalogue-pipeline/blob/main/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/IdState.scala#L37

However, this parameter is encoded as `type` when serialised to please the Scala JSON parser Circe: https://github.com/wellcomecollection/catalogue-pipeline/blob/main/pipeline/id_minter/src/main/scala/weco/pipeline/id_minter/steps/SourceIdentifierEmbedder.scala#L41

The result is that python consumers of the `Identifiable`  class will write an unexpected serialisation that cannot be read by Scala readers.

This change resolves the issue by naming the parameter `type` and avoiding needing a Codec to go back and forth from ES.

## How to test

- [ ] Run the tests, do they pass?

## How can we measure success?

Python & Scala services remain interroperable.

## Have we considered potential risks?

Hopefully this mitigates risk by ensuring we serialise data in a standard format and avoid param names different from those on stored data. 
