### PR TITLE
LoC extractor bug fix

### DIFF
--- a/catalogue_graph/src/transformers/loc/raw_concept.py
+++ b/catalogue_graph/src/transformers/loc/raw_concept.py
@@ -95,7 +95,9 @@ class RawLibraryOfCongressConcept:
         alternative_labels = []
         for n in self.raw_concept.get("@graph", []):
             if n["@id"] in raw_alternative_identifiers:
-                alternative_labels.append(self._extract_value(n["madsrdf:variantLabel"]))
+                alternative_labels.append(
+                    self._extract_value(n["madsrdf:variantLabel"])
+                )
 
         return alternative_labels
 


### PR DESCRIPTION
## What does this change?

Change how we extract alternative labels of LoC source concepts to prevent the pipeline from failing due to some entries in the `@graph` dictionary not having a `@type` property.

## How to test

Run the pipeline locally.

## How can we measure success?

The LoC nodes extractor runs successfully.

## Have we considered potential risks?

Risks are minimal.
