### PR TITLE
Allow ingestor service to read images_ingestor ES API key

### DIFF
--- a/pipeline/inferrer/inference_manager/src/test/scala/weco/pipeline/inference_manager/services/InferenceManagerWorkerServiceTest.scala
+++ b/pipeline/inferrer/inference_manager/src/test/scala/weco/pipeline/inference_manager/services/InferenceManagerWorkerServiceTest.scala
@@ -92,8 +92,9 @@ class InferenceManagerWorkerServiceTest
             id =>
               val image = augmentedImages(id)
               inside(image.state) {
-                case ImageState.Augmented(_, id, inferredData, _) =>
+                case ImageState.Augmented(_, id, inferredData, augmentedTime) =>
                   images should contain key id
+                  augmentedTime shouldBe defined
                   val seed = id.hashCode
                   inside(inferredData) {
                     case InferredData(
@@ -147,7 +148,8 @@ class InferenceManagerWorkerServiceTest
             id =>
               val image = augmentedImages(id)
               inside(image.state) {
-                case ImageState.Augmented(_, _, inferredData, _) =>
+                case ImageState.Augmented(_, _, inferredData, augmentedTime) =>
+                  augmentedTime shouldBe defined
                   inside(inferredData) {
                     case InferredData(
                           features,

--- a/pipeline/terraform/modules/pipeline/graph/iam.tf
+++ b/pipeline/terraform/modules/pipeline/graph/iam.tf
@@ -7,7 +7,7 @@ locals {
 
 data "aws_iam_policy_document" "allow_catalogue_graph_secret_read" {
   statement {
-    actions = ["secretsmanager:GetSecretValue"]
+    actions   = ["secretsmanager:GetSecretValue"]
     resources = [
       "${local.secrets_manager_prefix}:catalogue-graph/*"
     ]
@@ -28,13 +28,14 @@ data "aws_iam_policy_document" "allow_slack_secret_read" {
 
 data "aws_iam_policy_document" "ingestor_allow_pipeline_storage_secret_read" {
   statement {
-    actions = ["secretsmanager:GetSecretValue"]
+    actions   = ["secretsmanager:GetSecretValue"]
     resources = [
       "${local.secrets_manager_prefix}:${var.es_cluster_host}*",
       "${local.secrets_manager_prefix}:${var.es_cluster_port}*",
       "${local.secrets_manager_prefix}:${var.es_cluster_protocol}*",
       "${local.secrets_manager_prefix}:${var.es_secrets.concepts_ingestor}*",
       "${local.secrets_manager_prefix}:${var.es_secrets.works_ingestor}*",
+      "${local.secrets_manager_prefix}:${var.es_secrets.images_ingestor}*",
       "${local.secrets_manager_prefix}:${var.es_secrets.graph_extractor}*"
     ]
   }
@@ -42,7 +43,7 @@ data "aws_iam_policy_document" "ingestor_allow_pipeline_storage_secret_read" {
 
 data "aws_iam_policy_document" "allow_pipeline_storage_secret_read_denormalised_read_only" {
   statement {
-    actions = ["secretsmanager:GetSecretValue"]
+    actions   = ["secretsmanager:GetSecretValue"]
     resources = [
       "${local.secrets_manager_prefix}:${var.es_cluster_host}*",
       "${local.secrets_manager_prefix}:${var.es_cluster_port}*",

--- a/pipeline/terraform/modules/pipeline/graph/iam.tf
+++ b/pipeline/terraform/modules/pipeline/graph/iam.tf
@@ -7,7 +7,7 @@ locals {
 
 data "aws_iam_policy_document" "allow_catalogue_graph_secret_read" {
   statement {
-    actions   = ["secretsmanager:GetSecretValue"]
+    actions = ["secretsmanager:GetSecretValue"]
     resources = [
       "${local.secrets_manager_prefix}:catalogue-graph/*"
     ]
@@ -28,7 +28,7 @@ data "aws_iam_policy_document" "allow_slack_secret_read" {
 
 data "aws_iam_policy_document" "ingestor_allow_pipeline_storage_secret_read" {
   statement {
-    actions   = ["secretsmanager:GetSecretValue"]
+    actions = ["secretsmanager:GetSecretValue"]
     resources = [
       "${local.secrets_manager_prefix}:${var.es_cluster_host}*",
       "${local.secrets_manager_prefix}:${var.es_cluster_port}*",
@@ -43,7 +43,7 @@ data "aws_iam_policy_document" "ingestor_allow_pipeline_storage_secret_read" {
 
 data "aws_iam_policy_document" "allow_pipeline_storage_secret_read_denormalised_read_only" {
   statement {
-    actions   = ["secretsmanager:GetSecretValue"]
+    actions = ["secretsmanager:GetSecretValue"]
     resources = [
       "${local.secrets_manager_prefix}:${var.es_cluster_host}*",
       "${local.secrets_manager_prefix}:${var.es_cluster_port}*",

--- a/pipeline/terraform/modules/pipeline/graph/variables.tf
+++ b/pipeline/terraform/modules/pipeline/graph/variables.tf
@@ -28,6 +28,7 @@ variable "es_secrets" {
   type = object({
     concepts_ingestor = string
     works_ingestor    = string
+    images_ingestor   = string
     graph_extractor   = string
   })
 }

--- a/pipeline/terraform/modules/pipeline/subsystem_graph.tf
+++ b/pipeline/terraform/modules/pipeline/subsystem_graph.tf
@@ -13,6 +13,7 @@ module "graph_pipeline" {
   es_secrets = {
     concepts_ingestor = module.elastic.pipeline_storage_es_service_secrets["concepts_ingestor"]["es_apikey"],
     works_ingestor    = module.elastic.pipeline_storage_es_service_secrets["works_ingestor"]["es_apikey"],
+    images_ingestor   = module.elastic.pipeline_storage_es_service_secrets["images_ingestor"]["es_apikey"],
     graph_extractor   = module.elastic.pipeline_storage_es_service_secrets["graph_extractor"]["es_apikey"],
   }
 }


### PR DESCRIPTION
## What does this change?

Builds on top of https://github.com/wellcomecollection/catalogue-pipeline/pull/3342, giving the ingestor service the permission to access the `ingestor_images` Elasticsearch API key in SecretsManager to stop the service from failing.