### PR TITLE
remove cluster, security groups in/out

### DIFF
--- a/infrastructure/critical/outputs.tf
+++ b/infrastructure/critical/outputs.tf
@@ -1,9 +1,5 @@
 # RDS
 
-output "rds_serverless_cluster_id" {
-  value = module.identifiers_serverless_rds_cluster.rds_cluster_id
-}
-
 output "rds_v2_serverless_cluster_id" {
   value = module.identifiers_v2_serverless_rds_cluster.rds_cluster_id
 }
@@ -22,10 +18,6 @@ output "rds_v2_master_user_secret_arn" {
 
 output "rds_subnet_group_name" {
   value = aws_db_subnet_group.default.name
-}
-
-output "rds_access_security_group_id" {
-  value = aws_security_group.rds_ingress_security_group.id
 }
 
 # Miro Hybrid Store

--- a/infrastructure/critical/rds_id_minter.tf
+++ b/infrastructure/critical/rds_id_minter.tf
@@ -15,55 +15,6 @@ resource "aws_db_subnet_group" "default" {
   subnet_ids = local.private_subnets_new
 }
 
-resource "aws_security_group" "database_sg" {
-  description = "Allows connection to RDS instance via TCP and egress to the world"
-  vpc_id      = local.vpc_id_new
-  name        = "identifiers_database_sg"
-
-  ingress {
-    protocol  = "tcp"
-    from_port = 3306
-    to_port   = 3306
-
-    cidr_blocks = [
-      local.admin_cidr_ingress,
-    ]
-  }
-
-  ingress {
-    from_port = 3306
-    to_port   = 3306
-    protocol  = "tcp"
-
-    security_groups = [aws_security_group.rds_ingress_security_group.id]
-  }
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-}
-
-module "identifiers_serverless_rds_cluster" {
-  source = "./modules/rds-serverless"
-
-  cluster_identifier = "identifiers-serverless"
-  database_name      = "identifiers"
-  master_username    = local.username
-  master_password    = local.password
-
-  db_security_group_id     = aws_security_group.database_sg.id
-  aws_db_subnet_group_name = aws_db_subnet_group.default.name
-
-  max_scaling_capacity = 16
-
-  snapshot_identifier = "aurora-mysql-v3-pre-migration-24-10-08"
-
-  engine_version = "8.0.mysql_aurora.3.08.2"
-}
-
 resource "aws_security_group" "database_v2_sg" {
   description = "Allows connection to identifiers-v2 RDS instance via TCP and egress to the world"
   vpc_id      = local.vpc_id_new
@@ -130,21 +81,4 @@ resource "aws_security_group" "rds_v2_ingress_security_group" {
   }
 }
 
-
-resource "aws_security_group" "rds_ingress_security_group" {
-  name        = "pipeline_rds_ingress_security_group"
-  description = "Allow traffic to rds database"
-  vpc_id      = local.vpc_id_new
-
-  ingress {
-    from_port = 0
-    to_port   = 0
-    protocol  = "-1"
-    self      = true
-  }
-
-  tags = {
-    Name = "pipeline-rds-access"
-  }
-}
 


### PR DESCRIPTION
## What does this change?

https://github.com/wellcomecollection/platform/issues/6312

The old `identifiers` db/cluster have been manually deleted through the AWS console
These TF changes merely align the config with the remaining deployed resources

## How to test

Run `terraform plan` in infrastructure/critical

-> Plan: 0 to add, 0 to change, 8 to destroy.
2 security groups: `database_sg` and `rds_ingress_security_group`
3 secrets (see infrastructure/critical/modules/rds-serverless/secrets.tf) and 
3 secret versions 

## How can we measure success?

Clean tf config 🫧🧽

## Have we considered potential risks?

The risky bit was deleting the db cluster itself 😅
