### PR TITLE
Elasticsearch bulk indexing tweaks

### DIFF
--- a/catalogue_graph/src/core/transformer.py
+++ b/catalogue_graph/src/core/transformer.py
@@ -1,13 +1,15 @@
 from collections.abc import Generator, Iterable
 from itertools import batched
-from typing import Any, TypeVar, cast
+from typing import Any, TypeVar
 
-import elasticsearch.helpers
 import structlog
 from elasticsearch import Elasticsearch
 from pydantic import BaseModel
 
 from core.source import BaseSource
+from utils.elasticsearch import (
+    index_es_batch,
+)
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -88,24 +90,6 @@ class ElasticBaseTransformer[T: BaseModel](BaseTransformer):
                 "_source": record.model_dump(),
             }
 
-    def _index_es_batch(
-        self, es_client: Elasticsearch, es_actions: list[dict]
-    ) -> list[dict[str, Any]]:
-        success_count, es_errors = elasticsearch.helpers.bulk(
-            es_client,
-            es_actions,
-            raise_on_error=False,
-            stats_only=False,
-        )
-        logger.info(
-            "Indexed batch",
-            success_count=success_count,
-            batch_size=len(es_actions),
-        )
-
-        # Since we called `bulk` with `stats_only=False`, we know that es_errors is a list of dicts
-        return cast(list[dict[str, Any]], es_errors)
-
     def stream_to_index(self, es_client: Elasticsearch, index_name: str) -> None:
         # Reset run-specific state so manifests reflect the current execution only
         self.successful_ids.clear()
@@ -116,7 +100,7 @@ class ElasticBaseTransformer[T: BaseModel](BaseTransformer):
             es_actions = list(
                 self._generate_bulk_load_actions(transformed_batch, index_name)
             )
-            es_errors = self._index_es_batch(es_client, es_actions)
+            _, es_errors = index_es_batch(es_client, es_actions)
 
             batch_error_ids = set()
             for e in es_errors:

--- a/catalogue_graph/src/ingestor/steps/ingestor_indexer.py
+++ b/catalogue_graph/src/ingestor/steps/ingestor_indexer.py
@@ -5,9 +5,20 @@ from argparse import ArgumentParser
 from collections.abc import Generator
 
 import boto3
-import config
 import structlog
+
+import config
 import utils.elasticsearch
+from ingestor.models.indexable.concept import IndexableConcept
+from ingestor.models.indexable.image import IndexableImage
+from ingestor.models.indexable.record import IndexableRecord
+from ingestor.models.indexable.work import IndexableWork
+from ingestor.models.step_events import (
+    IngestorIndexerLambdaEvent,
+    IngestorIndexerMonitorLambdaEvent,
+    IngestorIndexerObject,
+    IngestorStepEvent,
+)
 from utils.argparse import add_pipeline_event_args, validate_es_mode_for_writes
 from utils.aws import df_from_s3_parquet, dicts_from_s3_jsonl
 from utils.elasticsearch import (
@@ -19,17 +30,6 @@ from utils.logger import ExecutionContext, get_trace_id, setup_logging
 from utils.reporting import IndexerReport
 from utils.steps import create_job_id, run_ecs_handler
 from utils.types import IngestorType
-
-from ingestor.models.indexable.concept import IndexableConcept
-from ingestor.models.indexable.image import IndexableImage
-from ingestor.models.indexable.record import IndexableRecord
-from ingestor.models.indexable.work import IndexableWork
-from ingestor.models.step_events import (
-    IngestorIndexerLambdaEvent,
-    IngestorIndexerMonitorLambdaEvent,
-    IngestorIndexerObject,
-    IngestorStepEvent,
-)
 
 logger = structlog.get_logger(__name__)
 
@@ -78,9 +78,10 @@ def generate_operations(
         version = int(datum.get_modified_time().timestamp() * 1000)  # epoch millis
 
         # Documents whose modified date is set to the start of the Unix epoch will have a version of 0.
-        # We floor this to 1 for backward compatibility with documents which use Elasticsearch's default versioning.
+        # We floor this to 100 for backward compatibility with documents which use Elasticsearch's default versioning
+        # (which increments every time a given document is reindexed).
         # This won't be needed after we do a full reindex.
-        version = max(1, version)
+        version = max(100, version)
 
         yield {
             "_index": index_name,
@@ -157,9 +158,7 @@ def handler(
             total_errors=len(all_es_errors),
             first_errors=all_es_errors[:5],
         )
-        raise RuntimeError(
-            f"Bulk indexing failed with {len(all_es_errors)} error(s)"
-        )
+        raise RuntimeError(f"Bulk indexing failed with {len(all_es_errors)} error(s)")
 
     return IngestorIndexerMonitorLambdaEvent(
         **event_payload,

--- a/catalogue_graph/src/ingestor/steps/ingestor_indexer.py
+++ b/catalogue_graph/src/ingestor/steps/ingestor_indexer.py
@@ -5,11 +5,21 @@ from argparse import ArgumentParser
 from collections.abc import Generator
 
 import boto3
-import elasticsearch.helpers
-import structlog
-
 import config
+import structlog
 import utils.elasticsearch
+from utils.argparse import add_pipeline_event_args, validate_es_mode_for_writes
+from utils.aws import df_from_s3_parquet, dicts_from_s3_jsonl
+from utils.elasticsearch import (
+    ElasticsearchMode,
+    get_standard_index_name,
+    index_es_batch,
+)
+from utils.logger import ExecutionContext, get_trace_id, setup_logging
+from utils.reporting import IndexerReport
+from utils.steps import create_job_id, run_ecs_handler
+from utils.types import IngestorType
+
 from ingestor.models.indexable.concept import IndexableConcept
 from ingestor.models.indexable.image import IndexableImage
 from ingestor.models.indexable.record import IndexableRecord
@@ -20,13 +30,6 @@ from ingestor.models.step_events import (
     IngestorIndexerObject,
     IngestorStepEvent,
 )
-from utils.argparse import add_pipeline_event_args, validate_es_mode_for_writes
-from utils.aws import df_from_s3_parquet, dicts_from_s3_jsonl
-from utils.elasticsearch import ElasticsearchMode, get_standard_index_name
-from utils.logger import ExecutionContext, get_trace_id, setup_logging
-from utils.reporting import IndexerReport
-from utils.steps import create_job_id, run_ecs_handler
-from utils.types import IngestorType
 
 logger = structlog.get_logger(__name__)
 
@@ -72,13 +75,18 @@ def generate_operations(
 ) -> Generator[dict]:
     for datum in indexable_data:
         source = json.loads(datum.model_dump_json(exclude_none=True))
+        version = int(datum.get_modified_time().timestamp() * 1000)  # epoch millis
+
+        # Documents whose modified date is set to the start of the Unix epoch will have a version of 0.
+        # We floor this to 1 for backward compatibility with documents which use Elasticsearch's default versioning.
+        # This won't be needed after we do a full reindex.
+        version = max(1, version)
+
         yield {
             "_index": index_name,
             "_id": datum.get_id(),
             "_source": source,
-            "_version": int(
-                datum.get_modified_time().timestamp() * 1000
-            ),  # epoch millis
+            "_version": version,
             "_version_type": "external_gte",
         }
 
@@ -120,6 +128,8 @@ def handler(
     )
 
     total_success_count = 0
+    all_es_errors = []
+
     for s3_object in objects_to_index:
         indexable_data = get_indexable_data(event, s3_object.s3_uri)
 
@@ -130,19 +140,26 @@ def handler(
             index_name=index_name,
         )
 
-        success_count, _ = elasticsearch.helpers.bulk(
-            es_client, generate_operations(index_name, indexable_data)
-        )
-
-        logger.info("Successfully indexed documents", count=success_count)
-
+        operations = list(generate_operations(index_name, indexable_data))
+        success_count, es_errors = index_es_batch(es_client, operations)
         total_success_count += success_count
+        all_es_errors += es_errors
 
     event_payload = event.model_dump(exclude={"objects_to_index"})
 
     logger.info("Preparing indexer pipeline report")
     report = IndexerReport(**event_payload, success_count=total_success_count)
     report.publish()
+
+    if all_es_errors:
+        logger.error(
+            "Bulk indexing errors encountered",
+            total_errors=len(all_es_errors),
+            first_errors=all_es_errors[:5],
+        )
+        raise RuntimeError(
+            f"Bulk indexing failed with {len(all_es_errors)} error(s)"
+        )
 
     return IngestorIndexerMonitorLambdaEvent(
         **event_payload,

--- a/catalogue_graph/src/utils/elasticsearch.py
+++ b/catalogue_graph/src/utils/elasticsearch.py
@@ -1,7 +1,9 @@
-from typing import Literal
+from typing import Any, Literal, cast
 
 import elasticsearch
+import elasticsearch.helpers
 import structlog
+from elasticsearch import Elasticsearch
 from pydantic import BaseModel
 
 from config import (
@@ -73,3 +75,23 @@ def get_client(
         "Creating Elasticsearch client", es_mode=es_mode, host_config=host_config
     )
     return elasticsearch.Elasticsearch(host_config, api_key=config.apikey, timeout=60)
+
+
+def index_es_batch(
+    es_client: Elasticsearch, es_actions: list[dict]
+) -> tuple[int, list[dict[str, Any]]]:
+    success_count, es_errors = elasticsearch.helpers.bulk(
+        es_client,
+        es_actions,
+        raise_on_error=False,
+        stats_only=False,
+    )
+    logger.info(
+        "Indexed batch",
+        success_count=success_count,
+        batch_size=len(es_actions),
+    )
+
+    # Since we called `bulk` with `stats_only=False`, we know that es_errors is a list of dicts
+    es_errors = cast(list[dict[str, Any]], es_errors)
+    return success_count, es_errors


### PR DESCRIPTION
## What does this change?

* Fix https://wellcome.slack.com/archives/CQ720BG02/p1777571115196479
* If some documents fail to index, do not raise an exception immediately. Wait until the end of the run so that other documents in the same window are processed.

## How to test

Run the ingestor_indexer service locally on a window which contains works whose source modified date is `1970-01-01T00:00:00Z`. For example:

```
AWS_PROFILE=platform-developer uv run ingestor/steps/ingestor_indexer.py --ingestor-type=works --pipeline-date=2025-10-02 --use-cli --index-date=2026-03-03 --window-end=2026-04-30T17:30 --es-mode=public --environment=prod
```

## How can we measure success?

This issue is addressed: https://wellcome.slack.com/archives/CQ720BG02/p1777571115196479

## Have we considered potential risks?

This change should be low-risk.

