### PR TITLE
Use consistent merged index name resolution in pit_opener and merged_works_source

### DIFF
--- a/catalogue_graph/src/pit_opener.py
+++ b/catalogue_graph/src/pit_opener.py
@@ -1,17 +1,16 @@
 import argparse
 import typing
 
-import config
 from models.events import BasePipelineEvent
-from utils.elasticsearch import ElasticsearchMode, get_client, get_standard_index_name
+from utils.elasticsearch import ElasticsearchMode, get_client, get_merged_index_name
 
 
 def handler(event: BasePipelineEvent, es_mode: ElasticsearchMode = "private") -> dict:
     """Create a point in time (PIT) on the merged index and return its PIT ID."""
     es_client = get_client("graph_extractor", event.pipeline_date, es_mode)
-    index_name = get_standard_index_name(
-        config.ES_MERGED_INDEX_NAME, event.pipeline_date
-    )
+
+    index_name = get_merged_index_name(event)
+
     pit = es_client.open_point_in_time(index=index_name, keep_alive="15m")
 
     return {"pit_id": pit["id"]}

--- a/catalogue_graph/src/sources/merged_works_source.py
+++ b/catalogue_graph/src/sources/merged_works_source.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel
 import config
 from models.events import BasePipelineEvent, IncrementalWindow
 from sources.base_source import BaseSource
-from utils.elasticsearch import ElasticsearchMode, get_client, get_standard_index_name
+from utils.elasticsearch import ElasticsearchMode, get_client, get_merged_index_name
 
 ES_MGET_BATCH_SIZE = 10_000
 ES_REQUESTS_BACKOFF_RETRIES = int(os.environ.get("REQUESTS_BACKOFF_RETRIES", "3"))
@@ -59,10 +59,7 @@ class MergedWorksSource(BaseSource):
         self.fields = fields
         self.query = query
 
-        index_date = event.index_dates.merged or event.pipeline_date
-        self.index_name = get_standard_index_name(
-            config.ES_MERGED_INDEX_NAME, index_date
-        )
+        self.index_name = get_merged_index_name(event)
 
         # Use the provided point in time (PIT) ID, or create a new one
         if event.pit_id is not None:

--- a/catalogue_graph/src/utils/elasticsearch.py
+++ b/catalogue_graph/src/utils/elasticsearch.py
@@ -8,7 +8,9 @@ from config import (
     ES_LOCAL_HOST,
     ES_LOCAL_PORT,
     ES_LOCAL_SCHEME,
+    ES_MERGED_INDEX_NAME,
 )
+from models.events import BasePipelineEvent
 from utils.aws import get_secret
 
 # private: Connect to the production cluster via the private endpoint (production runs only)
@@ -22,6 +24,11 @@ def get_standard_index_name(prefix: str, date: str | None) -> str:
         return f"{prefix}-{date}"
 
     return prefix
+
+
+def get_merged_index_name(event: BasePipelineEvent) -> str:
+    index_date = event.index_dates.merged or event.pipeline_date
+    return get_standard_index_name(ES_MERGED_INDEX_NAME, index_date)
 
 
 class ElasticsearchConfig(BaseModel):

--- a/catalogue_graph/tests/utils/test_elasticsearch.py
+++ b/catalogue_graph/tests/utils/test_elasticsearch.py
@@ -1,0 +1,17 @@
+from models.events import BasePipelineEvent, PipelineIndexDates
+from utils.elasticsearch import get_merged_index_name
+
+
+def test_get_merged_index_name_uses_merged_date() -> None:
+    event = BasePipelineEvent(
+        pipeline_date="2023-01-01",
+        index_dates=PipelineIndexDates(merged="2023-02-02"),
+    )
+    assert get_merged_index_name(event) == "works-denormalised-2023-02-02"
+
+
+def test_get_merged_index_name_uses_pipeline_date_if_merged_date_missing() -> None:
+    event = BasePipelineEvent(
+        pipeline_date="2023-01-01", index_dates=PipelineIndexDates(merged=None)
+    )
+    assert get_merged_index_name(event) == "works-denormalised-2023-01-01"


### PR DESCRIPTION
## What does this change?

> [!Warning]
> https://github.com/wellcomecollection/catalogue-pipeline/pull/3172 must be merged first for this change to be safe.

This PR introduces a new helper function `get_merged_index_name` in `utils/elasticsearch.py` to centralise the logic for determining the merged index name. This function is now used in both `pit_opener.py` and `merged_works_source.py`.

Previously, `pit_opener.py` was only using `event.pipeline_date` to construct the index name, whereas `merged_works_source.py` was checking `event.index_dates.merged` first. This change ensures that `pit_opener.py` also respects `event.index_dates.merged` if it is present, aligning the behaviour across both components.

This is particularly useful for ensuring that the correct index is used when running locally vs in AWS, or when specific index dates are provided.

## How to test

- Run the newly added tests in `catalogue_graph/tests/utils/test_elasticsearch.py`:
  ```bash
  uv run pytest catalogue_graph/tests/utils/test_elasticsearch.py
  ```
- Verify that the existing tests pass:
  ```bash
  uv run pytest
  ```

## How can we measure success?

- Consistent index name resolution across the pipeline components.
- `pit_opener` correctly opens a PIT on the specified merged index date if provided.

## Have we considered potential risks?

- If `event.index_dates.merged` is set incorrectly, `pit_opener` might try to open a PIT on a non-existent index. However, this is the intended behaviour to allow flexibility.
