### PR TITLE
get bag from S3 on 307 from storage bag api

### DIFF
--- a/mets_adapter/mets_adapter/src/main/scala/weco/pipeline/mets_adapter/Main.scala
+++ b/mets_adapter/mets_adapter/src/main/scala/weco/pipeline/mets_adapter/Main.scala
@@ -49,7 +49,10 @@ object Main extends WellcomeTypesafeApp {
       new MetsAdapterWorkerService(
         SQSBuilder.buildSQSStream(config),
         SNSBuilder.buildSNSMessageSender(config, subject = "METS adapter"),
-        bagRetriever = new HttpBagRetriever(oauthClient),
+        bagRetriever = new HttpBagRetriever(
+          client = oauthClient,
+          redirectClient = new PekkoHttpClient()
+        ),
         metsStore = metsStore
       )
   }

--- a/mets_adapter/mets_adapter/src/main/scala/weco/pipeline/mets_adapter/Main.scala
+++ b/mets_adapter/mets_adapter/src/main/scala/weco/pipeline/mets_adapter/Main.scala
@@ -33,8 +33,10 @@ object Main extends WellcomeTypesafeApp {
       implicit val dynamoClient: DynamoDbClient =
         DynamoDbClient.builder().build()
 
+      val httpClient = new PekkoHttpClient()
+
       val oauthClient = new StorageServiceOauthHttpClient(
-        underlying = new PekkoHttpClient(),
+        underlying = httpClient,
         baseUri = Uri(config.requireString("bags.api.url")),
         tokenUri = Uri(config.requireString("bags.oauth.url")),
         credentials = BasicHttpCredentials(
@@ -51,7 +53,7 @@ object Main extends WellcomeTypesafeApp {
         SNSBuilder.buildSNSMessageSender(config, subject = "METS adapter"),
         bagRetriever = new HttpBagRetriever(
           client = oauthClient,
-          redirectClient = new PekkoHttpClient()
+          redirectClient = httpClient
         ),
         metsStore = metsStore
       )

--- a/mets_adapter/mets_adapter/src/main/scala/weco/pipeline/mets_adapter/services/BagRetriever.scala
+++ b/mets_adapter/mets_adapter/src/main/scala/weco/pipeline/mets_adapter/services/BagRetriever.scala
@@ -98,7 +98,8 @@ class HttpBagRetriever(client: HttpGet, redirectClient: HttpClient)(
             // strip the query parameters from the URI before throwing, contain credentials
             Future.failed(
               new Exception(
-                s"Received error following redirect to ${uri.withQuery(Uri.Query.Empty)}: $status"
+                s"Received error following redirect to ${uri
+                    .withQuery(Uri.Query.Empty)}: $status"
               )
             )
         }

--- a/mets_adapter/mets_adapter/src/main/scala/weco/pipeline/mets_adapter/services/BagRetriever.scala
+++ b/mets_adapter/mets_adapter/src/main/scala/weco/pipeline/mets_adapter/services/BagRetriever.scala
@@ -47,10 +47,13 @@ class HttpBagRetriever(client: HttpGet, redirectClient: HttpClient)(
     response.status match {
       case StatusCodes.OK => parseResponseIntoBag(response)
       case StatusCodes.TemporaryRedirect =>
+        response.discardEntityBytes()
         response.header[Location] match {
           case Some(location) =>
-            debug(s"Following redirect to ${location.uri}")
-            followRedirect(location.uri)
+            val uri = location.uri
+            // strip the query parameters from the URI before logging, contain credentials
+            debug(s"Following redirect to ${uri.withQuery(Uri.Query.Empty)}")
+            followRedirect(uri)
           case None =>
             Future.failed(
               new Exception(
@@ -59,14 +62,17 @@ class HttpBagRetriever(client: HttpGet, redirectClient: HttpClient)(
             )
         }
       case StatusCodes.NotFound =>
+        response.discardEntityBytes()
         Future.failed(
           new Exception(
             s"Bag $space/$externalIdentifier does not exist in storage service"
           )
         )
       case StatusCodes.Unauthorized =>
+        response.discardEntityBytes()
         Future.failed(new Exception("Failed to authorize with storage service"))
       case status =>
+        response.discardEntityBytes()
         Future.failed(
           new Exception(s"Received error from storage service: $status")
         )
@@ -78,9 +84,11 @@ class HttpBagRetriever(client: HttpGet, redirectClient: HttpClient)(
       bag <- response.status match {
         case StatusCodes.OK => parseResponseIntoBag(response)
         case status =>
+          response.discardEntityBytes()
+          // strip the query parameters from the URI before throwing, contain credentials
           Future.failed(
             new Exception(
-              s"Received error following redirect to $uri: $status"
+              s"Received error following redirect to ${uri.withQuery(Uri.Query.Empty)}: $status"
             )
           )
       }

--- a/mets_adapter/mets_adapter/src/main/scala/weco/pipeline/mets_adapter/services/BagRetriever.scala
+++ b/mets_adapter/mets_adapter/src/main/scala/weco/pipeline/mets_adapter/services/BagRetriever.scala
@@ -78,21 +78,31 @@ class HttpBagRetriever(client: HttpGet, redirectClient: HttpClient)(
         )
     }
 
+  private val allowedRedirectPrefix =
+    "https://wellcomecollection-storage-prod-large-response-cache.s3.eu-west-1.amazonaws.com/responses/"
+
   private def followRedirect(uri: Uri): Future[Bag] =
-    for {
-      response <- redirectClient.singleRequest(HttpRequest(uri = uri))
-      bag <- response.status match {
-        case StatusCodes.OK => parseResponseIntoBag(response)
-        case status =>
-          response.discardEntityBytes()
-          // strip the query parameters from the URI before throwing, contain credentials
-          Future.failed(
-            new Exception(
-              s"Received error following redirect to ${uri.withQuery(Uri.Query.Empty)}: $status"
+    if (!uri.toString.startsWith(allowedRedirectPrefix))
+      Future.failed(
+        new Exception(
+          s"Refusing to follow redirect to unexpected URL: ${uri.withQuery(Uri.Query.Empty)}"
+        )
+      )
+    else
+      for {
+        response <- redirectClient.singleRequest(HttpRequest(uri = uri))
+        bag <- response.status match {
+          case StatusCodes.OK => parseResponseIntoBag(response)
+          case status =>
+            response.discardEntityBytes()
+            // strip the query parameters from the URI before throwing, contain credentials
+            Future.failed(
+              new Exception(
+                s"Received error following redirect to ${uri.withQuery(Uri.Query.Empty)}: $status"
+              )
             )
-          )
-      }
-    } yield bag
+        }
+      } yield bag
 
   private def parseResponseIntoBag(response: HttpResponse): Future[Bag] =
     Unmarshal(response.entity).to[Bag].recover {

--- a/mets_adapter/mets_adapter/src/main/scala/weco/pipeline/mets_adapter/services/BagRetriever.scala
+++ b/mets_adapter/mets_adapter/src/main/scala/weco/pipeline/mets_adapter/services/BagRetriever.scala
@@ -3,12 +3,13 @@ package weco.pipeline.mets_adapter.services
 import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.http.scaladsl.model.Uri.Path
 import org.apache.pekko.http.scaladsl.model._
+import org.apache.pekko.http.scaladsl.model.headers.Location
 import org.apache.pekko.http.scaladsl.unmarshalling.Unmarshal
 import com.github.pjfanning.pekkohttpcirce.FailFastCirceSupport._
 import grizzled.slf4j.Logging
 import io.circe.generic.auto._
 import weco.pipeline.mets_adapter.models._
-import weco.http.client.HttpGet
+import weco.http.client.{HttpClient, HttpGet}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -16,7 +17,7 @@ trait BagRetriever {
   def getBag(space: String, externalIdentifier: String): Future[Bag]
 }
 
-class HttpBagRetriever(client: HttpGet)(
+class HttpBagRetriever(client: HttpGet, redirectClient: HttpClient)(
   implicit actorSystem: ActorSystem,
   executionContext: ExecutionContext
 ) extends BagRetriever
@@ -45,6 +46,18 @@ class HttpBagRetriever(client: HttpGet)(
   ): Future[Bag] =
     response.status match {
       case StatusCodes.OK => parseResponseIntoBag(response)
+      case StatusCodes.TemporaryRedirect =>
+        response.header[Location] match {
+          case Some(location) =>
+            debug(s"Following redirect to ${location.uri}")
+            followRedirect(location.uri)
+          case None =>
+            Future.failed(
+              new Exception(
+                "Received 307 redirect from storage service but no Location header"
+              )
+            )
+        }
       case StatusCodes.NotFound =>
         Future.failed(
           new Exception(
@@ -58,6 +71,20 @@ class HttpBagRetriever(client: HttpGet)(
           new Exception(s"Received error from storage service: $status")
         )
     }
+
+  private def followRedirect(uri: Uri): Future[Bag] =
+    for {
+      response <- redirectClient.singleRequest(HttpRequest(uri = uri))
+      bag <- response.status match {
+        case StatusCodes.OK => parseResponseIntoBag(response)
+        case status =>
+          Future.failed(
+            new Exception(
+              s"Received error following redirect to $uri: $status"
+            )
+          )
+      }
+    } yield bag
 
   private def parseResponseIntoBag(response: HttpResponse): Future[Bag] =
     Unmarshal(response.entity).to[Bag].recover {

--- a/mets_adapter/mets_adapter/src/test/scala/weco/pipeline/mets_adapter/services/BagRetrieverTest.scala
+++ b/mets_adapter/mets_adapter/src/test/scala/weco/pipeline/mets_adapter/services/BagRetrieverTest.scala
@@ -209,7 +209,7 @@ class BagRetrieverTest
   }
 
   it("follows a 307 redirect to fetch the bag from S3") {
-    val redirectUri = Uri("https://s3.example.com/large-bag-response.json")
+    val redirectUri = Uri("https://wellcomecollection-storage-prod-large-response-cache.s3.eu-west-1.amazonaws.com/responses/digitised/b30414726/v1")
     val bagJson =
       """
         |{
@@ -300,6 +300,34 @@ class BagRetrieverTest
               name = "data/b30414726.xml",
               path = "v1/data/b30414726.xml"
             )
+        }
+    }
+  }
+
+  it("refuses to follow a 307 redirect to an unexpected URL") {
+    val redirectUri = Uri("https://evil.example.com/steal-data")
+    val responses = Seq(
+      (
+        HttpRequest(uri = Uri("http://storage:1234/bags/digitised/b30414726")),
+        HttpResponse(
+          status = StatusCodes.TemporaryRedirect,
+          headers = List(Location(redirectUri))
+        )
+      )
+    )
+
+    withBagRetriever(responses) {
+      retriever =>
+        val future =
+          retriever.getBag(
+            space = "digitised",
+            externalIdentifier = "b30414726"
+          )
+
+        whenReady(future.failed) {
+          _.getMessage should startWith(
+            "Refusing to follow redirect to unexpected URL"
+          )
         }
     }
   }

--- a/mets_adapter/mets_adapter/src/test/scala/weco/pipeline/mets_adapter/services/BagRetrieverTest.scala
+++ b/mets_adapter/mets_adapter/src/test/scala/weco/pipeline/mets_adapter/services/BagRetrieverTest.scala
@@ -1,13 +1,14 @@
 package weco.pipeline.mets_adapter.services
 
 import org.apache.pekko.http.scaladsl.model._
+import org.apache.pekko.http.scaladsl.model.headers.Location
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.pekko.fixtures.Pekko
 import weco.fixtures.TestWith
 import weco.pipeline.mets_adapter.models._
-import weco.http.client.{HttpGet, MemoryHttpClient}
+import weco.http.client.{HttpClient, HttpGet, MemoryHttpClient}
 
 import java.time.Instant
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -207,8 +208,127 @@ class BagRetrieverTest
     }
   }
 
+  it("follows a 307 redirect to fetch the bag from S3") {
+    val redirectUri = Uri("https://s3.example.com/large-bag-response.json")
+    val bagJson =
+      """
+        |{
+        |  "id": "digitised/b30414726",
+        |  "space": {
+        |    "id": "digitised",
+        |    "type": "Space"
+        |  },
+        |  "info": {
+        |    "externalIdentifier": "b30414726",
+        |    "payloadOxum": "9999999999.999",
+        |    "baggingDate": "2023-01-01",
+        |    "sourceOrganization": "intranda GmbH",
+        |    "externalDescription": "A very large bag",
+        |    "internalSenderIdentifier": "1234",
+        |    "internalSenderDescription": "large_bag_b30414726",
+        |    "type": "BagInfo"
+        |  },
+        |  "manifest": {
+        |    "checksumAlgorithm": "SHA-256",
+        |    "files": [
+        |      {
+        |        "checksum": "abc123",
+        |        "name": "data/b30414726.xml",
+        |        "path": "v1/data/b30414726.xml",
+        |        "size": 1000,
+        |        "type": "File"
+        |      }
+        |    ],
+        |    "type": "BagManifest"
+        |  },
+        |  "tagManifest": {
+        |    "checksumAlgorithm": "SHA-256",
+        |    "files": [],
+        |    "type": "BagManifest"
+        |  },
+        |  "location": {
+        |    "provider": {
+        |      "id": "amazon-s3",
+        |      "type": "Provider"
+        |    },
+        |    "bucket": "wellcomecollection-storage",
+        |    "path": "digitised/b30414726",
+        |    "type": "Location"
+        |  },
+        |  "replicaLocations": [],
+        |  "createdDate": "2023-01-01T12:00:00.000000Z",
+        |  "version": "v1",
+        |  "type": "Bag"
+        |}
+        |""".stripMargin
+
+    val storageResponses = Seq(
+      (
+        HttpRequest(uri = Uri("http://storage:1234/bags/digitised/b30414726")),
+        HttpResponse(
+          status = StatusCodes.TemporaryRedirect,
+          headers = List(Location(redirectUri))
+        )
+      )
+    )
+
+    val redirectResponses = Seq(
+      (
+        HttpRequest(uri = redirectUri),
+        HttpResponse(
+          entity = HttpEntity(
+            contentType = ContentTypes.`application/json`,
+            bagJson
+          )
+        )
+      )
+    )
+
+    withBagRetriever(storageResponses, redirectResponses) {
+      retriever =>
+        val future =
+          retriever.getBag(
+            space = "digitised",
+            externalIdentifier = "b30414726"
+          )
+
+        whenReady(future) {
+          bag =>
+            bag.location.bucket shouldBe "wellcomecollection-storage"
+            bag.location.path shouldBe "digitised/b30414726"
+            bag.manifest.files.head shouldBe BagFile(
+              name = "data/b30414726.xml",
+              path = "v1/data/b30414726.xml"
+            )
+        }
+    }
+  }
+
+  it("fails if a 307 redirect has no Location header") {
+    val responses = Seq(
+      (
+        HttpRequest(uri = Uri("http://storage:1234/bags/digitised/b30414726")),
+        HttpResponse(status = StatusCodes.TemporaryRedirect)
+      )
+    )
+
+    withBagRetriever(responses) {
+      retriever =>
+        val future =
+          retriever.getBag(
+            space = "digitised",
+            externalIdentifier = "b30414726"
+          )
+
+        whenReady(future.failed) {
+          _.getMessage shouldBe "Received 307 redirect from storage service but no Location header"
+        }
+    }
+  }
+
   def withBagRetriever[R](
-    responses: Seq[(HttpRequest, HttpResponse)]
+    responses: Seq[(HttpRequest, HttpResponse)],
+    redirectResponses: Seq[(HttpRequest, HttpResponse)] = Seq.empty
   )(testWith: TestWith[BagRetriever, R]): R =
     withActorSystem {
       implicit actorSystem =>
@@ -216,6 +336,8 @@ class BagRetrieverTest
           override val baseUri: Uri = Uri("http://storage:1234/bags")
         }
 
-        testWith(new HttpBagRetriever(client))
+        val redClient: HttpClient = new MemoryHttpClient(redirectResponses)
+
+        testWith(new HttpBagRetriever(client, redClient))
     }
 }

--- a/mets_adapter/mets_adapter/src/test/scala/weco/pipeline/mets_adapter/services/BagRetrieverTest.scala
+++ b/mets_adapter/mets_adapter/src/test/scala/weco/pipeline/mets_adapter/services/BagRetrieverTest.scala
@@ -332,6 +332,45 @@ class BagRetrieverTest
     }
   }
 
+  it("fails if fetching the bag from S3 returns an error") {
+    val redirectUri = Uri(
+      "https://wellcomecollection-storage-prod-large-response-cache.s3.eu-west-1.amazonaws.com/responses/digitised/b30414726/v1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=abc123secret"
+    )
+    val storageResponses = Seq(
+      (
+        HttpRequest(uri = Uri("http://storage:1234/bags/digitised/b30414726")),
+        HttpResponse(
+          status = StatusCodes.TemporaryRedirect,
+          headers = List(Location(redirectUri))
+        )
+      )
+    )
+
+    val redirectResponses = Seq(
+      (
+        HttpRequest(uri = redirectUri),
+        HttpResponse(status = StatusCodes.Forbidden)
+      )
+    )
+
+    withBagRetriever(storageResponses, redirectResponses) {
+      retriever =>
+        val future =
+          retriever.getBag(
+            space = "digitised",
+            externalIdentifier = "b30414726"
+          )
+
+        whenReady(future.failed) {
+          err =>
+            val msg = err.getMessage
+            msg shouldBe "Received error following redirect to https://wellcomecollection-storage-prod-large-response-cache.s3.eu-west-1.amazonaws.com/responses/digitised/b30414726/v1: 403 Forbidden"
+            msg should not include "X-Amz-Signature"
+            msg should not include "abc123secret"
+        }
+    }
+  }
+
   it("fails if a 307 redirect has no Location header") {
     val responses = Seq(
       (

--- a/mets_adapter/mets_adapter/src/test/scala/weco/pipeline/mets_adapter/services/BagRetrieverTest.scala
+++ b/mets_adapter/mets_adapter/src/test/scala/weco/pipeline/mets_adapter/services/BagRetrieverTest.scala
@@ -336,8 +336,8 @@ class BagRetrieverTest
           override val baseUri: Uri = Uri("http://storage:1234/bags")
         }
 
-        val redClient: HttpClient = new MemoryHttpClient(redirectResponses)
+        val redirectClient: HttpClient = new MemoryHttpClient(redirectResponses)
 
-        testWith(new HttpBagRetriever(client, redClient))
+        testWith(new HttpBagRetriever(client, redirectClient))
     }
 }


### PR DESCRIPTION
## What does this change?

The METS adapter's `BagRetriever` was failing with `java.lang.Exception: Received error from storage service: 307 Temporary Redirect` when the storage service returned a 307 redirect for large bags. This happens when the bag response is too large for a standard HTTP response — the storage service uploads it to S3 and returns a presigned URL via a `307 Temporary Redirect` with a `Location` header.

This PR adds handling for the `307 TemporaryRedirect` case in `HttpBagRetriever.handleResponse`:

- Reads the `Location` header from the 307 response and follows the redirect to fetch the bag JSON from the presigned S3 URL.
- Uses a separate `redirectClient: HttpClient` (a plain Pekko HTTP client, no OAuth) to follow the redirect. This avoids leaking OAuth credentials to the S3 presigned URL.
- A single `PekkoHttpClient` instance is shared between the OAuth client and the redirect client (in `Main.scala`) to avoid creating duplicate connection pools.
- **Redirect URL validation**: the redirect is only followed if the URL starts with `https://wellcomecollection-storage-prod-large-response-cache.s3.eu-west-1.amazonaws.com/responses/` — any other redirect target is rejected with a clear error.
- **Presigned URL redaction**: query parameters (which contain presigned URL credentials) are stripped from all log messages and error messages.
- **Connection pool hygiene**: response entities are discarded on all non-OK status paths to prevent Pekko HTTP connection pool leaks.
- Fails with a clear error if the 307 response is missing a `Location` header.

See Slack thread for context: https://wellcome.slack.com/archives/C02ANCYL90E/p1776938470259489

## How to test

Unit tests in `BagRetrieverTest` cover the new behaviour:

- **Successful redirect**: a 307 redirect is followed to fetch the bag from the presigned URL.
- **Missing Location header**: a 307 without a `Location` header produces a clear error.
- **Unexpected redirect URL**: a 307 pointing to an unexpected host is rejected.

All `mets_adapter` tests pass:

```
sbt "project mets_adapter" "test"
```

## How can we measure success?

Large bags that previously caused `307 Temporary Redirect` errors in the METS adapter will now be fetched successfully. We should see the related errors disappear from logs after deployment.

## Have we considered potential risks?

- The redirect client is a plain HTTP client with no authentication — this is intentional since the redirect target is a presigned S3 URL that already contains its own auth. Sending an OAuth token to S3 would be unnecessary and a credential leak risk.
- Redirect URLs are validated against an expected S3 bucket prefix before following, so the adapter won't chase arbitrary redirects.
- The redirect is only followed for `307 TemporaryRedirect`; other redirect status codes continue to be treated as errors.
- Sharing a single `PekkoHttpClient` between the OAuth wrapper and the redirect client avoids resource duplication without changing behaviour — `PekkoHttpClient` is stateless and thread-safe.
