### PR TITLE
Resolve ECS AMI from SSM (AL2023) for inferrer

### DIFF
--- a/pipeline/terraform/2025-10-02/main.tf
+++ b/pipeline/terraform/2025-10-02/main.tf
@@ -73,7 +73,7 @@ module "pipeline" {
   allow_delete_indices = false
 
   # Base AMI for ECS instances
-  ami_id = "ami-056dd98084762c908"
+  ami_id = "resolve:ssm:arn:aws:ssm:eu-west-1:760097843905:parameter/imagebuilder/weco-al2023-ecs-optimised-x86_64/latest"
 
   pipeline_date = local.pipeline_date
   release_label = local.pipeline_date


### PR DESCRIPTION
## What does this change?

Switches the `ami_id` input on the `2025-10-02` pipeline module from a hard-coded AMI ID (`ami-056dd98084762c908`) to an `resolve:ssm:` reference to the AL2023 ECS-optimised AMI parameter published by our Image Builder pipeline:

```
resolve:ssm:arn:aws:ssm:eu-west-1:760097843905:parameter/imagebuilder/weco-al2023-ecs-optimised-x86_64/latest
```

This means new ECS instances launched into the pipeline cluster will automatically pick up the latest AL2023 ECS-optimised AMI as it is rebuilt weekly, without needing a Terraform change.

Depends on / follows from [wellcomecollection/platform-infrastructure#487](https://github.com/wellcomecollection/platform-infrastructure/pull/487), which adds the SSM parameter publishing to the Image Builder pipeline.

## How to test

This has already been applied and tested by launching an inferrer ECS instance, which came up successfully on the AL2023 AMI resolved from the SSM parameter.

For future verification:

1. `cd pipeline/terraform/2025-10-02 && terraform plan` — confirm the launch template's `image_id` switches to the `resolve:ssm:...` reference.
2. After `terraform apply`, trigger an instance refresh (or scale up the inferrer ASG) and confirm new EC2 instances launch healthily and register with the ECS cluster.

## How can we measure success?

- New instances in the pipeline cluster launch from the AL2023 AMI ID currently published in the SSM parameter.
- When platform-infrastructure rebuilds the AMI weekly, subsequent instance refreshes pick up the new AMI with no code change here.

## Have we considered potential risks?

- **AL2 → AL2023 OS change**: instances now launch on Amazon Linux 2023 instead of the previously pinned AL2 AMI. Verified by launching an inferrer instance against the new parameter; the ECS agent registers as expected.
- **SSM resolution at launch time**: `resolve:ssm:` is resolved by EC2 when the launch template is used. If the parameter is missing or the launch role lacks `ssm:GetParameter`, instance launches will fail. The parameter is in place (PR #487) and the ECS instance role already has SSM read access.
- **Implicit AMI updates**: because the AMI is no longer pinned, weekly rebuilds will roll forward automatically on the next instance refresh. This is the intended behaviour, but it means we don't review each AMI bump in Terraform.
