### PR TITLE
Handle application/octet-stream from S3 large-response cache

### DIFF
--- a/mets_adapter/mets_adapter/src/main/scala/weco/pipeline/mets_adapter/services/BagRetriever.scala
+++ b/mets_adapter/mets_adapter/src/main/scala/weco/pipeline/mets_adapter/services/BagRetriever.scala
@@ -88,11 +88,14 @@ class HttpBagRetriever(client: HttpGet, redirectClient: HttpClient)(
           s"Refusing to follow redirect to unexpected URL: ${uri.withQuery(Uri.Query.Empty)}"
         )
       )
-    else
+    else {
+      info(
+        s"Following redirect for large bag response to ${uri.withQuery(Uri.Query.Empty)}"
+      )
       for {
         response <- redirectClient.singleRequest(HttpRequest(uri = uri))
         bag <- response.status match {
-          case StatusCodes.OK => parseResponseIntoBag(response)
+          case StatusCodes.OK => parseRedirectedResponseIntoBag(uri, response)
           case status =>
             response.discardEntityBytes()
             // strip the query parameters from the URI before throwing, contain credentials
@@ -104,6 +107,37 @@ class HttpBagRetriever(client: HttpGet, redirectClient: HttpClient)(
             )
         }
       } yield bag
+    }
+
+  // The S3 large-response cache serves the cached body with
+  // `Content-Type: application/octet-stream` even though the body is JSON.
+  // Match on the entity's content type and normalise it before unmarshalling
+  // so the circe unmarshaller (which only accepts application/json) will
+  // accept it. Anything we don't recognise fails loudly.
+  private def parseRedirectedResponseIntoBag(
+    uri: Uri,
+    response: HttpResponse
+  ): Future[Bag] =
+    response.entity.contentType match {
+      case ContentTypes.`application/json` =>
+        parseResponseIntoBag(response)
+      case ct if ct.mediaType == MediaTypes.`application/octet-stream` =>
+        info(
+          s"Redirected bag response from ${uri.withQuery(Uri.Query.Empty)} had Content-Type $ct; treating as application/json"
+        )
+        parseResponseIntoBag(
+          response.withEntity(
+            response.entity.withContentType(ContentTypes.`application/json`)
+          )
+        )
+      case ct =>
+        response.discardEntityBytes()
+        Future.failed(
+          new Exception(
+            s"Unexpected Content-Type from redirected bag response: $ct"
+          )
+        )
+    }
 
   private def parseResponseIntoBag(response: HttpResponse): Future[Bag] =
     Unmarshal(response.entity).to[Bag].recover {

--- a/mets_adapter/mets_adapter/src/test/scala/weco/pipeline/mets_adapter/services/BagRetrieverTest.scala
+++ b/mets_adapter/mets_adapter/src/test/scala/weco/pipeline/mets_adapter/services/BagRetrieverTest.scala
@@ -209,7 +209,9 @@ class BagRetrieverTest
   }
 
   it("follows a 307 redirect to fetch the bag from S3") {
-    val redirectUri = Uri("https://wellcomecollection-storage-prod-large-response-cache.s3.eu-west-1.amazonaws.com/responses/digitised/b30414726/v1")
+    val redirectUri = Uri(
+      "https://wellcomecollection-storage-prod-large-response-cache.s3.eu-west-1.amazonaws.com/responses/digitised/b30414726/v1"
+    )
     val bagJson =
       """
         |{
@@ -300,6 +302,143 @@ class BagRetrieverTest
               name = "data/b30414726.xml",
               path = "v1/data/b30414726.xml"
             )
+        }
+    }
+  }
+
+  it(
+    "follows a 307 redirect and parses a bag served as application/octet-stream"
+  ) {
+    val redirectUri = Uri(
+      "https://wellcomecollection-storage-prod-large-response-cache.s3.eu-west-1.amazonaws.com/responses/digitised/b30414727/v1"
+    )
+    val bagJson =
+      """
+        |{
+        |  "id": "digitised/b30414727",
+        |  "space": { "id": "digitised", "type": "Space" },
+        |  "info": {
+        |    "externalIdentifier": "b30414727",
+        |    "payloadOxum": "1.1",
+        |    "baggingDate": "2023-01-02",
+        |    "sourceOrganization": "intranda GmbH",
+        |    "externalDescription": "A very large bag with a wonky content type",
+        |    "internalSenderIdentifier": "1235",
+        |    "internalSenderDescription": "large_bag_b30414727",
+        |    "type": "BagInfo"
+        |  },
+        |  "manifest": {
+        |    "checksumAlgorithm": "SHA-256",
+        |    "files": [
+        |      {
+        |        "checksum": "def456",
+        |        "name": "data/b30414727.xml",
+        |        "path": "v1/data/b30414727.xml",
+        |        "size": 1000,
+        |        "type": "File"
+        |      }
+        |    ],
+        |    "type": "BagManifest"
+        |  },
+        |  "tagManifest": {
+        |    "checksumAlgorithm": "SHA-256",
+        |    "files": [],
+        |    "type": "BagManifest"
+        |  },
+        |  "location": {
+        |    "provider": { "id": "amazon-s3", "type": "Provider" },
+        |    "bucket": "wellcomecollection-storage",
+        |    "path": "digitised/b30414727",
+        |    "type": "Location"
+        |  },
+        |  "replicaLocations": [],
+        |  "createdDate": "2023-01-02T12:00:00.000000Z",
+        |  "version": "v1",
+        |  "type": "Bag"
+        |}
+        |""".stripMargin
+
+    val storageResponses = Seq(
+      (
+        HttpRequest(uri = Uri("http://storage:1234/bags/digitised/b30414727")),
+        HttpResponse(
+          status = StatusCodes.TemporaryRedirect,
+          headers = List(Location(redirectUri))
+        )
+      )
+    )
+
+    val redirectResponses = Seq(
+      (
+        HttpRequest(uri = redirectUri),
+        HttpResponse(
+          entity = HttpEntity(
+            contentType = ContentTypes.`application/octet-stream`,
+            bagJson.getBytes("UTF-8")
+          )
+        )
+      )
+    )
+
+    withBagRetriever(storageResponses, redirectResponses) {
+      retriever =>
+        val future =
+          retriever.getBag(
+            space = "digitised",
+            externalIdentifier = "b30414727"
+          )
+
+        whenReady(future) {
+          bag =>
+            bag.location.bucket shouldBe "wellcomecollection-storage"
+            bag.location.path shouldBe "digitised/b30414727"
+            bag.manifest.files.head shouldBe BagFile(
+              name = "data/b30414727.xml",
+              path = "v1/data/b30414727.xml"
+            )
+        }
+    }
+  }
+
+  it("fails if a redirected bag response has an unexpected Content-Type") {
+    val redirectUri = Uri(
+      "https://wellcomecollection-storage-prod-large-response-cache.s3.eu-west-1.amazonaws.com/responses/digitised/b30414728/v1"
+    )
+
+    val storageResponses = Seq(
+      (
+        HttpRequest(uri = Uri("http://storage:1234/bags/digitised/b30414728")),
+        HttpResponse(
+          status = StatusCodes.TemporaryRedirect,
+          headers = List(Location(redirectUri))
+        )
+      )
+    )
+
+    val redirectResponses = Seq(
+      (
+        HttpRequest(uri = redirectUri),
+        HttpResponse(
+          entity = HttpEntity(
+            contentType = ContentTypes.`text/html(UTF-8)`,
+            "<html>not a bag</html>"
+          )
+        )
+      )
+    )
+
+    withBagRetriever(storageResponses, redirectResponses) {
+      retriever =>
+        val future =
+          retriever.getBag(
+            space = "digitised",
+            externalIdentifier = "b30414728"
+          )
+
+        whenReady(future.failed) {
+          _.getMessage should startWith(
+            "Unexpected Content-Type from redirected bag response:"
+          )
         }
     }
   }


### PR DESCRIPTION
## What does this change?

Follow-up to #3338 (which added 307 redirect handling for large bag responses in the METS adapter).

After deploying #3338, we hit another failure on the redirect path:

```
Failed parsing response into a Bag:
  org.apache.pekko.http.scaladsl.unmarshalling.Unmarshaller$UnsupportedContentTypeException:
  Unsupported Content-Type [Some(application/octet-stream)], supported: application/json
```

The S3 large-response cache sometimes serves the cached object with `Content-Type: application/octet-stream` even though the body is valid JSON. `FailFastCirceSupport` only registers an unmarshaller for `application/json`, so the parse fails — even though we know (because the redirect target is locked down to a Wellcome-controlled S3 prefix) that the body really is JSON.

This PR pattern-matches on the response `Content-Type` on the **redirect path only** in `HttpBagRetriever`:

- `application/json` → parse normally.
- `application/octet-stream` (any charset) → log at info that we're treating it as JSON, rewrite the entity's content type to `application/json`, and parse.
- Anything else → fail loudly with an `Unexpected Content-Type from redirected bag response: …` error.

The non-redirect (direct storage service) path still requires `application/json` — it's the storage service that controls that response, so loosening it isn't necessary.

Also adds an info log when a redirect is followed (URL stripped of query params to avoid logging the S3 presigned signature) so we have visibility on how often the large-bag redirect path fires.

Context:
- Slack thread / suggestion from Agnes G: https://wellcome.slack.com/archives/CQ720BG02/p1776959708590179
- Related platform issue: https://github.com/wellcomecollection/platform/issues/6332
- Predecessor PR: #3338

## How to test

Two new unit tests in `BagRetrieverTest` cover the new behaviour:

- **Octet-stream redirect**: a 307 redirect followed by an S3 response served as `application/octet-stream` is parsed successfully.
- **Unexpected Content-Type**: a redirect response with an unrecognised content type (e.g. `text/html`) fails with the expected error.

The pre-existing tests (including the original `application/json` redirect path) continue to pass.

```
sbt "project mets_adapter" "testOnly weco.pipeline.mets_adapter.services.BagRetrieverTest"
```

## How can we measure success?

After deployment, the `Failed parsing response into a Bag: … Unsupported Content-Type [Some(application/octet-stream)] …` errors observed for large bags should stop appearing in the METS adapter logs. We should also see the new `Following redirect for large bag response …` info logs when large bags are fetched.

## Have we considered potential risks?

- We're trusting that any object served from `wellcomecollection-storage-prod-large-response-cache` is JSON regardless of its declared content type. That trust already exists implicitly in #3338's redirect allow-list (we only follow redirects to that prefix), and is now made explicit with the content-type rewrite. The storage service is the only writer of that cache.
- Anything other than `application/json` or `application/octet-stream` from the redirect target now fails loudly rather than being silently mishandled, so an unexpected upstream change won't go unnoticed.
- The change is scoped to the redirect path only; the primary storage-service response handling is unchanged.
