### PR TITLE
Fix ExportTaskIdentifier exceeding 60-char RDS limit

### DIFF
--- a/infrastructure/critical/README.md
+++ b/infrastructure/critical/README.md
@@ -9,3 +9,17 @@ In order to run terraform the Elastic Cloud terraform provider requires that the
 You can run `run_terraform.sh` to set the correct environment variable and run terraform. Any parameters you pass to that script will be passed to `terraform`.
 
 The script will by default set AWS_PROFILE to "platform", but you can use a different value by setting AWS_PROFILE yourself.
+
+## RDS Snapshot Export (id-minter)
+
+The `export_id_minter.tf` file defines a Step Functions state machine that exports id-minter RDS backup snapshots to S3 as Parquet. It is triggered automatically by EventBridge when an AWS Backup job completes.
+
+To start an export manually, you need to provide both an `id` (used to build the `ExportTaskIdentifier`) and the snapshot ARN in `resources`:
+
+```bash
+aws stepfunctions start-execution \
+  --state-machine-arn <arn> \
+  --input '{"id":"manual-2026-02-11","resources":["arn:aws:rds:eu-west-1:ACCOUNT:cluster-snapshot:awsbackup:job-XXXX"]}'
+```
+
+The `id` field must contain only letters, digits, and hyphens, and the resulting `ExportTaskIdentifier` (`id-exp-{id}`) must be at most 60 characters. When triggered by EventBridge, the event ID (a UUID) is used automatically.

--- a/infrastructure/critical/export_id_minter.tf
+++ b/infrastructure/critical/export_id_minter.tf
@@ -7,7 +7,11 @@
 #
 #   aws stepfunctions start-execution \
 #     --state-machine-arn <arn> \
-#     --input '{"resources":["arn:aws:rds:eu-west-1:ACCOUNT:cluster-snapshot:awsbackup:job-XXXX"]}'
+#     --input '{"id":"manual-2026-02-11","resources":["arn:aws:rds:eu-west-1:ACCOUNT:cluster-snapshot:awsbackup:job-XXXX"]}'
+#
+# The "id" field is used to build the ExportTaskIdentifier
+# (id-exp-{id}), which must be <= 60 characters. When triggered
+# by EventBridge the event ID (a UUID) is used automatically.
 # -------------------------------------------------------
 
 data "aws_caller_identity" "current" {}
@@ -186,7 +190,7 @@ locals {
         Type     = "Task"
         Resource = "arn:aws:states:::aws-sdk:rds:startExportTask"
         Parameters = {
-          "ExportTaskIdentifier.$" = "States.Format('identifiers-export-{}', $$.Execution.Name)"
+          "ExportTaskIdentifier.$" = "States.Format('id-exp-{}', $.id)"
           "SourceArn.$"            = "$.resources[0]"
           S3BucketName             = local.export_s3_bucket
           "S3Prefix.$"             = "States.Format('exports/identifiers/{}', States.ArrayGetItem(States.StringSplit($$.Execution.StartTime, 'T'), 0))"


### PR DESCRIPTION
## What does this change?

Fixes the `StartExportTask` step in the id-minter RDS export state machine, which was failing because the `ExportTaskIdentifier` exceeded the RDS 60-character limit.

**Root cause:** When EventBridge triggers a Step Functions execution, the execution name is `{eventId}_{targetId}` — two UUIDs joined by an underscore (73 chars). The previous identifier format was:

```
identifiers-export-{Execution.Name}
```

= 20 + 73 = **93 characters**, well over the 60-char limit.

**Fix:** Use the EventBridge event ID (`$.id` from the input payload) with a shorter prefix:

```
id-exp-{event_id}
```

= 7 + 36 = **43 characters**, safely under the limit.

Also updates the README and TF header comment to document the manual invocation format (which now requires an `id` field in the input).

Follows on from #3222.

## How to test

- Already applied via `terraform apply`.
- The next scheduled AWS Backup completion (daily at 03:00 UTC) will trigger the state machine automatically and should succeed.
- Can also be tested manually:
  ```bash
  aws stepfunctions start-execution \
    --state-machine-arn <arn> \
    --input '{"id":"manual-test","resources":["arn:aws:rds:eu-west-1:ACCOUNT:cluster-snapshot:awsbackup:job-XXXX"]}'
  ```

## How can we measure success?

The nightly RDS export state machine execution completes successfully instead of failing at `StartExportTask`.

## Have we considered potential risks?

- The `id` field is always present in EventBridge events, so automated triggers are unaffected.
- Manual invocations now require an `id` field in the input — this is documented in the README and TF file header.
- There is no risk of identifier collision since each EventBridge event has a unique ID.
