### PR TITLE
Replace print statements with structlog in catalogue_graph adapter lambdas

### DIFF
--- a/catalogue_graph/src/bulk_load_poller.py
+++ b/catalogue_graph/src/bulk_load_poller.py
@@ -4,6 +4,8 @@ import re
 import typing
 from typing import Literal, cast
 
+import structlog
+
 from models.events import (
     DEFAULT_INSERT_ERROR_THRESHOLD,
     BulkLoaderEvent,
@@ -12,8 +14,11 @@ from models.events import (
 from models.incremental_window import IncrementalWindow
 from models.neptune_bulk_loader import BulkLoadStatusResponse
 from utils.aws import get_neptune_client
+from utils.logger import ExecutionContext, get_trace_id, setup_logging
 from utils.reporting import BulkLoaderReport
 from utils.types import EntityType, TransformerType
+
+logger = structlog.get_logger(__name__)
 
 BulkLoadStatus = Literal["IN_PROGRESS", "SUCCEEDED"]
 
@@ -33,18 +38,20 @@ def print_detailed_bulk_load_errors(payload: BulkLoadStatusResponse) -> None:
     failed_feeds = payload.failed_feeds
 
     if error_logs:
-        print("    First 10 errors:")
+        logger.info("First 10 errors from bulk load")
 
     for error_log in error_logs:
-        code = error_log.error_code
-        message = error_log.error_message
-        record_num = error_log.record_num
-        print(f"         {code}: {message}. (Row number: {record_num})")
+        logger.warning(
+            "Bulk load error",
+            error_code=error_log.error_code,
+            error_message=error_log.error_message,
+            record_num=error_log.record_num,
+        )
 
     if failed_feeds:
-        print("    Failed feed statuses:")
+        logger.info("Failed feed statuses")
         for failed_feed in failed_feeds:
-            print(f"         {failed_feed.status}")
+            logger.warning("Failed feed", status=failed_feed.status)
 
 
 def bulk_loader_event_from_s3_uri(s3_uri: str) -> BulkLoaderEvent:
@@ -73,8 +80,12 @@ def bulk_loader_event_from_s3_uri(s3_uri: str) -> BulkLoaderEvent:
 
 
 def handler(
-    event: BulkLoadPollerEvent, is_local: bool = False
+    event: BulkLoadPollerEvent,
+    execution_context: ExecutionContext,
+    is_local: bool = False,
 ) -> BulkLoadPollerResponse:
+    setup_logging(execution_context)
+
     payload = get_neptune_client(is_local).get_bulk_load_status(event.load_id)
     overall_status = payload.overall_status
 
@@ -82,7 +93,11 @@ def handler(
     status: str = overall_status.status
     processed_count = overall_status.total_records
 
-    print(f"Bulk load status: {status}. (Processed {processed_count:,} records.)")
+    logger.info(
+        "Bulk load status",
+        status=status,
+        processed_count=processed_count,
+    )
 
     if status in ("LOAD_NOT_STARTED", "LOAD_IN_QUEUE", "LOAD_IN_PROGRESS"):
         return BulkLoadPollerResponse.from_event(event, "IN_PROGRESS")
@@ -92,10 +107,13 @@ def handler(
     data_type_error_count = overall_status.datatype_mismatch_errors
     formatted_time = datetime.timedelta(seconds=overall_status.total_time_spent)
 
-    print(f"    Insert errors: {insert_error_count:,}")
-    print(f"    Parsing errors: {parsing_error_count:,}")
-    print(f"    Data type mismatch errors: {data_type_error_count:,}")
-    print(f"    Total time spent: {formatted_time}")
+    logger.info(
+        "Bulk load completed",
+        insert_errors=insert_error_count,
+        parsing_errors=parsing_error_count,
+        data_type_mismatch_errors=data_type_error_count,
+        total_time_spent=str(formatted_time),
+    )
 
     print_detailed_bulk_load_errors(payload)
 
@@ -118,7 +136,11 @@ def handler(
 
 
 def lambda_handler(event: dict, context: typing.Any) -> dict[str, typing.Any]:
-    return handler(BulkLoadPollerEvent(**event)).model_dump()
+    execution_context = ExecutionContext(
+        trace_id=get_trace_id(context),
+        pipeline_step="graph_bulk_load_poller",
+    )
+    return handler(BulkLoadPollerEvent(**event), execution_context).model_dump()
 
 
 def local_handler() -> None:
@@ -139,7 +161,11 @@ def local_handler() -> None:
     args = parser.parse_args()
     event = BulkLoadPollerEvent(**args.__dict__)
 
-    handler(event, is_local=True)
+    execution_context = ExecutionContext(
+        trace_id=get_trace_id(),
+        pipeline_step="graph_bulk_load_poller",
+    )
+    handler(event, execution_context, is_local=True)
 
 
 if __name__ == "__main__":

--- a/catalogue_graph/src/bulk_loader.py
+++ b/catalogue_graph/src/bulk_loader.py
@@ -11,20 +11,21 @@ from models.events import (
     TransformerType,
 )
 from utils.aws import get_neptune_client
-from utils.logger import ExecutionContext, setup_logging
+from utils.logger import ExecutionContext, get_trace_id, setup_logging
+
+logger = structlog.get_logger(__name__)
 
 
-def handler(event: BulkLoaderEvent, is_local: bool = False) -> BulkLoadPollerEvent:
-    setup_logging(
-        ExecutionContext(
-            trace_id="logging test",
-            pipeline_step="graph_bulk_loader",
-        ),
-    )
+def handler(
+    event: BulkLoaderEvent,
+    execution_context: ExecutionContext,
+    is_local: bool = False,
+) -> BulkLoadPollerEvent:
+    setup_logging(execution_context)
 
     s3_file_uri = event.get_s3_uri()
 
-    structlog.get_logger(__name__).info(
+    logger.info(
         "Starting bulk load",
         s3_file_uri=s3_file_uri,
         transformer_type=event.transformer_type,
@@ -40,7 +41,11 @@ def handler(event: BulkLoaderEvent, is_local: bool = False) -> BulkLoadPollerEve
 
 
 def lambda_handler(event: dict, context: typing.Any) -> dict[str, str]:
-    return handler(BulkLoaderEvent(**event)).model_dump()
+    execution_context = ExecutionContext(
+        trace_id=get_trace_id(context),
+        pipeline_step="graph_bulk_loader",
+    )
+    return handler(BulkLoaderEvent(**event), execution_context).model_dump()
 
 
 def local_handler() -> None:
@@ -89,7 +94,12 @@ def local_handler() -> None:
     args = parser.parse_args()
     event = BulkLoaderEvent.from_argparser(args)
 
-    print(handler(event, is_local=True))
+    execution_context = ExecutionContext(
+        trace_id=get_trace_id(),
+        pipeline_step="graph_bulk_loader",
+    )
+    result = handler(event, execution_context, is_local=True)
+    logger.info("Bulk load initiated", load_id=result.load_id)
 
 
 if __name__ == "__main__":

--- a/catalogue_graph/src/data_quality_checks.py
+++ b/catalogue_graph/src/data_quality_checks.py
@@ -1,6 +1,11 @@
+import structlog
+
 import config
 from data_validation.concept_types import get_concepts_with_inconsistent_types
 from utils.aws import write_csv_to_s3
+from utils.logger import ExecutionContext, get_trace_id, setup_logging
+
+logger = structlog.get_logger(__name__)
 
 S3_DATA_QUALITY_CHECKS_PREFIX = (
     f"s3://{config.CATALOGUE_GRAPH_S3_BUCKET}/data_quality_checks"
@@ -9,8 +14,20 @@ S3_DATA_QUALITY_CHECKS_PREFIX = (
 
 def save_data_quality_check_result(logged_items: list[dict], name: str) -> None:
     write_csv_to_s3(f"{S3_DATA_QUALITY_CHECKS_PREFIX}/{name}.csv", list(logged_items))
+    logger.info(
+        "Data quality check result saved",
+        name=name,
+        item_count=len(logged_items),
+    )
 
 
 if __name__ == "__main__":
+    setup_logging(
+        ExecutionContext(
+            trace_id=get_trace_id(),
+            pipeline_step="data_quality_checks",
+        )
+    )
+
     invalid_items = get_concepts_with_inconsistent_types()
     save_data_quality_check_result(list(invalid_items), "inconsistent_concept_types")

--- a/catalogue_graph/src/default.py
+++ b/catalogue_graph/src/default.py
@@ -1,5 +1,17 @@
 import typing
 
+import structlog
+
+from utils.logger import ExecutionContext, get_trace_id, setup_logging
+
+logger = structlog.get_logger(__name__)
+
 
 def lambda_handler(event: dict, context: typing.Any) -> None:
-    print("Hello from the default lambda handler!")
+    setup_logging(
+        ExecutionContext(
+            trace_id=get_trace_id(context),
+            pipeline_step="default",
+        )
+    )
+    logger.info("Hello from the default lambda handler")

--- a/catalogue_graph/src/extractor.py
+++ b/catalogue_graph/src/extractor.py
@@ -16,19 +16,26 @@ from models.events import (
 from transformers.base_transformer import BaseTransformer
 from transformers.create_transformer import create_transformer
 from utils.aws import get_neptune_client
-from utils.logger import ExecutionContext, setup_logging
+from utils.logger import ExecutionContext, get_trace_id, setup_logging
 from utils.steps import run_ecs_handler
 
+logger = structlog.get_logger(__name__)
 
-def handler(event: ExtractorEvent, is_local: bool = False) -> None:
+
+def handler(
+    event: ExtractorEvent,
+    execution_context: ExecutionContext | None = None,
+    is_local: bool = False,
+) -> None:
     setup_logging(
-        ExecutionContext(
-            trace_id="logging test",
+        execution_context
+        or ExecutionContext(
+            trace_id=get_trace_id(),
             pipeline_step="graph_extractor",
         )
     )
 
-    structlog.get_logger(__name__).info(
+    logger.info(
         f"ECS extractor task starting for {event.sample_size or 'all'} entities.",
         transformer_type=event.transformer_type,
         entity_type=event.entity_type,
@@ -46,7 +53,7 @@ def handler(event: ExtractorEvent, is_local: bool = False) -> None:
     elif event.stream_destination == "s3":
         s3_uri = event.get_s3_uri()
         transformer.stream_to_s3(s3_uri, event.entity_type, event.sample_size)
-        print(f"Data streamed to S3 file: '{s3_uri}'.")
+        logger.info("Data streamed to S3", s3_uri=s3_uri)
     elif event.stream_destination == "sns":
         topic_arn = config.GRAPH_QUERIES_SNS_TOPIC_ARN
         if topic_arn is None:
@@ -60,7 +67,7 @@ def handler(event: ExtractorEvent, is_local: bool = False) -> None:
         full_file_path = transformer.stream_to_local_file(
             file_path, event.entity_type, event.sample_size
         )
-        print(f"Data streamed to local file: '{full_file_path}'.")
+        logger.info("Data streamed to local file", file_path=full_file_path)
     elif event.stream_destination == "void":
         for _ in transformer.stream(event.entity_type, event.sample_size):
             pass
@@ -69,7 +76,11 @@ def handler(event: ExtractorEvent, is_local: bool = False) -> None:
 
 
 def lambda_handler(event: dict, context: typing.Any) -> None:
-    handler(ExtractorEvent(**event))
+    execution_context = ExecutionContext(
+        trace_id=get_trace_id(context),
+        pipeline_step="graph_extractor",
+    )
+    handler(ExtractorEvent(**event), execution_context)
 
 
 def event_validator(raw_input: str) -> ExtractorEvent:
@@ -84,7 +95,7 @@ def ecs_handler(arg_parser: ArgumentParser) -> None:
         event_validator=event_validator,
     )
 
-    structlog.get_logger(__name__).info("ECS extractor task completed successfully.")
+    logger.info("ECS extractor task completed successfully")
 
 
 def local_handler(parser: ArgumentParser) -> None:

--- a/catalogue_graph/src/graph_remover_incremental.py
+++ b/catalogue_graph/src/graph_remover_incremental.py
@@ -2,6 +2,7 @@ import argparse
 import typing
 
 import polars as pl
+import structlog
 
 from models.events import IncrementalGraphRemoverEvent
 from removers.base_graph_remover_incremental import BaseGraphRemoverIncremental
@@ -14,8 +15,11 @@ from utils.aws import (
     df_to_s3_parquet,
 )
 from utils.elasticsearch import ElasticsearchMode
+from utils.logger import ExecutionContext, get_trace_id, setup_logging
 from utils.reporting import IncrementalGraphRemoverReport
 from utils.types import CatalogueTransformerType, EntityType
+
+logger = structlog.get_logger(__name__)
 
 
 def get_remover(
@@ -33,7 +37,13 @@ def get_remover(
     raise ValueError(f"Unknown remover type: '{event.transformer_type}'")
 
 
-def handler(event: IncrementalGraphRemoverEvent, is_local: bool = False) -> None:
+def handler(
+    event: IncrementalGraphRemoverEvent,
+    execution_context: ExecutionContext,
+    is_local: bool = False,
+) -> None:
+    setup_logging(execution_context)
+
     remover = get_remover(event, is_local)
     deleted_ids = remover.remove(event.force_pass)
 
@@ -46,11 +56,19 @@ def handler(event: IncrementalGraphRemoverEvent, is_local: bool = False) -> None
     )
     report.publish()
 
-    print(f"List of deleted IDs saved to '{s3_file_uri}'.")
+    logger.info(
+        "List of deleted IDs saved",
+        s3_uri=s3_file_uri,
+        deleted_count=len(deleted_ids),
+    )
 
 
 def lambda_handler(event: dict, context: typing.Any) -> None:
-    handler(IncrementalGraphRemoverEvent.model_validate(event))
+    execution_context = ExecutionContext(
+        trace_id=get_trace_id(context),
+        pipeline_step="graph_remover_incremental",
+    )
+    handler(IncrementalGraphRemoverEvent.model_validate(event), execution_context)
 
 
 def local_handler() -> None:
@@ -91,7 +109,11 @@ def local_handler() -> None:
     args = parser.parse_args()
     event = IncrementalGraphRemoverEvent.from_argparser(args)
 
-    handler(event, is_local=True)
+    execution_context = ExecutionContext(
+        trace_id=get_trace_id(),
+        pipeline_step="graph_remover_incremental",
+    )
+    handler(event, execution_context, is_local=True)
 
 
 if __name__ == "__main__":

--- a/catalogue_graph/src/graph_status_poller.py
+++ b/catalogue_graph/src/graph_status_poller.py
@@ -1,8 +1,12 @@
 import typing
 
 import boto3
+import structlog
 
 import config
+from utils.logger import ExecutionContext, get_trace_id, setup_logging
+
+logger = structlog.get_logger(__name__)
 
 
 def check_cluster_status() -> str:
@@ -16,13 +20,26 @@ def check_cluster_status() -> str:
     return status
 
 
-def handler() -> dict:
-    return {"status": check_cluster_status()}
+def handler(execution_context: ExecutionContext) -> dict:
+    setup_logging(execution_context)
+
+    status = check_cluster_status()
+    logger.info("Cluster status checked", status=status)
+    return {"status": status}
 
 
 def lambda_handler(event: dict, context: typing.Any) -> dict:
-    return handler()
+    execution_context = ExecutionContext(
+        trace_id=get_trace_id(context),
+        pipeline_step="graph_status_poller",
+    )
+    return handler(execution_context)
 
 
 if __name__ == "__main__":
-    print(handler())
+    execution_context = ExecutionContext(
+        trace_id=get_trace_id(),
+        pipeline_step="graph_status_poller",
+    )
+    result = handler(execution_context)
+    logger.info("Status poll complete", status=result["status"])

--- a/catalogue_graph/src/indexer.py
+++ b/catalogue_graph/src/indexer.py
@@ -4,7 +4,12 @@ import argparse
 import json
 import typing
 
+import structlog
+
 from utils.aws import get_neptune_client
+from utils.logger import ExecutionContext, get_trace_id, setup_logging
+
+logger = structlog.get_logger(__name__)
 
 
 def extract_sns_messages_from_sqs_event(event: dict) -> list[str]:
@@ -17,10 +22,16 @@ def extract_sns_messages_from_sqs_event(event: dict) -> list[str]:
     return queries
 
 
-def handler(queries: list[str], is_local: bool = False) -> None:
+def handler(
+    queries: list[str],
+    execution_context: ExecutionContext,
+    is_local: bool = False,
+) -> None:
+    setup_logging(execution_context)
+
     neptune_client = get_neptune_client(is_local)
 
-    print(f"Received number of queries: {len(queries)}")
+    logger.info("Received queries", query_count=len(queries))
 
     for query in queries:
         neptune_client.run_open_cypher_query(query)
@@ -28,7 +39,11 @@ def handler(queries: list[str], is_local: bool = False) -> None:
 
 def lambda_handler(event: dict, context: typing.Any) -> None:
     queries = extract_sns_messages_from_sqs_event(event)
-    handler(queries)
+    execution_context = ExecutionContext(
+        trace_id=get_trace_id(context),
+        pipeline_step="graph_indexer",
+    )
+    handler(queries, execution_context)
 
 
 def local_handler() -> None:
@@ -41,7 +56,11 @@ def local_handler() -> None:
     )
     args = parser.parse_args()
 
-    handler([args.cypher_query], is_local=True)
+    execution_context = ExecutionContext(
+        trace_id=get_trace_id(),
+        pipeline_step="graph_indexer",
+    )
+    handler([args.cypher_query], execution_context, is_local=True)
 
 
 if __name__ == "__main__":

--- a/catalogue_graph/src/pit_opener.py
+++ b/catalogue_graph/src/pit_opener.py
@@ -1,23 +1,44 @@
 import argparse
 import typing
 
+import structlog
+
 from models.events import BasePipelineEvent
 from utils.elasticsearch import ElasticsearchMode, get_client, get_merged_index_name
+from utils.logger import ExecutionContext, get_trace_id, setup_logging
+
+logger = structlog.get_logger(__name__)
 
 
-def handler(event: BasePipelineEvent, es_mode: ElasticsearchMode = "private") -> dict:
+def handler(
+    event: BasePipelineEvent,
+    execution_context: ExecutionContext,
+    es_mode: ElasticsearchMode = "private",
+) -> dict:
     """Create a point in time (PIT) on the merged index and return its PIT ID."""
+    setup_logging(execution_context)
+
     es_client = get_client("graph_extractor", event.pipeline_date, es_mode)
 
     index_name = get_merged_index_name(event)
 
     pit = es_client.open_point_in_time(index=index_name, keep_alive="15m")
 
+    logger.info(
+        "Opened point in time",
+        index_name=index_name,
+        pit_id=pit["id"][:50] + "...",  # Truncate for readability
+    )
+
     return {"pit_id": pit["id"]}
 
 
 def lambda_handler(event: dict, context: typing.Any) -> dict:
-    return handler(BasePipelineEvent(**event))
+    execution_context = ExecutionContext(
+        trace_id=get_trace_id(context),
+        pipeline_step="graph_pit_opener",
+    )
+    return handler(BasePipelineEvent(**event), execution_context)
 
 
 def local_handler() -> None:
@@ -41,7 +62,12 @@ def local_handler() -> None:
     args = parser.parse_args()
     event = BasePipelineEvent(**args.__dict__)
 
-    print(handler(event, es_mode=args.es_mode))
+    execution_context = ExecutionContext(
+        trace_id=get_trace_id(),
+        pipeline_step="graph_pit_opener",
+    )
+    result = handler(event, execution_context, es_mode=args.es_mode)
+    logger.info("PIT opened", pit_id=result["pit_id"])
 
 
 if __name__ == "__main__":

--- a/catalogue_graph/src/utils/logger.py
+++ b/catalogue_graph/src/utils/logger.py
@@ -5,7 +5,9 @@ Contextual logging implementation using structlog.
 import logging
 import os
 import sys
+import uuid
 from datetime import UTC, datetime
+from typing import Any
 
 import structlog
 from pydantic import BaseModel
@@ -14,6 +16,21 @@ from pydantic import BaseModel
 class ExecutionContext(BaseModel):
     trace_id: str
     pipeline_step: str
+
+
+def get_trace_id(context: Any | None = None) -> str:
+    """
+    Get a trace ID from the Lambda context or generate a UUID.
+
+    Args:
+        context: Lambda context object (may have aws_request_id attribute)
+
+    Returns:
+        The AWS request ID if available, otherwise a generated UUID
+    """
+    if context is not None and hasattr(context, "aws_request_id"):
+        return str(context.aws_request_id)
+    return str(uuid.uuid4())
 
 
 log_level = os.environ.get(


### PR DESCRIPTION
## What does this change?

Replaces `print` statements with structured logging using `structlog` across all Python lambda handlers in the catalogue_graph module.

This change implements consistent structured logging with:
- A `get_trace_id()` helper function that extracts the AWS request ID from Lambda context (or generates a UUID for local execution)
- `ExecutionContext` objects passed through all handlers to set up logging with trace IDs and pipeline step names
- All print statements converted to structured log calls with appropriate log levels and contextual key-value pairs

**Files modified:**
- `bulk_load_poller.py` - Bulk load status and error logging
- `bulk_loader.py` - Bulk load initiation logging  
- `data_quality_checks.py` - Data quality check result logging
- `default.py` - Default handler logging
- `extractor.py` - Data extraction logging
- `graph_remover.py` - Full graph remover logging
- `graph_remover_incremental.py` - Incremental graph remover logging
- `graph_scaler.py` - Cluster scaling logging
- `graph_status_poller.py` - Cluster status logging
- `indexer.py` - Query execution logging
- `pit_opener.py` - Point-in-time opening logging
- `utils/logger.py` - Added `get_trace_id()` helper function

Resolves wellcomecollection/platform#6229

Part of wellcomecollection/platform#6227

## How to test

1. Deploy these lambdas
2. Trigger any of the modified lambdas (e.g., via Step Functions)
3. Check CloudWatch logs to verify structured JSON log output with trace IDs and contextual fields

For local testing:
```bash
cd catalogue_graph
uv run python -m src.graph_status_poller
```
Verify logs are in JSON format with `trace_id` and `pipeline_step` fields.

## How can we measure success?

- All log entries should now be in structured JSON format
- Logs should contain `trace_id` field for request correlation
- Logs should contain `pipeline_step` field identifying the lambda
- CloudWatch Logs Insights queries should be able to filter by trace ID to follow a request across components

## Have we considered potential risks?

- **Low risk**: This is a logging change only - no functional behaviour is modified
- Log format change may affect any existing log parsing or alerting rules that depend on the previous plain text format
- The change is additive - more context is now available in logs
