### PR TITLE
Use OPTIONAL MATCH for HAS_SOURCE_CONCEPT in SOURCE_CONCEPT_QUERY

### DIFF
--- a/catalogue_graph/src/ingestor/queries/concept_queries.py
+++ b/catalogue_graph/src/ingestor/queries/concept_queries.py
@@ -24,7 +24,7 @@ CONCEPT_TYPE_QUERY = """
 SOURCE_CONCEPT_QUERY = """
     UNWIND $ids AS id
     MATCH (concept:Concept {`~id`: id})
-    MATCH (concept)-[:HAS_SOURCE_CONCEPT]->(linked_source_concept)-[:SAME_AS*0..]->(sameas_linked_source_concept)
+    OPTIONAL MATCH (concept)-[:HAS_SOURCE_CONCEPT]->(linked_source_concept)-[:SAME_AS*0..]->(sameas_linked_source_concept)
     OPTIONAL MATCH (concept)-[:SAME_AS]->(direct_match)
     
     WITH concept, linked_source_concept,


### PR DESCRIPTION
## What does this change?

Following #3197 (weco-authority source concepts) and #3233 (tweaks to fix indexing of weco-authority overrides), this changes `SOURCE_CONCEPT_QUERY` to use `OPTIONAL MATCH` for the `HAS_SOURCE_CONCEPT` traversal, so that `SAME_AS` matches to weco-authority concepts are included even when there are no `HAS_SOURCE_CONCEPT` matches.

Previously, the query used a mandatory `MATCH` for the `HAS_SOURCE_CONCEPT` path:
```cypher
MATCH (concept)-[:HAS_SOURCE_CONCEPT]->(linked_source_concept)-[:SAME_AS*0..]->(sameas_linked_source_concept)
```

This meant that if a concept had no `HAS_SOURCE_CONCEPT` relationships (e.g. [`usgkq8dj`](https://wellcomecollection.org/concepts/usgkq8dj)), the entire row was filtered out and the subsequent `OPTIONAL MATCH` for direct `SAME_AS` relationships never ran — so the weco-authority source concept was unreachable.

Changing to `OPTIONAL MATCH` allows the direct `SAME_AS` path to still provide results when `HAS_SOURCE_CONCEPT` yields nothing. This was also verified with label-derived concepts that have no matches via either path (e.g. `jm2gs7uh`).

Investigation context: #3237, [Slack thread](https://wellcome.slack.com/archives/C02ANCYL90E/p1770916306032239).

## How to test

This was tested by:
1. Running the `graph_weco_authority.ipynb` notebook (from #3237) against the Neptune graph to confirm that previously unreachable weco-authority concepts are now returned by `SOURCE_CONCEPT_QUERY`
2. Running the `graph_reindex_by_id.ipynb` notebook (from #3237) to reindex affected concepts into a test concepts index
3. Pointing a local concepts API and version of the website at the test index and verifying the following concepts now display correctly (on www-dev, _these have now been run in prod_):

   - https://wellcomecollection.org/concepts/usgkq8dj
   - https://wellcomecollection.org/concepts/ce7rratv
   - https://wellcomecollection.org/concepts/pestkwqm

## How can we measure success?

Weco-authority concepts that previously had missing images/descriptions on their concept pages will now display them correctly after reindexing.

## Have we considered potential risks?

Low risk — the change only broadens the query to include results that were previously silently excluded. Concepts that already had `HAS_SOURCE_CONCEPT` matches are unaffected since `OPTIONAL MATCH` returns the same results as `MATCH` when matches exist. Concepts with neither `HAS_SOURCE_CONCEPT` nor `SAME_AS` matches will now return empty lists instead of being filtered out entirely.
