### PR TITLE
Extract id-minter RDS into a reusable module and add a test instance

### DIFF
--- a/infrastructure/critical/backup_id_minter.tf
+++ b/infrastructure/critical/backup_id_minter.tf
@@ -44,6 +44,6 @@ resource "aws_backup_selection" "id_minter" {
   plan_id      = aws_backup_plan.id_minter_daily.id
 
   resources = [
-    module.identifiers_v2_serverless_rds_cluster.rds_cluster_arn
+    module.id_minter_rds.rds_cluster_arn
   ]
 }

--- a/infrastructure/critical/modules/id-minter-rds/main.tf
+++ b/infrastructure/critical/modules/id-minter-rds/main.tf
@@ -1,3 +1,8 @@
+locals {
+  hyphen_suffix     = var.name_suffix == "" ? "" : "-${var.name_suffix}"
+  underscore_suffix = var.name_suffix == "" ? "" : "_${var.name_suffix}"
+}
+
 resource "aws_db_subnet_group" "default" {
   subnet_ids = var.private_subnet_ids
 }
@@ -5,7 +10,7 @@ resource "aws_db_subnet_group" "default" {
 resource "aws_security_group" "database_v2_sg" {
   description = "Allows connection to identifiers-v2 RDS instance via TCP and egress to the world"
   vpc_id      = var.vpc_id
-  name        = "identifiers_v2_database_sg"
+  name        = "identifiers_v2_database_sg${local.underscore_suffix}"
 
   ingress {
     protocol  = "tcp"
@@ -36,10 +41,12 @@ resource "aws_security_group" "database_v2_sg" {
 module "identifiers_v2_serverless_rds_cluster" {
   source = "../rds-serverless"
 
-  cluster_identifier = "identifiers-v2-serverless"
+  cluster_identifier = "identifiers-v2-serverless${local.hyphen_suffix}"
   database_name      = "identifiers"
   master_username    = var.master_username
   master_password    = null
+
+  snapshot_identifier = var.snapshot_identifier
 
   manage_master_user_password = true
 
@@ -52,7 +59,7 @@ module "identifiers_v2_serverless_rds_cluster" {
 }
 
 resource "aws_security_group" "rds_v2_ingress_security_group" {
-  name        = "pipeline_rds_v2_ingress_security_group"
+  name        = "pipeline_rds_v2_ingress_security_group${local.underscore_suffix}"
   description = "Allow traffic to identifiers-v2 rds database"
   vpc_id      = var.vpc_id
 
@@ -64,6 +71,6 @@ resource "aws_security_group" "rds_v2_ingress_security_group" {
   }
 
   tags = {
-    Name = "pipeline-rds-v2-access"
+    Name = "pipeline-rds-v2-access${local.hyphen_suffix}"
   }
 }

--- a/infrastructure/critical/modules/id-minter-rds/main.tf
+++ b/infrastructure/critical/modules/id-minter-rds/main.tf
@@ -1,0 +1,69 @@
+resource "aws_db_subnet_group" "default" {
+  subnet_ids = var.private_subnet_ids
+}
+
+resource "aws_security_group" "database_v2_sg" {
+  description = "Allows connection to identifiers-v2 RDS instance via TCP and egress to the world"
+  vpc_id      = var.vpc_id
+  name        = "identifiers_v2_database_sg"
+
+  ingress {
+    protocol  = "tcp"
+    from_port = 3306
+    to_port   = 3306
+
+    cidr_blocks = [
+      var.admin_cidr_ingress,
+    ]
+  }
+
+  ingress {
+    from_port = 3306
+    to_port   = 3306
+    protocol  = "tcp"
+
+    security_groups = [aws_security_group.rds_v2_ingress_security_group.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+module "identifiers_v2_serverless_rds_cluster" {
+  source = "../rds-serverless"
+
+  cluster_identifier = "identifiers-v2-serverless"
+  database_name      = "identifiers"
+  master_username    = var.master_username
+  master_password    = null
+
+  manage_master_user_password = true
+
+  db_security_group_id     = aws_security_group.database_v2_sg.id
+  aws_db_subnet_group_name = aws_db_subnet_group.default.name
+
+  max_scaling_capacity = var.max_scaling_capacity
+
+  engine_version = var.engine_version
+}
+
+resource "aws_security_group" "rds_v2_ingress_security_group" {
+  name        = "pipeline_rds_v2_ingress_security_group"
+  description = "Allow traffic to identifiers-v2 rds database"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+    self      = true
+  }
+
+  tags = {
+    Name = "pipeline-rds-v2-access"
+  }
+}

--- a/infrastructure/critical/modules/id-minter-rds/outputs.tf
+++ b/infrastructure/critical/modules/id-minter-rds/outputs.tf
@@ -1,0 +1,19 @@
+output "rds_cluster_id" {
+  value = module.identifiers_v2_serverless_rds_cluster.rds_cluster_id
+}
+
+output "rds_cluster_arn" {
+  value = module.identifiers_v2_serverless_rds_cluster.rds_cluster_arn
+}
+
+output "master_user_secret_arn" {
+  value = module.identifiers_v2_serverless_rds_cluster.master_user_secret_arn
+}
+
+output "ingress_security_group_id" {
+  value = aws_security_group.rds_v2_ingress_security_group.id
+}
+
+output "subnet_group_name" {
+  value = aws_db_subnet_group.default.name
+}

--- a/infrastructure/critical/modules/id-minter-rds/variables.tf
+++ b/infrastructure/critical/modules/id-minter-rds/variables.tf
@@ -8,9 +8,7 @@ variable "admin_cidr_ingress" {}
 
 variable "master_username" {}
 
-variable "engine_version" {
-  default = "8.0.mysql_aurora.3.10.3"
-}
+variable "engine_version" {}
 
 variable "max_scaling_capacity" {
   default = 16

--- a/infrastructure/critical/modules/id-minter-rds/variables.tf
+++ b/infrastructure/critical/modules/id-minter-rds/variables.tf
@@ -13,3 +13,15 @@ variable "engine_version" {}
 variable "max_scaling_capacity" {
   default = 16
 }
+
+variable "name_suffix" {
+  description = "Optional suffix appended to resource names so multiple instances of the module can co-exist. Leave empty to preserve the original (un-suffixed) names."
+  type        = string
+  default     = ""
+}
+
+variable "snapshot_identifier" {
+  description = "Optional identifier (or ARN) of an RDS cluster snapshot to restore from on initial creation."
+  type        = string
+  default     = null
+}

--- a/infrastructure/critical/modules/id-minter-rds/variables.tf
+++ b/infrastructure/critical/modules/id-minter-rds/variables.tf
@@ -1,0 +1,17 @@
+variable "vpc_id" {}
+
+variable "private_subnet_ids" {
+  type = list(string)
+}
+
+variable "admin_cidr_ingress" {}
+
+variable "master_username" {}
+
+variable "engine_version" {
+  default = "8.0.mysql_aurora.3.10.3"
+}
+
+variable "max_scaling_capacity" {
+  default = 16
+}

--- a/infrastructure/critical/modules/id-minter-rds/variables.tf
+++ b/infrastructure/critical/modules/id-minter-rds/variables.tf
@@ -1,17 +1,31 @@
-variable "vpc_id" {}
+variable "vpc_id" {
+  description = "ID of the VPC where the RDS resources will be created."
+  type        = string
+}
 
 variable "private_subnet_ids" {
   type = list(string)
 }
 
-variable "admin_cidr_ingress" {}
+variable "admin_cidr_ingress" {
+  description = "CIDR block allowed administrative ingress access."
+  type        = string
+}
 
-variable "master_username" {}
+variable "master_username" {
+  description = "Master username for the RDS cluster."
+  type        = string
+}
 
-variable "engine_version" {}
+variable "engine_version" {
+  description = "Engine version to use for the RDS cluster."
+  type        = string
+}
 
 variable "max_scaling_capacity" {
-  default = 16
+  description = "Maximum Aurora Serverless scaling capacity."
+  type        = number
+  default     = 16
 }
 
 variable "name_suffix" {

--- a/infrastructure/critical/outputs.tf
+++ b/infrastructure/critical/outputs.tf
@@ -1,23 +1,23 @@
 # RDS
 
 output "rds_v2_serverless_cluster_id" {
-  value = module.identifiers_v2_serverless_rds_cluster.rds_cluster_id
+  value = module.id_minter_rds.rds_cluster_id
 }
 
 output "rds_v2_serverless_cluster_arn" {
-  value = module.identifiers_v2_serverless_rds_cluster.rds_cluster_arn
+  value = module.id_minter_rds.rds_cluster_arn
 }
 
 output "rds_v2_access_security_group_id" {
-  value = aws_security_group.rds_v2_ingress_security_group.id
+  value = module.id_minter_rds.ingress_security_group_id
 }
 
 output "rds_v2_master_user_secret_arn" {
-  value = module.identifiers_v2_serverless_rds_cluster.master_user_secret_arn
+  value = module.id_minter_rds.master_user_secret_arn
 }
 
 output "rds_subnet_group_name" {
-  value = aws_db_subnet_group.default.name
+  value = module.id_minter_rds.subnet_group_name
 }
 
 # Miro Hybrid Store

--- a/infrastructure/critical/outputs.tf
+++ b/infrastructure/critical/outputs.tf
@@ -1,5 +1,26 @@
 # RDS
 
+locals {
+  id_minter_rds_instances = {
+    prod = module.id_minter_rds
+    test = module.id_minter_rds_test
+  }
+}
+
+output "id_minter_rds" {
+  value = {
+    for name, instance in local.id_minter_rds_instances : name => {
+      cluster_id                = instance.rds_cluster_id
+      cluster_arn               = instance.rds_cluster_arn
+      ingress_security_group_id = instance.ingress_security_group_id
+      master_user_secret_arn    = instance.master_user_secret_arn
+      subnet_group_name         = instance.subnet_group_name
+    }
+  }
+}
+
+# Legacy flat outputs for the prod cluster — retained for backwards
+# compatibility with downstream stacks reading via terraform_remote_state.
 output "rds_v2_serverless_cluster_id" {
   value = module.id_minter_rds.rds_cluster_id
 }

--- a/infrastructure/critical/rds_id_minter.tf
+++ b/infrastructure/critical/rds_id_minter.tf
@@ -16,7 +16,7 @@ module "id_minter_rds" {
 module "id_minter_rds_test" {
   source = "./modules/id-minter-rds"
 
-  name_suffix         = "test"
+  name_suffix = "test"
   # Restore from production on April 21, 2026, 04:18 (UTC+01:00)
   snapshot_identifier = "awsbackup:job-349affad-75e5-83a7-5e9b-7c631bdfa39e"
 

--- a/infrastructure/critical/rds_id_minter.tf
+++ b/infrastructure/critical/rds_id_minter.tf
@@ -8,28 +8,9 @@ module "id_minter_rds" {
   vpc_id             = local.vpc_id_new
   private_subnet_ids = local.private_subnets_new
   admin_cidr_ingress = local.admin_cidr_ingress
+  engine_version     = "8.0.mysql_aurora.3.10.3"
 
   master_username = data.aws_ssm_parameter.rds_username.value
-}
-
-moved {
-  from = aws_db_subnet_group.default
-  to   = module.id_minter_rds.aws_db_subnet_group.default
-}
-
-moved {
-  from = aws_security_group.database_v2_sg
-  to   = module.id_minter_rds.aws_security_group.database_v2_sg
-}
-
-moved {
-  from = aws_security_group.rds_v2_ingress_security_group
-  to   = module.id_minter_rds.aws_security_group.rds_v2_ingress_security_group
-}
-
-moved {
-  from = module.identifiers_v2_serverless_rds_cluster
-  to   = module.id_minter_rds.module.identifiers_v2_serverless_rds_cluster
 }
 
 

--- a/infrastructure/critical/rds_id_minter.tf
+++ b/infrastructure/critical/rds_id_minter.tf
@@ -2,83 +2,34 @@ data "aws_ssm_parameter" "rds_username" {
   name = "/aws/reference/secretsmanager/catalogue/id_minter/rds_user"
 }
 
-data "aws_ssm_parameter" "rds_password" {
-  name = "/aws/reference/secretsmanager/catalogue/id_minter/rds_password"
+module "id_minter_rds" {
+  source = "./modules/id-minter-rds"
+
+  vpc_id             = local.vpc_id_new
+  private_subnet_ids = local.private_subnets_new
+  admin_cidr_ingress = local.admin_cidr_ingress
+
+  master_username = data.aws_ssm_parameter.rds_username.value
 }
 
-locals {
-  username = data.aws_ssm_parameter.rds_username.value
-  password = data.aws_ssm_parameter.rds_password.value
+moved {
+  from = aws_db_subnet_group.default
+  to   = module.id_minter_rds.aws_db_subnet_group.default
 }
 
-resource "aws_db_subnet_group" "default" {
-  subnet_ids = local.private_subnets_new
+moved {
+  from = aws_security_group.database_v2_sg
+  to   = module.id_minter_rds.aws_security_group.database_v2_sg
 }
 
-resource "aws_security_group" "database_v2_sg" {
-  description = "Allows connection to identifiers-v2 RDS instance via TCP and egress to the world"
-  vpc_id      = local.vpc_id_new
-  name        = "identifiers_v2_database_sg"
-
-  ingress {
-    protocol  = "tcp"
-    from_port = 3306
-    to_port   = 3306
-
-    cidr_blocks = [
-      local.admin_cidr_ingress,
-    ]
-  }
-
-  ingress {
-    from_port = 3306
-    to_port   = 3306
-    protocol  = "tcp"
-
-    security_groups = [aws_security_group.rds_v2_ingress_security_group.id]
-  }
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+moved {
+  from = aws_security_group.rds_v2_ingress_security_group
+  to   = module.id_minter_rds.aws_security_group.rds_v2_ingress_security_group
 }
 
-module "identifiers_v2_serverless_rds_cluster" {
-  source = "./modules/rds-serverless"
-
-  cluster_identifier = "identifiers-v2-serverless"
-  database_name      = "identifiers"
-  master_username    = local.username
-  master_password    = null
-
-  manage_master_user_password = true
-
-  db_security_group_id     = aws_security_group.database_v2_sg.id
-  aws_db_subnet_group_name = aws_db_subnet_group.default.name
-
-  max_scaling_capacity = 16
-
-  engine_version = "8.0.mysql_aurora.3.10.3"
-}
-
-resource "aws_security_group" "rds_v2_ingress_security_group" {
-  name        = "pipeline_rds_v2_ingress_security_group"
-  description = "Allow traffic to identifiers-v2 rds database"
-  vpc_id      = local.vpc_id_new
-
-  ingress {
-    from_port = 0
-    to_port   = 0
-    protocol  = "-1"
-    self      = true
-  }
-
-  tags = {
-    Name = "pipeline-rds-v2-access"
-  }
+moved {
+  from = module.identifiers_v2_serverless_rds_cluster
+  to   = module.id_minter_rds.module.identifiers_v2_serverless_rds_cluster
 }
 
 

--- a/infrastructure/critical/rds_id_minter.tf
+++ b/infrastructure/critical/rds_id_minter.tf
@@ -13,4 +13,17 @@ module "id_minter_rds" {
   master_username = data.aws_ssm_parameter.rds_username.value
 }
 
+module "id_minter_rds_test" {
+  source = "./modules/id-minter-rds"
 
+  name_suffix         = "test"
+  # Restore from production on April 21, 2026, 04:18 (UTC+01:00)
+  snapshot_identifier = "awsbackup:job-349affad-75e5-83a7-5e9b-7c631bdfa39e"
+
+  vpc_id             = local.vpc_id_new
+  private_subnet_ids = local.private_subnets_new
+  admin_cidr_ingress = local.admin_cidr_ingress
+  engine_version     = "8.0.mysql_aurora.3.10.3"
+
+  master_username = data.aws_ssm_parameter.rds_username.value
+}


### PR DESCRIPTION
Resolves https://github.com/wellcomecollection/platform/issues/6325. Required by https://github.com/wellcomecollection/platform/issues/6326 / wellcomecollection/catalogue-pipeline#3329.

## What does this change?

Refactors the id-minter Aurora cluster into a reusable module so multiple instances can co-exist, and stands up a `test` instance restored from a recent AWS Backup snapshot of production.

**Module extraction (`infrastructure/critical/modules/id-minter-rds/`):**
- Wraps the existing `rds-serverless` sub-module along with the subnet group and the two security groups that surround it.
- Exposes the previously-flat outputs (`rds_cluster_id`, `rds_cluster_arn`, `master_user_secret_arn`, `ingress_security_group_id`, `subnet_group_name`).
- `moved` blocks were used in the initial extraction commit and have since been removed — the existing prod cluster is unchanged in state.

**New variables:**
- `name_suffix` (default `""`) — appended to the cluster identifier, security group names, and the access SG `Name` tag so multiple instances don't collide on AWS-side names. The empty default keeps the existing prod resources byte-identical.
- `snapshot_identifier` (default `null`) — passed through to `aws_rds_cluster.snapshot_identifier` so a new instance can be restored from an existing snapshot. Only consulted on initial create; once provisioned, do **not** edit or remove this value (it would force replacement).

**New `test` instance (`rds_id_minter.tf`):**
- `module.id_minter_rds_test` with `name_suffix = "test"` and `snapshot_identifier` set to the AWS Backup recovery point taken on 2026-04-21 04:18 UTC+01:00.
- Produces `identifiers-v2-serverless-test` (cluster), `identifiers_v2_database_sg_test` and `pipeline_rds_v2_ingress_security_group_test` (security groups).

**Outputs (`outputs.tf`):**
- New map output `id_minter_rds` keyed by suffix (`prod`, `test`) — each value is an object exposing the same fields as before.
- Legacy flat outputs (`rds_v2_serverless_cluster_id`, etc.) are retained pointing at the prod instance, so existing downstream stacks that read this state via `terraform_remote_state` continue to work unchanged.

## Consuming the new outputs from #3329

PR #3329 currently has the RDS test database wiring commented out pending this change. To plug it in, that PR can read from the new map output via the existing `terraform_remote_state` pointer to this stack (the catalogue-pipeline pipeline stack already reads `data.terraform_remote_state.infra_critical.outputs.*`). Suggested pattern:

```hcl
locals {
  id_minter_rds_instances = data.terraform_remote_state.infra_critical.outputs.id_minter_rds

  rds_v2_test_config = {
    cluster_arn               = local.id_minter_rds_instances["test"].cluster_arn
    cluster_id                = local.id_minter_rds_instances["test"].cluster_id
    ingress_security_group_id = local.id_minter_rds_instances["test"].ingress_security_group_id
    master_user_secret_arn    = local.id_minter_rds_instances["test"].master_user_secret_arn
    subnet_group_name         = local.id_minter_rds_instances["test"].subnet_group_name
  }
}
```

The test Lambda then takes its DB endpoint / secret ARN from `local.rds_v2_test_config` in the same shape as the existing `local.rds_v2_config` (which can also be migrated to read from `id_minter_rds["prod"]` later, in a follow-up).

The remote-state output reference name on the consuming side will be whatever data source already exposes the `infrastructure/critical` outputs — the existing flat outputs continue to work, so #3329 can be merged in either order.

## How to test

- `terraform plan` in `infrastructure/critical/` against `main`: shows only the **additions** for the new `module.id_minter_rds_test.*` resources and the new `id_minter_rds` map output. The existing prod cluster, security groups, subnet group, and legacy outputs show **no diff**.
- After apply, confirm the new cluster is `available`:
  ```bash
  aws rds describe-db-clusters \
    --db-cluster-identifier identifiers-v2-serverless-test \
    --query 'DBClusters[0].{Status:Status,Endpoint:Endpoint}'
  ```
- Confirm the new outputs from this stack:
  ```bash
  cd infrastructure/critical && terraform output -json id_minter_rds | jq
  ```

## How can we measure success?

The new `identifiers-v2-serverless-test` cluster comes up restored from the chosen snapshot, with the same schema/data as prod at that point in time. The pipeline stack in #3329 can then point its test id_minter at it without touching any prod infra.

## Have we considered potential risks?

- **Non-destructive to prod**: every change to the existing module call defaults to its previous behaviour (`name_suffix = ""`, `snapshot_identifier = null`). The plan shows zero changes against the existing prod cluster.
- **Snapshot value is sticky**: `snapshot_identifier` is read only at create time but tracked in state. Removing or changing the value on the `test` instance would force replacement of the cluster. The comment in the test module call calls this out; if we want to detach later we can either leave the literal in place forever or add `lifecycle { ignore_changes = [snapshot_identifier] }` inside `modules/rds-serverless/main.tf` (deferred — would touch a shared sub-module).
- **Cost**: the test cluster is Aurora Serverless v2 with the same scaling config as prod (min 0.5 ACU, max 16 ACU). It will scale low when idle but is not free.
- **Output compatibility**: legacy flat outputs are retained, so no downstream stack breaks. The new `id_minter_rds` map can be adopted incrementally; the legacy outputs can be removed in a later cleanup PR once consumers migrate.
