### PR TITLE
Remove ebsco_adapter publish step from pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -122,22 +122,6 @@ steps:
       - "common/window_generator"
       - "tei_adapter/tei_updater"
 
-  - label: "{{ matrix }} (Publish/Image)"
-    branches: "main"
-    plugins:
-      - wellcomecollection/aws-assume-role#v0.2.2:
-          role: "arn:aws:iam::760097843905:role/platform-ci"
-      - ecr#v2.5.0:
-          login: true
-      - docker-compose#v4.16.0:
-          config: "{{ matrix }}/docker-compose.yml"
-          cli-version: 2
-          push:
-            - publish:760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/ebsco_adapter:ref.${BUILDKITE_COMMIT}
-            - publish:760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/ebsco_adapter:latest
-    matrix:
-      - "ebsco_adapter/ebsco_adapter"
-
   - wait
 
   - label: trigger adapter deployments


### PR DESCRIPTION
This pull request removes the step responsible for publishing the Docker image for the `ebsco_adapter` in the Buildkite pipeline configuration. This means that the pipeline will no longer build and push the `ebsco_adapter` image to ECR as part of the CI/CD process.

Pipeline changes:

* Removed the "(Publish/Image)" step from `.buildkite/pipeline.yml`, which handled building and pushing the `ebsco_adapter` Docker image to the AWS ECR registry for the `main` branch.