### PR TITLE
Replace prints with structlog in catalogue-graph ingestor

### DIFF
--- a/catalogue_graph/src/ingestor/extractors/base_extractor.py
+++ b/catalogue_graph/src/ingestor/extractors/base_extractor.py
@@ -2,6 +2,8 @@ import time
 from collections.abc import Generator, Iterable
 from typing import Any, Literal
 
+import structlog
+
 from ingestor.queries.concept_queries import (
     BROADER_THAN_QUERY,
     CONCEPT_QUERY,
@@ -22,6 +24,8 @@ from ingestor.queries.work_queries import (
     WORK_CONCEPTS_QUERY,
 )
 from utils.aws import get_neptune_client
+
+logger = structlog.get_logger(__name__)
 
 ConceptRelatedQuery = Literal[
     "related_to",
@@ -96,9 +100,11 @@ class GraphBaseExtractor:
             parameters=self.neptune_params,
             chunk_size=chunk_size,
         )
-        print(
-            f"Ran a set of '{query_type}' queries in {round(time.time() - start)}s, "
-            f"retrieving {len(results)} records."
+        logger.info(
+            "Ran Neptune queries",
+            query_type=query_type,
+            duration_seconds=round(time.time() - start),
+            records_retrieved=len(results),
         )
 
         return results

--- a/catalogue_graph/src/ingestor/extractors/concepts_extractor.py
+++ b/catalogue_graph/src/ingestor/extractors/concepts_extractor.py
@@ -4,6 +4,8 @@ from concurrent.futures import ThreadPoolExecutor
 from itertools import batched
 from typing import get_args
 
+import structlog
+
 from ingestor.models.neptune.query_result import (
     ExtractedConcept,
     ExtractedRelatedConcept,
@@ -20,6 +22,8 @@ from .base_extractor import (
     ConceptRelatedQuery,
     GraphBaseExtractor,
 )
+
+logger = structlog.get_logger(__name__)
 
 CONCEPT_QUERY_PARAMS = {
     # There are a few Wikidata supernodes which cause performance issues in queries.
@@ -207,7 +211,7 @@ class GraphConceptsExtractor(GraphBaseExtractor):
 
     def extract_raw(self) -> Generator[tuple]:
         for concept_ids in self.get_concept_stream():
-            print(f"Will process a batch of {len(concept_ids)} concepts.")
+            logger.info("Processing batch of concepts", count=len(concept_ids))
             concepts = self.get_concepts(concept_ids).items()
 
             # Run related concept queries in parallel

--- a/catalogue_graph/src/ingestor/extractors/works_extractor.py
+++ b/catalogue_graph/src/ingestor/extractors/works_extractor.py
@@ -1,6 +1,7 @@
 from collections.abc import Generator, Iterator
 from itertools import batched
 
+import structlog
 from pydantic import BaseModel
 
 from ingestor.models.merged.work import (
@@ -13,6 +14,8 @@ from sources.merged_works_source import MergedWorksSource
 from utils.elasticsearch import ElasticsearchMode
 
 from .base_extractor import GraphBaseExtractor
+
+logger = structlog.get_logger(__name__)
 
 WORKS_BATCH_SIZE = 40_000
 
@@ -131,7 +134,7 @@ class GraphWorksExtractor(GraphBaseExtractor):
 
         # Before processing related works, filter out works which were already processed above
         related_ids = self.related_ids.difference(self.streamed_ids)
-        print(f"Will process a total of {len(related_ids)} related works.")
+        logger.info("Will process related works", count=len(related_ids))
 
         related_works_source = self.get_related_works_source(list(related_ids))
         related_works_stream = (

--- a/catalogue_graph/src/ingestor/run_local.py
+++ b/catalogue_graph/src/ingestor/run_local.py
@@ -3,6 +3,8 @@
 import argparse
 import typing
 
+import structlog
+
 from ingestor.models.step_events import (
     IngestorIndexerLambdaEvent,
     IngestorLoaderLambdaEvent,
@@ -12,10 +14,12 @@ from ingestor.steps.ingestor_loader import create_job_id
 from ingestor.steps.ingestor_loader import handler as loader_handler
 from utils.types import IngestorType
 
+logger = structlog.get_logger(__name__)
+
 
 def run_index(loader_result: IngestorIndexerLambdaEvent) -> None:
     result = indexer_handler(loader_result, es_mode="public")
-    print(f"Indexed {result.success_count} documents.")
+    logger.info("Indexed documents", count=result.success_count)
 
 
 # Run the whole pipeline locally.

--- a/catalogue_graph/src/ingestor/steps/ingestor_deletions.py
+++ b/catalogue_graph/src/ingestor/steps/ingestor_deletions.py
@@ -2,6 +2,7 @@ import argparse
 import typing
 
 import polars as pl
+import structlog
 
 from ingestor.models.step_events import IngestorDeletionsLambdaEvent
 from models.events import (
@@ -10,8 +11,11 @@ from models.events import (
 from removers.elasticsearch_remover import ElasticsearchRemover
 from utils.aws import df_from_s3_parquet
 from utils.elasticsearch import ElasticsearchMode
+from utils.logger import ExecutionContext, get_trace_id, setup_logging
 from utils.reporting import DeletionReport
 from utils.safety import validate_fractional_change
+
+logger = structlog.get_logger(__name__)
 
 
 def get_ids_to_delete(event: IngestorDeletionsLambdaEvent) -> set[str]:
@@ -35,8 +39,24 @@ def get_ids_to_delete(event: IngestorDeletionsLambdaEvent) -> set[str]:
 
 
 def handler(
-    event: IngestorDeletionsLambdaEvent, es_mode: ElasticsearchMode = "private"
+    event: IngestorDeletionsLambdaEvent,
+    execution_context: ExecutionContext | None = None,
+    es_mode: ElasticsearchMode = "private",
 ) -> None:
+    setup_logging(
+        execution_context
+        or ExecutionContext(
+            trace_id=get_trace_id(),
+            pipeline_step="ingestor_deletions",
+        )
+    )
+
+    logger.info(
+        "Received event",
+        pipeline_date=event.pipeline_date,
+        index_date=event.index_date,
+    )
+
     es_remover = ElasticsearchRemover(event, es_mode)
     ids_to_delete = get_ids_to_delete(event)
     current_id_count = es_remover.get_document_count()
@@ -55,7 +75,11 @@ def handler(
 
 
 def lambda_handler(event: dict, context: typing.Any) -> None:
-    handler(IngestorDeletionsLambdaEvent.model_validate(event))
+    execution_context = ExecutionContext(
+        trace_id=get_trace_id(context),
+        pipeline_step="ingestor_deletions",
+    )
+    handler(IngestorDeletionsLambdaEvent.model_validate(event), execution_context)
 
 
 def local_handler() -> None:

--- a/catalogue_graph/src/ingestor/steps/ingestor_indexer.py
+++ b/catalogue_graph/src/ingestor/steps/ingestor_indexer.py
@@ -6,6 +6,7 @@ from collections.abc import Generator
 
 import boto3
 import elasticsearch.helpers
+import structlog
 
 import config
 import utils.elasticsearch
@@ -20,9 +21,12 @@ from ingestor.models.step_events import (
 )
 from utils.aws import df_from_s3_parquet, dicts_from_s3_jsonl
 from utils.elasticsearch import ElasticsearchMode, get_standard_index_name
+from utils.logger import ExecutionContext, get_trace_id, setup_logging
 from utils.reporting import IndexerReport
 from utils.steps import create_job_id, run_ecs_handler
 from utils.types import IngestorType
+
+logger = structlog.get_logger(__name__)
 
 RECORD_CLASSES: dict[IngestorType, type[IndexableRecord]] = {
     "concepts": IndexableConcept,
@@ -33,13 +37,16 @@ RECORD_CLASSES: dict[IngestorType, type[IndexableRecord]] = {
 def _get_objects_to_index(
     base_event: IngestorStepEvent,
 ) -> Generator[IngestorIndexerObject]:
-    print("Listing S3 objects to index...")
+    logger.info("Listing S3 objects to index")
     bucket_name = config.CATALOGUE_GRAPH_S3_BUCKET
     prefix = base_event.get_path_prefix()
     load_format = base_event.load_format
 
-    print(
-        f"Will process all {load_format} files prefixed with 's3://{bucket_name}/{prefix}/*'."
+    logger.info(
+        "Processing files from S3",
+        bucket=bucket_name,
+        prefix=prefix,
+        load_format=load_format,
     )
 
     paginator = boto3.client("s3").get_paginator("list_objects_v2")
@@ -79,14 +86,29 @@ def get_indexable_data(
     else:
         data = dicts_from_s3_jsonl(s3_uri)
 
-    print(f"Extracted {len(data)} records from {s3_uri}.")
+    logger.info("Extracted records from S3", count=len(data), s3_uri=s3_uri)
     return [record_class.from_raw_document(row) for row in data]
 
 
 def handler(
-    event: IngestorIndexerLambdaEvent, es_mode: ElasticsearchMode = "private"
+    event: IngestorIndexerLambdaEvent,
+    execution_context: ExecutionContext | None = None,
+    es_mode: ElasticsearchMode = "private",
 ) -> IngestorIndexerMonitorLambdaEvent:
-    print(f"Received event: {event}.")
+    setup_logging(
+        execution_context
+        or ExecutionContext(
+            trace_id=get_trace_id(),
+            pipeline_step="ingestor_indexer",
+        )
+    )
+
+    logger.info(
+        "Received event",
+        ingestor_type=event.ingestor_type,
+        pipeline_date=event.pipeline_date,
+        job_id=event.job_id,
+    )
 
     objects_to_index = event.objects_to_index or _get_objects_to_index(event)
     es_client = utils.elasticsearch.get_client(
@@ -100,21 +122,24 @@ def handler(
     for s3_object in objects_to_index:
         indexable_data = get_indexable_data(event, s3_object.s3_uri)
 
-        print(
-            f"Loading {len(indexable_data)} {event.ingestor_type} to ES index '{index_name}'..."
+        logger.info(
+            "Loading documents to ES index",
+            count=len(indexable_data),
+            ingestor_type=event.ingestor_type,
+            index_name=index_name,
         )
 
         success_count, _ = elasticsearch.helpers.bulk(
             es_client, generate_operations(index_name, indexable_data)
         )
 
-        print(f"Successfully indexed {success_count} documents.")
+        logger.info("Successfully indexed documents", count=success_count)
 
         total_success_count += success_count
 
     event_payload = event.model_dump(exclude={"objects_to_index"})
 
-    print("Preparing indexer pipeline report ...")
+    logger.info("Preparing indexer pipeline report")
     report = IndexerReport(**event_payload, success_count=total_success_count)
     report.publish()
 
@@ -125,7 +150,13 @@ def handler(
 
 
 def lambda_handler(event: dict, context: typing.Any) -> dict[str, typing.Any]:
-    return handler(IngestorIndexerLambdaEvent(**event)).model_dump(mode="json")
+    execution_context = ExecutionContext(
+        trace_id=get_trace_id(context),
+        pipeline_step="ingestor_indexer",
+    )
+    return handler(IngestorIndexerLambdaEvent(**event), execution_context).model_dump(
+        mode="json"
+    )
 
 
 def event_validator(raw_input: str) -> IngestorIndexerLambdaEvent:
@@ -155,6 +186,8 @@ def ecs_handler(arg_parser: ArgumentParser) -> None:
         event_validator=event_validator,
         es_mode=es_mode,
     )
+
+    logger.info("ECS ingestor indexer task completed successfully")
 
 
 def local_handler(parser: ArgumentParser) -> None:

--- a/catalogue_graph/src/ingestor/steps/ingestor_loader.py
+++ b/catalogue_graph/src/ingestor/steps/ingestor_loader.py
@@ -3,6 +3,8 @@ import json
 import typing
 from argparse import ArgumentParser
 
+import structlog
+
 from ingestor.models.step_events import (
     IngestorIndexerLambdaEvent,
     IngestorLoaderLambdaEvent,
@@ -14,9 +16,12 @@ from ingestor.transformers.base_transformer import (
 from ingestor.transformers.concepts_transformer import ElasticsearchConceptsTransformer
 from ingestor.transformers.works_transformer import ElasticsearchWorksTransformer
 from utils.elasticsearch import ElasticsearchMode
+from utils.logger import ExecutionContext, get_trace_id, setup_logging
 from utils.reporting import LoaderReport
 from utils.steps import create_job_id, run_ecs_handler
 from utils.types import IngestorType
+
+logger = structlog.get_logger(__name__)
 
 
 def create_transformer(
@@ -32,10 +37,24 @@ def create_transformer(
 
 def handler(
     event: IngestorLoaderLambdaEvent,
+    execution_context: ExecutionContext | None = None,
     es_mode: ElasticsearchMode = "private",
     load_destination: LoadDestination = "s3",
 ) -> IngestorIndexerLambdaEvent:
-    print(f"Received event: {event}")
+    setup_logging(
+        execution_context
+        or ExecutionContext(
+            trace_id=get_trace_id(),
+            pipeline_step="ingestor_loader",
+        )
+    )
+
+    logger.info(
+        "Received event",
+        ingestor_type=event.ingestor_type,
+        pipeline_date=event.pipeline_date,
+        job_id=event.job_id,
+    )
 
     transformer = create_transformer(event, es_mode)
     objects_to_index = transformer.load_documents(event, load_destination)
@@ -89,12 +108,21 @@ def ecs_handler(arg_parser: ArgumentParser) -> None:
         es_mode=es_mode,
     )
 
+    logger.info("ECS ingestor loader task completed successfully")
+
 
 def lambda_handler(event: dict, context: typing.Any) -> dict:
+    execution_context = ExecutionContext(
+        trace_id=get_trace_id(context),
+        pipeline_step="ingestor_loader",
+    )
+
     if "job_id" not in event:
         event["job_id"] = create_job_id()
 
-    return handler(IngestorLoaderLambdaEvent(**event)).model_dump(mode="json")
+    return handler(IngestorLoaderLambdaEvent(**event), execution_context).model_dump(
+        mode="json"
+    )
 
 
 def local_handler(parser: ArgumentParser) -> None:

--- a/catalogue_graph/src/ingestor/transformers/base_transformer.py
+++ b/catalogue_graph/src/ingestor/transformers/base_transformer.py
@@ -7,6 +7,7 @@ import boto3
 import polars as pl
 import pyarrow as pa
 import smart_open
+import structlog
 from pydantic import BaseModel
 
 from ingestor.extractors.base_extractor import GraphBaseExtractor
@@ -20,6 +21,8 @@ from ingestor.models.indexable_work import (
 from ingestor.models.step_events import IngestorIndexerObject, IngestorLoaderLambdaEvent
 from utils.arrow import pydantic_to_pyarrow_schema
 from utils.types import IngestorType
+
+logger = structlog.get_logger(__name__)
 
 S3_BATCH_SIZE = 10_000
 
@@ -130,6 +133,6 @@ class ElasticsearchBaseTransformer:
                 )
             )
 
-            print(f"{len(documents)} items loaded to '{full_path}'.")
+            logger.info("Items loaded", count=len(documents), path=full_path)
 
         return loaded_objects

--- a/catalogue_graph/src/ingestor/transformers/concepts_transformer.py
+++ b/catalogue_graph/src/ingestor/transformers/concepts_transformer.py
@@ -1,5 +1,7 @@
 from typing import TextIO
 
+import structlog
+
 from ingestor.extractors.base_extractor import ConceptRelatedQuery
 from ingestor.extractors.concepts_extractor import GraphConceptsExtractor
 from ingestor.models.indexable_concept import (
@@ -19,6 +21,8 @@ from utils.elasticsearch import ElasticsearchMode
 from .base_transformer import ElasticsearchBaseTransformer
 from .raw_concept import MissingLabelError
 from .raw_related_concepts import RawNeptuneRelatedConcept
+
+logger = structlog.get_logger(__name__)
 
 
 class ElasticsearchConceptsTransformer(ElasticsearchBaseTransformer):
@@ -115,8 +119,9 @@ class ElasticsearchConceptsTransformer(ElasticsearchBaseTransformer):
             return IndexableConcept(query=query, display=display)
         except MissingLabelError:
             # There is currently one concept which does not have a label ('k6p2u5fh')
-            print(
-                f"Concept {neptune_concept.wellcome_id} does not have a label and will not be indexed."
+            logger.warning(
+                "Concept does not have a label and will not be indexed",
+                concept_id=neptune_concept.wellcome_id,
             )
 
         return None

--- a/catalogue_graph/src/ingestor/transformers/work_query_transformer.py
+++ b/catalogue_graph/src/ingestor/transformers/work_query_transformer.py
@@ -1,5 +1,6 @@
 from collections.abc import Generator, Iterable
 
+import structlog
 from dateutil import parser
 
 from ingestor.extractors.works_extractor import VisibleExtractedWork
@@ -7,6 +8,8 @@ from ingestor.models.display.access_status import DisplayAccessStatus
 from models.pipeline.location import DigitalLocation, PhysicalLocation
 
 from .work_base_transformer import WorkBaseTransformer
+
+logger = structlog.get_logger(__name__)
 
 # The Scala pipeline uses the date `-9999-01-01T00:00:00Z` as 'negative infinity'. The Python standard library doesn't
 # support dates with negative years, and so we hardcode the corresponding Unix timestamp here instead of installing
@@ -169,8 +172,9 @@ class QueryWorkTransformer(WorkBaseTransformer):
                                 parser.parse(date.range.from_time).timestamp() * 1000
                             )
                         except parser.ParserError:
-                            print(
-                                f"Could not parse a production date of work {self.state.canonical_id}"
+                            logger.warning(
+                                "Could not parse production date",
+                                work_id=self.state.canonical_id,
                             )
 
     @property


### PR DESCRIPTION
## What does this change?

This PR replaces `print` statements with structured logging using `structlog` throughout the `catalogue_graph/src/ingestor/` folder, including adding `setup_logging` to all handler functions.

**Handlers updated with `setup_logging`:**
- `ingestor_loader.py` - loader handler and lambda_handler
- `ingestor_indexer.py` - indexer handler and lambda_handler
- `ingestor_deletions.py` - deletions handler and lambda_handler

**Other files updated with structlog:**
- `extractors/base_extractor.py`, `works_extractor.py`, `concepts_extractor.py`
- `transformers/base_transformer.py`, `concepts_transformer.py`, `work_query_transformer.py`
- `run_local.py`

This follows the pattern established in `extractor.py` where handlers call `setup_logging()` with an `ExecutionContext` to configure structured logging with trace IDs.

Resolves wellcomecollection/platform#6262.
Follows #3202.

## How to test

1. Run the test suite: `uv run pytest tests/`
2. Run quality checks: `uv run mypy .` and `uv run ruff check`
3. All tests pass and no type errors are introduced

## How can we measure success?

- Ingestor logs will be output in structured JSON format when running in production, making them easier to query and filter in CloudWatch
- Logs will include trace IDs for correlating related log entries across a pipeline run

## Have we considered potential risks?

- Low risk change - only replaces print statements with logger calls and adds setup_logging to handlers
- All existing tests pass
- Follows the same pattern already used in `extractor.py`
