### PR TITLE
Update catalogue-graph local deploy instructions

### DIFF
--- a/catalogue_graph/README.md
+++ b/catalogue_graph/README.md
@@ -180,19 +180,38 @@ apply).
 For ad‑hoc (non‑CI) deployment of the shared Lambda image:
 
 ```shell
-# From ./catalogue_graph/
+# Ensure you are logged into AWS
+aws sso login
+
+# Docker login ECR public (to pull base images)
+aws ecr-public get-login-password \
+--region us-east-1 \
+--profile platform-developer | docker login \
+--username AWS \
+--password-stdin public.ecr.aws
+
+# Docker login ECR private (to push built image)
+aws ecr get-login-password \
+--profile platform-developer | docker login \
+--username AWS \
+--password-stdin 760097843905.dkr.ecr.eu-west-1.amazonaws.com
+
+# From ./catalogue_graph/ build and tag the image
 docker buildx build --platform linux/amd64 \
 --provenance=false \
 -t 760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/unified_pipeline_lambda:dev \
 --build-arg PYTHON_IMAGE_VERSION=$(cat .python-version) \
 -f lambda.Dockerfile .
 
+# Push the built image to ECR
 docker push 760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/unified_pipeline_lambda:dev
 
-# (Optional) apply infrastructure changes
-cd terraform
-terraform plan
-terraform apply
+# Update a particular Lambda function to use the new image
+aws lambda update-function-code \
+--function-name catalogue-2025-10-02-my_lambda_name \
+--image-uri 760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/unified_pipeline_lambda:dev \
+--profile platform-developer \
+--publish
 ```
 
 Extractor ECS image (separate service) can be built/pushed similarly using the `extractor` target.


### PR DESCRIPTION
## What does this change?

Updates instructions for building and deploying the unified pipeline lambda image locally.