### PR TITLE
Catch EBSCO transform issues and add them to returned errors

### DIFF
--- a/catalogue_graph/src/adapters/ebsco/steps/transformer.py
+++ b/catalogue_graph/src/adapters/ebsco/steps/transformer.py
@@ -118,7 +118,6 @@ def transform(
                     "detail": detail,
                 }
             )
-
     return works, errors
 
 


### PR DESCRIPTION
## What does this change?

Currently the EBSCO adapter will fail on any transform exception. This change allows it to continue but log and record errors for return in the error manifest.

Related: https://github.com/wellcomecollection/platform/issues/6151

Blocking: https://github.com/wellcomecollection/platform/issues/6150

## How to test

- [ ] Run the tests, do they pass?
- [ ] Test this on a real failure in production, does it behave as expected?

## How can we measure success?

We are able to successfully run transforms for large volumes of records as in a reindex with some failure.

## Have we considered potential risks?

This will hide some failures inside error files and logs, but that's an expected situation for transformers at present.
