### PR TITLE
Read Iceberg rows in batches

### DIFF
--- a/catalogue_graph/src/adapters/utils/pipeline_store.py
+++ b/catalogue_graph/src/adapters/utils/pipeline_store.py
@@ -47,7 +47,7 @@ class PipelineStore(ABC):
 
     def get_all_records(self) -> pa.Table:
         """Return all records in the table from all namespaces."""
-        return self.table.scan().to_arrow().cast(self.schema)
+        return self.table.scan().to_arrow_batch_reader().cast(self.schema)
 
     def current_snapshot_id(self) -> int | None:
         snapshot = self.table.current_snapshot()
@@ -62,7 +62,7 @@ class PipelineStore(ABC):
         full_filter = And(EqualTo("namespace", self.namespace), iceberg_filter)
         return (
             self.table.scan(row_filter=full_filter, snapshot_id=snapshot_id)
-            .to_arrow()
+            .to_arrow_batch_reader()
             .cast(self.schema)
         )
 


### PR DESCRIPTION
## What does this change?

https://github.com/wellcomecollection/platform/issues/6352

When materialising Iceberg tables into Arrow tables, use `to_arrow_batch_reader` instead of `to_arrow` to keep memory usage low.

This is a partial fix to the recent Folio adapter memory issues and should be combined with other tweaks (partitioning/sorting on the Iceberg table) to minimise the amount of data we need to process and speed up execution.

## How to test

Run the folio adapter using the even below with and without this tweak in place, observing memory usage.

```
{
  "job_id": "20260429T1029",
  "window": {
    "start_time": "2026-04-29T09:30:00Z",
    "end_time": "2026-04-29T10:29:47Z"
  },
  "metadata_prefix": "marc21_withholdings",
  "set_spec": null,
  "max_windows": null,
  "window_minutes": 15,
  "allow_partial_final_window": null
}
```

## How can we measure success?

Memory consumed by adapter services should not exceed ~2GB.

## Have we considered potential risks?

This change is low risk.

