### PR TITLE
Fix timezone comparison in MetricReporter

### DIFF
--- a/catalogue_graph/src/clients/metric_reporter.py
+++ b/catalogue_graph/src/clients/metric_reporter.py
@@ -19,7 +19,7 @@ class MetricReporter:
         dimensions = dimensions or {}
 
         # CloudWatch does not support sending metrics older than 2 weeks
-        two_weeks_ago = datetime.now() - timedelta(weeks=2)
+        two_weeks_ago = datetime.now(tz=timestamp.tzinfo) - timedelta(weeks=2)
         if two_weeks_ago > timestamp:
             print(
                 "Did not publish CloudWatch metrics. Provided timestamp is too far in the past."


### PR DESCRIPTION
## What does this change?

This fixes a bug following merge of https://github.com/wellcomecollection/catalogue-pipeline/pull/3125.

It ensures that if `timestamp` has an associated timezone, `two_weeks_ago` uses the same one to avoid the error "can't compare offset-naive and offset-aware datetimes".

## How to test

- [ ] Update manually in production, test the pipeline succeeds.

## How can we measure success?

Metrics are successfully published to CloudWatch without errors.

## Have we considered potential risks?

Low risk, standard datetime handling fix.