### PR TITLE
Export id-minter RDS backups to S3 as Parquet via Step Functions

### DIFF
--- a/infrastructure/critical/RDS_BACKUP.md
+++ b/infrastructure/critical/RDS_BACKUP.md
@@ -44,12 +44,12 @@ Each export is encrypted with the `alias/id-minter-rds-export` KMS key.
 
 ## Manual trigger
 
-The state machine accepts the same input shape as the EventBridge event, so you can trigger an export for any known recovery point:
+The state machine reads the snapshot ARN from the `resources` array in the EventBridge event. For manual triggers, provide the recovery point ARN in the same field:
 
 ```bash
 aws stepfunctions start-execution \
   --state-machine-arn arn:aws:states:eu-west-1:760097843905:stateMachine:id-minter-rds-export \
-  --input '{"detail":{"recoveryPointArn":"arn:aws:rds:eu-west-1:760097843905:cluster-snapshot:awsbackup:job-XXXX"}}'
+  --input '{"resources":["arn:aws:rds:eu-west-1:760097843905:cluster-snapshot:awsbackup:job-XXXX"]}'
 ```
 
 To find available recovery points:

--- a/infrastructure/critical/export_id_minter.tf
+++ b/infrastructure/critical/export_id_minter.tf
@@ -7,7 +7,7 @@
 #
 #   aws stepfunctions start-execution \
 #     --state-machine-arn <arn> \
-#     --input '{"detail":{"recoveryPointArn":"arn:aws:rds:eu-west-1:ACCOUNT:cluster-snapshot:awsbackup:job-XXXX"}}'
+#     --input '{"resources":["arn:aws:rds:eu-west-1:ACCOUNT:cluster-snapshot:awsbackup:job-XXXX"]}'
 # -------------------------------------------------------
 
 data "aws_caller_identity" "current" {}
@@ -187,7 +187,7 @@ locals {
         Resource = "arn:aws:states:::aws-sdk:rds:startExportTask"
         Parameters = {
           "ExportTaskIdentifier.$" = "States.Format('identifiers-export-{}', $$.Execution.Name)"
-          "SourceArn.$"            = "$.detail.recoveryPointArn"
+          "SourceArn.$"            = "$.resources[0]"
           S3BucketName             = local.export_s3_bucket
           "S3Prefix.$"             = "States.Format('exports/identifiers/{}', States.ArrayGetItem(States.StringSplit($$.Execution.StartTime, 'T'), 0))"
           IamRoleArn               = aws_iam_role.rds_s3_export.arn


### PR DESCRIPTION
## What does this change?

Adds automated daily export of the id-minter RDS Aurora cluster backups to S3 as Parquet files, building on the AWS Backup plan from #3221.

This is part of wellcomecollection/platform#6269 — setting up database to S3 export jobs for the id-minter database.

### New resources

| Resource | Purpose |
|---|---|
| **S3 bucket** (`aws_s3_bucket.id_minter`) | Imported existing `wellcomecollection-platform-id-minter` bucket into this Terraform stack |
| **S3 lifecycle rule** | Expires objects under `exports/` after 30 days |
| **KMS key + alias** | Encryption for RDS export (required by `StartExportTask`) |
| **IAM role** (`rds_s3_export`) | Assumed by the RDS export service — S3 + KMS permissions |
| **SNS topic** | Failure notifications (`id-minter-rds-export-alerts`) |
| **Step Functions state machine** | Orchestrates the export — calls `rds:StartExportTask` and polls `rds:DescribeExportTasks` via SDK integrations (no Lambda) |
| **EventBridge rule + target** | Triggers the state machine when AWS Backup completes for the id-minter vault |

### State machine flow

```
StartExportTask → WaitForExport (5 min) → DescribeExportTask → CheckExportStatus
                       ↑                                            │
                       └── STARTING/IN_PROGRESS ────────────────────┘
                                                          │
                                              COMPLETE → Succeed
                                         FAILED/CANCELED → SNS notify → Fail
```

### S3 output structure

```
s3://wellcomecollection-platform-id-minter/exports/identifiers/2026-02-09/{export-task-id}/identifiers/{table}/...parquet
```

### Manual trigger

The state machine can be triggered manually with a known recovery point ARN:

```bash
aws stepfunctions start-execution \
  --state-machine-arn <arn> \
  --input '{"detail":{"recoveryPointArn":"arn:aws:rds:..."}}'
```

## How to test

1. `terraform plan` in `infrastructure/critical` — should show no changes (already applied and tested).
2. The state machine has been manually triggered and successfully exported a snapshot to S3.
3. Automated daily flow: AWS Backup (03:00 UTC) → EventBridge → Step Functions → S3 export.

## How can we measure success?

- Daily Parquet exports appearing in `s3://wellcomecollection-platform-id-minter/exports/identifiers/` with date-partitioned prefixes.
- Step Functions execution history shows successful completions.
- No SNS failure notifications.

## Have we considered potential risks?

- **No downtime risk**: Exports are from snapshots, not the live cluster.
- **Cost**: KMS key (~$1/month), S3 storage for Parquet exports (modest, with 30-day lifecycle expiration), and Step Functions executions (negligible).
- **S3 object permissions**: The RDS export role has `s3:GetObject`, `s3:PutObject*`, `s3:DeleteObject` on `/*` of the bucket (broader than just `/exports/*`) because RDS validates these permissions at the bucket level upfront. Write operations only target the `exports/` prefix.
- **KMS permissions**: Both key policy and IAM policies grant KMS access (belt-and-suspenders) after discovering that IAM-only grants via the root delegation were insufficient.
