### PR TITLE
Update iceberg schema for adapters to include deleted field

### DIFF
--- a/catalogue_graph/src/adapters/utils/schemata.py
+++ b/catalogue_graph/src/adapters/utils/schemata.py
@@ -1,6 +1,6 @@
 import pyarrow as pa
 from pyiceberg.schema import Schema
-from pyiceberg.types import NestedField, StringType, TimestamptzType, BooleanType
+from pyiceberg.types import BooleanType, NestedField, StringType, TimestamptzType
 
 # namespace - e.g. ebsco - in case we decide to store everything in one table
 # last modified - different from changeset because this allows changeset to be meaningful.
@@ -23,7 +23,11 @@ SCHEMA = Schema(
     ),
     # Whether the record has been deleted.
     NestedField(
-        field_id=6, name="deleted", field_type=BooleanType(), required=False, default_value=False
+        field_id=6,
+        name="deleted",
+        field_type=BooleanType(),
+        required=False,
+        default_value=False,
     ),
 )
 

--- a/catalogue_graph/tests/adapters/ebsco/test_iceberg.py
+++ b/catalogue_graph/tests/adapters/ebsco/test_iceberg.py
@@ -320,6 +320,7 @@ def test_all_actions(temporary_table: IcebergTable) -> None:
             "content": "hello",
             "changeset": None,
             "last_modified": None,
+            "deleted": None,
             "namespace": "ebsco_test",
         }
     ]

--- a/catalogue_graph/tests/adapters/utils/test_adapter_store_snapshot_sync.py
+++ b/catalogue_graph/tests/adapters/utils/test_adapter_store_snapshot_sync.py
@@ -312,6 +312,7 @@ def test_snapshot_sync_all_actions(temporary_table: IcebergTable) -> None:
             "content": "hello",
             "changeset": None,
             "last_modified": None,
+            "deleted": None,
             "namespace": "test_namespace",
         }
     ]


### PR DESCRIPTION
## What does this change?

This is a schema change only to add a deletion field to the adapter store. Included in this change is a schema update to the production data store to accommodate upcoming changes to use the schema.

This change is required to uncouple adapter store identifiers directly from source identifiers used in works as we may want to extract these from a record body and not be tied to that supplied by the source.

The following change has been run first locally to test the change, then on the tables in AWS:

```
from pyiceberg.types import BooleanType 

with ebsco_adapter_table.update_schema() as update:
    update.add_column(path="deleted", field_type=BooleanType(), required=False, default_value=False)

with axiell_adapter_table.update_schema() as update:
    update.add_column(path="deleted", field_type=BooleanType(), required=False, default_value=False)
```

## How to test

- [x] Do the tables in Athena show up with the new schema?
- [x] Does the existing pipeline continue to work?

## How can we measure success?

We are able to move forward in development on https://github.com/wellcomecollection/platform/issues/6245 

## Have we considered potential risks?

Updating the production schema may break things running in production, mitigated by this schema change being "safe" in that it adds a new optional field so running services should be able to use their existing schema as a subset of what's applied to the tables.

