### PR TITLE
Switch merged index to 2025-10-02 and remove merger delta

### DIFF
--- a/pipeline/terraform/modules/pipeline/service_merger.tf
+++ b/pipeline/terraform/modules/pipeline/service_merger.tf
@@ -34,18 +34,3 @@ module "merger" {
   queue_config  = local.queue_config
   es_config     = local.es_config
 }
-
-module "merger_delta" {
-  source = "./merger"
-
-  pipeline_date = var.pipeline_date
-  index_date    = "2025-10-09"
-
-  vpc_config   = local.service_vpc_config
-  queue_config = local.queue_config
-  es_config    = local.es_config
-
-  es_index_config = {
-    es_works_identified_index = local.es_works_identified_index
-  }
-}

--- a/pipeline/terraform/modules/pipeline/subsystem_graph.tf
+++ b/pipeline/terraform/modules/pipeline/subsystem_graph.tf
@@ -3,7 +3,7 @@ module "graph_pipeline" {
 
   pipeline_date = var.pipeline_date
   index_dates = {
-    merged   = "2025-10-09"
+    merged   = "2025-10-02"
     works    = "2025-11-20"
     concepts = "2025-10-09"
   }


### PR DESCRIPTION
## What does this change?

This change removes the merger-delta, that is no longer being deployed to, and makes the merged index date explicit to be clear about which index we are using. We will keep the index in Elasticsearch for now in case we see any issues and need to use it.

See also https://github.com/wellcomecollection/catalogue-pipeline/pull/3171, this PR should be merged first.

## How to test

- [ ] Apply the terraform, check the 10-09 index is not removed.
- [ ] Ensure the incremental-pipeline run succeeds.

## How can we measure success?

Removing unused, surprising setup.

## Have we considered potential risks?

`10-09` is specified in the event date at present, but is not being used because the pit opened service defaults to `10-02` the pipeline date. #3171 makes the merged index use consistent, but must be merged after this PR to be safe.
