### PR TITLE
id_minter: demote per-ID logs to debug and clamp noisy library loggers

### DIFF
--- a/catalogue_graph/src/id_minter/resolvers/minting_resolver.py
+++ b/catalogue_graph/src/id_minter/resolvers/minting_resolver.py
@@ -202,7 +202,7 @@ class MintingResolver:
         for sid in source_ids:
             if sid in found:
                 result[sid] = found[sid]
-                logger.info(
+                logger.debug(
                     "Resolved ID",
                     source_id=f"{sid[0]}[{sid[1]}/{sid[2]}]",
                     canonical_id=found[sid],
@@ -289,7 +289,7 @@ class MintingResolver:
                 assert (
                     pred is not None
                 )  # needs_inheritance only contains source ids with a predecessor
-                logger.info(
+                logger.debug(
                     "Resolved ID",
                     source_id=f"{source_key[0]}[{source_key[1]}/{source_key[2]}]",
                     canonical_id=canonical_id,
@@ -412,14 +412,14 @@ class MintingResolver:
                     # Only mark as assigned if we won the race (our claimed ID was used)
                     if actual_canonical == claimed_mapping.get(source_key):
                         used_canonical_ids.add(actual_canonical)
-                        logger.info(
+                        logger.debug(
                             "Resolved ID",
                             source_id=f"{source_key[0]}[{source_key[1]}/{source_key[2]}]",
                             canonical_id=actual_canonical,
                             method="minted",
                         )
                     else:
-                        logger.info(
+                        logger.debug(
                             "Resolved ID",
                             source_id=f"{source_key[0]}[{source_key[1]}/{source_key[2]}]",
                             canonical_id=actual_canonical,

--- a/catalogue_graph/src/utils/logger.py
+++ b/catalogue_graph/src/utils/logger.py
@@ -37,6 +37,14 @@ log_level = os.environ.get(
     "LOG_LEVEL", "INFO"
 )  # we can adjust the log level in tf. Defaults to INFO in local
 
+# Third-party loggers that are excessively chatty at DEBUG level. Each is
+# clamped to its mapped level regardless of the root LOG_LEVEL so that running
+# the app at DEBUG doesn't drown our own logs in library noise.
+NOISY_LIBRARY_LOGGERS: dict[str, str] = {
+    "botocore": "INFO",
+    "urllib3": "INFO",
+}
+
 
 def setup_structlog() -> None:
     """
@@ -114,6 +122,10 @@ def setup_logging(context: ExecutionContext | None = None) -> None:
     setup_structlog()
     # Force the root logger to desired level to override any AWS Lambda defaults
     logging.getLogger().setLevel(log_level)
+
+    # Clamp noisy third-party loggers so application DEBUG runs are still readable.
+    for logger_name, level in NOISY_LIBRARY_LOGGERS.items():
+        logging.getLogger(logger_name).setLevel(level)
 
     if context is None:
         context = ExecutionContext(

--- a/catalogue_graph/src/utils/logger.py
+++ b/catalogue_graph/src/utils/logger.py
@@ -124,7 +124,7 @@ def setup_logging(context: ExecutionContext | None = None) -> None:
     logging.getLogger().setLevel(log_level)
 
     # Clamp noisy third-party loggers so application DEBUG runs are still
-    # readable. 
+    # readable.
     root_level = logging.getLogger().getEffectiveLevel()
     for logger_name, level in NOISY_LIBRARY_LOGGERS.items():
         clamped = max(root_level, logging.getLevelNamesMapping()[level])

--- a/catalogue_graph/src/utils/logger.py
+++ b/catalogue_graph/src/utils/logger.py
@@ -123,9 +123,12 @@ def setup_logging(context: ExecutionContext | None = None) -> None:
     # Force the root logger to desired level to override any AWS Lambda defaults
     logging.getLogger().setLevel(log_level)
 
-    # Clamp noisy third-party loggers so application DEBUG runs are still readable.
+    # Clamp noisy third-party loggers so application DEBUG runs are still
+    # readable. 
+    root_level = logging.getLogger().getEffectiveLevel()
     for logger_name, level in NOISY_LIBRARY_LOGGERS.items():
-        logging.getLogger(logger_name).setLevel(level)
+        clamped = max(root_level, logging.getLevelNamesMapping()[level])
+        logging.getLogger(logger_name).setLevel(clamped)
 
     if context is None:
         context = ExecutionContext(


### PR DESCRIPTION
Follow-up to #3345.

## What does this change?

Tames the volume of `id_minter` logs at INFO and makes DEBUG runs actually
useful when investigating ID resolution.

- Demote the four per-ID `"Resolved ID"` log lines in
  `MintingResolver._mint_ids_with_rollback` from `info` to `debug`. The
  aggregate summary lines (`Batch lookup complete`, `Inherited predecessor
  canonical IDs`, `Minted new canonical IDs`) stay at `info`, so normal
  operation still tells you what happened, without one log line per resolved
  identifier (which becomes thousands per window during reindexes).
- Add a `NOISY_LIBRARY_LOGGERS: dict[str, str]` mapping in
  `catalogue_graph/src/utils/logger.py` and clamp each named logger to its
  mapped level inside `setup_logging()`, after the root level has been set.
  Currently clamps `botocore` and `urllib3` to `INFO`, both are extremely
  chatty at DEBUG (a single SNS publish emits ~93 `botocore.*` lines + 6
  `urllib3.connectionpool` lines). The map is intentionally per-library so
  individual clamps can be lifted (or new libraries added) without a code
  rewrite.

Net effect: running with `LOG_LEVEL=DEBUG` now surfaces the per-ID
`"Resolved ID"` events while keeping AWS SDK / HTTP transport noise at INFO.

## How to test

Local sanity check:

```bash
cd catalogue_graph
LOG_LEVEL=DEBUG uv run python -c "
import logging, sys
sys.path.insert(0, 'src')
from utils.logger import setup_logging, NOISY_LIBRARY_LOGGERS
setup_logging()
for name in ('', *NOISY_LIBRARY_LOGGERS):
    print(name or 'root', logging.getLevelName(logging.getLogger(name).getEffectiveLevel()))
"
```

Should print `root DEBUG`, `botocore INFO`, `urllib3 INFO`.

Then trigger a botocore call at DEBUG and confirm no `botocore.hooks` /
`botocore.auth` / `botocore.endpoint` debug spam appears.

Standard checks pass:

```bash
uv run ruff format
uv run ruff check --fix
uv run mypy src/id_minter/resolvers/minting_resolver.py src/utils/logger.py
uv run pytest tests/id_minter -q --no-cov   # 132 passed
```

## How can we measure success?

- INFO-level log volume per id_minter window is unchanged for normal
  operation (no per-ID lines were ever expected at INFO in steady-state
  reindex traffic -- they were just dominating the output).
- Promoting `LOG_LEVEL` to `DEBUG` for an investigation now produces output
  whose signal is dominated by `id_minter.*` events rather than AWS SDK
  signing/endpoint chatter.

## Have we considered potential risks?

- The four demoted log lines were the *only* per-ID log records, the aggregate
  summary lines still report `existing` / `needs_inheritance` /
  `needs_new_id` / `assigned` / `races_lost` counts, which is the useful
  per-batch information.
- `botocore` / `urllib3` clamps only kick in when `setup_logging()` runs
  (the Lambda / CLI entry points). Tests that stub out boto3 are unaffected;
  CI behaviour does not change.
- The clamp uses `logging.getLogger(name).setLevel(...)`, which is idempotent
  and reversible per-logger if a future caller wants to override it.

