### PR TITLE
Use ES external versioning

### DIFF
--- a/catalogue_graph/src/ingestor/models/indexable/concept.py
+++ b/catalogue_graph/src/ingestor/models/indexable/concept.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from pydantic import BaseModel
 
@@ -66,7 +66,7 @@ class IndexableConcept(IndexableRecord):
         return self.query.id
 
     def get_modified_time(self) -> datetime:
-        return datetime.now()
+        return datetime.now(UTC)
 
     @staticmethod
     def from_raw_document(concept: dict) -> "IndexableConcept":

--- a/catalogue_graph/src/ingestor/models/indexable/concept.py
+++ b/catalogue_graph/src/ingestor/models/indexable/concept.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from pydantic import BaseModel
 
 from ingestor.models.display.identifier import DisplayIdentifier
@@ -62,6 +64,9 @@ class IndexableConcept(IndexableRecord):
 
     def get_id(self) -> str:
         return self.query.id
+
+    def get_modified_time(self) -> datetime:
+        return datetime.now()
 
     @staticmethod
     def from_raw_document(concept: dict) -> "IndexableConcept":

--- a/catalogue_graph/src/ingestor/models/indexable/image.py
+++ b/catalogue_graph/src/ingestor/models/indexable/image.py
@@ -23,6 +23,9 @@ class IndexableImage(IndexableRecord):
     def get_id(self) -> str:
         return self.query.id
 
+    def get_modified_time(self) -> datetime:
+        return datetime.fromisoformat(self.modified_time)
+
     @staticmethod
     def from_raw_document(image: dict) -> "IndexableImage":
         return IndexableImage.model_validate(image)

--- a/catalogue_graph/src/ingestor/models/indexable/image.py
+++ b/catalogue_graph/src/ingestor/models/indexable/image.py
@@ -24,6 +24,7 @@ class IndexableImage(IndexableRecord):
         return self.query.id
 
     def get_modified_time(self) -> datetime:
+        # Set by the merger service
         return datetime.fromisoformat(self.modified_time)
 
     @staticmethod

--- a/catalogue_graph/src/ingestor/models/indexable/record.py
+++ b/catalogue_graph/src/ingestor/models/indexable/record.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from datetime import datetime
 
 from models.pipeline.serialisable import ElasticsearchModel
 
@@ -6,6 +7,10 @@ from models.pipeline.serialisable import ElasticsearchModel
 class IndexableRecord(ElasticsearchModel, ABC):
     @abstractmethod
     def get_id(self) -> str:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_modified_time(self) -> datetime:
         raise NotImplementedError
 
     @staticmethod

--- a/catalogue_graph/src/ingestor/models/indexable/work.py
+++ b/catalogue_graph/src/ingestor/models/indexable/work.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from ingestor.extractors.works.base_works_extractor import VisibleExtractedWork
 from ingestor.models.aggregate.work import WorkAggregatableValues
 from ingestor.models.debug.work import (
@@ -26,6 +28,9 @@ class IndexableWork(IndexableRecord):
 
     def get_id(self) -> str:
         return self.debug.source.id
+
+    def get_modified_time(self) -> datetime:
+        return datetime.fromisoformat(self.debug.source.modified_time)
 
     @staticmethod
     def from_raw_document(work: dict) -> "IndexableWork":

--- a/catalogue_graph/src/ingestor/models/merged/work.py
+++ b/catalogue_graph/src/ingestor/models/merged/work.py
@@ -1,5 +1,3 @@
-from pydantic import model_validator
-
 from ingestor.models.shared.merge_candidate import MergeCandidate
 from models.pipeline.id_label import Id
 from models.pipeline.work import (
@@ -17,17 +15,6 @@ class MergedWorkState(WorkState):
     merged_time: str
     availabilities: list[Id]
     merge_candidates: list[MergeCandidate]
-
-    @model_validator(mode="before")
-    @classmethod
-    def _set_modified_time(cls, data: dict) -> dict:
-        if isinstance(data, dict) and ("merged_time" in data or "mergedTime" in data):
-            d = dict(data)
-            # Prefer snake_case if present else camelCase
-            merged_val = d.get("merged_time", d.get("mergedTime"))
-            d["modified_time"] = merged_val
-            return d
-        return data
 
     def id(self) -> str:
         return self.canonical_id

--- a/catalogue_graph/src/ingestor/steps/ingestor_indexer.py
+++ b/catalogue_graph/src/ingestor/steps/ingestor_indexer.py
@@ -76,6 +76,10 @@ def generate_operations(
             "_index": index_name,
             "_id": datum.get_id(),
             "_source": source,
+            "_version": int(
+                datum.get_modified_time().timestamp() * 1000
+            ),  # epoch millis
+            "_version_type": "external_gte",
         }
 
 

--- a/catalogue_graph/src/models/pipeline/source/work.py
+++ b/catalogue_graph/src/models/pipeline/source/work.py
@@ -10,6 +10,7 @@ class SourceWorkState(WorkState):
     # deserialisation in the scala pipeline, we include them here.
     internal_work_stubs: list[str] = Field(default_factory=list)
     merge_candidates: list[MergeCandidate] = Field(default_factory=list)
+    modified_time: str
 
     def id(self) -> str:
         return str(self.source_identifier)

--- a/catalogue_graph/src/models/pipeline/work_state.py
+++ b/catalogue_graph/src/models/pipeline/work_state.py
@@ -21,7 +21,6 @@ class WorkRelations(SerialisableModel):
 class WorkState(SerialisableModel):
     source_identifier: SourceIdentifier
     source_modified_time: str
-    modified_time: str
     relations: WorkRelations | None = None
 
     def id(self) -> str:

--- a/catalogue_graph/tests/fixtures/ingestor/concepts/mock_es_inputs.json
+++ b/catalogue_graph/tests/fixtures/ingestor/concepts/mock_es_inputs.json
@@ -30,7 +30,9 @@
         "sameAs": [],
         "displayImages": []
       }
-    }
+    },
+    "_version": 1735732800000,
+    "_version_type": "external_gte"
   },
   {
     "_index": "concepts-indexed-2025-01-01",
@@ -56,8 +58,8 @@
             "type": "Identifier",
             "identifierType": {
               "id": "lc-names",
-              "label": "Library of Congress Name authority records",
-              "type": "IdentifierType"
+              "type": "IdentifierType",
+              "label": "Library of Congress Name authority records"
             }
           }
         ],
@@ -80,7 +82,9 @@
         ],
         "displayImages": []
       }
-    }
+    },
+    "_version": 1735732800000,
+    "_version_type": "external_gte"
   },
   {
     "_index": "concepts-indexed-2025-01-01",
@@ -113,7 +117,9 @@
         "sameAs": [],
         "displayImages": []
       }
-    }
+    },
+    "_version": 1735732800000,
+    "_version_type": "external_gte"
   },
   {
     "_index": "concepts-indexed-2025-01-01",
@@ -139,8 +145,8 @@
             "type": "Identifier",
             "identifierType": {
               "id": "lc-names",
-              "label": "Library of Congress Name authority records",
-              "type": "IdentifierType"
+              "type": "IdentifierType",
+              "label": "Library of Congress Name authority records"
             }
           }
         ],
@@ -156,10 +162,10 @@
           "people": [],
           "frequentCollaborators": [
             {
-              "conceptType": "Person",
-              "id": "tgk79tta",
               "label": "Pfeiffer, J. William",
-              "relationshipType": ""
+              "id": "tgk79tta",
+              "relationshipType": "",
+              "conceptType": "Person"
             }
           ],
           "relatedTopics": [],
@@ -170,7 +176,9 @@
         ],
         "displayImages": []
       }
-    }
+    },
+    "_version": 1735732800000,
+    "_version_type": "external_gte"
   },
   {
     "_index": "concepts-indexed-2025-01-01",
@@ -203,7 +211,9 @@
         "sameAs": [],
         "displayImages": []
       }
-    }
+    },
+    "_version": 1735732800000,
+    "_version_type": "external_gte"
   },
   {
     "_index": "concepts-indexed-2025-01-01",
@@ -229,8 +239,8 @@
             "type": "Identifier",
             "identifierType": {
               "id": "lc-names",
-              "label": "Library of Congress Name authority records",
-              "type": "IdentifierType"
+              "type": "IdentifierType",
+              "label": "Library of Congress Name authority records"
             }
           }
         ],
@@ -253,7 +263,9 @@
         ],
         "displayImages": []
       }
-    }
+    },
+    "_version": 1735732800000,
+    "_version_type": "external_gte"
   },
   {
     "_index": "concepts-indexed-2025-01-01",
@@ -281,8 +293,8 @@
             "type": "Identifier",
             "identifierType": {
               "id": "lc-names",
-              "label": "Library of Congress Name authority records",
-              "type": "IdentifierType"
+              "type": "IdentifierType",
+              "label": "Library of Congress Name authority records"
             }
           }
         ],
@@ -307,7 +319,9 @@
         ],
         "displayImages": []
       }
-    }
+    },
+    "_version": 1735732800000,
+    "_version_type": "external_gte"
   },
   {
     "_index": "concepts-indexed-2025-01-01",
@@ -336,8 +350,8 @@
             "type": "Identifier",
             "identifierType": {
               "id": "lc-names",
-              "label": "Library of Congress Name authority records",
-              "type": "IdentifierType"
+              "type": "IdentifierType",
+              "label": "Library of Congress Name authority records"
             }
           }
         ],
@@ -354,6 +368,7 @@
           "narrowerThan": [],
           "broaderThan": [],
           "people": [],
+          "frequentCollaborators": [],
           "relatedTopics": [
             {
               "label": "Disease Outbreaks",
@@ -380,7 +395,6 @@
               "conceptType": "Concept"
             }
           ],
-          "frequentCollaborators": [],
           "foundedBy": []
         },
         "sameAs": [
@@ -388,7 +402,9 @@
         ],
         "displayImages": []
       }
-    }
+    },
+    "_version": 1735732800000,
+    "_version_type": "external_gte"
   },
   {
     "_index": "concepts-indexed-2025-01-01",
@@ -414,8 +430,8 @@
             "type": "Identifier",
             "identifierType": {
               "id": "lc-names",
-              "label": "Library of Congress Name authority records",
-              "type": "IdentifierType"
+              "type": "IdentifierType",
+              "label": "Library of Congress Name authority records"
             }
           }
         ],
@@ -438,40 +454,43 @@
         ],
         "displayImages": []
       }
-    }
+    },
+    "_version": 1735732800000,
+    "_version_type": "external_gte"
   },
   {
-    "_id": "a22d7muq",
     "_index": "concepts-indexed-2025-01-01",
+    "_id": "a22d7muq",
     "_source": {
-      "display": {
-        "alternativeLabels": [],
-        "displayLabel": "Brown, Bruce, 1942-",
+      "query": {
         "id": "a22d7muq",
         "identifiers": [],
         "label": "Brown, Bruce, 1942-",
+        "alternativeLabels": [],
+        "type": "Person"
+      },
+      "display": {
+        "id": "a22d7muq",
+        "identifiers": [],
+        "label": "Brown, Bruce, 1942-",
+        "displayLabel": "Brown, Bruce, 1942-",
+        "alternativeLabels": [],
+        "type": "Person",
         "relatedConcepts": {
-          "broaderThan": [],
-          "fieldsOfWork": [],
-          "frequentCollaborators": [],
-          "narrowerThan": [],
-          "people": [],
           "relatedTo": [],
+          "fieldsOfWork": [],
+          "narrowerThan": [],
+          "broaderThan": [],
+          "people": [],
+          "frequentCollaborators": [],
           "relatedTopics": [],
           "foundedBy": []
         },
         "sameAs": [],
-        "displayImages": [],
-        "type": "Person"
-      },
-      "query": {
-        "alternativeLabels": [],
-        "id": "a22d7muq",
-        "identifiers": [],
-        "label": "Brown, Bruce, 1942-",
-        "type": "Person"
+        "displayImages": []
       }
-    }
+    },
+    "_version": 1735732800000,
+    "_version_type": "external_gte"
   }
-
 ]

--- a/catalogue_graph/tests/fixtures/ingestor/works/mock_es_inputs.json
+++ b/catalogue_graph/tests/fixtures/ingestor/works/mock_es_inputs.json
@@ -3,6 +3,66 @@
     "_index": "works-indexed-2025-01-01",
     "_id": "a222zvge",
     "_source": {
+      "type": "Visible",
+      "debug": {
+        "source": {
+          "id": "a222zvge",
+          "identifier": {
+            "identifierType": {
+              "id": "calm-record-id"
+            },
+            "ontologyType": "Work",
+            "value": "e6606c3a-5404-4c5b-8337-3936d3d5f30b"
+          },
+          "version": 13,
+          "modifiedTime": "2025-06-30T16:20:14Z"
+        },
+        "mergedTime": "2025-08-19T19:23:53.532022Z",
+        "indexedTime": "2025-09-08T17:23:33.132490Z",
+        "mergeCandidates": [
+          {
+            "id": {
+              "sourceIdentifier": {
+                "identifierType": {
+                  "id": "calm-ref-no"
+                },
+                "ontologyType": "Work",
+                "value": "GC176/C/1"
+              },
+              "otherIdentifiers": [],
+              "canonicalId": "jqd7k4sp",
+              "type": "Identified"
+            },
+            "reason": "Archivematica work"
+          }
+        ],
+        "redirectSources": [
+          {
+            "sourceIdentifier": {
+              "identifierType": {
+                "id": "sierra-system-number"
+              },
+              "ontologyType": "Work",
+              "value": "b18659135"
+            },
+            "otherIdentifiers": [],
+            "canonicalId": "w4bajds8",
+            "type": "Identified"
+          },
+          {
+            "sourceIdentifier": {
+              "identifierType": {
+                "id": "mets"
+              },
+              "ontologyType": "Work",
+              "value": "b18659135"
+            },
+            "otherIdentifiers": [],
+            "canonicalId": "dfcyrkxh",
+            "type": "Identified"
+          }
+        ]
+      },
       "query": {
         "id": "a222zvge",
         "title": "'An Outline'; 'Opening Statement to 1933 only'; 'List of chief scientific writings up to 1940'; 'List of Exhibits'",
@@ -339,6 +399,9 @@
           "closed-stores",
           "iiif-presentation"
         ],
+        "items.locations.createdDate": [
+          "2014-02-30T16:20:14Z"
+        ],
         "partOf.id": [
           "rqyum5sv",
           "dkhx5djp"
@@ -350,80 +413,79 @@
         "availabilities.id": [
           "closed-stores",
           "online"
-        ],
-        "items.locations.createdDate": [
-          "2014-02-30T16:20:14Z"
-        ]
-      },
-      "type": "Visible",
-      "debug": {
-        "source": {
-          "id": "a222zvge",
-          "identifier": {
-            "identifierType": {
-              "id": "calm-record-id"
-            },
-            "ontologyType": "Work",
-            "value": "e6606c3a-5404-4c5b-8337-3936d3d5f30b"
-          },
-          "version": 13,
-          "modifiedTime": "2025-06-30T16:20:14Z"
-        },
-        "mergedTime": "2025-08-19T19:23:53.532022Z",
-        "indexedTime": "2025-09-08T17:23:33.132490Z",
-        "mergeCandidates": [
-          {
-            "id": {
-              "canonicalId": "jqd7k4sp",
-              "type": "Identified",
-              "sourceIdentifier": {
-                "identifierType": {
-                  "id": "calm-ref-no"
-                },
-                "ontologyType": "Work",
-                "value": "GC176/C/1"
-              },
-              "otherIdentifiers": []
-            },
-            "reason": "Archivematica work"
-          }
-        ],
-        "redirectSources": [
-          {
-            "canonicalId": "w4bajds8",
-            "type": "Identified",
-            "sourceIdentifier": {
-              "identifierType": {
-                "id": "sierra-system-number"
-              },
-              "ontologyType": "Work",
-              "value": "b18659135"
-            },
-            "otherIdentifiers": []
-          },
-          {
-            "canonicalId": "dfcyrkxh",
-            "type": "Identified",
-            "sourceIdentifier": {
-              "identifierType": {
-                "id": "mets"
-              },
-              "ontologyType": "Work",
-              "value": "b18659135"
-            },
-            "otherIdentifiers": []
-          }
         ]
       }
-    }
+    },
+    "_version": 1751300414000,
+    "_version_type": "external_gte"
   },
   {
     "_index": "works-indexed-2025-01-01",
     "_id": "a2239muq",
     "_source": {
+      "type": "Visible",
+      "debug": {
+        "source": {
+          "id": "a2239muq",
+          "identifier": {
+            "identifierType": {
+              "id": "sierra-system-number"
+            },
+            "ontologyType": "Work",
+            "value": "b15192982"
+          },
+          "version": 58,
+          "modifiedTime": "2025-07-17T13:07:35Z"
+        },
+        "mergedTime": "2025-08-19T18:10:40.041562Z",
+        "indexedTime": "2025-09-08T17:23:33.141933Z",
+        "mergeCandidates": [
+          {
+            "id": {
+              "sourceIdentifier": {
+                "identifierType": {
+                  "id": "sierra-system-number"
+                },
+                "ontologyType": "Work",
+                "value": "b30598977"
+              },
+              "otherIdentifiers": [],
+              "canonicalId": "hcqs6xp6",
+              "type": "Identified"
+            },
+            "reason": "Physical/digitised Sierra work"
+          }
+        ],
+        "redirectSources": [
+          {
+            "sourceIdentifier": {
+              "identifierType": {
+                "id": "mets"
+              },
+              "ontologyType": "Work",
+              "value": "b30598977"
+            },
+            "otherIdentifiers": [],
+            "canonicalId": "jstyg2xn",
+            "type": "Identified"
+          },
+          {
+            "sourceIdentifier": {
+              "identifierType": {
+                "id": "sierra-system-number"
+              },
+              "ontologyType": "Work",
+              "value": "b30598977"
+            },
+            "otherIdentifiers": [],
+            "canonicalId": "hcqs6xp6",
+            "type": "Identified"
+          }
+        ]
+      },
       "query": {
         "id": "a2239muq",
-        "title": "Ueber den Krebs der Nasenhöhle ... / vorgelegt von Hermann Wolter.",
+        "title": "Ueber den Krebs der Nasenh\u00f6hle ... / vorgelegt von Hermann Wolter.",
         "physicalDescription": "69 pages ; 23 cm",
         "alternativeTitles": [],
         "languages.label": [
@@ -454,7 +516,7 @@
           "QZ200:276:22"
         ],
         "notes.contents": [
-          "Universität Leipzig."
+          "Universit\u00e4t Leipzig."
         ],
         "partOf.title": [],
         "production.label": [
@@ -467,7 +529,7 @@
         ],
         "contributors.agent.label": [
           "Wolter, Hermann (Wilhelm Victor Hermann), 1868-",
-          "Universität Leipzig (1409-1953)"
+          "Universit\u00e4t Leipzig (1409-1953)"
         ],
         "genres.concepts.label": [
           "Academic dissertations"
@@ -475,7 +537,7 @@
       },
       "display": {
         "id": "a2239muq",
-        "title": "Ueber den Krebs der Nasenhöhle ... / vorgelegt von Hermann Wolter.",
+        "title": "Ueber den Krebs der Nasenh\u00f6hle ... / vorgelegt von Hermann Wolter.",
         "alternativeTitles": [],
         "physicalDescription": "69 pages ; 23 cm",
         "workType": {
@@ -508,7 +570,7 @@
           {
             "agent": {
               "id": "un9788h3",
-              "label": "Universität Leipzig (1409-1953)",
+              "label": "Universit\u00e4t Leipzig (1409-1953)",
               "identifiers": [
                 {
                   "value": "n85086716",
@@ -833,7 +895,7 @@
         "notes": [
           {
             "contents": [
-              "Universität Leipzig."
+              "Universit\u00e4t Leipzig."
             ],
             "noteType": {
               "id": "dissertation-note",
@@ -888,7 +950,7 @@
           },
           {
             "id": "un9788h3",
-            "label": "Universität Leipzig (1409-1953)"
+            "label": "Universit\u00e4t Leipzig (1409-1953)"
           }
         ],
         "items.locations.license": [
@@ -937,7 +999,7 @@
         ],
         "contributors.agent.label": [
           "Wolter, Hermann (Wilhelm Victor Hermann), 1868-",
-          "Universität Leipzig (1409-1953)"
+          "Universit\u00e4t Leipzig (1409-1953)"
         ],
         "contributors.agent.id": [
           "eq9qvtwy",
@@ -976,82 +1038,43 @@
           "closed-stores",
           "iiif-presentation"
         ],
+        "items.locations.createdDate": [
+          "2014-02-30T16:20:14Z"
+        ],
         "partOf.id": [],
         "partOf.title": [],
         "availabilities.id": [
           "closed-stores",
           "online"
-        ],
-        "items.locations.createdDate": [
-          "2014-02-30T16:20:14Z"
-        ]
-      },
-      "type": "Visible",
-      "debug": {
-        "source": {
-          "id": "a2239muq",
-          "identifier": {
-            "identifierType": {
-              "id": "sierra-system-number"
-            },
-            "ontologyType": "Work",
-            "value": "b15192982"
-          },
-          "version": 58,
-          "modifiedTime": "2025-07-17T13:07:35Z"
-        },
-        "mergedTime": "2025-08-19T18:10:40.041562Z",
-        "indexedTime": "2025-09-08T17:23:33.141933Z",
-        "mergeCandidates": [
-          {
-            "id": {
-              "canonicalId": "hcqs6xp6",
-              "type": "Identified",
-              "sourceIdentifier": {
-                "identifierType": {
-                  "id": "sierra-system-number"
-                },
-                "ontologyType": "Work",
-                "value": "b30598977"
-              },
-              "otherIdentifiers": []
-            },
-            "reason": "Physical/digitised Sierra work"
-          }
-        ],
-        "redirectSources": [
-          {
-            "canonicalId": "jstyg2xn",
-            "type": "Identified",
-            "sourceIdentifier": {
-              "identifierType": {
-                "id": "mets"
-              },
-              "ontologyType": "Work",
-              "value": "b30598977"
-            },
-            "otherIdentifiers": []
-          },
-          {
-            "canonicalId": "hcqs6xp6",
-            "type": "Identified",
-            "sourceIdentifier": {
-              "identifierType": {
-                "id": "sierra-system-number"
-              },
-              "ontologyType": "Work",
-              "value": "b30598977"
-            },
-            "otherIdentifiers": []
-          }
         ]
       }
-    }
+    },
+    "_version": 1752757655000,
+    "_version_type": "external_gte"
   },
   {
     "_index": "works-indexed-2025-01-01",
     "_id": "a223k4ra",
     "_source": {
+      "type": "Visible",
+      "debug": {
+        "source": {
+          "id": "a223k4ra",
+          "identifier": {
+            "identifierType": {
+              "id": "ebsco-alt-lookup"
+            },
+            "ontologyType": "Work",
+            "value": "ebs13464940e"
+          },
+          "version": 20250904,
+          "modifiedTime": "2025-09-05T12:35:57.811942Z"
+        },
+        "mergedTime": "2025-09-05T15:04:54.894994Z",
+        "indexedTime": "2025-09-08T17:23:33.142879Z",
+        "mergeCandidates": [],
+        "redirectSources": []
+      },
       "query": {
         "id": "a223k4ra",
         "title": "The danger and mischiefs of popery, set forth by the late Bishop of London, in his fifth pastoral letter",
@@ -1258,40 +1281,83 @@
         "items.id": [],
         "items.identifiers.value": [],
         "items.locations.locationType.id": [],
+        "items.locations.createdDate": [],
         "partOf.id": [],
         "partOf.title": [
           "Eighteenth Century Collections Online"
         ],
         "availabilities.id": [
           "online"
-        ],
-        "items.locations.createdDate": []
-      },
-      "type": "Visible",
-      "debug": {
-        "source": {
-          "id": "a223k4ra",
-          "identifier": {
-            "identifierType": {
-              "id": "ebsco-alt-lookup"
-            },
-            "ontologyType": "Work",
-            "value": "ebs13464940e"
-          },
-          "version": 20250904,
-          "modifiedTime": "2025-09-05T12:35:57.811942Z"
-        },
-        "mergedTime": "2025-09-05T15:04:54.894994Z",
-        "indexedTime": "2025-09-08T17:23:33.142879Z",
-        "mergeCandidates": [],
-        "redirectSources": []
+        ]
       }
-    }
+    },
+    "_version": 1757075757811,
+    "_version_type": "external_gte"
   },
   {
     "_index": "works-indexed-2025-01-01",
     "_id": "a2242545",
     "_source": {
+      "type": "Visible",
+      "debug": {
+        "source": {
+          "id": "a2242545",
+          "identifier": {
+            "identifierType": {
+              "id": "calm-record-id"
+            },
+            "ontologyType": "Work",
+            "value": "129b0826-3ac4-4aea-8b0c-490d5889df46"
+          },
+          "version": 7,
+          "modifiedTime": "2023-12-04T12:35:47Z"
+        },
+        "mergedTime": "2025-08-19T20:00:15.198906Z",
+        "indexedTime": "2025-09-08T17:23:33.143605Z",
+        "mergeCandidates": [
+          {
+            "id": {
+              "sourceIdentifier": {
+                "identifierType": {
+                  "id": "calm-ref-no"
+                },
+                "ontologyType": "Work",
+                "value": "UGC198/8/5/8"
+              },
+              "otherIdentifiers": [],
+              "canonicalId": "hmy2udbf",
+              "type": "Identified"
+            },
+            "reason": "Archivematica work"
+          }
+        ],
+        "redirectSources": [
+          {
+            "sourceIdentifier": {
+              "identifierType": {
+                "id": "sierra-system-number"
+              },
+              "ontologyType": "Work",
+              "value": "b19871831"
+            },
+            "otherIdentifiers": [],
+            "canonicalId": "adyxgsj4",
+            "type": "Identified"
+          },
+          {
+            "sourceIdentifier": {
+              "identifierType": {
+                "id": "mets"
+              },
+              "ontologyType": "Work",
+              "value": "b19871831"
+            },
+            "otherIdentifiers": [],
+            "canonicalId": "ugpnzjrn",
+            "type": "Identified"
+          }
+        ]
+      },
       "query": {
         "id": "a2242545",
         "title": "Draft manuscript notes for a seminar at the Institute de Biologie Moleculaire, Universite Paris",
@@ -1606,6 +1672,9 @@
         "items.locations.locationType.id": [
           "iiif-presentation"
         ],
+        "items.locations.createdDate": [
+          "2014-02-30T16:20:14Z"
+        ],
         "partOf.id": [
           "uad4jhwg",
           "y5tqfx79",
@@ -1618,77 +1687,35 @@
         ],
         "availabilities.id": [
           "online"
-        ],
-        "items.locations.createdDate": [
-          "2014-02-30T16:20:14Z"
-        ]
-      },
-      "type": "Visible",
-      "debug": {
-        "source": {
-          "id": "a2242545",
-          "identifier": {
-            "identifierType": {
-              "id": "calm-record-id"
-            },
-            "ontologyType": "Work",
-            "value": "129b0826-3ac4-4aea-8b0c-490d5889df46"
-          },
-          "version": 7,
-          "modifiedTime": "2023-12-04T12:35:47Z"
-        },
-        "mergedTime": "2025-08-19T20:00:15.198906Z",
-        "indexedTime": "2025-09-08T17:23:33.143605Z",
-        "mergeCandidates": [
-          {
-            "id": {
-              "canonicalId": "hmy2udbf",
-              "type": "Identified",
-              "sourceIdentifier": {
-                "identifierType": {
-                  "id": "calm-ref-no"
-                },
-                "ontologyType": "Work",
-                "value": "UGC198/8/5/8"
-              },
-              "otherIdentifiers": []
-            },
-            "reason": "Archivematica work"
-          }
-        ],
-        "redirectSources": [
-          {
-            "canonicalId": "adyxgsj4",
-            "type": "Identified",
-            "sourceIdentifier": {
-              "identifierType": {
-                "id": "sierra-system-number"
-              },
-              "ontologyType": "Work",
-              "value": "b19871831"
-            },
-            "otherIdentifiers": []
-          },
-          {
-            "canonicalId": "ugpnzjrn",
-            "type": "Identified",
-            "sourceIdentifier": {
-              "identifierType": {
-                "id": "mets"
-              },
-              "ontologyType": "Work",
-              "value": "b19871831"
-            },
-            "otherIdentifiers": []
-          }
         ]
       }
-    }
+    },
+    "_version": 1701693347000,
+    "_version_type": "external_gte"
   },
   {
     "_index": "works-indexed-2025-01-01",
     "_id": "a22526q9",
     "_source": {
+      "type": "Visible",
+      "debug": {
+        "source": {
+          "id": "a22526q9",
+          "identifier": {
+            "identifierType": {
+              "id": "sierra-system-number"
+            },
+            "ontologyType": "Work",
+            "value": "b31012152"
+          },
+          "version": 13,
+          "modifiedTime": "2022-01-12T10:29:21Z"
+        },
+        "mergedTime": "2025-08-19T18:37:10.778558Z",
+        "indexedTime": "2025-09-08T17:23:33.144325Z",
+        "mergeCandidates": [],
+        "redirectSources": []
+      },
       "query": {
         "id": "a22526q9",
         "title": "Prediche quadragesimali dell' anno 1495: Registro della prediche fatte nel 1495",
@@ -2003,6 +2030,9 @@
         "items.locations.locationType.id": [
           "online-resource"
         ],
+        "items.locations.createdDate": [
+          "2014-02-30T16:20:14Z"
+        ],
         "partOf.id": [],
         "partOf.title": [
           "Early European Books.",
@@ -2010,36 +2040,35 @@
         ],
         "availabilities.id": [
           "online"
-        ],
-        "items.locations.createdDate": [
-          "2014-02-30T16:20:14Z"
         ]
-      },
-      "type": "Visible",
-      "debug": {
-        "source": {
-          "id": "a22526q9",
-          "identifier": {
-            "identifierType": {
-              "id": "sierra-system-number"
-            },
-            "ontologyType": "Work",
-            "value": "b31012152"
-          },
-          "version": 13,
-          "modifiedTime": "2022-01-12T10:29:21Z"
-        },
-        "mergedTime": "2025-08-19T18:37:10.778558Z",
-        "indexedTime": "2025-09-08T17:23:33.144325Z",
-        "mergeCandidates": [],
-        "redirectSources": []
       }
-    }
+    },
+    "_version": 1641983361000,
+    "_version_type": "external_gte"
   },
   {
     "_index": "works-indexed-2025-01-01",
     "_id": "a2262ru9",
     "_source": {
+      "type": "Visible",
+      "debug": {
+        "source": {
+          "id": "a2262ru9",
+          "identifier": {
+            "identifierType": {
+              "id": "sierra-system-number"
+            },
+            "ontologyType": "Work",
+            "value": "b16699178"
+          },
+          "version": 28,
+          "modifiedTime": "2024-07-03T16:07:56Z"
+        },
+        "mergedTime": "2025-08-19T21:17:47.025238Z",
+        "indexedTime": "2025-09-08T17:23:33.145771Z",
+        "mergeCandidates": [],
+        "redirectSources": []
+      },
       "query": {
         "id": "a2262ru9",
         "title": "\"The parish of St George-the-martyr is a veritable hospital town\" : medical treatment available to the Holborn poor during the second half of the nineteenth century / Jacqueline Watson.",
@@ -2591,38 +2620,40 @@
         "items.locations.locationType.id": [
           "closed-stores"
         ],
+        "items.locations.createdDate": [],
         "partOf.id": [],
         "partOf.title": [],
         "availabilities.id": [
           "closed-stores"
-        ],
-        "items.locations.createdDate": []
-      },
-      "type": "Visible",
-      "debug": {
-        "source": {
-          "id": "a2262ru9",
-          "identifier": {
-            "identifierType": {
-              "id": "sierra-system-number"
-            },
-            "ontologyType": "Work",
-            "value": "b16699178"
-          },
-          "version": 28,
-          "modifiedTime": "2024-07-03T16:07:56Z"
-        },
-        "mergedTime": "2025-08-19T21:17:47.025238Z",
-        "indexedTime": "2025-09-08T17:23:33.145771Z",
-        "mergeCandidates": [],
-        "redirectSources": []
+        ]
       }
-    }
+    },
+    "_version": 1720022876000,
+    "_version_type": "external_gte"
   },
   {
     "_index": "works-indexed-2025-01-01",
     "_id": "a226rz35",
     "_source": {
+      "type": "Visible",
+      "debug": {
+        "source": {
+          "id": "a226rz35",
+          "identifier": {
+            "identifierType": {
+              "id": "sierra-system-number"
+            },
+            "ontologyType": "Work",
+            "value": "b31244361"
+          },
+          "version": 19,
+          "modifiedTime": "2023-08-18T11:38:24Z"
+        },
+        "mergedTime": "2025-08-19T16:26:08.065319Z",
+        "indexedTime": "2025-09-08T17:23:33.147668Z",
+        "mergeCandidates": [],
+        "redirectSources": []
+      },
       "query": {
         "id": "a226rz35",
         "title": "Prodigiorum ac ostentorum chronicon / [Konrad Lykosthenes].",
@@ -2966,6 +2997,7 @@
         "items.locations.locationType.id": [
           "online-resource"
         ],
+        "items.locations.createdDate": [],
         "partOf.id": [],
         "partOf.title": [
           "Early European Books.",
@@ -2973,37 +3005,51 @@
         ],
         "availabilities.id": [
           "online"
-        ],
-        "items.locations.createdDate": []
-      },
-      "type": "Visible",
-      "debug": {
-        "source": {
-          "id": "a226rz35",
-          "identifier": {
-            "identifierType": {
-              "id": "sierra-system-number"
-            },
-            "ontologyType": "Work",
-            "value": "b31244361"
-          },
-          "version": 19,
-          "modifiedTime": "2023-08-18T11:38:24Z"
-        },
-        "mergedTime": "2025-08-19T16:26:08.065319Z",
-        "indexedTime": "2025-09-08T17:23:33.147668Z",
-        "mergeCandidates": [],
-        "redirectSources": []
+        ]
       }
-    }
+    },
+    "_version": 1692358704000,
+    "_version_type": "external_gte"
   },
   {
     "_index": "works-indexed-2025-01-01",
     "_id": "a227dajt",
     "_source": {
+      "type": "Visible",
+      "debug": {
+        "source": {
+          "id": "a227dajt",
+          "identifier": {
+            "identifierType": {
+              "id": "sierra-system-number"
+            },
+            "ontologyType": "Work",
+            "value": "b21053613"
+          },
+          "version": 14,
+          "modifiedTime": "2023-08-18T15:49:59Z"
+        },
+        "mergedTime": "2025-08-19T18:37:19.909853Z",
+        "indexedTime": "2025-09-08T17:23:33.148976Z",
+        "mergeCandidates": [],
+        "redirectSources": [
+          {
+            "sourceIdentifier": {
+              "identifierType": {
+                "id": "mets"
+              },
+              "ontologyType": "Work",
+              "value": "b21053613"
+            },
+            "otherIdentifiers": [],
+            "canonicalId": "gqj73sk6",
+            "type": "Identified"
+          }
+        ]
+      },
       "query": {
         "id": "a227dajt",
-        "title": "L'homoeopathie à l'Académie de médecine de Belgique en 1877 : réponse au défi de M. le professeur Crocq / par le docteur Gailliard.",
+        "title": "L'homoeopathie \u00e0 l'Acad\u00e9mie de m\u00e9decine de Belgique en 1877 : r\u00e9ponse au d\u00e9fi de M. le professeur Crocq / par le docteur Gailliard.",
         "physicalDescription": "93 pages ; 25 cm",
         "alternativeTitles": [],
         "languages.label": [
@@ -3046,7 +3092,7 @@
       },
       "display": {
         "id": "a227dajt",
-        "title": "L'homoeopathie à l'Académie de médecine de Belgique en 1877 : réponse au défi de M. le professeur Crocq / par le docteur Gailliard.",
+        "title": "L'homoeopathie \u00e0 l'Acad\u00e9mie de m\u00e9decine de Belgique en 1877 : r\u00e9ponse au d\u00e9fi de M. le professeur Crocq / par le docteur Gailliard.",
         "alternativeTitles": [],
         "physicalDescription": "93 pages ; 25 cm",
         "workType": {
@@ -3472,53 +3518,71 @@
         "items.locations.locationType.id": [
           "iiif-presentation"
         ],
+        "items.locations.createdDate": [],
         "partOf.id": [],
         "partOf.title": [
           "Medical Heritage Library"
         ],
         "availabilities.id": [
           "online"
-        ],
-        "items.locations.createdDate": []
-      },
-      "type": "Visible",
-      "debug": {
-        "source": {
-          "id": "a227dajt",
-          "identifier": {
-            "identifierType": {
-              "id": "sierra-system-number"
-            },
-            "ontologyType": "Work",
-            "value": "b21053613"
-          },
-          "version": 14,
-          "modifiedTime": "2023-08-18T15:49:59Z"
-        },
-        "mergedTime": "2025-08-19T18:37:19.909853Z",
-        "indexedTime": "2025-09-08T17:23:33.148976Z",
-        "mergeCandidates": [],
-        "redirectSources": [
-          {
-            "canonicalId": "gqj73sk6",
-            "type": "Identified",
-            "sourceIdentifier": {
-              "identifierType": {
-                "id": "mets"
-              },
-              "ontologyType": "Work",
-              "value": "b21053613"
-            },
-            "otherIdentifiers": []
-          }
         ]
       }
-    }
+    },
+    "_version": 1692373799000,
+    "_version_type": "external_gte"
   },
   {
     "_index": "works-indexed-2025-01-01",
     "_id": "a227y9ye",
     "_source": {
+      "type": "Visible",
+      "debug": {
+        "source": {
+          "id": "a227y9ye",
+          "identifier": {
+            "identifierType": {
+              "id": "calm-record-id"
+            },
+            "ontologyType": "Work",
+            "value": "bff9122c-212a-4dbe-89fe-f355a5185cca"
+          },
+          "version": 13,
+          "modifiedTime": "2025-07-31T10:24:39Z"
+        },
+        "mergedTime": "2025-08-19T19:29:45.995295Z",
+        "indexedTime": "2025-09-08T17:23:33.151936Z",
+        "mergeCandidates": [
+          {
+            "id": {
+              "sourceIdentifier": {
+                "identifierType": {
+                  "id": "calm-ref-no"
+                },
+                "ontologyType": "Work",
+                "value": "PPRAS/A/2/1"
+              },
+              "otherIdentifiers": [],
+              "canonicalId": "zyphxyta",
+              "type": "Identified"
+            },
+            "reason": "Archivematica work"
+          }
+        ],
+        "redirectSources": [
+          {
+            "sourceIdentifier": {
+              "identifierType": {
+                "id": "sierra-system-number"
+              },
+              "ontologyType": "Work",
+              "value": "b19603782"
+            },
+            "otherIdentifiers": [],
+            "canonicalId": "cpmtamr5",
+            "type": "Identified"
+          }
+        ]
+      },
       "query": {
         "id": "a227y9ye",
         "title": "Wartime, bombing",
@@ -3789,6 +3853,7 @@
         "items.locations.locationType.id": [
           "closed-stores"
         ],
+        "items.locations.createdDate": [],
         "partOf.id": [
           "dupg64pv",
           "f5yb28yc",
@@ -3801,63 +3866,35 @@
         ],
         "availabilities.id": [
           "closed-stores"
-        ],
-        "items.locations.createdDate": []
-      },
-      "type": "Visible",
-      "debug": {
-        "source": {
-          "id": "a227y9ye",
-          "identifier": {
-            "identifierType": {
-              "id": "calm-record-id"
-            },
-            "ontologyType": "Work",
-            "value": "bff9122c-212a-4dbe-89fe-f355a5185cca"
-          },
-          "version": 13,
-          "modifiedTime": "2025-07-31T10:24:39Z"
-        },
-        "mergedTime": "2025-08-19T19:29:45.995295Z",
-        "indexedTime": "2025-09-08T17:23:33.151936Z",
-        "mergeCandidates": [
-          {
-            "id": {
-              "canonicalId": "zyphxyta",
-              "type": "Identified",
-              "sourceIdentifier": {
-                "identifierType": {
-                  "id": "calm-ref-no"
-                },
-                "ontologyType": "Work",
-                "value": "PPRAS/A/2/1"
-              },
-              "otherIdentifiers": []
-            },
-            "reason": "Archivematica work"
-          }
-        ],
-        "redirectSources": [
-          {
-            "canonicalId": "cpmtamr5",
-            "type": "Identified",
-            "sourceIdentifier": {
-              "identifierType": {
-                "id": "sierra-system-number"
-              },
-              "ontologyType": "Work",
-              "value": "b19603782"
-            },
-            "otherIdentifiers": []
-          }
         ]
       }
-    }
+    },
+    "_version": 1753957479000,
+    "_version_type": "external_gte"
   },
   {
     "_index": "works-indexed-2025-01-01",
     "_id": "a2284uhb",
     "_source": {
+      "type": "Visible",
+      "debug": {
+        "source": {
+          "id": "a2284uhb",
+          "identifier": {
+            "identifierType": {
+              "id": "sierra-system-number"
+            },
+            "ontologyType": "Work",
+            "value": "b30948988"
+          },
+          "version": 15,
+          "modifiedTime": "2022-01-12T10:28:08Z"
+        },
+        "mergedTime": "2025-08-19T20:22:07.952627Z",
+        "indexedTime": "2025-09-08T17:23:33.153066Z",
+        "mergeCandidates": [],
+        "redirectSources": []
+      },
       "query": {
         "id": "a2284uhb",
         "title": "Index locorum in commentario Caesaris Belli gallici descriptorum (Rev: Bonus Accursius)",
@@ -4172,6 +4209,7 @@
         "items.locations.locationType.id": [
           "online-resource"
         ],
+        "items.locations.createdDate": [],
         "partOf.id": [],
         "partOf.title": [
           "Early European Books.",
@@ -4179,28 +4217,10 @@
         ],
         "availabilities.id": [
           "online"
-        ],
-        "items.locations.createdDate": []
-      },
-      "type": "Visible",
-      "debug": {
-        "source": {
-          "id": "a2284uhb",
-          "identifier": {
-            "identifierType": {
-              "id": "sierra-system-number"
-            },
-            "ontologyType": "Work",
-            "value": "b30948988"
-          },
-          "version": 15,
-          "modifiedTime": "2022-01-12T10:28:08Z"
-        },
-        "mergedTime": "2025-08-19T20:22:07.952627Z",
-        "indexedTime": "2025-09-08T17:23:33.153066Z",
-        "mergeCandidates": [],
-        "redirectSources": []
+        ]
       }
-    }
+    },
+    "_version": 1641983288000,
+    "_version_type": "external_gte"
   }
 ]

--- a/catalogue_graph/tests/ingestor/test_generate_operations.py
+++ b/catalogue_graph/tests/ingestor/test_generate_operations.py
@@ -1,0 +1,63 @@
+from datetime import UTC, datetime
+
+import polars as pl
+from freezegun import freeze_time
+
+from ingestor.models.indexable.concept import IndexableConcept
+from ingestor.models.indexable.image import IndexableImage
+from ingestor.models.indexable.work import IndexableWork
+from ingestor.steps.ingestor_indexer import generate_operations
+from tests.ingestor.test_images_transformer import _build_extracted_image
+
+
+def test_generate_operations_works_version_from_source_modified_time() -> None:
+    df = pl.read_parquet("tests/fixtures/ingestor/works/00000000-00000010.parquet")
+    row = df.to_dicts()[0]
+    work = IndexableWork.from_raw_document(row)
+
+    ops = list(generate_operations("test-index", [work]))
+
+    assert len(ops) == 1
+    assert ops[0]["_index"] == "test-index"
+    assert ops[0]["_id"] == work.get_id()
+    assert ops[0]["_version_type"] == "external_gte"
+
+    # Version should be epoch millis of source modified_time
+    expected_dt = datetime.fromisoformat(work.debug.source.modified_time)
+    expected_version = int(expected_dt.timestamp() * 1000)
+    assert ops[0]["_version"] == expected_version
+
+
+@freeze_time("2025-06-15T10:30:00Z")
+def test_generate_operations_concepts_version_from_now() -> None:
+    df = pl.read_parquet("tests/fixtures/ingestor/concepts/00000000-00000010.parquet")
+    row = df.to_dicts()[0]
+    concept = IndexableConcept.from_raw_document(row)
+
+    ops = list(generate_operations("test-index", [concept]))
+
+    assert len(ops) == 1
+    assert ops[0]["_version_type"] == "external_gte"
+
+    # Version should be epoch millis of frozen now()
+    expected_version = int(
+        datetime(2025, 6, 15, 10, 30, 0, tzinfo=UTC).timestamp() * 1000
+    )
+    assert ops[0]["_version"] == expected_version
+
+
+@freeze_time("2025-04-21T12:00:00Z")
+def test_generate_operations_images_version_from_modified_time() -> None:
+    extracted = _build_extracted_image()
+    image = IndexableImage.from_extracted_image(extracted)
+
+    ops = list(generate_operations("test-index", [image]))
+
+    assert len(ops) == 1
+    assert ops[0]["_version_type"] == "external_gte"
+
+    # modified_time from the fixture is "2025-04-01T10:00:00Z"
+    expected_version = int(
+        datetime(2025, 4, 1, 10, 0, 0, tzinfo=UTC).timestamp() * 1000
+    )
+    assert ops[0]["_version"] == expected_version

--- a/catalogue_graph/tests/test_ingestor_indexer.py
+++ b/catalogue_graph/tests/test_ingestor_indexer.py
@@ -4,6 +4,7 @@ from typing import Any, cast
 import polars
 import pydantic_core
 import pytest
+from freezegun import freeze_time
 
 import config
 from ingestor.models.step_events import (
@@ -47,6 +48,7 @@ def get_mock_indexer_event(record_type: IngestorType) -> IngestorIndexerLambdaEv
     )
 
 
+@freeze_time("2025-01-01T12:00:00Z")
 @pytest.mark.parametrize("record_type", ["concepts", "works"])
 def test_ingestor_indexer_discovers_parquet_objects(record_type: IngestorType) -> None:
     pipeline_date = "2025-01-01"
@@ -106,6 +108,7 @@ def test_ingestor_indexer_discovers_parquet_objects(record_type: IngestorType) -
     }
 
 
+@freeze_time("2025-01-01T12:00:00Z")
 @pytest.mark.parametrize("record_type", ["concepts", "works"])
 def test_ingestor_indexer_handles_explicit_objects(record_type: IngestorType) -> None:
     pipeline_date = "2025-01-01"


### PR DESCRIPTION
## What does this change?

Add a version guard when indexing work/image documents to the final API indexes, replicating the Scala ingestors (see [here](https://github.com/wellcomecollection/catalogue-pipeline/blob/250007c56ac1b4cdac38495b1f49b6abf5cd4c09/common/pipeline_storage/src/main/scala/weco/pipeline_storage/elastic/ElasticIndexer.scala#L63-L64) and [here](https://github.com/wellcomecollection/catalogue-pipeline/blob/c2ba5120e025ecb9099b6575dd6bc7b3233eafc6/common/pipeline_storage/src/main/scala/weco/pipeline_storage/Indexer.scala#L43)).

For images, the version is based on the `modifiedTime` field, which is created by the merger. As a result, an image which got merged earlier will never overwrite an image which got merged later.

For works, the version is based on the `sourceModifiedTime` field.

## How to test

The version guard is covered by unit tests and can be tested against a real (local) Elasticsearch index using this script: https://gist.github.com/StepanBrychta/b3b932db5b41e97df6684e8dbbbf57c0

## How can we measure success?

With this change in place, we no longer have to worry about processing order. Even if an earlier time window finishes processing after a later time window, the final indexes should store the latest data.

## Have we considered potential risks?

There is a risk that documents won't be correctly propagated to the final index if the versioning guard doesn't work as expected. However, the Scala ingestors used the same mechanism and the same version fields, so this is unlikely to be the case. In addition, Elasticsearch would raise a `ConflictError` if we tried to overwrite a document with an older version, alerting us that the mechanism might not work as expected.
