### PR TITLE
Manifest multiple mergers

### DIFF
--- a/pipeline/terraform/2025-10-02/main.tf
+++ b/pipeline/terraform/2025-10-02/main.tf
@@ -35,8 +35,13 @@ module "pipeline" {
       concepts = {}
     }
     "2025-10-09" = {
-      works    = { indexed = "works_indexed.2024-11-14" }
-      images   = {}
+      works    = { 
+        indexed = "works_indexed.2024-11-14" 
+        denormalised = "works_denormalised.2025-08-14"
+      }
+      images   = {
+        initial = "empty"
+      }
       concepts = { indexed = "concepts_indexed.2025-06-17" }
     }
   }

--- a/pipeline/terraform/modules/pipeline/merger/data.tf
+++ b/pipeline/terraform/modules/pipeline/merger/data.tf
@@ -1,0 +1,23 @@
+locals {
+  namespace_suffix = var.index_date != null ? "-${var.index_date}" : ""
+  namespace = "catalogue-${var.pipeline_date}${local.namespace_suffix}"
+
+  es_upstream_config = {
+      es_upstream_host     = var.es_config.es_host
+      es_upstream_port     = var.es_config.es_port
+      es_upstream_protocol = var.es_config.es_protocol
+      es_upstream_apikey   = var.es_config.es_apikey
+  }
+  es_downstream_config = {
+      es_downstream_host     = var.es_config.es_host
+      es_downstream_port     = var.es_config.es_port
+      es_downstream_protocol = var.es_config.es_protocol
+      es_downstream_apikey   = var.es_config.es_apikey
+  }
+
+  index_date = var.index_date != null ? var.index_date : var.pipeline_date
+
+  es_works_identified_index   = var.es_index_config.es_works_identified_index != null ? var.es_index_config.es_works_identified_index : "works-identified-${local.index_date}"
+  es_works_denormalised_index = var.es_index_config.es_works_denormalised_index != null ? var.es_index_config.es_works_denormalised_index : "works-denormalised-${local.index_date}"
+  es_images_initial_index     = var.es_index_config.es_images_initial_index != null ? var.es_index_config.es_images_initial_index : "images-initial-${local.index_date}"
+}

--- a/pipeline/terraform/modules/pipeline/merger/main.tf
+++ b/pipeline/terraform/modules/pipeline/merger/main.tf
@@ -1,0 +1,55 @@
+module "merger_works_output_topic" {
+  source = "../../topic"
+
+  name       = "${local.namespace}_merger_works_output"
+  role_names = [module.merger_lambda.lambda_role_name]
+}
+
+module "merger_works_path_output_topic" {
+  source = "../../topic"
+
+  name       = "${local.namespace}_merger_works_with_path_output"
+  role_names = [module.merger_lambda.lambda_role_name]
+}
+
+module "merger_works_incomplete_path_output_topic" {
+  source = "../../topic"
+
+  name       = "${local.namespace}_merger_works_incomplete_path_output"
+  role_names = [module.merger_lambda.lambda_role_name]
+}
+
+module "merger_images_output_topic" {
+  source = "../../topic"
+
+  name       = "${local.namespace}_merger_images_output"
+  role_names = [module.merger_lambda.lambda_role_name]
+}
+
+module "merger_lambda" {
+  source = "../../pipeline_lambda"
+
+  service_name  = "merger${local.namespace_suffix}"
+  pipeline_date = var.pipeline_date
+  vpc_config    = var.vpc_config
+
+  environment_variables = {
+    merger_works_topic_arn             = module.merger_works_output_topic.arn
+    merger_paths_topic_arn             = module.merger_works_path_output_topic.arn
+    merger_path_concatenator_topic_arn = module.merger_works_incomplete_path_output_topic.arn
+    merger_images_topic_arn            = module.merger_images_output_topic.arn
+
+    es_identified_works_index   = local.es_works_identified_index
+    es_denormalised_works_index = local.es_works_denormalised_index
+    es_initial_images_index     = local.es_images_initial_index
+  }
+
+  secret_env_vars = merge(
+    local.es_upstream_config, 
+    local.es_downstream_config
+  )
+
+  ecr_repository_name = "uk.ac.wellcome/merger"
+
+  queue_config = var.queue_config
+}

--- a/pipeline/terraform/modules/pipeline/merger/outputs.tf
+++ b/pipeline/terraform/modules/pipeline/merger/outputs.tf
@@ -1,0 +1,19 @@
+output "works_output_topic_arn" {
+  description = "The ARN of the merger works output topic"
+  value       = module.merger_works_output_topic.arn
+}
+
+output "works_path_output_topic_arn" {
+  description = "The ARN of the merger works with path output topic"
+  value       = module.merger_works_path_output_topic.arn
+}
+
+output "works_incomplete_path_output_topic_arn" {
+  description = "The ARN of the merger works incomplete path output topic"
+  value       = module.merger_works_incomplete_path_output_topic.arn
+}
+
+output "images_output_topic_arn" {
+  description = "The ARN of the merger images output topic"
+  value       = module.merger_images_output_topic.arn
+}

--- a/pipeline/terraform/modules/pipeline/merger/variables.tf
+++ b/pipeline/terraform/modules/pipeline/merger/variables.tf
@@ -1,0 +1,54 @@
+variable "pipeline_date" {
+  type = string
+}
+
+variable "index_date" {
+  type = string
+  default = null
+}
+
+variable "vpc_config" {
+  type = object({
+    subnet_ids         = list(string)
+    security_group_ids = list(string)
+  })
+}
+
+variable "es_config" {
+  type = object({
+    es_host     = string
+    es_port     = string
+    es_protocol = string
+    es_apikey   = string
+  })
+}
+
+variable "es_index_config" {
+  type = object({
+    es_works_identified_index = optional(string, null)
+    es_works_denormalised_index = optional(string, null)
+    es_images_initial_index = optional(string, null)
+  })
+  default = {}
+}
+
+variable "queue_config" {
+  type = object({
+    name       = optional(string, null)
+    topic_arns = optional(list(string), [])
+    // Note this must be greater than or equal to the lambda timeout
+    visibility_timeout_seconds = optional(number, 30)
+    // 4 days, to allow message retention if something goes wrong over a weekend
+    message_retention_seconds = optional(number, 345600)
+    max_receive_count         = optional(number, 4)
+    dlq_alarm_arn             = optional(string, null)
+
+    # Batching configuration
+    batch_size              = optional(number, 1)
+    batching_window_seconds = optional(number, null)
+
+    # Scaling configuration
+    maximum_concurrency = optional(number, 2)
+  })
+  default = null
+}

--- a/pipeline/terraform/modules/pipeline/service_image_inferrer.tf
+++ b/pipeline/terraform/modules/pipeline/service_image_inferrer.tf
@@ -44,7 +44,7 @@ module "image_inferrer" {
   name = "image_inferrer"
 
   topic_arns = [
-    module.merger_images_output_topic.arn,
+    module.merger.images_output_topic_arn,
   ]
 
   queue_visibility_timeout_seconds = local.queue_visibility_timeout

--- a/pipeline/terraform/modules/pipeline/service_ingestor_works.tf
+++ b/pipeline/terraform/modules/pipeline/service_ingestor_works.tf
@@ -32,7 +32,7 @@ module "ingestor_works" {
   container_image = local.ingestor_works_image
 
   topic_arns = [
-    module.merger_works_output_topic.arn,
+    module.merger.works_output_topic_arn,
     module.relation_embedder_sub.relation_embedder_output_topic_arn
   ]
 

--- a/pipeline/terraform/modules/pipeline/service_merger.tf
+++ b/pipeline/terraform/modules/pipeline/service_merger.tf
@@ -1,73 +1,11 @@
-module "merger_works_output_topic" {
-  source = "../topic"
-
-  name       = "${local.namespace}_merger_works_output"
-  role_names = [module.merger_lambda.lambda_role_name]
-}
-
-module "merger_works_path_output_topic" {
-  source = "../topic"
-
-  name       = "${local.namespace}_merger_works_with_path_output"
-  role_names = [module.merger_lambda.lambda_role_name]
-}
-
-module "merger_works_incomplete_path_output_topic" {
-  source = "../topic"
-
-  name       = "${local.namespace}_merger_works_incomplete_path_output"
-  role_names = [module.merger_lambda.lambda_role_name]
-}
-
-module "merger_images_output_topic" {
-  source = "../topic"
-
-  name       = "${local.namespace}_merger_images_output"
-  role_names = [module.merger_lambda.lambda_role_name]
-}
-
-module "merger_lambda" {
-  source = "../pipeline_lambda"
-
-  pipeline_date = var.pipeline_date
-
-  service_name = "merger"
-
-  vpc_config = {
+locals {
+  service_vpc_config = {
     subnet_ids = local.network_config.subnets
     security_group_ids = [
       aws_security_group.egress.id,
       local.network_config.ec_privatelink_security_group_id,
     ]
   }
-
-  environment_variables = {
-    merger_works_topic_arn             = module.merger_works_output_topic.arn
-    merger_paths_topic_arn             = module.merger_works_path_output_topic.arn
-    merger_path_concatenator_topic_arn = module.merger_works_incomplete_path_output_topic.arn
-    merger_images_topic_arn            = module.merger_images_output_topic.arn
-
-    es_identified_works_index   = local.es_works_identified_index
-    es_denormalised_works_index = local.es_works_denormalised_index
-    es_initial_images_index     = local.es_images_initial_index
-
-  }
-  secret_env_vars = merge(
-    module.elastic.pipeline_storage_es_service_secrets["merger"], // old config, to be removed
-    {
-      es_upstream_host     = module.elastic.pipeline_storage_private_host
-      es_upstream_port     = module.elastic.pipeline_storage_port
-      es_upstream_protocol = module.elastic.pipeline_storage_protocol
-      es_upstream_apikey   = module.elastic.pipeline_storage_es_service_secrets["merger"]["es_apikey"]
-
-      es_downstream_host     = module.elastic.pipeline_storage_private_host
-      es_downstream_port     = module.elastic.pipeline_storage_port
-      es_downstream_protocol = module.elastic.pipeline_storage_protocol
-      es_downstream_apikey   = module.elastic.pipeline_storage_es_service_secrets["merger"]["es_apikey"]
-    }
-  )
-
-  ecr_repository_name = "uk.ac.wellcome/merger"
   queue_config = {
     visibility_timeout_seconds = local.queue_visibility_timeout_seconds
     max_receive_count          = local.max_receive_count
@@ -76,5 +14,36 @@ module "merger_lambda" {
     topic_arns = [
       module.matcher_output_topic.arn,
     ]
+  }
+
+  es_config = {
+    es_host     = module.elastic.pipeline_storage_private_host
+    es_port     = module.elastic.pipeline_storage_port
+    es_protocol = module.elastic.pipeline_storage_protocol
+    es_apikey   = module.elastic.pipeline_storage_es_service_secrets["merger"]["es_apikey"]
+  }
+}
+
+module "merger" {
+  source = "./merger"
+
+  pipeline_date = var.pipeline_date
+  vpc_config    = local.service_vpc_config
+  queue_config  = local.queue_config
+  es_config     = local.es_config
+}
+
+module "merger_delta" {
+  source = "./merger"
+
+  pipeline_date = var.pipeline_date
+  index_date = "2025-10-09"
+
+  vpc_config   = local.service_vpc_config
+  queue_config = local.queue_config
+  es_config    = local.es_config
+
+  es_index_config = {
+    es_works_identified_index = local.es_works_identified_index
   }
 }

--- a/pipeline/terraform/modules/pipeline/subsystem_relation_embedder.tf
+++ b/pipeline/terraform/modules/pipeline/subsystem_relation_embedder.tf
@@ -10,10 +10,10 @@ module "relation_embedder_sub" {
 
   # path_concatenator
   path_concatenator_image           = local.path_concatenator_image
-  path_concatenator_input_topic_arn = module.merger_works_incomplete_path_output_topic.arn
+  path_concatenator_input_topic_arn = module.merger.works_incomplete_path_output_topic_arn
 
   # batcher
-  batcher_input_topic_arn = module.merger_works_path_output_topic.arn
+  batcher_input_topic_arn = module.merger.works_path_output_topic_arn
 
   # ecs services config
   min_capacity                = var.min_capacity


### PR DESCRIPTION
## What does this change?

This PR refactors the merger service infrastructure by extracting it into a reusable Terraform module. The changes include:

- Creating a new `merger` module under `pipeline/terraform/modules/pipeline/merger/` with dedicated `data.tf`, `main.tf`, `outputs.tf`, and `variables.tf` files.
- Refactoring `service_merger.tf` to use the new module and adding a `merger_delta` instance for the "2025-10-09" index date.
- Updating references in `service_image_inferrer.tf`, `service_ingestor_works.tf`, and `subsystem_relation_embedder.tf` to use the new module outputs.
- Minor updates to the pipeline configuration in `2025-10-02/main.tf` to include denormalised works and initial images for the "2025-10-09" date.
- A small formatting change in `ebsco_adapter.ipynb` notebook.

This resolves https://github.com/wellcomecollection/platform/issues/6185 and also modularizing the merger infrastructure for better maintainability and reusability.

## How to test

- Run Terraform plan and apply in the pipeline environment to ensure the new module deploys correctly.
- Verify that the merger Lambda functions are created and configured with the correct environment variables and topic ARNs.
- Test the pipeline end-to-end to confirm that works and images are processed through the merger service as expected.
- Check that the new `merger_delta` instance handles the specific index date configuration properly.

## How can we measure success?

- Terraform deployment succeeds without errors.
- All merger-related Lambda functions are operational and processing messages.
- No regressions in pipeline performance or data processing.
- The new module can be reused in future pipeline configurations without issues.

## Have we considered potential risks?

- **Module extraction risk**: The refactoring moves existing configuration into a module, which could introduce typos or misconfigurations. Thorough testing is required.
- **Topic ARN changes**: Updating references to use module outputs instead of direct module references could break if the outputs are incorrect. Double-check references.
- **Environment variable propagation**: Ensure that all necessary environment variables and secrets are correctly passed to the new module instances.
- **Index date handling**: The addition of `merger_delta` with a specific index date is a one off and will need removing for future new pipelines.