### PR TITLE
Add VW_PEOPLE_VARIATIONS to MIMSY dump tool

### DIFF
--- a/scripts/mimsy_dump/mimsy_dump.py
+++ b/scripts/mimsy_dump/mimsy_dump.py
@@ -162,6 +162,7 @@ def main():
             "VW_OTHER_MEASUREMENTS",
             "VW_OTHER_NUMBERS",
             "VW_PEOPLE_DATES",
+            "VW_PEOPLE_VARIATIONS",
             "VW_REPORTS",
             "VW_SOURCE_DETAILS",
             "VW_TIMELINE",


### PR DESCRIPTION
## What does this change?

Adds the `VW_PEOPLE_VARIATIONS` view to the MIMSY dump tool's default list of views.

This was requested by VS to help with the MIMSY migration process. The export has already been delivered to VS.

Closes https://github.com/wellcomecollection/platform/issues/6260

## How to test

Run the MIMSY dump tool and verify that the `VW_PEOPLE_VARIATIONS` view is now included in the default views:

```bash
cd scripts/mimsy_dump
uv run mimsy-dump --no-zip
```

The output should now include `mimsy_VW_PEOPLE_VARIATIONS.csv`.

## How can we measure success?

VS has received the updated dump containing the `PEOPLE_VARIATIONS` data they requested.

## Have we considered potential risks?

This is a low-risk change - it simply adds another view to the default export list. The MIMSY dump tool is a temporary utility for the migration process and doesn't affect production systems.
