### PR TITLE
Improve Axiell window gap notifications

### DIFF
--- a/catalogue_graph/src/adapters/utils/window_notifier.py
+++ b/catalogue_graph/src/adapters/utils/window_notifier.py
@@ -167,6 +167,7 @@ class WindowNotifier:
         reload_job_id = job_id or f"gap-reload-{first_gap.start.strftime('%Y%m%d')}"
 
         command = (
+            f"AWS_PROFILE=platform-developer \\\n"
             f"uv run python -m adapters.axiell.steps.reloader \\\n"
             f"  --job-id {reload_job_id} \\\n"
             f"  --window-start {window_start} \\\n"
@@ -177,6 +178,7 @@ class WindowNotifier:
         return [
             f"Run locally to reload gaps:\n```bash\n{command}\n```",
             "Add `--dry-run` flag to preview without processing",
+            "Add --window-minutes to adjust window size if needed",
         ]
 
     def _build_context(


### PR DESCRIPTION
## What does this change?

This PR improves the Axiell adapter trigger’s window gap notifications (sent via AWS Chatbot):

- Only reports **historical** coverage gaps (i.e. gaps *before* the next batch start time), so we don’t alert on gaps that are about to be processed anyway.
- Sends a more useful message with total gaps + total missing hours, plus context (table name, job ID, trigger timestamp).
- Limits the number of gaps shown (first 5) and groups messages into 6‑hour thread “buckets” to reduce spam.
- Adds actionable “next steps” instructions, including a ready-to-run reloader command.

It also enforces the lag circuit breaker **before** attempting to notify, to avoid repeated alerts when we’re already too far behind.

This PR is intentionally **stacked on** `rk/reloader-update` (PR #3166), because the suggested reloader command references `--window-minutes` added there.

## How to test

From `catalogue_graph/`:

- `uv run pytest -q tests/adapters/axiell/test_trigger.py`

(These tests cover when we notify / don’t notify, and ensure gaps between `last_success_end` and `now` aren’t reported.)

## How can we measure success?

- Trigger logs show the coverage report summary, and notifications are only sent for historical gaps.
- Slack/Teams notifications contain enough context to debug quickly, and threads reduce notification noise.

## Have we considered potential risks?

- **Under-reporting gaps:** We now avoid notifying for gaps between `last_success_end` and `now` because they should be handled by the next batch. If the batch fails repeatedly, those gaps may persist until a subsequent run. This is mitigated by existing lag enforcement and future notifications once gaps become “historical”.
- **Hidden detail:** We only display the first 5 gaps in the message to keep notifications readable; the totals still reflect all detected gaps.
