### PR TITLE
Update rules for requesting 12/11/25

### DIFF
--- a/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala
+++ b/common/source_model/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequesting.scala
@@ -152,13 +152,23 @@ object SierraRulesForRequesting {
 
       // These cases cover the lines:
       //
-      //    q|i||108||=|u||
+      //    v|i||108||=|u||
       //    #ls Line above opacmsg = Unavailable for vs 27/08/24
+      //    q|i||108||=|b||
+      //    #ls Line above opacmsg = @digitisation for th 12/11/25
+      //    [note also that the 'q' element on the line above has been changed to 'v' ]
       case i
           if i
             .fixedField("108")
             .contains("u") =>
         NotRequestable.ItemUnavailable()
+      case i
+          if i
+            .fixedField("108")
+            .contains("b") =>
+        NotRequestable.AtDigitisation(
+          "At digitisation"
+        )
 
       // These cases cover the lines:
       //

--- a/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequestingTest.scala
+++ b/common/source_model/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraRulesForRequestingTest.scala
@@ -67,7 +67,9 @@ class SierraRulesForRequestingTest
     )
   }
 
-  it("blocks an item if fixed field 108 (status) is n,a,p or u") {
+  it(
+    "blocks an item if fixed field 108 (status) is n,a,p - manual request required"
+  ) {
     List("n", "a", "p").map {
       status =>
         val item = createSierraItemDataWith(
@@ -79,12 +81,28 @@ class SierraRulesForRequestingTest
           NotRequestable.NeedsManualRequest
         ]
     }
+  }
 
+  it(
+    "blocks an item if fixed field 108 (status) is u - unavailable"
+  ) {
     val item = createSierraItemDataWith(
       fixedFields = Map("108" -> FixedField(label = "STATUS", value = "u"))
     )
+    SierraRulesForRequesting(item) shouldBe a[
+      NotRequestable.ItemUnavailable
+    ]
+  }
 
-    SierraRulesForRequesting(item) shouldBe a[NotRequestable.ItemUnavailable]
+  it(
+    "blocks an item if fixed field 108 (status) is b - at digitisation"
+  ) {
+    val item = createSierraItemDataWith(
+      fixedFields = Map("108" -> FixedField(label = "STATUS", value = "b"))
+    )
+    SierraRulesForRequesting(item) shouldBe a[
+      NotRequestable.AtDigitisation
+    ]
   }
 
   it("does not block an item if fixed field 87 (loan rule) is zero") {
@@ -338,7 +356,7 @@ class SierraRulesForRequestingTest
       (
         "4",
         Requestable
-      ),
+      )
     )
 
     forAll(testCases) {


### PR DESCRIPTION
## What does this change?

Resolves https://github.com/wellcomecollection/platform/issues/6212

Adds the rule for
> q|i||108||=|b||
> #ls Line above opacmsg = https://github.com/digitisation for th 12/11/25

See also [similar changes](https://github.com/search?q=org%3Awellcomecollection+%22rules+for+requesting%22&type=pullrequests).

## How to test

SierraRulesForRequestingTest has been updated accordingly
LS should be able to confirm that the relevant records have the correct status when that value starts being used in December.
 
## How can we measure success?

Things marked this way for digitisation won't be requestable.

## Have we considered potential risks?

This is self contained - either it works as expected and requests are blocked, or it doesn't and they are not.
