### PR TITLE
scan for source and optional predecessor to mint

### DIFF
--- a/catalogue_graph/src/id_minter/embedder.py
+++ b/catalogue_graph/src/id_minter/embedder.py
@@ -129,8 +129,7 @@ def process_work(
         predecessor_count=predecessor_count,
     )
 
-    found = resolver.mint_ids(mint_requests)  # type: ignore[arg-type]  # SourceIdentifierKey is a tuple[str, str, str]
-
+    found = resolver.mint_ids(mint_requests)  # type: ignore[arg-type]  # list invariance: SourceIdentifierKey is a NamedTuple subtype of SourceId
     id_map: dict[SourceIdentifierKey, str] = {
         SourceIdentifierKey(*k): v for k, v in found.items()
     }

--- a/catalogue_graph/src/id_minter/embedder.py
+++ b/catalogue_graph/src/id_minter/embedder.py
@@ -124,7 +124,7 @@ def process_work(
 
     logger.info(
         "Embedding canonical IDs",
-        source_identifier=source_id,
+        source_identifier=str(source_id),
         source_identifier_count=len(mint_requests),
         predecessor_count=predecessor_count,
     )
@@ -139,7 +139,7 @@ def process_work(
 
     logger.info(
         "Finished embedding canonical IDs",
-        source_identifier=source_id,
+        source_identifier=str(source_id),
         ids_embedded=len(id_map),
     )
 

--- a/catalogue_graph/src/id_minter/embedder.py
+++ b/catalogue_graph/src/id_minter/embedder.py
@@ -14,9 +14,9 @@ import structlog
 from id_minter.models.identifier import (
     TYPES_NORMALIZED_TO_CONCEPT,
     IdResolver,
-    SourceId,
     SourceIdentifierKey,
 )
+from models.pipeline.identifier import SourceIdentifier
 
 logger = structlog.get_logger(__name__)
 
@@ -64,10 +64,17 @@ def make_key(source_identifier: dict) -> SourceIdentifierKey:
     )
 
 
-def extract_source_identifiers(work_json: dict) -> list[SourceIdentifierKey]:
+def extract_source_identifiers(
+    work_json: dict,
+) -> list[tuple[SourceIdentifierKey, SourceIdentifierKey | None]]:
     return [
-        make_key(node["sourceIdentifier"])
-        for node in scan(work_json, lambda d: "sourceIdentifier" in d)
+        (
+            make_key(node["sourceIdentifier"]),
+            make_key(node["predecessorIdentifier"])
+            if "predecessorIdentifier" in node
+            else None,
+        )
+        for node in scan(work_json, lambda node: "sourceIdentifier" in node)
     ]
 
 
@@ -109,43 +116,21 @@ def embed_canonical_ids(
 def process_work(
     work_json: dict,
     resolver: IdResolver,
-    predecessors: dict[SourceIdentifierKey, SourceIdentifierKey] | None = None,
 ) -> dict:
-    # TODO: We have not yet decided how works will indicate their predecessors.
-    # The `predecessors` parameter is plumbed through but the mechanism for
-    # deriving it from the work JSON needs to be designed and implemented.
-    source_id = work_json.get("state", {}).get("sourceIdentifier", {})
-    source_id_str = (
-        f"{source_id.get('ontologyType', '?')}"
-        f"[{source_id.get('identifierType', {}).get('id', '?')}"
-        f"/{source_id.get('value', '?')}]"
-    )
+    source_id = SourceIdentifier.model_validate(work_json["state"]["sourceIdentifier"])
 
-    preds = predecessors or {}
-    keys = extract_source_identifiers(work_json)
-    predecessor_count = sum(1 for k in keys if k in preds)
+    mint_requests = extract_source_identifiers(work_json)
+    predecessor_count = sum(1 for _, pred in mint_requests if pred is not None)
+
     logger.info(
         "Embedding canonical IDs",
-        source_identifier=source_id_str,
-        source_identifier_count=len(keys),
+        source_identifier=source_id,
+        source_identifier_count=len(mint_requests),
         predecessor_count=predecessor_count,
     )
 
-    if not keys:
-        logger.info(
-            "No source identifiers found, skipping",
-            source_identifier=source_id_str,
-        )
-        return work_json
+    found = resolver.mint_ids(mint_requests)  # type: ignore[arg-type]  # SourceIdentifierKey is a tuple[str, str, str]
 
-    requests: list[tuple[SourceId, SourceId | None]] = [
-        (
-            (k[0], k[1], k[2]),
-            (preds[k][0], preds[k][1], preds[k][2]) if k in preds else None,
-        )
-        for k in keys
-    ]
-    found = resolver.mint_ids(requests)
     id_map: dict[SourceIdentifierKey, str] = {
         SourceIdentifierKey(*k): v for k, v in found.items()
     }
@@ -154,7 +139,7 @@ def process_work(
 
     logger.info(
         "Finished embedding canonical IDs",
-        source_identifier=source_id_str,
+        source_identifier=source_id,
         ids_embedded=len(id_map),
     )
 

--- a/catalogue_graph/src/id_minter/resolvers/minting_resolver.py
+++ b/catalogue_graph/src/id_minter/resolvers/minting_resolver.py
@@ -164,6 +164,8 @@ class MintingResolver:
         # mint/lookup). Also build a mapping from source_id -> predecessor for
         # records that have a predecessor specified (used for canonical ID inheritance
         # during migrations from one source system to another).
+        # Note: Duplicate sourceIdentifiers would be collapsed here; upstream guarantees
+        # a 1:1 mapping between sourceIdentifier and predecessorIdentifier, so this is safe
         source_ids = list(dict.fromkeys(req[0] for req in requests))
         predecessors = {req[0]: req[1] for req in requests if req[1] is not None}
         predecessor_ids = list(predecessors.values())

--- a/catalogue_graph/tests/id_minter/test_embedder.py
+++ b/catalogue_graph/tests/id_minter/test_embedder.py
@@ -97,7 +97,7 @@ class TestScan:
 
         keys = extract_source_identifiers(doc)
 
-        assert keys == [key_of(si)]
+        assert keys == [(key_of(si), None)]
 
     def test_retrieves_multiple_nested_source_identifiers(self) -> None:
         sis = [create_source_identifier() for _ in range(4)]
@@ -116,7 +116,31 @@ class TestScan:
 
         keys = extract_source_identifiers(doc)
 
-        assert set(keys) == {key_of(si) for si in sis}
+        assert set(keys) == {(key_of(si), None) for si in sis}
+
+    def test_retrieves_predecessor_alongside_source_identifier(self) -> None:
+        si = create_source_identifier(identifier_type="axiell-system-number")
+        pred = create_source_identifier(identifier_type="sierra-system-number")
+        doc = {"sourceIdentifier": si, "predecessorIdentifier": pred}
+
+        keys = extract_source_identifiers(doc)
+
+        assert keys == [(key_of(si), key_of(pred))]
+
+    def test_mixed_nodes_with_and_without_predecessors(self) -> None:
+        si1 = create_source_identifier()
+        si2 = create_source_identifier(identifier_type="axiell-system-number")
+        pred2 = create_source_identifier(identifier_type="sierra-system-number")
+        doc = {
+            "sourceIdentifier": si1,
+            "items": [
+                {"sourceIdentifier": si2, "predecessorIdentifier": pred2},
+            ],
+        }
+
+        keys = extract_source_identifiers(doc)
+
+        assert set(keys) == {(key_of(si1), None), (key_of(si2), key_of(pred2))}
 
     def test_raises_on_invalid_source_identifier(self) -> None:
         doc = {"sourceIdentifier": {"something": "something"}}
@@ -277,7 +301,7 @@ class TestProcessWork:
     def test_single_identifier_minted(self) -> None:
         si = create_source_identifier()
         cid = create_canonical_id()
-        doc = {"sourceIdentifier": si}
+        doc = {"state": {"sourceIdentifier": si}, "sourceIdentifier": si}
 
         key = key_of(si)
         resolver = FakeResolver(ids={(key[0], key[1], key[2]): cid})
@@ -291,7 +315,7 @@ class TestProcessWork:
         """When the resolver doesn't already know an ID, mint_ids creates it."""
         si = create_source_identifier()
         cid = create_canonical_id()
-        doc = {"sourceIdentifier": si}
+        doc = {"state": {"sourceIdentifier": si}, "sourceIdentifier": si}
 
         key = key_of(si)
         resolver = FakeResolver(ids={(key[0], key[1], key[2]): cid})
@@ -308,6 +332,7 @@ class TestProcessWork:
         cid1 = create_canonical_id()
         cid2 = create_canonical_id()
         doc = {
+            "state": {"sourceIdentifier": si1},
             "sourceIdentifier": si1,
             "type": "Identifiable",
             "items": [{"sourceIdentifier": si2, "type": "Identifiable"}],
@@ -337,6 +362,7 @@ class TestProcessWork:
         cid1 = create_canonical_id()
         cid2 = create_canonical_id()
         doc = {
+            "state": {"sourceIdentifier": si1},
             "sourceIdentifier": si1,
             "items": [{"sourceIdentifier": si2}],
         }
@@ -363,24 +389,141 @@ class TestProcessWork:
         si_new = create_source_identifier(identifier_type="axiell-collections-id")
         si_pred = create_source_identifier(identifier_type="sierra-system-number")
         cid = create_canonical_id()
-        doc = {"sourceIdentifier": si_new}
+        doc = {
+            "state": {"sourceIdentifier": si_new, "predecessorIdentifier": si_pred},
+        }
 
         k_new = key_of(si_new)
         k_pred = key_of(si_pred)
         resolver = FakeResolver(ids={(k_new[0], k_new[1], k_new[2]): cid})
 
-        result = process_work(doc, resolver, predecessors={k_new: k_pred})
+        result = process_work(doc, resolver)
 
-        assert result["canonicalId"] == cid
+        assert result["state"]["canonicalId"] == cid
         assert len(resolver.mint_calls) == 1
-        assert resolver.mint_calls[0][0][1] == (k_pred[0], k_pred[1], k_pred[2])
+        assert (k_new, k_pred) in resolver.mint_calls[0]
 
-    def test_empty_work_returns_unchanged(self) -> None:
-        doc = {"title": "A work with no identifiers"}
-        resolver = FakeResolver()
+    def test_no_data_identifiers_still_mints_state(self) -> None:
+        """State always has a sourceIdentifier; it gets minted even if nothing else does."""
+        si = create_source_identifier()
+        cid = create_canonical_id()
+        doc = {
+            "state": {"sourceIdentifier": si},
+            "title": "A work with no other sourceIdentifiers",
+        }
+
+        key = key_of(si)
+        resolver = FakeResolver(ids={(key[0], key[1], key[2]): cid})
 
         result = process_work(doc, resolver)
 
-        assert result == doc
-        assert not resolver.lookup_calls
-        assert not resolver.mint_calls
+        assert result["title"] == "A work with no other sourceIdentifiers"
+        assert result["state"]["canonicalId"] == cid
+        assert len(resolver.mint_calls) == 1
+
+    def test_nested_item_with_predecessor(self) -> None:
+        """A data entity's sourceIdentifier, eg. an item, can have its own predecessorIdentifier."""
+        si_work = create_source_identifier()
+        si_item = create_source_identifier(
+            identifier_type="axiell-system-number", ontology_type="Item"
+        )
+        si_item_pred = create_source_identifier(
+            identifier_type="sierra-system-number", ontology_type="Item"
+        )
+        cid_work = create_canonical_id()
+        cid_item = create_canonical_id()
+        doc = {
+            "state": {"sourceIdentifier": si_work},
+            "sourceIdentifier": si_work,
+            "items": [
+                {
+                    "sourceIdentifier": si_item,
+                    "predecessorIdentifier": si_item_pred,
+                }
+            ],
+        }
+
+        k_work = key_of(si_work)
+        k_item = key_of(si_item)
+        k_item_pred = key_of(si_item_pred)
+        resolver = FakeResolver(
+            ids={
+                (k_work[0], k_work[1], k_work[2]): cid_work,
+                (k_item[0], k_item[1], k_item[2]): cid_item,
+            }
+        )
+
+        result = process_work(doc, resolver)
+
+        assert result["canonicalId"] == cid_work
+        assert result["items"][0]["canonicalId"] == cid_item
+        assert (k_work, None) in resolver.mint_calls[0]
+        assert (k_item, k_item_pred) in resolver.mint_calls[0]
+
+    def test_state_with_predecessor(self) -> None:
+        """State's sourceIdentifier can also have a predecessorIdentifier."""
+        si_new = create_source_identifier(identifier_type="axiell-system-number")
+        si_pred = create_source_identifier(identifier_type="sierra-system-number")
+        cid = create_canonical_id()
+        doc = {
+            "state": {
+                "sourceIdentifier": si_new,
+                "predecessorIdentifier": si_pred,
+            },
+            "sourceIdentifier": si_new,
+        }
+
+        k_new = key_of(si_new)
+        k_pred = key_of(si_pred)
+        resolver = FakeResolver(ids={(k_new[0], k_new[1], k_new[2]): cid})
+
+        result = process_work(doc, resolver)
+
+        assert result["state"]["canonicalId"] == cid
+        assert result["canonicalId"] == cid
+        assert (k_new, k_pred) in resolver.mint_calls[0]
+
+    def test_multiple_predecessors_across_doc(self) -> None:
+        """Both state and a nested item have predecessors."""
+        si_work = create_source_identifier(identifier_type="axiell-system-number")
+        si_work_pred = create_source_identifier(identifier_type="sierra-system-number")
+        si_item = create_source_identifier(
+            identifier_type="axiell-system-number", ontology_type="Item"
+        )
+        si_item_pred = create_source_identifier(
+            identifier_type="sierra-system-number", ontology_type="Item"
+        )
+        cid_work = create_canonical_id()
+        cid_item = create_canonical_id()
+        doc = {
+            "state": {
+                "sourceIdentifier": si_work,
+                "predecessorIdentifier": si_work_pred,
+            },
+            "sourceIdentifier": si_work,
+            "predecessorIdentifier": si_work_pred,
+            "items": [
+                {
+                    "sourceIdentifier": si_item,
+                    "predecessorIdentifier": si_item_pred,
+                }
+            ],
+        }
+
+        k_work = key_of(si_work)
+        k_work_pred = key_of(si_work_pred)
+        k_item = key_of(si_item)
+        k_item_pred = key_of(si_item_pred)
+        resolver = FakeResolver(
+            ids={
+                (k_work[0], k_work[1], k_work[2]): cid_work,
+                (k_item[0], k_item[1], k_item[2]): cid_item,
+            }
+        )
+
+        result = process_work(doc, resolver)
+
+        assert result["canonicalId"] == cid_work
+        assert result["items"][0]["canonicalId"] == cid_item
+        assert (k_work, k_work_pred) in resolver.mint_calls[0]
+        assert (k_item, k_item_pred) in resolver.mint_calls[0]

--- a/catalogue_graph/tests/id_minter/test_embedder.py
+++ b/catalogue_graph/tests/id_minter/test_embedder.py
@@ -401,7 +401,7 @@ class TestProcessWork:
 
         assert result["state"]["canonicalId"] == cid
         assert len(resolver.mint_calls) == 1
-        assert (k_new, k_pred) in resolver.mint_calls[0]
+        assert set(resolver.mint_calls[0]) == {(k_new, k_pred)}
 
     def test_no_data_identifiers_still_mints_state(self) -> None:
         """State always has a sourceIdentifier; it gets minted even if nothing else does."""
@@ -457,8 +457,7 @@ class TestProcessWork:
 
         assert result["canonicalId"] == cid_work
         assert result["items"][0]["canonicalId"] == cid_item
-        assert (k_work, None) in resolver.mint_calls[0]
-        assert (k_item, k_item_pred) in resolver.mint_calls[0]
+        assert set(resolver.mint_calls[0]) == {(k_work, None), (k_item, k_item_pred)}
 
     def test_state_with_predecessor(self) -> None:
         """State's sourceIdentifier can also have a predecessorIdentifier."""
@@ -469,8 +468,7 @@ class TestProcessWork:
             "state": {
                 "sourceIdentifier": si_new,
                 "predecessorIdentifier": si_pred,
-            },
-            "sourceIdentifier": si_new,
+            }
         }
 
         k_new = key_of(si_new)
@@ -480,8 +478,7 @@ class TestProcessWork:
         result = process_work(doc, resolver)
 
         assert result["state"]["canonicalId"] == cid
-        assert result["canonicalId"] == cid
-        assert (k_new, k_pred) in resolver.mint_calls[0]
+        assert set(resolver.mint_calls[0]) == {(k_new, k_pred)}
 
     def test_multiple_predecessors_across_doc(self) -> None:
         """Both state and a nested item have predecessors."""
@@ -525,5 +522,7 @@ class TestProcessWork:
 
         assert result["canonicalId"] == cid_work
         assert result["items"][0]["canonicalId"] == cid_item
-        assert (k_work, k_work_pred) in resolver.mint_calls[0]
-        assert (k_item, k_item_pred) in resolver.mint_calls[0]
+        assert set(resolver.mint_calls[0]) == {
+            (k_work, k_work_pred),
+            (k_item, k_item_pred),
+        }


### PR DESCRIPTION
https://github.com/wellcomecollection/platform/issues/6326

## What does this change?

The id minter's embedder previously required predecessor identifiers to be passed in as an external `dict[SourceIdentifierKey, SourceIdentifierKey]` parameter to `process_work()`. This was a placeholder — the mechanism for deriving predecessors from the work JSON had not been designed.

This change implements predecessor discovery by scanning the document itself. Any node that has a `sourceIdentifier` can now optionally have a sibling `predecessorIdentifier`, and both are extracted together as a pair.

Key changes in `embedder.py`:
- `extract_source_identifiers` now returns `list[tuple[SourceIdentifierKey, SourceIdentifierKey | None]]` — each source identifier paired with its optional predecessor
- Removed the `predecessors` parameter from `process_work()` — predecessors are discovered from the document
- Uses `SourceIdentifier.model_validate()` from the pipeline models instead of manual dict access for the state-level source identifier
- Removed the dead `if not keys` early-return (state always has a `sourceIdentifier`)
- Simplified logging to use `SourceIdentifier.__str__()` via structlog

Test changes in `test_embedder.py`:
- Updated existing tests to match the new `(key, predecessor | None)` return type
- Added scan tests: node with predecessor, mixed nodes with/without predecessors
- Added process_work tests: nested item with predecessor, state with predecessor, multiple predecessors across document
- Test docs now include `state.sourceIdentifier` to mirror real data shape

## How to test

```bash
cd catalogue_graph
uv run pytest tests/id_minter/test_embedder.py -v
```

All 21 tests should pass.

## How can we measure success?

When work documents with `predecessorIdentifier` fields (e.g. Axiell records replacing Sierra records) are processed, the predecessor's canonical ID should be inherited rather than a new one minted. This can be verified by checking the minting resolver logs for `method=inherited` entries.

## Have we considered potential risks?

- **Backward compatible**: Documents without `predecessorIdentifier` fields behave exactly as before (predecessor is `None`).
- **Type boundary**: `SourceIdentifierKey` (NamedTuple) is structurally compatible with `SourceId` (plain tuple) used in the DB layer. A `type: ignore[arg-type]` comment documents this at the boundary.
- **No new external dependencies**: Uses the existing `SourceIdentifier` pydantic model already in the codebase.


