### PR TITLE
Python date handling in catalogue-pipeline

### DIFF
--- a/catalogue_graph/src/adapters/ebsco/transformers/parsers/period.py
+++ b/catalogue_graph/src/adapters/ebsco/transformers/parsers/period.py
@@ -189,11 +189,11 @@ def fill_year_prefix(from_year: str, to_year: str) -> str:
     return to_year
 
 
-def start_of_year(year: str) -> str:
-    return (datetime(int(year), 1, 1) if year else datetime.min).isoformat()
+def start_of_year(year: str) -> datetime:
+    return datetime(int(year), 1, 1) if year else datetime.min
 
 
-def end_of_year(year: str) -> str:
+def end_of_year(year: str) -> datetime:
     return (
         datetime(int(year), 12, 31, 23, 59, 59, 1000000 - 1) if year else datetime.max
-    ).isoformat()
+    )

--- a/catalogue_graph/src/ingestor/transformers/work_aggregate_transformer.py
+++ b/catalogue_graph/src/ingestor/transformers/work_aggregate_transformer.py
@@ -1,4 +1,3 @@
-import re
 from collections.abc import Generator
 
 from pydantic import BaseModel
@@ -71,11 +70,7 @@ class AggregateWorkTransformer:
         for event in self.data.production:
             for date in event.dates:
                 if date.range is not None:
-                    from_year_match = re.match(r"^-?\d+", date.range.from_time)
-                    if not from_year_match:
-                        raise ValueError(f"Invalid date format: {date.range.from_time}")
-
-                    year = from_year_match.group()
+                    year = str(date.range.from_time.year)
                     yield AggregatableField(id=year, label=year)
 
     @property

--- a/catalogue_graph/src/ingestor/transformers/work_query_transformer.py
+++ b/catalogue_graph/src/ingestor/transformers/work_query_transformer.py
@@ -130,9 +130,7 @@ class QueryWorkTransformer:
                     else:
                         try:
                             # Number of milliseconds since the Unix epoch
-                            yield int(
-                                parser.parse(date.range.from_time).timestamp() * 1000
-                            )
+                            yield int(date.range.from_time.timestamp() * 1000)
                         except parser.ParserError:
                             print(
                                 f"Could not parse a production date of work {self.state.canonical_id}"

--- a/catalogue_graph/src/models/pipeline/concept.py
+++ b/catalogue_graph/src/models/pipeline/concept.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Literal
 
 from pydantic import Field, field_validator
@@ -66,8 +67,8 @@ class Genre(SerialisableModel):
 
 
 class DateTimeRange(SerialisableModel):
-    from_time: str = Field(alias="from")
-    to_time: str = Field(alias="to")
+    from_time: datetime = Field(alias="from")
+    to_time: datetime = Field(alias="to")
     label: str | None = None
 
 

--- a/catalogue_graph/src/models/pipeline/serialisable.py
+++ b/catalogue_graph/src/models/pipeline/serialisable.py
@@ -1,5 +1,33 @@
+from datetime import UTC, datetime
+
 from pydantic import BaseModel, ConfigDict
 from pydantic.alias_generators import to_camel
+
+
+def convert_datetime_to_iso_8601_with_z_suffix(dt: datetime) -> str:
+    """
+    Return an ISO-8601 UTC string with a 'Z' suffix.
+    Behaviours:
+      - If datetime is timezone-aware, convert to UTC before serialising.
+      - Naive datetimes are assumed to already represent UTC.
+      - Include fractional seconds only if microseconds are non-zero.
+      - Trim trailing zeros from fractional seconds (e.g. 123000 -> 123; 120000 -> 12).
+    Examples:
+      2025-10-23T12:34:56Z
+      2025-10-23T12:34:56.123Z
+      2025-10-23T12:34:56.123456Z
+    """
+    if dt.tzinfo is not None:
+        dt = dt.astimezone(UTC).replace(tzinfo=None)
+
+    base = dt.strftime("%Y-%m-%dT%H:%M:%S")
+
+    if dt.microsecond:
+        micro = f"{dt.microsecond:06d}".rstrip("0")
+        if micro:  # After trimming zeros could still be empty
+            return f"{base}.{micro}Z"
+
+    return f"{base}Z"
 
 
 class ElasticsearchModel(BaseModel):
@@ -11,6 +39,7 @@ class ElasticsearchModel(BaseModel):
         validate_by_name=True,
         validate_by_alias=True,
         serialize_by_alias=True,
+        json_encoders={datetime: convert_datetime_to_iso_8601_with_z_suffix},
     )
 
 

--- a/catalogue_graph/tests/adapters/ebsco/transformers/test_production.py
+++ b/catalogue_graph/tests/adapters/ebsco/transformers/test_production.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import pytest
 from pymarc.record import Field, Indicators, Record, Subfield
 
@@ -57,8 +59,8 @@ def test_fall_back_to_008(marc_record: Record) -> None:
     assert lone_element(production.places).label == "Australian Capital Territory"
     period = lone_element(production.dates)
     assert period.range.label == "1979-1995"
-    assert period.range.from_time == "1979-01-01T00:00:00"
-    assert period.range.to_time == "1995-12-31T23:59:59.999999"
+    assert period.range.from_time == datetime(1979, 1, 1, 0, 0, 0)
+    assert period.range.to_time == datetime(1995, 12, 31, 23, 59, 59, 999999)
 
 
 @pytest.mark.parametrize(
@@ -89,8 +91,8 @@ def test_production_from_abc(marc_record: Record) -> None:
     assert lone_element(production.agents).label == "Mankind"
     period = lone_element(production.dates)
     assert period.range.label == "1998"
-    assert period.range.from_time == "1998-01-01T00:00:00"
-    assert period.range.to_time == "1998-12-31T23:59:59.999999"
+    assert period.range.from_time == datetime(1998, 1, 1, 0, 0, 0)
+    assert period.range.to_time == datetime(1998, 12, 31, 23, 59, 59, 999999)
 
 
 @pytest.mark.parametrize(
@@ -128,8 +130,8 @@ def test_ignores_008(marc_record: Record) -> None:
     assert lone_element(production.agents).label == "Mankind"
     period = lone_element(production.dates)
     assert period.range.label == "1998"
-    assert period.range.from_time == "1998-01-01T00:00:00"
-    assert period.range.to_time == "1998-12-31T23:59:59.999999"
+    assert period.range.from_time == datetime(1998, 1, 1, 0, 0, 0)
+    assert period.range.to_time == datetime(1998, 12, 31, 23, 59, 59, 999999)
 
 
 @pytest.mark.parametrize(
@@ -356,4 +358,4 @@ def test_populate_first_production_with_008_dates_if_none_of_its_own(
     assert lone_element(production.places).label == "New York"
     period = lone_element(production.dates)
     assert period.range.label == "1979"
-    assert period.range.from_time == "1979-01-01T00:00:00"
+    assert period.range.from_time == datetime(1979, 1, 1, 0, 0, 0)

--- a/catalogue_graph/tests/fixtures/ingestor/works/mock_es_inputs.json
+++ b/catalogue_graph/tests/fixtures/ingestor/works/mock_es_inputs.json
@@ -364,10 +364,10 @@
             "value": "e6606c3a-5404-4c5b-8337-3936d3d5f30b"
           },
           "version": 13,
-          "modifiedTime": "2025-06-30T16:20:14"
+          "modifiedTime": "2025-06-30T16:20:14Z"
         },
-        "mergedTime": "2025-08-19T19:23:53.532022",
-        "indexedTime": "2025-09-08T17:23:33.132490",
+        "mergedTime": "2025-08-19T19:23:53.532022Z",
+        "indexedTime": "2025-09-08T17:23:33.13249Z",
         "mergeCandidates": [
           {
             "id": {
@@ -992,10 +992,10 @@
             "value": "b15192982"
           },
           "version": 58,
-          "modifiedTime": "2025-07-17T13:07:35"
+          "modifiedTime": "2025-07-17T13:07:35Z"
         },
-        "mergedTime": "2025-08-19T18:10:40.041562",
-        "indexedTime": "2025-09-08T17:23:33.141933",
+        "mergedTime": "2025-08-19T18:10:40.041562Z",
+        "indexedTime": "2025-09-08T17:23:33.141933Z",
         "mergeCandidates": [
           {
             "id": {
@@ -1272,10 +1272,10 @@
             "value": "ebs13464940e"
           },
           "version": 20250904,
-          "modifiedTime": "2025-09-05T12:35:57.811942"
+          "modifiedTime": "2025-09-05T12:35:57.811942Z"
         },
-        "mergedTime": "2025-09-05T15:04:54.894994",
-        "indexedTime": "2025-09-08T17:23:33.142879",
+        "mergedTime": "2025-09-05T15:04:54.894994Z",
+        "indexedTime": "2025-09-08T17:23:33.142879Z",
         "mergeCandidates": [],
         "redirectSources": []
       }
@@ -1625,10 +1625,10 @@
             "value": "129b0826-3ac4-4aea-8b0c-490d5889df46"
           },
           "version": 7,
-          "modifiedTime": "2023-12-04T12:35:47"
+          "modifiedTime": "2023-12-04T12:35:47Z"
         },
-        "mergedTime": "2025-08-19T20:00:15.198906",
-        "indexedTime": "2025-09-08T17:23:33.143605",
+        "mergedTime": "2025-08-19T20:00:15.198906Z",
+        "indexedTime": "2025-09-08T17:23:33.143605Z",
         "mergeCandidates": [
           {
             "id": {
@@ -2014,10 +2014,10 @@
             "value": "b31012152"
           },
           "version": 13,
-          "modifiedTime": "2022-01-12T10:29:21"
+          "modifiedTime": "2022-01-12T10:29:21Z"
         },
-        "mergedTime": "2025-08-19T18:37:10.778558",
-        "indexedTime": "2025-09-08T17:23:33.144325",
+        "mergedTime": "2025-08-19T18:37:10.778558Z",
+        "indexedTime": "2025-09-08T17:23:33.144325Z",
         "mergeCandidates": [],
         "redirectSources": []
       }
@@ -2596,10 +2596,10 @@
             "value": "b16699178"
           },
           "version": 28,
-          "modifiedTime": "2024-07-03T16:07:56"
+          "modifiedTime": "2024-07-03T16:07:56Z"
         },
-        "mergedTime": "2025-08-19T21:17:47.025238",
-        "indexedTime": "2025-09-08T17:23:33.145771",
+        "mergedTime": "2025-08-19T21:17:47.025238Z",
+        "indexedTime": "2025-09-08T17:23:33.145771Z",
         "mergeCandidates": [],
         "redirectSources": []
       }
@@ -2973,10 +2973,10 @@
             "value": "b31244361"
           },
           "version": 19,
-          "modifiedTime": "2023-08-18T11:38:24"
+          "modifiedTime": "2023-08-18T11:38:24Z"
         },
-        "mergedTime": "2025-08-19T16:26:08.065319",
-        "indexedTime": "2025-09-08T17:23:33.147668",
+        "mergedTime": "2025-08-19T16:26:08.065319Z",
+        "indexedTime": "2025-09-08T17:23:33.147668Z",
         "mergeCandidates": [],
         "redirectSources": []
       }
@@ -3477,10 +3477,10 @@
             "value": "b21053613"
           },
           "version": 14,
-          "modifiedTime": "2023-08-18T15:49:59"
+          "modifiedTime": "2023-08-18T15:49:59Z"
         },
-        "mergedTime": "2025-08-19T18:37:19.909853",
-        "indexedTime": "2025-09-08T17:23:33.148976",
+        "mergedTime": "2025-08-19T18:37:19.909853Z",
+        "indexedTime": "2025-09-08T17:23:33.148976Z",
         "mergeCandidates": [],
         "redirectSources": [
           {
@@ -3799,10 +3799,10 @@
             "value": "bff9122c-212a-4dbe-89fe-f355a5185cca"
           },
           "version": 13,
-          "modifiedTime": "2025-07-31T10:24:39"
+          "modifiedTime": "2025-07-31T10:24:39Z"
         },
-        "mergedTime": "2025-08-19T19:29:45.995295",
-        "indexedTime": "2025-09-08T17:23:33.151936",
+        "mergedTime": "2025-08-19T19:29:45.995295Z",
+        "indexedTime": "2025-09-08T17:23:33.151936Z",
         "mergeCandidates": [
           {
             "id": {
@@ -4176,10 +4176,10 @@
             "value": "b30948988"
           },
           "version": 15,
-          "modifiedTime": "2022-01-12T10:28:08"
+          "modifiedTime": "2022-01-12T10:28:08Z"
         },
-        "mergedTime": "2025-08-19T20:22:07.952627",
-        "indexedTime": "2025-09-08T17:23:33.153066",
+        "mergedTime": "2025-08-19T20:22:07.952627Z",
+        "indexedTime": "2025-09-08T17:23:33.153066Z",
         "mergeCandidates": [],
         "redirectSources": []
       }

--- a/catalogue_graph/tests/fixtures/works/visible_maximal.json
+++ b/catalogue_graph/tests/fixtures/works/visible_maximal.json
@@ -123,7 +123,39 @@
     ],
     "physicalDescription": "Physical",
     "production": [
-      {"agents": [], "dates": [], "function": null, "label": "Production", "places": []}
+      {
+        "agents": [],
+        "dates": [
+          {
+            "id": {
+              "canonicalId": "canon14",
+              "otherIdentifiers": [
+                {
+                  "identifierType": {"id": "ID114"},
+                  "ontologyType": "catalogue",
+                  "value": "val114"
+                }
+              ],
+              "sourceIdentifier": {
+                "identifierType": {"id": "ID14"},
+                "ontologyType": "catalogue",
+                "value": "val14"
+              },
+              "type": "Identified"
+            },
+            "label": "Production Period",
+            "type": "Concept",
+            "range": {
+              "from": "2021-06-01T09:00:00Z",
+              "to": "2021-06-01T17:00:00Z",
+              "label": "One Day"
+            }
+          }
+        ],
+        "function": null,
+        "label": "Production",
+        "places": []
+      }
     ],
     "referenceNumber": "REF123",
     "subjects": [

--- a/catalogue_graph/tests/models/test_serialisable.py
+++ b/catalogue_graph/tests/models/test_serialisable.py
@@ -1,0 +1,58 @@
+from datetime import datetime, timedelta, timezone
+
+# src is added to PYTHONPATH via pytest config, so we import from package root under src
+from models.pipeline.serialisable import SerialisableModel
+
+
+class SampleModel(SerialisableModel):
+    created_at: datetime
+    some_value: int
+
+
+def _dump(model: SampleModel) -> str:
+    return model.model_dump_json()
+
+
+def test_datetime_without_microseconds_serialises_without_fraction() -> None:
+    dt = datetime(2025, 10, 23, 12, 34, 56)
+    m = SampleModel(created_at=dt, some_value=1)
+    assert '"createdAt":"2025-10-23T12:34:56Z"' in _dump(m)
+
+
+def test_datetime_with_full_microseconds_serialises_full_fraction() -> None:
+    dt = datetime(2025, 10, 23, 12, 34, 56, 123456)
+    m = SampleModel(created_at=dt, some_value=1)
+    assert '"createdAt":"2025-10-23T12:34:56.123456Z"' in _dump(m)
+
+
+def test_datetime_with_trailing_zero_microseconds_trims_fraction() -> None:
+    dt = datetime(2025, 10, 23, 12, 34, 56, 123000)
+    m = SampleModel(created_at=dt, some_value=1)
+    assert '"createdAt":"2025-10-23T12:34:56.123Z"' in _dump(m)
+
+
+def test_datetime_with_many_trailing_zeros_trims_all() -> None:
+    dt = datetime(2025, 10, 23, 12, 34, 56, 120000)  # 120000 -> "12"
+    m = SampleModel(created_at=dt, some_value=1)
+    assert '"createdAt":"2025-10-23T12:34:56.12Z"' in _dump(m)
+
+
+def test_timezone_aware_datetime_converted_to_utc() -> None:
+    # 13:34:56+01:00 should become 12:34:56Z
+    tz_dt = datetime(
+        2025, 10, 23, 13, 34, 56, 654321, tzinfo=timezone(timedelta(hours=1))
+    )
+    m = SampleModel(created_at=tz_dt, some_value=1)
+    assert '"createdAt":"2025-10-23T12:34:56.654321Z"' in _dump(m)
+
+
+def test_alias_inbound_and_outbound_serialisation() -> None:
+    # Provide snake_case inbound, ensure outbound serialises camelCase keys
+    dt = datetime(2025, 10, 23, 12, 0, 0)
+    m = SampleModel(created_at=dt, some_value=42)
+    dumped = _dump(m)
+    assert '"createdAt":"2025-10-23T12:00:00Z"' in dumped
+    assert '"someValue":42' in dumped
+    # model fields accessible via snake_case
+    assert m.created_at == dt
+    assert m.some_value == 42


### PR DESCRIPTION
## What does this change?

This change improves date handling in the EBSCO adapter and catalogue graph by:

- Changing `DateTimeRange.from_time` and `to_time` fields from strings to `datetime` objects in the `Concept` model
- Updating the `start_of_year` and `end_of_year` functions in the EBSCO period parser to return `datetime` objects instead of ISO strings
- Simplifying date parsing in the work aggregate and query transformers by directly accessing `datetime` attributes instead of regex parsing
- Adding custom datetime serialization to the `ElasticsearchModel` base class to output ISO 8601 format with 'Z' suffix for UTC
- Updating tests and fixtures to reflect the new datetime handling and serialization format

These changes ensure consistent datetime object usage throughout the pipeline, eliminate string parsing overhead, and provide proper UTC serialization for Elasticsearch.

This work is part of: https://github.com/wellcomecollection/platform/issues/6150

## How to test

- Run the EBSCO adapter tests: `uv run pytest -q ebsco_adapter/ebsco_adapter_iceberg/tests`
- Run the catalogue graph tests: `uv run pytest catalogue_graph/tests/models/test_serialisable.py` and `uv run pytest catalogue_graph/tests/models/test_work_serialisation.py`
- Verify that date fields in production events are correctly serialized as datetime objects with 'Z' suffix in JSON output

## How can we measure success?

- All tests pass without errors
- Date ranges in production events are properly deserialized and serialized as datetime objects
- JSON output includes datetime fields in ISO 8601 format with 'Z' suffix (e.g., "2025-10-23T12:34:56Z")
- No regressions in existing functionality

## Have we considered potential risks?

- **Serialization format change**: The switch to 'Z' suffix for UTC datetimes may affect downstream consumers expecting different formats. However, this aligns with ISO 8601 standards and improves consistency and seems to match what we have now.
- **Datetime object handling**: Using datetime objects instead of strings may introduce timezone-related issues if not handled properly. The custom serializer ensures UTC conversion for timezone-aware datetimes, which I believe is how the current pipeline deals with dates.
- **Performance impact**: Direct datetime attribute access should be more efficient than regex parsing, but this should be monitored in production.
- **Backward compatibility**: Existing code expecting string dates may need updates, but the changes are internal to the pipeline models.