### PR TITLE
id_minter: fix silent SNS publish failures and improve throughput

### DIFF
--- a/catalogue_graph/src/id_minter/sns.py
+++ b/catalogue_graph/src/id_minter/sns.py
@@ -50,11 +50,12 @@ def publish_ids_to_sns(
     )
 
     published = 0
+    actual_workers = min(max_workers, num_batches)
     sns_client = boto3.Session().client(
         "sns",
-        config=Config(max_pool_connections=max_workers),
+        config=Config(max_pool_connections=actual_workers),
     )
-    with ThreadPoolExecutor(max_workers=min(max_workers, num_batches)) as pool:
+    with ThreadPoolExecutor(max_workers=actual_workers) as pool:
         futures = {
             pool.submit(publish_batch_to_sns, topic_arn, batch, sns_client): idx
             for idx, batch in enumerate(batches)

--- a/catalogue_graph/src/id_minter/sns.py
+++ b/catalogue_graph/src/id_minter/sns.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
+import boto3
 import structlog
 
 from utils.aws import publish_batch_to_sns
@@ -21,7 +22,7 @@ logger = structlog.get_logger(__name__)
 SNS_BATCH_SIZE = 10
 
 # How many publish_batch calls to run concurrently.
-SNS_MAX_WORKERS = 8
+SNS_MAX_WORKERS = 50
 
 
 def publish_ids_to_sns(
@@ -48,9 +49,10 @@ def publish_ids_to_sns(
     )
 
     published = 0
+    sns_client = boto3.Session().client("sns")
     with ThreadPoolExecutor(max_workers=min(max_workers, num_batches)) as pool:
         futures = {
-            pool.submit(publish_batch_to_sns, topic_arn, batch): idx
+            pool.submit(publish_batch_to_sns, topic_arn, batch, sns_client): idx
             for idx, batch in enumerate(batches)
         }
         for future in as_completed(futures):

--- a/catalogue_graph/src/id_minter/sns.py
+++ b/catalogue_graph/src/id_minter/sns.py
@@ -13,6 +13,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import boto3
 import structlog
+from botocore.config import Config
 
 from utils.aws import publish_batch_to_sns
 
@@ -49,7 +50,10 @@ def publish_ids_to_sns(
     )
 
     published = 0
-    sns_client = boto3.Session().client("sns")
+    sns_client = boto3.Session().client(
+        "sns",
+        config=Config(max_pool_connections=max_workers),
+    )
     with ThreadPoolExecutor(max_workers=min(max_workers, num_batches)) as pool:
         futures = {
             pool.submit(publish_batch_to_sns, topic_arn, batch, sns_client): idx

--- a/catalogue_graph/src/utils/aws.py
+++ b/catalogue_graph/src/utils/aws.py
@@ -32,7 +32,11 @@ def get_ssm_parameter(parameter_name: str) -> str:
     return parameter_value
 
 
-def publish_batch_to_sns(topic_arn: str, messages: list[str]) -> None:
+def publish_batch_to_sns(
+    topic_arn: str,
+    messages: list[str],
+    client: Any | None = None,
+) -> None:
     """Publishes a batch of up to 10 messages to the specified SNS topic."""
 
     assert len(messages) <= 10
@@ -47,7 +51,8 @@ def publish_batch_to_sns(topic_arn: str, messages: list[str]) -> None:
             }
         )
 
-    boto3.Session().client("sns").publish_batch(
+    sns_client = client or boto3.Session().client("sns")
+    sns_client.publish_batch(
         TopicArn=topic_arn,
         PublishBatchRequestEntries=request_entries,
     )

--- a/catalogue_graph/src/utils/aws.py
+++ b/catalogue_graph/src/utils/aws.py
@@ -51,7 +51,7 @@ def publish_batch_to_sns(
             }
         )
 
-    sns_client = client or boto3.Session().client("sns")
+    sns_client = boto3.Session().client("sns") if client is None else client
     response = sns_client.publish_batch(
         TopicArn=topic_arn,
         PublishBatchRequestEntries=request_entries,

--- a/catalogue_graph/src/utils/aws.py
+++ b/catalogue_graph/src/utils/aws.py
@@ -52,10 +52,16 @@ def publish_batch_to_sns(
         )
 
     sns_client = client or boto3.Session().client("sns")
-    sns_client.publish_batch(
+    response = sns_client.publish_batch(
         TopicArn=topic_arn,
         PublishBatchRequestEntries=request_entries,
     )
+
+    failed = response.get("Failed", [])
+    if failed:
+        raise RuntimeError(
+            f"Failed to publish {len(failed)}/{len(messages)} SNS messages: {failed}"
+        )
 
 
 def get_csv_from_s3(s3_uri: str) -> Generator[Any]:

--- a/catalogue_graph/tests/id_minter/test_sns.py
+++ b/catalogue_graph/tests/id_minter/test_sns.py
@@ -8,6 +8,7 @@ import pytest
 
 from id_minter.sns import publish_ids_to_sns
 from tests.mocks import MockSNSClient
+from utils.aws import publish_batch_to_sns
 
 TEST_TOPIC = "arn:aws:sns:eu-west-1:123456789:test-topic"
 
@@ -87,3 +88,27 @@ class TestPublishIdsToSns:
                 publish_ids_to_sns(TEST_TOPIC, ["fail0001"])
         finally:
             MockSNSClient.publish_batch = original  # type: ignore[method-assign]
+
+
+class TestPublishBatchToSns:
+    def test_partial_failure_raises(self) -> None:
+        """publish_batch_to_sns raises when the response contains failed entries."""
+
+        class FailingClient:
+            def publish_batch(self, **kwargs):  # type: ignore[no-untyped-def]
+                return {
+                    "Successful": [],
+                    "Failed": [
+                        {
+                            "Id": "batch_message_0",
+                            "Code": "InternalError",
+                            "Message": "something went wrong",
+                            "SenderFault": False,
+                        }
+                    ],
+                }
+
+        with pytest.raises(RuntimeError, match="Failed to publish 1/2 SNS messages"):
+            publish_batch_to_sns(
+                TEST_TOPIC, ["msg1", "msg2"], client=FailingClient()
+            )

--- a/catalogue_graph/tests/id_minter/test_sns.py
+++ b/catalogue_graph/tests/id_minter/test_sns.py
@@ -109,6 +109,4 @@ class TestPublishBatchToSns:
                 }
 
         with pytest.raises(RuntimeError, match="Failed to publish 1/2 SNS messages"):
-            publish_batch_to_sns(
-                TEST_TOPIC, ["msg1", "msg2"], client=FailingClient()
-            )
+            publish_batch_to_sns(TEST_TOPIC, ["msg1", "msg2"], client=FailingClient())

--- a/catalogue_graph/tests/mocks.py
+++ b/catalogue_graph/tests/mocks.py
@@ -183,6 +183,7 @@ class MockSNSClient(MockAwsService):
                 "PublishBatchRequestEntries": PublishBatchRequestEntries,
             }
         )
+        return {"Successful": [], "Failed": []}
 
     def publish(self, **kwargs: Any) -> dict[str, Any]:
         """Mock SNS publish method for single message publishing."""
@@ -240,7 +241,7 @@ class MockBoto3Session:
             "cloudwatch": MockCloudwatchClient(),
         }
 
-    def client(self, client_name: str) -> MockAwsService:
+    def client(self, client_name: str, **kwargs: Any) -> MockAwsService:
         if client_name not in self.clients:
             raise KeyError("There is no mock client for the specified client_name.")
         return self.clients[client_name]


### PR DESCRIPTION
## What does this change?

We've been seeing failing id minter runs in the alerts channel due to timeouts. This change follows https://github.com/wellcomecollection/catalogue-pipeline/pull/3341, after identifying we are spending a long time in publishing to SNS. 

See: https://wellcome.slack.com/archives/CQ720BG02/p1777516598038549

This PR fixes the SNS publishing in the id minter in two ways:

1. **Check for partial failures from `publish_batch`.** `publish_batch_to_sns` now inspects the `Failed` list in the response and raises a `RuntimeError` if any messages failed to publish, so failures are no longer silently swallowed.

2. **Improve SNS publishing throughput.** The id minter publishes many thousands of messages after minting IDs. Previously each `publish_batch` call created its own boto3 client and HTTP connection, which was wasteful. Now:
   - A single `boto3` SNS client is created per `publish_ids_to_sns` invocation and shared across all concurrent batch calls.
   - The client's connection pool is sized to match the thread pool (`max_pool_connections`).
   - The max worker count is raised from 8 → 50 to better utilise concurrency.

Also adds a test for the partial-failure detection path and updates the mock to return the expected `publish_batch` response shape.

## How to test

Run the id minter tests:

```bash
cd catalogue_graph
uv run pytest tests/id_minter/test_sns.py -v
```

Verify the new `test_partial_failure_raises` test passes, confirming that a `RuntimeError` is raised when `publish_batch` reports failed entries.

We have also tested this on a large batch with a dev image of this branch in production with success.

## How can we measure success?

- The failing id minter alerts should stop appearing in the alerts channel.
- If SNS publish failures do occur, they will now surface as explicit errors rather than being silently dropped, making them easier to diagnose.

## Have we considered potential risks?

- Raising on partial failure means the id minter step will now fail loudly instead of silently losing messages. This is the desired behaviour — a retry is preferable to silent data loss.
- Increasing `SNS_MAX_WORKERS` to 50 increases concurrency but is bounded by the connection pool and seems to be within SNS service limits. The single shared client avoids the overhead of creating many separate clients.
