### PR TITLE
Update reindexer for new state machine adapter trigger

### DIFF
--- a/reindexer/scripts/eventbridge.py
+++ b/reindexer/scripts/eventbridge.py
@@ -1,7 +1,9 @@
 import json
 
+EVENTBUS_NAME = "catalogue-pipeline-adapter-event-bus"
 EVENTBRIDGE_SOURCE = "weco.pipeline.reindex"
 EVENTBRIDGE_REINDEX_TARGETS = ["ebsco"]
+EVENT_REQUESTED_DETAIL_TYPE = "weco.pipeline.reindex.requested"
 
 
 def send_eventbridge_reindex_event(session, reindex_target):
@@ -19,8 +21,9 @@ def send_eventbridge_reindex_event(session, reindex_target):
         Entries=[
             {
                 "Source": EVENTBRIDGE_SOURCE,
-                "DetailType": "Reindex triggered by start_reindex.py",
-                "Detail": json.dumps({"ReindexTargets": [reindex_target]}),
+                "DetailType": EVENT_REQUESTED_DETAIL_TYPE,
+                "Detail": json.dumps({"reindex_targets": [reindex_target]}),
+                "EventBusName": EVENTBUS_NAME,
             }
         ]
     )


### PR DESCRIPTION
## What does this change?

Updates the `reindexer/scripts/eventbridge.py` script to use a specific EventBridge event bus (`catalogue-pipeline-adapter-event-bus`) and a standardized detail type (`weco.pipeline.reindex.requested`) for reindex events. Also changes the JSON key from `ReindexTargets` to `reindex_targets` for consistency.

This change is part of removing the old EBSCO Adapter and Transformer code, as outlined in the linked issue.

## How to test

- Run the reindex script and verify that events are published to the correct EventBridge bus.
- Check that downstream consumers (e.g., EBSCO indexer) receive the events with the expected detail type and payload structure.
- Ensure no errors occur in the event publishing process.

## How to measure success?

- Events are successfully sent to `catalogue-pipeline-adapter-event-bus`.
- The detail type matches `weco.pipeline.reindex.requested`.
- The payload uses `reindex_targets` (lowercase) instead of `ReindexTargets`.
- No breaking changes for existing reindex functionality.

## Have we considered potential risks?

- The event bus `catalogue-pipeline-adapter-event-bus` must exist in the target environment; if not, events will fail to publish.
- Downstream services must be updated to handle the new detail type and payload key if they haven't already.
- If the old detail type is still in use elsewhere, this could cause issues, but since this is part of removing old code, it should be coordinated.

Resolves https://github.com/wellcomecollection/platform/issues/6210