### PR TITLE
Align es index mappings with live index mappings

### DIFF
--- a/index_config/mappings.images_indexed.2024-11-14.json
+++ b/index_config/mappings.images_indexed.2024-11-14.json
@@ -163,13 +163,29 @@
           "type": "dense_vector",
           "dims": 4096,
           "index": true,
-          "similarity": "dot_product"
+          "similarity": "dot_product",
+          "index_options": {
+            "type": "bbq_hnsw",
+            "m": 16,
+            "ef_construction": 100,
+            "rescore_vector": {
+              "oversample": 3
+            }
+          }
         },
         "paletteEmbedding": {
           "type": "dense_vector",
           "dims": 1000,
           "index": true,
-          "similarity": "dot_product"
+          "similarity": "dot_product",
+          "index_options": {
+            "type": "bbq_hnsw",
+            "m": 16,
+            "ef_construction": 100,
+            "rescore_vector": {
+              "oversample": 3
+            }
+          }
         }
       }
     },

--- a/index_config/mappings.works_source.2025-10-02.json
+++ b/index_config/mappings.works_source.2025-10-02.json
@@ -1,4 +1,3 @@
-
 {
   "dynamic": "false",
   "properties": {
@@ -19,11 +18,15 @@
         "sourceIdentifier": {
           "dynamic": "false",
           "properties": {
-            "value": {
-              "type": "keyword",
-              "normalizer": "lowercase_normalizer"
+            "identifierType": {
+              "properties": {
+                "id": {
+                  "type": "keyword",
+                  "normalizer": "lowercase_normalizer"
+                }
+              }
             },
-            "identifierType.id": {
+            "value": {
               "type": "keyword",
               "normalizer": "lowercase_normalizer"
             }


### PR DESCRIPTION
## What does this change?

Reduces terraform churn by aligning ES mappings in the repo with how they look when applied in ES, previously they were different (although evaluated to the same).