### PR TITLE
Use consistent adapter-store schema

### DIFF
--- a/catalogue_graph/src/adapters/axiell/record_writer.py
+++ b/catalogue_graph/src/adapters/axiell/record_writer.py
@@ -6,7 +6,7 @@ from lxml import etree
 from oai_pmh_client.models import Record
 
 from adapters.utils.adapter_store import AdapterStore
-from adapters.utils.schemata import ARROW_SCHEMA_WITH_TIMESTAMP
+from adapters.utils.schemata import ARROW_SCHEMA
 from adapters.utils.window_harvester import WindowCallbackResult
 
 
@@ -55,7 +55,7 @@ class WindowRecordWriter:
         updated_record_ids: list[str] | None = None
 
         if rows:
-            table = pa.Table.from_pylist(rows, schema=ARROW_SCHEMA_WITH_TIMESTAMP)
+            table = pa.Table.from_pylist(rows, schema=ARROW_SCHEMA)
             update = self.table_client.incremental_update(table)
             if update:
                 changeset_id = update.changeset_id

--- a/catalogue_graph/src/adapters/utils/schemata.py
+++ b/catalogue_graph/src/adapters/utils/schemata.py
@@ -31,22 +31,13 @@ SCHEMA = Schema(
     ),
 )
 
-# The Arrow schema corresponds to the "Real Data" as stored in iceberg, i.e. without
-# the metadata recording when it was changed.
-# This is used to compare new data with existing data in order to apply updates.
-ARROW_SCHEMA = pa.schema(
-    [
-        pa.field("namespace", type=pa.string(), nullable=False),
-        pa.field("id", type=pa.string(), nullable=False),
-        pa.field("content", type=pa.string(), nullable=True),
-    ]
-)
+# The Arrow schema matching the above Iceberg schema, needs to be kept in sync
+ARROW_FIELDS: list[pa.Field] = [
+    pa.field("namespace", type=pa.string(), nullable=False),
+    pa.field("id", type=pa.string(), nullable=False),
+    pa.field("content", type=pa.string(), nullable=True),
+    pa.field("last_modified", type=pa.timestamp("us", "UTC"), nullable=True),
+    pa.field("deleted", type=pa.bool_(), nullable=True),
+]
 
-# Extended Arrow schema that includes last_modified for comparison operations during incremental updates.
-# This allows us to compare timestamps to prevent overwriting newer records with older ones.
-ARROW_SCHEMA_WITH_TIMESTAMP = pa.schema(
-    list(ARROW_SCHEMA)
-    + [
-        pa.field("last_modified", type=pa.timestamp("us", "UTC"), nullable=True),
-    ]
-)
+ARROW_SCHEMA = pa.schema(ARROW_FIELDS)

--- a/catalogue_graph/tests/adapters/axiell/test_record_writer.py
+++ b/catalogue_graph/tests/adapters/axiell/test_record_writer.py
@@ -7,7 +7,7 @@ from oai_pmh_client.models import Header, Record
 
 from adapters.axiell.record_writer import WindowRecordWriter
 from adapters.utils.adapter_store import AdapterStore
-from adapters.utils.schemata import ARROW_SCHEMA_WITH_TIMESTAMP
+from adapters.utils.schemata import ARROW_SCHEMA
 
 
 def test_writes_records_to_store() -> None:
@@ -50,7 +50,7 @@ def test_writes_records_to_store() -> None:
     table = call_args[0][0]
 
     assert isinstance(table, pa.Table)
-    assert table.schema.equals(ARROW_SCHEMA_WITH_TIMESTAMP)
+    assert table.schema.equals(ARROW_SCHEMA)
     assert table.num_rows == 1
 
     row = table.to_pylist()[0]

--- a/catalogue_graph/tests/adapters/ebsco/helpers.py
+++ b/catalogue_graph/tests/adapters/ebsco/helpers.py
@@ -10,7 +10,7 @@ import pyarrow as pa
 
 from adapters.ebsco.marcxml_loader import MarcXmlFileLoader
 from adapters.ebsco.steps.loader import EBSCO_NAMESPACE
-from adapters.utils.schemata import ARROW_SCHEMA, ARROW_SCHEMA_WITH_TIMESTAMP
+from adapters.utils.schemata import ARROW_SCHEMA
 
 
 def lone_element(list_of_one: list) -> Any:
@@ -63,8 +63,7 @@ def data_to_namespaced_table(
         for row in rows:
             row.setdefault("last_modified", now)
 
-    schema = ARROW_SCHEMA_WITH_TIMESTAMP if add_timestamp else ARROW_SCHEMA
-    file_loader = MarcXmlFileLoader(schema=schema, namespace=namespace)
+    file_loader = MarcXmlFileLoader(schema=ARROW_SCHEMA, namespace=namespace)
 
     return file_loader.data_to_pa_table(rows)
 

--- a/catalogue_graph/tests/adapters/ebsco/test_iceberg.py
+++ b/catalogue_graph/tests/adapters/ebsco/test_iceberg.py
@@ -35,8 +35,9 @@ def test_noop(temporary_table: IcebergTable) -> None:
     # No Changeset identifier is returned
     assert changeset is None
     # The data is the same as before the update
+    expected_field_names = tuple(field.name for field in ARROW_SCHEMA)
     assert (
-        temporary_table.scan(selected_fields=("namespace", "id", "content"))
+        temporary_table.scan(selected_fields=expected_field_names)
         .to_arrow()
         .cast(ARROW_SCHEMA)
         .equals(data)
@@ -261,7 +262,7 @@ def test_delete_records(temporary_table: IcebergTable) -> None:
 def test_all_actions(temporary_table: IcebergTable) -> None:
     """
     Given an existing Iceberg table
-    And an update file with new, changed, absent and unchanged  records
+    And an update file with new, changed, absent and unchanged records
     When the update is applied
     Then all the appropriate actions are taken
     And all the new, changed and deleted rows are identifiably grouped by a changeset property

--- a/catalogue_graph/tests/adapters/ebsco/test_marcxml_loader.py
+++ b/catalogue_graph/tests/adapters/ebsco/test_marcxml_loader.py
@@ -133,6 +133,8 @@ def test_loads_one_record_into_pa_table(
                 </record>
                 """
             ),
+            "last_modified": None,
+            "deleted": None,
         }
     ]
 
@@ -169,6 +171,8 @@ def test_loads_multiple_records_preserving_content_and_order(
                 </record>
                 """
             ),
+            "last_modified": None,
+            "deleted": None,
         },
         {
             "namespace": EBSCO_NAMESPACE,
@@ -184,6 +188,8 @@ def test_loads_multiple_records_preserving_content_and_order(
                 </record>
                 """
             ),
+            "last_modified": None,
+            "deleted": None,
         },
         {
             "namespace": EBSCO_NAMESPACE,
@@ -199,6 +205,8 @@ def test_loads_multiple_records_preserving_content_and_order(
                 </record>
                 """
             ),
+            "last_modified": None,
+            "deleted": None,
         },
     ]
 


### PR DESCRIPTION
## What does this change?

This is a follow-on to wellcomecollection/catalogue-pipeline#3181 (branched from `rk/schema-evolution-add-deleted-adapters`) as part of wellcomecollection/platform#6245.

It makes the adapter-store table handling consistently use a single Arrow schema everywhere (including `last_modified` and `deleted`), rather than switching between multiple schemas depending on operation.

In particular:

- Casts all incoming Arrow tables for adapter-store writes to the repo-standard `ARROW_SCHEMA`, failing fast with a helpful error if an adapter produces an incompatible schema.
- Tightens `incremental_update()` validation to require a non-null `last_modified` (to avoid overwriting newer records with untimed data).
- Ensures `snapshot_sync()` writes use a consistent `last_modified` timestamp and marks records missing from a snapshot as deleted (via `deleted=True`).

This is groundwork for the eventual change described in platform#6245: keeping the contents of deleted records (rather than using null content as the deletion signal) and relying on an explicit deletion flag so we can still extract stable source identifiers upstream of the transformer.

## How to test

- Run the adapter store unit tests (especially snapshot sync / incremental update) and confirm they pass.
- Run an adapter flow that writes to an Iceberg adapter-store table and confirm:
  - incremental updates reject rows where `last_modified` is null
  - snapshot sync produces `deleted=True` for records missing from a snapshot

## How can we measure success?

- This PR unblocks follow-on work for wellcomecollection/platform#6245 by ensuring we have a consistent schema shape available across adapter-store operations.
- Subsequent changes can retain record bodies for deleted records while still surfacing deletions via an explicit `deleted` flag.

## Have we considered potential risks?

- **Stricter schema casting may cause failures** if an adapter produces a table with missing/mismatched fields. This is intentional (fail fast) and mitigated by the unit test suite.
- **Stricter `last_modified` requirement** may reject previously-accepted incremental updates that had null timestamps. This protects against accidental overwrites with untimed/older data.
