### PR TITLE
Enable FOLIO adapter schedule

### DIFF
--- a/catalogue_graph/infra/adapters/folio/main.tf
+++ b/catalogue_graph/infra/adapters/folio/main.tf
@@ -166,7 +166,7 @@ resource "aws_scheduler_schedule" "folio_adapter_15_minute_run" {
 
   schedule_expression = "rate(15 minutes)"
   # Enable this to turn on regular harvest
-  state = "DISABLED"
+  state = "ENABLED"
 
   target {
     arn      = aws_sfn_state_machine.state_machine.arn


### PR DESCRIPTION
## What does this change?

Enables the FOLIO adapter's 15-minute scheduled harvest by changing the EventBridge Scheduler state from `DISABLED` to `ENABLED`.

This follows the merge of:
- https://github.com/wellcomecollection/catalogue-pipeline/pull/3215 (FOLIO OAI-PMH adapter)
- https://github.com/wellcomecollection/catalogue-pipeline/pull/3216

The reloader has been run to ingest all available records up to this point. Enabling the schedule will now keep the catalogue up to date with ongoing changes from FOLIO.

Part of https://github.com/wellcomecollection/platform/issues/6247

## How to test

After deploying, verify the `folio_adapter_15_minute_run` EventBridge schedule is in the `ENABLED` state in the AWS console, and that the FOLIO adapter Step Function starts executing every 15 minutes.

## How can we measure success?

The FOLIO adapter Step Function should be running on schedule and successfully harvesting new/updated records from FOLIO.

## Have we considered potential risks?

Low risk — the adapter infrastructure and code are already deployed and tested. This only enables the schedule. If issues arise, reverting this one-line change disables the schedule again.
