### PR TITLE
Add OAI-PMH loader report with S3 persistence and summary suppression

### DIFF
--- a/catalogue_graph/infra/adapters/axiell/lambda_loader.tf
+++ b/catalogue_graph/infra/adapters/axiell/lambda_loader.tf
@@ -13,6 +13,13 @@ module "loader_lambda" {
 
   memory_size = 10240
   timeout     = 900
+
+  environment = {
+    variables = {
+      S3_BUCKET = data.aws_s3_bucket.axiell_adapter.id
+      S3_PREFIX = "prod"
+    }
+  }
 }
 
 # IAM policy for writing to Iceberg table

--- a/catalogue_graph/infra/adapters/folio/lambda_loader.tf
+++ b/catalogue_graph/infra/adapters/folio/lambda_loader.tf
@@ -13,6 +13,13 @@ module "loader_lambda" {
 
   memory_size = 10240
   timeout     = 900
+
+  environment = {
+    variables = {
+      S3_BUCKET = data.aws_s3_bucket.folio_adapter.id
+      S3_PREFIX = "prod"
+    }
+  }
 }
 
 # IAM policy for writing to Iceberg table

--- a/catalogue_graph/src/adapters/axiell/config.py
+++ b/catalogue_graph/src/adapters/axiell/config.py
@@ -104,10 +104,10 @@ ES_MODE = os.getenv("ES_MODE", "private")
 
 # Manifest storage configuration
 S3_BUCKET = os.getenv(
-    "AXIELL_TRANSFORMER_S3_BUCKET",
+    "S3_BUCKET",
     "wellcomecollection-platform-axiell-adapter",
 )
-S3_PREFIX = os.getenv("AXIELL_TRANSFORMER_S3_PREFIX", "dev")
+S3_PREFIX = os.getenv("S3_PREFIX", "dev")
 BATCH_S3_PREFIX = os.path.join(S3_PREFIX, "batches")
 
 
@@ -144,4 +144,7 @@ AXIELL_ADAPTER_CONFIG = OAIPMHAdapterConfig(
     local_window_status_db_name=LOCAL_WINDOW_STATUS_DB_NAME,
     local_window_status_table=LOCAL_WINDOW_STATUS_TABLE,
     local_window_status_namespace=LOCAL_WINDOW_STATUS_NAMESPACE,
+    # Reporting
+    report_s3_bucket=S3_BUCKET,
+    report_s3_prefix=S3_PREFIX,
 )

--- a/catalogue_graph/src/adapters/folio/config.py
+++ b/catalogue_graph/src/adapters/folio/config.py
@@ -97,6 +97,12 @@ LOADER_DETAIL_TYPE = os.getenv("FOLIO_LOADER_DETAIL_TYPE", "FolioWindowLoaded")
 # ---------------------------------------------------------------------------
 CHATBOT_TOPIC_ARN = os.getenv("FOLIO_CHATBOT_TOPIC_ARN")
 
+# ---------------------------------------------------------------------------
+# S3 storage
+# ---------------------------------------------------------------------------
+S3_BUCKET = os.getenv("S3_BUCKET", "wellcomecollection-platform-folio-adapter")
+S3_PREFIX = os.getenv("S3_PREFIX", "dev")
+
 
 # ---------------------------------------------------------------------------
 # OAI-PMH Adapter Config (Pydantic model for runtime)
@@ -131,4 +137,7 @@ FOLIO_ADAPTER_CONFIG = OAIPMHAdapterConfig(
     local_window_status_db_name=LOCAL_WINDOW_STATUS_DB_NAME,
     local_window_status_table=LOCAL_WINDOW_STATUS_TABLE,
     local_window_status_namespace=LOCAL_WINDOW_STATUS_NAMESPACE,
+    # Reporting
+    report_s3_bucket=S3_BUCKET,
+    report_s3_prefix=S3_PREFIX,
 )

--- a/catalogue_graph/src/adapters/oai_pmh/models/step_events.py
+++ b/catalogue_graph/src/adapters/oai_pmh/models/step_events.py
@@ -59,7 +59,7 @@ class OAIPMHLoaderResponse(BaseLoaderResponse):
     Contains summaries of processed windows and identifiers for downstream steps.
     """
 
-    summaries: list[WindowSummary]
+    summaries: list[WindowSummary] = Field(default_factory=list)
     """Status summaries for each processed sub-window."""
 
     changeset_ids: list[str] = Field(default_factory=list)

--- a/catalogue_graph/src/adapters/oai_pmh/reporting.py
+++ b/catalogue_graph/src/adapters/oai_pmh/reporting.py
@@ -8,10 +8,13 @@ from __future__ import annotations
 
 from typing import ClassVar
 
+from pydantic import Field
+
 from adapters.oai_pmh.models.step_events import (
     OAIPMHLoaderEvent,
     OAIPMHLoaderResponse,
 )
+from adapters.utils.window_summary import WindowSummary
 from models.events import IncrementalWindow
 from utils.reporting import PipelineMetric, PipelineReport
 
@@ -30,9 +33,24 @@ class OAIPMHReport(PipelineReport):
     publish_to_s3: bool = False
     """OAI-PMH adapter reports do not publish to S3 by default."""
 
+    report_s3_bucket: str | None = None
+    """S3 bucket for report storage."""
+
+    report_s3_prefix: str = "dev"
+    """S3 key prefix for report paths."""
+
     @property
     def metric_namespace(self) -> str:
         return "catalogue_adapters"
+
+    @property
+    def s3_uri(self) -> str:
+        start = self.window.start_time.strftime("%Y%m%dT%H%M%S")
+        end = self.window.end_time.strftime("%Y%m%dT%H%M%S")
+        return (
+            f"s3://{self.report_s3_bucket}/{self.report_s3_prefix}"
+            f"/reports/{self.adapter_type}/{self.label}/{start}_{end}.json"
+        )
 
     @property
     def metric_dimensions(self) -> dict:
@@ -46,6 +64,7 @@ class OAIPMHLoaderReport(OAIPMHReport):
     """Loader step report for OAI-PMH adapters."""
 
     label: ClassVar[str] = "adapter_loader"
+    summaries: list[WindowSummary] = Field(default_factory=list)
     window_success_count: int
     window_failure_count: int = 0
     record_changes_count: int = 0
@@ -58,6 +77,8 @@ class OAIPMHLoaderReport(OAIPMHReport):
         response: OAIPMHLoaderResponse,
         *,
         adapter_type: str,
+        report_s3_bucket: str | None = None,
+        report_s3_prefix: str = "dev",
     ) -> OAIPMHLoaderReport:
         """Create a report from loader event and response.
 
@@ -65,6 +86,8 @@ class OAIPMHLoaderReport(OAIPMHReport):
             event: The loader request event.
             response: The loader response with window summaries.
             adapter_type: Adapter identifier for metrics (e.g., 'axiell').
+            report_s3_bucket: S3 bucket for report storage (None to skip S3).
+            report_s3_prefix: S3 key prefix for report paths.
         """
         window_success_count = sum(
             1 for summary in response.summaries if summary.state == "success"
@@ -73,6 +96,10 @@ class OAIPMHLoaderReport(OAIPMHReport):
         return cls(
             window=event.window,
             adapter_type=adapter_type,
+            publish_to_s3=report_s3_bucket is not None,
+            report_s3_bucket=report_s3_bucket,
+            report_s3_prefix=report_s3_prefix,
+            summaries=response.summaries,
             window_success_count=window_success_count,
             window_failure_count=window_failure_count,
             record_changes_count=response.changed_record_count,

--- a/catalogue_graph/src/adapters/oai_pmh/runtime.py
+++ b/catalogue_graph/src/adapters/oai_pmh/runtime.py
@@ -127,6 +127,15 @@ class OAIPMHAdapterConfig(BaseModel):
     local_window_status_namespace: str
     """Namespace for window status (local)."""
 
+    # ---------------------------------------------------------------------------
+    # Reporting
+    # ---------------------------------------------------------------------------
+    report_s3_bucket: str | None = None
+    """S3 bucket for report storage (None to disable S3 report publishing)."""
+
+    report_s3_prefix: str = "dev"
+    """S3 key prefix for report paths."""
+
 
 class OAIPMHRuntimeConfig(ABC):
     """Base class for OAI-PMH adapter runtime configuration.


### PR DESCRIPTION
## What does this change?

Adds S3 report persistence and summary suppression to OAI-PMH adapter loaders (Axiell & FOLIO), following the pattern established by the EBSCO adapter.

### Problem

The OAI-PMH loader returns window summaries in the Step Functions response payload. When harvesting many windows, the summaries can exceed the Step Functions payload size limit, causing the step to fail.

### Solution

- **Report persistence**: `OAIPMHLoaderReport` now includes window summaries and writes them to S3 (e.g. `s3://{bucket}/{prefix}/reports/{adapter}/adapter_loader/{timestamp}.json`) via the existing `PipelineReport.publish()` mechanism.
- **Summary suppression**: After the report is published, summaries are cleared from the Step Functions response (`suppress_summaries=True` by default). CLI mode keeps summaries visible for debugging (`suppress_summaries=False`).
- **Unified S3 config**: Both adapters reuse the generic `S3_BUCKET`/`S3_PREFIX` env vars (already used by trigger lambdas) rather than introducing new ones.

### Files changed

- `src/adapters/oai_pmh/models/step_events.py` — `summaries` defaults to `[]` so responses remain valid after suppression
- `src/adapters/oai_pmh/runtime.py` — added `report_s3_bucket`/`report_s3_prefix` to `OAIPMHAdapterConfig`
- `src/adapters/oai_pmh/reporting.py` — `OAIPMHLoaderReport` gains `summaries` field, `s3_uri` property, and updated `from_loader()` factory
- `src/adapters/oai_pmh/steps/loader.py` — `suppress_summaries` config, S3 report wiring, post-publish suppression
- `src/adapters/axiell/config.py` — wires `S3_BUCKET`/`S3_PREFIX` to report config
- `src/adapters/folio/config.py` — adds `S3_BUCKET`/`S3_PREFIX` vars, wires to report config
- `infra/adapters/axiell/lambda_loader.tf` — adds `S3_BUCKET`/`S3_PREFIX` env vars for prod
- `infra/adapters/folio/lambda_loader.tf` — same
- `tests/adapters/oai_pmh/test_loader.py` — tests for report publishing, summary suppression, and suppression opt-out

## How to test

Tests cover the new behaviour:

```bash
cd catalogue_graph && uv run pytest tests/adapters/oai_pmh/ -q --tb=short
```

All 81 OAI-PMH tests pass. Full adapter test suite (129 tests) also passes.

## How can we measure success?

- Loader reports appear in S3 under `{prefix}/reports/{adapter}/adapter_loader/`
- Step Functions executions no longer fail with payload size errors
- Window summaries are preserved in S3 reports for debugging/auditing

## Have we considered potential risks?

- **S3 write permissions**: Already granted to loader lambdas (`s3:PutObject` on `prod/*`)
- **Backward compatibility**: `summaries` defaults to `[]`, so existing consumers handle empty lists gracefully
- **CLI experience**: Suppression is disabled in CLI mode so developers still see summaries locally

Towards wellcomecollection/platform#6266
