### PR TITLE
Set pipeline_step in ECS handler execution context

### DIFF
--- a/catalogue_graph/src/extractor.py
+++ b/catalogue_graph/src/extractor.py
@@ -83,10 +83,16 @@ def event_validator(raw_input: str) -> ExtractorEvent:
 
 
 def ecs_handler(arg_parser: ArgumentParser) -> None:
+    execution_context = ExecutionContext(
+        trace_id=get_trace_id(),
+        pipeline_step="graph_extractor",
+    )
+
     run_ecs_handler(
         arg_parser=arg_parser,
         handler=handler,
         event_validator=event_validator,
+        execution_context=execution_context,
     )
 
     logger.info("ECS extractor task completed successfully")

--- a/catalogue_graph/src/ingestor/steps/ingestor_indexer.py
+++ b/catalogue_graph/src/ingestor/steps/ingestor_indexer.py
@@ -174,10 +174,16 @@ def ecs_handler(arg_parser: ArgumentParser) -> None:
     args, _ = arg_parser.parse_known_args()
     es_mode = args.es_mode
 
+    execution_context = ExecutionContext(
+        trace_id=get_trace_id(),
+        pipeline_step="ingestor_indexer",
+    )
+
     run_ecs_handler(
         arg_parser=arg_parser,
         handler=handler,
         event_validator=event_validator,
+        execution_context=execution_context,
         es_mode=es_mode,
     )
 

--- a/catalogue_graph/src/ingestor/steps/ingestor_loader.py
+++ b/catalogue_graph/src/ingestor/steps/ingestor_loader.py
@@ -95,10 +95,16 @@ def ecs_handler(arg_parser: ArgumentParser) -> None:
     args, _ = arg_parser.parse_known_args()
     es_mode = args.es_mode
 
+    execution_context = ExecutionContext(
+        trace_id=get_trace_id(),
+        pipeline_step="ingestor_loader",
+    )
+
     run_ecs_handler(
         arg_parser=arg_parser,
         handler=handler,
         event_validator=event_validator,
+        execution_context=execution_context,
         es_mode=es_mode,
     )
 


### PR DESCRIPTION
## What does this change?

This PR fixes ECS handlers not setting the `pipeline_step` in log context, causing logs to show `pipeline_step: not_specified`.

Previously, only `lambda_handler` functions created an `ExecutionContext` with the appropriate `pipeline_step`. The `ecs_handler` functions called `run_ecs_handler` without passing execution context, so `setup_logging` defaulted to `"not_specified"`.

Changes:
- `run_ecs_handler` now requires an `execution_context` parameter explicitly, ensuring all ECS handlers provide logging context
- Each `ecs_handler` function now creates an `ExecutionContext` (matching the pattern used by `lambda_handler`)
- Updated handlers: `graph_extractor`, `ingestor_loader`, `ingestor_indexer`

Related to wellcomecollection/platform#6227

## How to test

Deploy an ECS task (e.g. ingestor_loader) and check CloudWatch logs. The `pipeline_step` field should now show the correct step name (e.g. `ingestor_loader`) instead of `not_specified`.

## How can we measure success?

Filter CloudWatch logs by `pipeline_step: not_specified` - there should be no new logs from ECS tasks with this value after deployment.

## Have we considered potential risks?

Low risk - this adds required context to logging without changing functional behaviour. The explicit `execution_context` parameter ensures future ECS handlers can't accidentally omit it.
