### PR TITLE
fix deprecation of aws_region.name

### DIFF
--- a/scripts/es_index_comparison/es_index_comparison/missing_images.py
+++ b/scripts/es_index_comparison/es_index_comparison/missing_images.py
@@ -1,4 +1,0 @@
-import os
-from es_index_comparison.es_index_comparison import build_client
-
-print(os.getenv("ES_API_KEY"))


### PR DESCRIPTION
## What does this change?

Updates the use of aws_region.name - it is now was_region.region

See: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region

## How to test

Run terraform plan.  It will no longer output this message:

> 
> │ Warning: Deprecated attribute
> │ 
> │   on ebsco/outputs.tf line 8, in output "state_machine_execution_url":
> │    8:   value       = "https://console.aws.amazon.com/states/home?region=${data.aws_region.current.name}#/statemachines/view/${aws_sfn_state_machine.state_machine.arn}"
> │ 
> │ The attribute "name" is deprecated. Refer to the provider documentation for details.


## How can we measure success?

When we next upgrade the was terraform provider, it won't suddenly start failing because this deprecated property has been removed.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? -->

