### PR TITLE
Fix Wikidata SPARQL query timeouts in get_all_ids

### DIFF
--- a/catalogue_graph/src/graph/sources/wikidata/sparql_client.py
+++ b/catalogue_graph/src/graph/sources/wikidata/sparql_client.py
@@ -15,8 +15,8 @@ logger = structlog.get_logger(__name__)
 # See: https://www.mediawiki.org/wiki/Wikidata_Query_Service/User_Manual#Query_limits
 # However, experimentally, running more than 4 queries in parallel consistently results in '429 Too Many Requests' errors.
 SPARQL_MAX_PARALLEL_QUERIES = 4
-SPARQL_REQUESTS_BACKOFF_RETRIES = int(os.environ.get("REQUESTS_BACKOFF_RETRIES", "3"))
-SPARQL_REQUESTS_BACKOFF_INTERVAL = 10
+SPARQL_REQUESTS_BACKOFF_RETRIES = int(os.environ.get("REQUESTS_BACKOFF_RETRIES", "5"))
+SPARQL_REQUESTS_BACKOFF_INTERVAL = 30
 
 
 def on_request_backoff(backoff_details: typing.Any) -> None:

--- a/catalogue_graph/src/graph/sources/wikidata/sparql_query_builder.py
+++ b/catalogue_graph/src/graph/sources/wikidata/sparql_query_builder.py
@@ -104,9 +104,9 @@ class SparqlQueryBuilder:
         Return a query to retrieve the ids of _all_ Wikidata items referencing an id from the `linked_ontology`.
         """
         if linked_ontology == "loc":
-            field_filter = "?item wdt:P244 _:anyValueP244."
+            field_filter = "?item wdt:P244 ?locId."
         elif linked_ontology == "mesh":
-            field_filter = "?item wdt:P486 _:anyValueP486."
+            field_filter = "?item wdt:P486 ?meshId."
         else:
             raise ValueError(f"Invalid linked ontology type: {linked_ontology}")
 

--- a/catalogue_graph/tests/fixtures/wikidata_linked_loc/all_ids_query.json
+++ b/catalogue_graph/tests/fixtures/wikidata_linked_loc/all_ids_query.json
@@ -1,4 +1,4 @@
 {
   "format": "json",
-  "query": "SELECT ?item WHERE { ?item wdt:P244 _:anyValueP244. }"
+  "query": "SELECT ?item WHERE { ?item wdt:P244 ?locId. }"
 }

--- a/catalogue_graph/tests/graph/steps/test_extractor.py
+++ b/catalogue_graph/tests/graph/steps/test_extractor.py
@@ -64,7 +64,7 @@ WIKIDATA_LINKED_LOC_SOURCE_MOCK_RESPONSE: MockResponseInput = {
     "status_code": 200,
     "params": {
         "format": "json",
-        "query": "SELECT ?item WHERE { ?item wdt:P244 _:anyValueP244. }",
+        "query": "SELECT ?item WHERE { ?item wdt:P244 ?locId. }",
     },
     "content_bytes": None,
     "json_data": {"results": {"bindings": []}},
@@ -76,7 +76,7 @@ WIKIDATA_LINKED_MESH_SOURCE_MOCK_RESPONSE: MockResponseInput = {
     "status_code": 200,
     "params": {
         "format": "json",
-        "query": "SELECT ?item WHERE { ?item wdt:P486 _:anyValueP486. }",
+        "query": "SELECT ?item WHERE { ?item wdt:P486 ?meshId. }",
     },
     "content_bytes": None,
     "json_data": {"results": {"bindings": []}},


### PR DESCRIPTION
## What does this change?

The `get_all_ids` SPARQL query used to fetch all Wikidata items with a Library of Congress (P244) or MeSH (P486) identifier was consistently timing out / returning 502 Bad Gateway errors from the Wikidata Query Service.

This PR makes two changes:

### 1. Replace blank node pattern with named variable

**Before:** `SELECT ?item WHERE { ?item wdt:P244 _:anyValueP244. }`
**After:** `SELECT ?item WHERE { ?item wdt:P244 ?locId. }`

Both forms are semantically  they ask for all items that have a LoC/MeSH identifier. The difference is how Blazegraph (the query engine behind Wikidata's SPARQL service) plans the query:equivalent 

- `_:anyValueP244` (blank node) is an existence check. Blazegraph may attempt to prove existence across the entire dataset before emitting any results, leading to timeouts on large properties like P244 (~1.7M items).
- `?locId` (named variable) lets Blazegraph use a fast index scan on the property path, streaming results immediately.

Comparative testing against the live Wikidata endpoint confirmed this:

| Query | Result |
|-------|--------|
| `?item wdt:P244 ?locId LIMIT 10` | 200 in ~10s (cold), 0.05s (warm) |
| `?item wdt:P244 _:anyValueP244 LIMIT 10` | Timed out 3/3 at 30s |
| `DISTINCT ... _:anyValueP244 LIMIT 10` | Timed out 1/3, then 29s, then 0.04s (cache) |
| Full query (no limit, blank node) | Timed out consistently |
| Full query (no limit, named variable) | 200 in ~9s |

The named variable form may return duplicate rows (one per P244 value per item), but `_get_all_ids()` already deduplicates via `set()` in Python, so application behaviour is unchanged.

### 2. Increase SPARQL retry parameters

 5
 30s

The previous 10s interval was too  testing showed that even when a query eventually succeeds via cache warming, it can need ~29s. The wider interval gives Wikidata time to compute and cache results before the retry fires.short 

## How to test

Run the extractor locally:

```bash
cd catalogue_graph
AWS_PROFILE=platform-developer uv run python src/graph/steps/extractor.py \
  --use-cli \
  --pipeline-date 2025-10-02 \
  --entity-type nodes \
  --transformer-type wikidata_linked_loc_concepts \
  --stream-destination void \
  --sample-size 10
```

On `main`, the initial `get_all_ids` query times out repeatedly with 502/backoff errors. On this branch, it returns ~1.7M IDs in ~9 seconds on the first attempt.

### Confirming blank node and named variable equivalence

**Direct SPARQL comparison (MeSH, P486):** Both query forms were run against the live Wikidata endpoint. MeSH was used because the dataset is much smaller than LoC, making the comparison fast:

| Query | Raw results | Unique IDs | Time |
|-------|-------------|------------|------|
| `SELECT ?item WHERE { ?item wdt:P486 _:anyValueP486. }` | 39,548 | 39,477 | ~1.1s |
| `SELECT ?item WHERE { ?item wdt:P486 ?meshId. }` | 39,548 | 39,477 | ~1.7s |

Both queries returned **identical sets of  zero symmetric difference.IDs** 

**End-to-end extractor comparison (MeSH, 100-node sample):** The extractor was run with `--stream-destination local --sample-size 100 --transformer-type wikidata_linked_mesh_concepts` using both query variants. Both runs:
- Retrieved `count=39477` Wikidata IDs from `get_all_ids`
- Produced CSVs with identical format (9 columns: `:ID,:LABEL,id,label,source,alternative_ids,alternative_labels,description,image_urls`)
- Output 101 lines (header + 100 `SourceConcept` nodes)

The specific rows differed between runs because `_get_all_ids()` returns a `set()` with non-deterministic iteration order, so each run samples a different 100 from the same 39,477 IDs. This is expected and unrelated to the query change.

## How can we measure success?

- The `get_all_ids` SPARQL query should no longer produce 502 errors or require retries to succeed.
- Extractor logs should show `Retrieved Wikidata ids count=...` without preceding backoff warnings.

## Have we considered potential risks?

- **Low risk.** The named variable form is semantically equivalent; the only difference is potentially more duplicate rows in the SPARQL response, which are already deduplicated in Python.
- The retry parameter increase is a safety  with the query fix, retries should rarely be needed, but if they are, the wider interval gives more headroom.net 
