### PR TITLE
Fix LicensedResources python transform

### DIFF
--- a/catalogue_graph/src/models/pipeline/access_condition.py
+++ b/catalogue_graph/src/models/pipeline/access_condition.py
@@ -25,7 +25,7 @@ Resource = AccessStatusRelationship(type="Resource")
 
 
 class AccessStatus(Type):
-    relationship: AccessStatusRelationship
+    relationship: AccessStatusRelationship | None = None
 
 
 LicensedResource = AccessStatus(type="LicensedResources", relationship=Resource)
@@ -33,6 +33,6 @@ LicensedResource = AccessStatus(type="LicensedResources", relationship=Resource)
 
 class AccessCondition(SerialisableModel):
     method: Type
-    status: Type | None = None
+    status: AccessStatus | None = None
     terms: str | None = None
     note: str | None = None

--- a/catalogue_graph/tests/fixtures/work/visible_source_maximal.json
+++ b/catalogue_graph/tests/fixtures/work/visible_source_maximal.json
@@ -125,6 +125,47 @@
     "notes": [
       {"contents": "Note contents", "noteType": {"id": "note", "label": "Note"}}
     ],
+    "formerFrequency": ["Weekly"],
+    "holdings": [
+      {
+        "enumeration": [
+          "Vol1"
+        ],
+        "location": null,
+        "note": "Holdings note"
+      },
+      {
+        "enumeration": [
+          "Vol2"
+        ],
+        "location": {
+          "accessConditions": [
+            {
+              "method": {
+                "type": "ViewOnline"
+              },
+              "note": null,
+              "status": {
+                "relationship": {
+                  "type": "Resource"
+                },
+                "type": "LicensedResources"
+              },
+              "terms": null
+            }
+          ],
+          "credit": null,
+          "license": null,
+          "linkText": null,
+          "locationType": {
+            "id": "online-resource"
+          },
+          "type": "DigitalLocation",
+          "url": "https://example.org/licensed"
+        },
+        "note": "Holdings with digital location"
+      }
+    ],
     "duration": 123,
     "items": [
       {
@@ -148,9 +189,6 @@
         "note": "Item Note",
         "title": "Item Title"
       }
-    ],
-    "holdings": [
-      {"enumeration": ["Vol1"], "location": null, "note": "Holdings note"}
     ],
     "collectionPath": {"label": "Collection", "path": "A/B/C"},
     "referenceNumber": "REF123",
@@ -178,7 +216,6 @@
     ],
     "workType": "Standard",
     "currentFrequency": "Monthly",
-    "formerFrequency": ["Weekly"],
     "designation": ["Designation1"]
   },
   "state": {

--- a/catalogue_graph/tests/models/test_work_serialisation.py
+++ b/catalogue_graph/tests/models/test_work_serialisation.py
@@ -9,6 +9,11 @@ from pydantic.alias_generators import to_camel
 
 from ingestor.models.shared.deleted_reason import DeletedReason
 from ingestor.models.shared.invisible_reason import InvisibleReason
+from models.pipeline.access_condition import (
+    AccessCondition,
+    LicensedResource,
+    ViewOnline,
+)
 from models.pipeline.collection_path import CollectionPath
 from models.pipeline.concept import Concept, Contributor, Genre, Subject
 from models.pipeline.holdings import Holdings
@@ -76,6 +81,17 @@ def maximal_work_data() -> WorkData:
         id=example_identified(12), title="Item Title", note="Item Note", locations=[]
     )
     holdings_min = Holdings(note="Holdings note", enumeration=["Vol1"], location=None)
+    access_condition = AccessCondition(method=ViewOnline, status=LicensedResource)
+    digital_location_with_license = DigitalLocation(
+        location_type=OnlineResource,
+        access_conditions=[access_condition],
+        url="https://example.org/licensed",
+    )
+    holdings_with_digital_location = Holdings(
+        note="Holdings with digital location",
+        enumeration=["Vol2"],
+        location=digital_location_with_license,
+    )
     image_data_min = ImageData(id=example_identified(13), version=1, locations=[])
 
     return WorkData(
@@ -97,7 +113,7 @@ def maximal_work_data() -> WorkData:
         notes=[note_min],
         duration=123,
         items=[item_min],
-        holdings=[holdings_min],
+        holdings=[holdings_min, holdings_with_digital_location],
         collection_path=CollectionPath(path="A/B/C", label="Collection"),
         reference_number="REF123",
         image_data=[image_data_min],


### PR DESCRIPTION
## What does this change?

This change updates the `AccessCondition` and `AccessStatus` models in the pipeline to properly support licensed resources with type information. Specifically:

- Makes the `relationship` field in `AccessStatus` optional
- Changes the `status` field in `AccessCondition` from `Type | None` to `AccessStatus | None`
- Updates test fixtures and serialization tests to include examples of licensed resource access conditions

Resolves https://github.com/wellcomecollection/platform/issues/6167.

## How to test

- Run the pipeline model tests: `pytest catalogue_graph/tests/models/test_work_serialisation.py`
- Execute the EBSCO adapter notebook to verify access condition transformation works correctly
- Run a reindex to see this error removed from transformed data.

## How can we measure success?

- All tests pass, including the updated serialization tests
- The model correctly handles licensed resource access conditions with proper type information
- No regressions in existing work data processing

## Have we considered potential risks?

Should be minimal, code is not in production yet - this change brings parity with existing Scala transform.