### PR TITLE
Allow graph services to write CloudWatch metrics

### DIFF
--- a/pipeline/terraform/modules/pipeline/graph/ecs_task_extractor.tf
+++ b/pipeline/terraform/modules/pipeline/graph/ecs_task_extractor.tf
@@ -29,6 +29,11 @@ resource "aws_iam_role_policy" "ecs_read_s3_policy" {
   policy = data.aws_iam_policy_document.s3_bulk_load_read.json
 }
 
+resource "aws_iam_role_policy" "graph_extractor_task_cloudwatch_write_policy" {
+  role   = module.extractor_ecs_task.task_role_name
+  policy = data.aws_iam_policy_document.cloudwatch_write.json
+}
+
 # openCypher queries will be streamed to this SNS topic (when SNS is chosen as the streaming destination)
 module "catalogue_graph_queries_topic" {
   source = "github.com/wellcomecollection/terraform-aws-sns-topic.git?ref=v1.0.0"

--- a/pipeline/terraform/modules/pipeline/graph/lambda_bulk_load_poller.tf
+++ b/pipeline/terraform/modules/pipeline/graph/lambda_bulk_load_poller.tf
@@ -47,3 +47,8 @@ resource "aws_iam_role_policy" "bulk_load_poller_s3_red" {
   policy = data.aws_iam_policy_document.s3_bulk_load_read.json
 }
 
+resource "aws_iam_role_policy" "bulk_load_poller_lambda_cloudwatch_write_policy" {
+  role   = module.bulk_load_poller_lambda.lambda_role_name
+  policy = data.aws_iam_policy_document.cloudwatch_write.json
+}
+

--- a/pipeline/terraform/modules/pipeline/graph/lambda_bulk_loader.tf
+++ b/pipeline/terraform/modules/pipeline/graph/lambda_bulk_loader.tf
@@ -44,3 +44,8 @@ resource "aws_iam_role_policy" "bulk_loader_lambda_neptune_policy" {
   role   = module.bulk_loader_lambda.lambda_role_name
   policy = data.aws_iam_policy_document.neptune_load_poll.json
 }
+
+resource "aws_iam_role_policy" "bulk_loader_lambda_cloudwatch_write_policy" {
+  role   = module.bulk_loader_lambda.lambda_role_name
+  policy = data.aws_iam_policy_document.cloudwatch_write.json
+}

--- a/pipeline/terraform/modules/pipeline/graph/lambda_ingestor_deletions.tf
+++ b/pipeline/terraform/modules/pipeline/graph/lambda_ingestor_deletions.tf
@@ -44,3 +44,8 @@ resource "aws_iam_role_policy" "ingestor_deletions_lambda_s3_policy" {
   role   = module.ingestor_deletions_lambda.lambda_role_name
   policy = data.aws_iam_policy_document.ingestor_deletions_s3_policy.json
 }
+
+resource "aws_iam_role_policy" "ingestor_deletions_lambda_cloudwatch_write_policy" {
+  role   = module.ingestor_deletions_lambda.lambda_role_name
+  policy = data.aws_iam_policy_document.cloudwatch_write.json
+}

--- a/pipeline/terraform/modules/pipeline/graph/lambda_pit_opener.tf
+++ b/pipeline/terraform/modules/pipeline/graph/lambda_pit_opener.tf
@@ -22,3 +22,8 @@ resource "aws_iam_role_policy" "pit_opener_lambda_read_pipeline_secrets_policy" 
   role   = module.elasticsearch_pit_opener_lambda.lambda_role_name
   policy = data.aws_iam_policy_document.allow_pipeline_storage_secret_read_denormalised_read_only.json
 }
+
+resource "aws_iam_role_policy" "pit_opener_lambda_cloudwatch_write_policy" {
+  role   = module.elasticsearch_pit_opener_lambda.lambda_role_name
+  policy = data.aws_iam_policy_document.cloudwatch_write.json
+}

--- a/pipeline/terraform/modules/pipeline/graph/lambda_remover.tf
+++ b/pipeline/terraform/modules/pipeline/graph/lambda_remover.tf
@@ -49,6 +49,11 @@ resource "aws_iam_role_policy" "graph_remover_lambda_s3_policy" {
   policy = data.aws_iam_policy_document.graph_remover_s3_policy.json
 }
 
+resource "aws_iam_role_policy" "graph_remover_lambda_cloudwatch_write_policy" {
+  role   = module.graph_remover_lambda.lambda_role_name
+  policy = data.aws_iam_policy_document.cloudwatch_write.json
+}
+
 data "aws_iam_policy_document" "graph_remover_s3_policy" {
   statement {
     actions = [

--- a/pipeline/terraform/modules/pipeline/graph/lambda_remover_incremental.tf
+++ b/pipeline/terraform/modules/pipeline/graph/lambda_remover_incremental.tf
@@ -61,3 +61,8 @@ resource "aws_iam_role_policy" "graph_remover_incremental_ecs_read_pipeline_secr
   role   = module.graph_remover_incremental_lambda.lambda_role_name
   policy = data.aws_iam_policy_document.allow_pipeline_storage_secret_read_denormalised_read_only.json
 }
+
+resource "aws_iam_role_policy" "graph_remover_incremental_lambda_cloudwatch_write_policy" {
+  role   = module.graph_remover_incremental_lambda.lambda_role_name
+  policy = data.aws_iam_policy_document.cloudwatch_write.json
+}


### PR DESCRIPTION
## What does this change?

Follows https://github.com/wellcomecollection/catalogue-pipeline/pull/3098

Adds CloudWatch write permissions to the IAM roles of the following graph pipeline services that were missed in the previous PR:

* Graph extractor ECS task
* Bulk loader Lambda
* Bulk load poller Lambda
* Full graph remover Lambda
* Incremental graph remover Lambda
* Ingestor deletions Lambda
* Ingestor PIT opener Lambda

These services now publish CloudWatch metrics as part of their pipeline reports (introduced in #3098), but didn't have the necessary IAM permissions to write those metrics.

## How to test

1. Deploy the changes
2. Run any of the affected services (e.g., bulk load poller, incremental graph remover, ingestor deletions)
3. Verify that metrics are successfully published to CloudWatch without IAM permission errors

## How can we measure success?

* All graph pipeline services can successfully publish their metrics to CloudWatch
* No IAM permission errors appear in CloudWatch Logs for these services
* Metrics appear in the `catalogue_graph_pipeline` CloudWatch namespace

## Have we considered potential risks?

This change only adds permissions to IAM roles, making the services more permissive. There are no breaking changes or removals of existing functionality.
