### PR TITLE
ignore production.function.type

### DIFF
--- a/scripts/es_index_comparison/configs/example_analysis.yaml
+++ b/scripts/es_index_comparison/configs/example_analysis.yaml
@@ -35,6 +35,7 @@ ignore_fields:
   - data.production[].dates[].range.to
   - data.production[].places[].type
   - data.subjects[].type
+  - data.production[].function.type
   # Number of differing documents to sample for console display
 sample_size: 10
 


### PR DESCRIPTION
## What does this change?
Adds another type value difference which  I think can be ignored

## How to test

`uv run es-index-compare run-all --config configs/example_analysis.yaml`

## How can we measure success?

Fewer reported discrepancies between the two indices

## Have we considered potential risks?
Maybe these ones are important.
