### PR TITLE
Related work processing bug fix

### DIFF
--- a/catalogue_graph/src/ingestor/extractors/base_extractor.py
+++ b/catalogue_graph/src/ingestor/extractors/base_extractor.py
@@ -20,7 +20,11 @@ from ingestor.queries.concept_queries import (
     SAME_AS_CONCEPT_QUERY,
     SOURCE_CONCEPT_QUERY,
 )
-from ingestor.queries.work_queries import WORK_ANCESTORS_QUERY, WORK_CHILDREN_QUERY
+from ingestor.queries.work_queries import (
+    WORK_ANCESTORS_QUERY,
+    WORK_CHILDREN_QUERY,
+    WORK_DESCENDANTS_QUERY,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -41,7 +45,7 @@ ConceptQuery = Literal[
     "same_as_concept",
     ConceptRelatedQuery,
 ]
-WorkQuery = Literal["work_children", "work_ancestors"]
+WorkQuery = Literal["work_children", "work_ancestors", "work_descendants"]
 
 NEPTUNE_CHUNK_SIZE = 5000
 
@@ -52,6 +56,7 @@ NEPTUNE_EXPENSIVE_CHUNK_SIZE = 1000
 NEPTUNE_QUERIES: dict[ConceptQuery | WorkQuery, str] = {
     "work_children": WORK_CHILDREN_QUERY,
     "work_ancestors": WORK_ANCESTORS_QUERY,
+    "work_descendants": WORK_DESCENDANTS_QUERY,
     "concept": CONCEPT_QUERY,
     "concept_type": CONCEPT_TYPE_QUERY,
     "source_concept": SOURCE_CONCEPT_QUERY,

--- a/catalogue_graph/src/ingestor/extractors/works_extractor.py
+++ b/catalogue_graph/src/ingestor/extractors/works_extractor.py
@@ -2,12 +2,13 @@ from collections.abc import Generator, Iterator
 from itertools import batched
 
 import structlog
-from elasticsearch import Elasticsearch
-from pydantic import BaseModel
-
 from clients.neptune_client import NeptuneClient
+from elasticsearch import Elasticsearch
 from graph.sources.catalogue.concepts_source import extract_identified_concepts
 from graph.sources.merged_works_source import MergedWorksSource
+from models.events import BasePipelineEvent
+from pydantic import BaseModel
+
 from ingestor.models.merged.work import (
     MergedWork,
     VisibleMergedWork,
@@ -17,7 +18,6 @@ from ingestor.models.neptune.query_result import (
     ExtractedConcept,
     WorkHierarchy,
 )
-from models.events import BasePipelineEvent
 
 from .base_extractor import GraphBaseExtractor
 from .work_concepts_extractor import WorkConceptsExtractor
@@ -165,7 +165,8 @@ class GraphWorksExtractor(GraphBaseExtractor):
                 )
 
                 # When a work is processed in incremental mode, its parent and descendants must be processed too.
-                # This is because each work document contains references to all its ancestors and children.
+                # This is because each work document stores the IDs of all of its ancestors (`partOf` field)
+                # and children (`parts` field), along with their titles and reference numbers.
                 if self.event.mode_label != "full":
                     raw_desc = descendants_batch.get(work_id, {}).get("descendants", [])
                     descendants = [WorkNode.model_validate(d) for d in raw_desc]

--- a/catalogue_graph/src/ingestor/extractors/works_extractor.py
+++ b/catalogue_graph/src/ingestor/extractors/works_extractor.py
@@ -2,13 +2,12 @@ from collections.abc import Generator, Iterator
 from itertools import batched
 
 import structlog
-from clients.neptune_client import NeptuneClient
 from elasticsearch import Elasticsearch
-from graph.sources.catalogue.concepts_source import extract_identified_concepts
-from graph.sources.merged_works_source import MergedWorksSource
-from models.events import BasePipelineEvent
 from pydantic import BaseModel
 
+from clients.neptune_client import NeptuneClient
+from graph.sources.catalogue.concepts_source import extract_identified_concepts
+from graph.sources.merged_works_source import MergedWorksSource
 from ingestor.models.merged.work import (
     MergedWork,
     VisibleMergedWork,
@@ -18,6 +17,7 @@ from ingestor.models.neptune.query_result import (
     ExtractedConcept,
     WorkHierarchy,
 )
+from models.events import BasePipelineEvent
 
 from .base_extractor import GraphBaseExtractor
 from .work_concepts_extractor import WorkConceptsExtractor

--- a/catalogue_graph/src/ingestor/extractors/works_extractor.py
+++ b/catalogue_graph/src/ingestor/extractors/works_extractor.py
@@ -151,7 +151,11 @@ class GraphWorksExtractor(GraphBaseExtractor):
             # Make graph queries to retrieve ancestors, children, and concepts for all visible works in each batch
             ancestors_batch = self._get_work_ancestors(visible_work_ids)
             children_batch = self._get_work_children(visible_work_ids)
-            descendants_batch = self._get_work_descendants(visible_work_ids)
+            descendants_batch = (
+                self._get_work_descendants(visible_work_ids)
+                if self.event.mode_label != "full"
+                else {}
+            )
             concepts_batch = self._get_work_concepts(visible_works)
 
             for es_work in visible_works:

--- a/catalogue_graph/src/ingestor/extractors/works_extractor.py
+++ b/catalogue_graph/src/ingestor/extractors/works_extractor.py
@@ -12,7 +12,11 @@ from ingestor.models.merged.work import (
     MergedWork,
     VisibleMergedWork,
 )
-from ingestor.models.neptune.query_result import ExtractedConcept, WorkHierarchy
+from ingestor.models.neptune.node import WorkNode
+from ingestor.models.neptune.query_result import (
+    ExtractedConcept,
+    WorkHierarchy,
+)
 from models.events import BasePipelineEvent
 
 from .base_extractor import GraphBaseExtractor
@@ -99,6 +103,10 @@ class GraphWorksExtractor(GraphBaseExtractor):
         """Return all children of each work in the current batch."""
         return self.make_neptune_query("work_children", ids)
 
+    def _get_work_descendants(self, ids: list[str]) -> dict:
+        """Return all descendants of each work in the current batch."""
+        return self.make_neptune_query("work_descendants", ids)
+
     def _get_work_concepts(self, works: list[VisibleMergedWork]) -> dict:
         """Return all concepts of each work in the current batch."""
         concept_ids_by_work = {}
@@ -143,6 +151,7 @@ class GraphWorksExtractor(GraphBaseExtractor):
             # Make graph queries to retrieve ancestors, children, and concepts for all visible works in each batch
             ancestors_batch = self._get_work_ancestors(visible_work_ids)
             children_batch = self._get_work_children(visible_work_ids)
+            descendants_batch = self._get_work_descendants(visible_work_ids)
             concepts_batch = self._get_work_concepts(visible_works)
 
             for es_work in visible_works:
@@ -155,15 +164,13 @@ class GraphWorksExtractor(GraphBaseExtractor):
                     children=children_batch.get(work_id, {}).get("children", []),
                 )
 
-                # When a work is processed, all of its children and ancestors must be processed too for consistency.
-                # (For example, if the title of a parent work changes, all of its children must be processed
-                # and reindexed to store the new title.)
-                self.related_ids.update(
-                    c.work.properties.id for c in hierarchy.children
-                )
-                self.related_ids.update(
-                    c.work.properties.id for c in hierarchy.ancestors
-                )
+                # When a work is processed, all of its descendants and parents must be processed too for consistency.
+                # This is because each work document contains references to all its ancestors and children.
+                raw_desc = descendants_batch.get(work_id, {}).get("descendants", [])
+                descendants = [WorkNode.model_validate(d) for d in raw_desc]
+                self.related_ids |= {d.properties.id for d in descendants}
+                if hierarchy.ancestors:
+                    self.related_ids.add(hierarchy.ancestors[0].work.properties.id)
 
                 yield VisibleExtractedWork(
                     work=es_work, hierarchy=hierarchy, concepts=concepts_batch[work_id]

--- a/catalogue_graph/src/ingestor/extractors/works_extractor.py
+++ b/catalogue_graph/src/ingestor/extractors/works_extractor.py
@@ -151,12 +151,14 @@ class GraphWorksExtractor(GraphBaseExtractor):
             # Make graph queries to retrieve ancestors, children, and concepts for all visible works in each batch
             ancestors_batch = self._get_work_ancestors(visible_work_ids)
             children_batch = self._get_work_children(visible_work_ids)
+            concepts_batch = self._get_work_concepts(visible_works)
+
+            # Descendants are only needed in incremental mode
             descendants_batch = (
                 self._get_work_descendants(visible_work_ids)
                 if self.event.mode_label != "full"
                 else {}
             )
-            concepts_batch = self._get_work_concepts(visible_works)
 
             for es_work in visible_works:
                 work_id = es_work.state.canonical_id

--- a/catalogue_graph/src/ingestor/extractors/works_extractor.py
+++ b/catalogue_graph/src/ingestor/extractors/works_extractor.py
@@ -164,13 +164,14 @@ class GraphWorksExtractor(GraphBaseExtractor):
                     children=children_batch.get(work_id, {}).get("children", []),
                 )
 
-                # When a work is processed, all of its descendants and parents must be processed too for consistency.
+                # When a work is processed in incremental mode, its parent and descendants must be processed too.
                 # This is because each work document contains references to all its ancestors and children.
-                raw_desc = descendants_batch.get(work_id, {}).get("descendants", [])
-                descendants = [WorkNode.model_validate(d) for d in raw_desc]
-                self.related_ids |= {d.properties.id for d in descendants}
-                if hierarchy.ancestors:
-                    self.related_ids.add(hierarchy.ancestors[0].work.properties.id)
+                if self.event.mode_label != "full":
+                    raw_desc = descendants_batch.get(work_id, {}).get("descendants", [])
+                    descendants = [WorkNode.model_validate(d) for d in raw_desc]
+                    self.related_ids |= {d.properties.id for d in descendants}
+                    if hierarchy.ancestors:
+                        self.related_ids.add(hierarchy.ancestors[0].work.properties.id)
 
                 yield VisibleExtractedWork(
                     work=es_work, hierarchy=hierarchy, concepts=concepts_batch[work_id]

--- a/catalogue_graph/src/ingestor/models/neptune/query_result.py
+++ b/catalogue_graph/src/ingestor/models/neptune/query_result.py
@@ -18,6 +18,7 @@ class WorkHierarchyItem(BaseModel):
 
 class WorkHierarchy(BaseModel):
     id: str
+    # Sorted from closest (parent) to furthest (root of work hierarchy)
     ancestors: list[WorkHierarchyItem] = []
     children: list[WorkHierarchyItem] = []
 

--- a/catalogue_graph/src/ingestor/queries/work_queries.py
+++ b/catalogue_graph/src/ingestor/queries/work_queries.py
@@ -24,3 +24,15 @@ WORK_CHILDREN_QUERY = """
         WITH work, child_work, COUNT(grandchild_identifier) AS child_work_parts
         RETURN work.id AS id, COLLECT({ work: child_work, parts: child_work_parts }) AS children
 """
+
+WORK_DESCENDANTS_QUERY = """
+    UNWIND $ids AS id
+    MATCH (work:Work {`~id`: id})
+
+    MATCH (work)-[:HAS_PATH_IDENTIFIER]->(identifier)
+    MATCH (identifier)<-[:HAS_PARENT*]-(descendant_identifier)
+    MATCH (descendant_identifier)<-[:HAS_PATH_IDENTIFIER]-(descendant_work)
+
+    WITH work.id AS id, descendant_work
+    RETURN id, COLLECT(descendant_work) AS descendants;
+"""

--- a/catalogue_graph/tests/ingestor/test_works_extractor.py
+++ b/catalogue_graph/tests/ingestor/test_works_extractor.py
@@ -36,6 +36,16 @@ EXTRACTED_CONCEPT_FIXTURE = load_json_fixture("neptune/full_extracted_concept.js
 
 EXPECTED_EXTRACTED_CONCEPT = ExtractedConcept.model_validate(EXTRACTED_CONCEPT_FIXTURE)
 
+DESCENDANT_WORK_NODE = {
+    "~id": "desc1",
+    "~labels": ["Work"],
+    "~properties": {
+        "id": "desc1",
+        "label": "Descendant work",
+        "type": "Work",
+    },
+}
+
 
 def get_extractor() -> GraphWorksExtractor:
     return GraphWorksExtractor(
@@ -63,13 +73,15 @@ def mock_graph_relationships(
     monkeypatch: pytest.MonkeyPatch,
     work_id: str,
     all_indexed_work_ids: list[str],
-    include: list[Literal["ancestors", "children", "concepts"]],
+    include: list[Literal["ancestors", "children", "concepts", "descendants"]],
 ) -> None:
-    ancestors, children = [], []
+    ancestors, children, descendants = [], [], []
     if "ancestors" in include:
         ancestors = [{"id": work_id, "ancestors": ANCESTORS_FIXTURE}]
     if "children" in include:
         children = [{"id": work_id, "children": CHILDREN_FIXTURE}]
+    if "descendants" in include:
+        descendants = [{"id": work_id, "descendants": [DESCENDANT_WORK_NODE]}]
     if "concepts" in include:
         concept_ids = [MOCK_CONCEPT_ID]
         monkeypatch.setattr(
@@ -81,7 +93,7 @@ def mock_graph_relationships(
     expected_params = {"ids": all_indexed_work_ids}
     add_neptune_mock_response(WORK_ANCESTORS_QUERY, expected_params, ancestors)
     add_neptune_mock_response(WORK_CHILDREN_QUERY, expected_params, children)
-    add_neptune_mock_response(WORK_DESCENDANTS_QUERY, expected_params, [])
+    add_neptune_mock_response(WORK_DESCENDANTS_QUERY, expected_params, descendants)
 
 
 def test_with_ancestors(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -164,3 +176,69 @@ def test_multiple_works(monkeypatch: pytest.MonkeyPatch) -> None:
     extracted_items = list(get_extractor().extract_raw())
     for result in expected_results:
         assert result in extracted_items
+
+
+def get_incremental_extractor(work_ids: list[str]) -> GraphWorksExtractor:
+    event = BasePipelineEvent(pipeline_date="dev", ids=work_ids)
+    return GraphWorksExtractor(
+        event,
+        get_mock_es_client("graph_extractor", event.pipeline_date),
+        get_mock_neptune_client(),
+    )
+
+
+def test_incremental_mode_collects_descendant_related_ids(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """In incremental mode, descendants are collected and processed as related works."""
+    mock_es_work("a24esypq")
+    mock_es_work("desc1")
+
+    # First pass: primary work has a descendant
+    mock_graph_relationships(monkeypatch, "a24esypq", ["a24esypq"], ["descendants"])
+    # Second pass: the descendant is fetched as a related work
+    mock_graph_relationships(monkeypatch, "desc1", ["desc1"], [])
+
+    extractor = get_incremental_extractor(["a24esypq"])
+    extracted_items = list(extractor.extract_raw())
+
+    assert len(extracted_items) == 2
+    extracted_ids = {item.work.state.canonical_id for item in extracted_items}
+    assert extracted_ids == {"a24esypq", "desc1"}
+
+
+def test_incremental_mode_collects_parent_as_related_work(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """In incremental mode, the parent (first ancestor) is collected as a related work."""
+    parent_id = ANCESTORS_FIXTURE[0]["work"]["~properties"]["id"]
+
+    mock_es_work("a24esypq")
+    mock_es_work(parent_id)
+
+    # First pass: primary work has ancestors (parent = first ancestor)
+    mock_graph_relationships(monkeypatch, "a24esypq", ["a24esypq"], ["ancestors"])
+    # Second pass: the parent is fetched as a related work
+    mock_graph_relationships(monkeypatch, parent_id, [parent_id], [])
+
+    extractor = get_incremental_extractor(["a24esypq"])
+    extracted_items = list(extractor.extract_raw())
+
+    assert len(extracted_items) == 2
+    extracted_ids = {item.work.state.canonical_id for item in extracted_items}
+    assert extracted_ids == {"a24esypq", parent_id}
+
+
+def test_full_mode_does_not_collect_related_ids(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """In full mode, no related work IDs are collected even when ancestors exist."""
+    mock_es_work("a24esypq")
+    mock_graph_relationships(
+        monkeypatch, "a24esypq", ["a24esypq"], ["ancestors", "children"]
+    )
+
+    extractor = get_extractor()
+    list(extractor.extract_raw())
+
+    assert extractor.related_ids == set()

--- a/catalogue_graph/tests/ingestor/test_works_extractor.py
+++ b/catalogue_graph/tests/ingestor/test_works_extractor.py
@@ -12,7 +12,11 @@ from ingestor.models.neptune.query_result import (
     ExtractedConcept,
     WorkHierarchy,
 )
-from ingestor.queries.work_queries import WORK_ANCESTORS_QUERY, WORK_CHILDREN_QUERY
+from ingestor.queries.work_queries import (
+    WORK_ANCESTORS_QUERY,
+    WORK_CHILDREN_QUERY,
+    WORK_DESCENDANTS_QUERY,
+)
 from models.events import BasePipelineEvent
 from tests.mocks import (
     MockElasticsearchClient,
@@ -77,6 +81,7 @@ def mock_graph_relationships(
     expected_params = {"ids": all_indexed_work_ids}
     add_neptune_mock_response(WORK_ANCESTORS_QUERY, expected_params, ancestors)
     add_neptune_mock_response(WORK_CHILDREN_QUERY, expected_params, children)
+    add_neptune_mock_response(WORK_DESCENDANTS_QUERY, expected_params, [])
 
 
 def test_with_ancestors(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## What does this change?

When an archive work is added to the catalogue graph (or when an existing work is updated), we need to process a subset of works from its hierarchy to keep data in the final index consistent.

Each work document in the final index stores a list of all ancestors and direct children. This means that when a work is updated, we need to process its direct parent and all of its descendants. At the moment, we're processing the updated work's ancestors (which is not necessary) and direct children (which is not sufficient). 


## How to test

Run the works ingestor in ID mode locally in the dev environment and verify that the correct works are being reprocessed.

## How can we measure success?

A consistent works index when changes are made to a work hierarchy. 

## Have we considered potential risks?

This change is low-risk.
