### PR TITLE
Metric bug fixes and improvements

### DIFF
--- a/catalogue_graph/src/utils/reporting.py
+++ b/catalogue_graph/src/utils/reporting.py
@@ -99,6 +99,9 @@ class BulkLoaderReport(GraphPipelineReport, BulkLoaderEvent):
         return [
             PipelineMetric(name="record_count", value=overall.total_records),
             PipelineMetric(name="duplicate_count", value=overall.total_duplicates),
+            PipelineMetric(
+                name="new_count", value=overall.total_records - overall.total_duplicates
+            ),
             PipelineMetric(name="parsing_error_count", value=overall.parsing_errors),
             PipelineMetric(
                 name="data_type_error_count", value=overall.datatype_mismatch_errors

--- a/catalogue_graph/tests/test_bulk_load_poller.py
+++ b/catalogue_graph/tests/test_bulk_load_poller.py
@@ -101,6 +101,7 @@ def test_bulk_load_succeeded() -> None:
     assert MockCloudwatchClient.metrics_reported == [
         _get_mock_metric("record_count", record_count),
         _get_mock_metric("duplicate_count", duplicate_count),
+        _get_mock_metric("new_count", record_count - duplicate_count),
         _get_mock_metric("parsing_error_count", 0),
         _get_mock_metric("data_type_error_count", 0),
         _get_mock_metric("insert_error_count", 0),
@@ -123,6 +124,7 @@ def test_bulk_load_failed() -> None:
     assert MockCloudwatchClient.metrics_reported == [
         _get_mock_metric("record_count", record_count),
         _get_mock_metric("duplicate_count", 0),
+        _get_mock_metric("new_count", record_count),
         _get_mock_metric("parsing_error_count", 0),
         _get_mock_metric("data_type_error_count", 0),
         _get_mock_metric("insert_error_count", insert_error_count),

--- a/pipeline/terraform/modules/pipeline/graph/ecs_task_extractor.tf
+++ b/pipeline/terraform/modules/pipeline/graph/ecs_task_extractor.tf
@@ -3,7 +3,7 @@ module "extractor_ecs_task" {
 
   task_name = "graph-extractor-${var.pipeline_date}"
 
-  image = "${data.aws_ecr_repository.unified_pipeline_task.repository_url}:dev"
+  image = "${data.aws_ecr_repository.unified_pipeline_task.repository_url}:env.${var.pipeline_date}"
 
   environment = {
     CATALOGUE_GRAPH_S3_BUCKET   = data.aws_s3_bucket.catalogue_graph_bucket.bucket

--- a/pipeline/terraform/modules/pipeline/graph/ecs_task_ingestor_indexer.tf
+++ b/pipeline/terraform/modules/pipeline/graph/ecs_task_ingestor_indexer.tf
@@ -3,7 +3,7 @@ module "ingestor_indexer_ecs_task" {
 
   task_name = "ingestor-indexer-${var.pipeline_date}"
 
-  image = "${data.aws_ecr_repository.unified_pipeline_task.repository_url}:dev"
+  image = "${data.aws_ecr_repository.unified_pipeline_task.repository_url}:env.${var.pipeline_date}"
 
   environment = {
     CATALOGUE_GRAPH_S3_BUCKET = data.aws_s3_bucket.catalogue_graph_bucket.bucket

--- a/pipeline/terraform/modules/pipeline/graph/ecs_task_ingestor_loader.tf
+++ b/pipeline/terraform/modules/pipeline/graph/ecs_task_ingestor_loader.tf
@@ -3,7 +3,7 @@ module "ingestor_loader_ecs_task" {
 
   task_name = "ingestor-loader-${var.pipeline_date}"
 
-  image = "${data.aws_ecr_repository.unified_pipeline_task.repository_url}:dev"
+  image = "${data.aws_ecr_repository.unified_pipeline_task.repository_url}:env.${var.pipeline_date}"
 
   environment = {
     CATALOGUE_GRAPH_S3_BUCKET = data.aws_s3_bucket.catalogue_graph_bucket.bucket


### PR DESCRIPTION
## What does this change?

* Publish a new graph bulk loader metric, recording how many new records were bulk loaded (as opposed to duplicate records, representing nodes/edges which already existed in the graph)
* Use ECR image tagged with the pipeline date in all ECS tasks
