### PR TITLE
Use union type in Concept id, instead of base class

### DIFF
--- a/catalogue_graph/src/models/pipeline/concept.py
+++ b/catalogue_graph/src/models/pipeline/concept.py
@@ -4,14 +4,15 @@ from pydantic import BaseModel, Field, field_validator
 
 from models.pipeline.id_label import Label
 from models.pipeline.identifier import (
-    BaseIdentify,
+    Identifiable,
+    Identified,
     Unidentifiable,
 )
 from utils.types import ConceptType
 
 
 class Concept(BaseModel):
-    id: BaseIdentify = Unidentifiable()
+    id: Identifiable | Identified | Unidentifiable = Unidentifiable()
     label: str
     type: ConceptType = "Concept"
 


### PR DESCRIPTION
## What does this change?

See: https://wellcome.slack.com/archives/C02ANCYL90E/p1760618994765259?thread_ts=1760608685.045549&cid=C02ANCYL90E

The type declaration should be Identifiable | Identified | Unidentifiable instead of BaseIdentify, otherwise the source_identifier and other_identifiers fields will be ignored. Pydantic needs to know it has to choose either Identified or Unidentifiable when loading in the raw data, otherwise it will just load everything into BaseIdentify and discard all fields which don't exist on this class.

## How to test

Do the tests pass?

## How can we measure success?

Serializing and deserializing correct types so things work as expected!

