### PR TITLE
Don't handle dates (yet)

### DIFF
--- a/catalogue_graph/src/adapters/ebsco/transformers/parsers/period.py
+++ b/catalogue_graph/src/adapters/ebsco/transformers/parsers/period.py
@@ -190,10 +190,10 @@ def fill_year_prefix(from_year: str, to_year: str) -> str:
 
 
 def start_of_year(year: str) -> str:
-    return (datetime(int(year), 1, 1) if year else datetime.min).isoformat()
+    return (datetime(int(year), 1, 1) if year else datetime.min).isoformat() + "Z"
 
 
 def end_of_year(year: str) -> str:
     return (
         datetime(int(year), 12, 31, 23, 59, 59, 1000000 - 1) if year else datetime.max
-    ).isoformat()
+    ).isoformat() + "Z"

--- a/catalogue_graph/tests/adapters/ebsco/transformers/test_production.py
+++ b/catalogue_graph/tests/adapters/ebsco/transformers/test_production.py
@@ -57,8 +57,8 @@ def test_fall_back_to_008(marc_record: Record) -> None:
     assert lone_element(production.places).label == "Australian Capital Territory"
     period = lone_element(production.dates)
     assert period.range.label == "1979-1995"
-    assert period.range.from_time == "1979-01-01T00:00:00"
-    assert period.range.to_time == "1995-12-31T23:59:59.999999"
+    assert period.range.from_time == "1979-01-01T00:00:00Z"
+    assert period.range.to_time == "1995-12-31T23:59:59.999999Z"
 
 
 @pytest.mark.parametrize(
@@ -89,8 +89,8 @@ def test_production_from_abc(marc_record: Record) -> None:
     assert lone_element(production.agents).label == "Mankind"
     period = lone_element(production.dates)
     assert period.range.label == "1998"
-    assert period.range.from_time == "1998-01-01T00:00:00"
-    assert period.range.to_time == "1998-12-31T23:59:59.999999"
+    assert period.range.from_time == "1998-01-01T00:00:00Z"
+    assert period.range.to_time == "1998-12-31T23:59:59.999999Z"
 
 
 @pytest.mark.parametrize(
@@ -128,8 +128,8 @@ def test_ignores_008(marc_record: Record) -> None:
     assert lone_element(production.agents).label == "Mankind"
     period = lone_element(production.dates)
     assert period.range.label == "1998"
-    assert period.range.from_time == "1998-01-01T00:00:00"
-    assert period.range.to_time == "1998-12-31T23:59:59.999999"
+    assert period.range.from_time == "1998-01-01T00:00:00Z"
+    assert period.range.to_time == "1998-12-31T23:59:59.999999Z"
 
 
 @pytest.mark.parametrize(
@@ -356,4 +356,4 @@ def test_populate_first_production_with_008_dates_if_none_of_its_own(
     assert lone_element(production.places).label == "New York"
     period = lone_element(production.dates)
     assert period.range.label == "1979"
-    assert period.range.from_time == "1979-01-01T00:00:00"
+    assert period.range.from_time == "1979-01-01T00:00:00Z"


### PR DESCRIPTION
## What does this change?

Alternative to https://github.com/wellcomecollection/catalogue-pipeline/pull/3054 for (not) dealing with dates yet.

## How to test

- [ ] Run the tests, do they pass?
- [ ] Does this work in a pipeline reindex run (can the Scala id_minter deal with it?)

## How can we measure success?

Clean run of the id_minter for an EBSCO reindex using the new transformer.

## Have we considered potential risks?

Not in production use yet, very small change.
