### PR TITLE
Move ECS event validation

### DIFF
--- a/.github/instructions/catalogue-graph.instructions.md
+++ b/.github/instructions/catalogue-graph.instructions.md
@@ -57,7 +57,7 @@ When adding or modifying an OAI-PMH adapter:
 ## Step Functions integration
 
 ECS tasks that participate in Step Functions use
-`utils.steps.run_ecs_handler(...)` which handles `--task-token`,
+`utils.steps.ecs_handler(...)` which handles `--task-token`,
 `send_task_success`/`send_task_failure`, and event validation via a Pydantic
 model. Don't reinvent this glue.
 

--- a/catalogue_graph/src/graph/steps/extractor.py
+++ b/catalogue_graph/src/graph/steps/extractor.py
@@ -17,7 +17,7 @@ from models.events import (
 from utils.argparse import add_pipeline_event_args
 from utils.elasticsearch import ElasticsearchMode
 from utils.logger import ExecutionContext, get_trace_id, setup_logging
-from utils.steps import run_ecs_handler
+from utils.steps import ecs_handler
 
 logger = structlog.get_logger(__name__)
 
@@ -130,7 +130,7 @@ if __name__ == "__main__":
         local_handler(parser)
     else:
         # This will automatically use `es_mode=private`
-        run_ecs_handler(
+        ecs_handler(
             arg_parser=parser,
             handler=handler,
             event_validator=event_validator,

--- a/catalogue_graph/src/graph/steps/extractor.py
+++ b/catalogue_graph/src/graph/steps/extractor.py
@@ -136,5 +136,3 @@ if __name__ == "__main__":
             event_validator=event_validator,
             pipeline_step="graph_extractor",
         )
-
-        logger.info("ECS extractor task completed successfully")

--- a/catalogue_graph/src/graph/steps/extractor.py
+++ b/catalogue_graph/src/graph/steps/extractor.py
@@ -69,23 +69,6 @@ def event_validator(raw_input: str) -> ExtractorEvent:
     return ExtractorEvent(**event)
 
 
-def ecs_handler(arg_parser: ArgumentParser) -> None:
-    execution_context = ExecutionContext(
-        trace_id=get_trace_id(),
-        pipeline_step="graph_extractor",
-    )
-
-    # This will automatically use `es_mode=private`
-    run_ecs_handler(
-        arg_parser=arg_parser,
-        handler=handler,
-        event_validator=event_validator,
-        execution_context=execution_context,
-    )
-
-    logger.info("ECS extractor task completed successfully")
-
-
 def local_handler(parser: ArgumentParser) -> None:
     add_pipeline_event_args(
         parser,
@@ -146,4 +129,12 @@ if __name__ == "__main__":
     if args.use_cli:
         local_handler(parser)
     else:
-        ecs_handler(parser)
+        # This will automatically use `es_mode=private`
+        run_ecs_handler(
+            arg_parser=parser,
+            handler=handler,
+            event_validator=event_validator,
+            pipeline_step="graph_extractor",
+        )
+
+        logger.info("ECS extractor task completed successfully")

--- a/catalogue_graph/src/ingestor/steps/ingestor_indexer.py
+++ b/catalogue_graph/src/ingestor/steps/ingestor_indexer.py
@@ -28,7 +28,7 @@ from utils.elasticsearch import (
 )
 from utils.logger import ExecutionContext, get_trace_id, setup_logging
 from utils.reporting import IndexerReport
-from utils.steps import create_job_id, run_ecs_handler
+from utils.steps import create_job_id, ecs_handler
 from utils.types import IngestorType
 
 logger = structlog.get_logger(__name__)
@@ -248,7 +248,7 @@ if __name__ == "__main__":
         local_handler(parser)
     else:
         # This will automatically use `es_mode=private`
-        run_ecs_handler(
+        ecs_handler(
             arg_parser=parser,
             handler=handler,
             event_validator=event_validator,

--- a/catalogue_graph/src/ingestor/steps/ingestor_indexer.py
+++ b/catalogue_graph/src/ingestor/steps/ingestor_indexer.py
@@ -254,5 +254,3 @@ if __name__ == "__main__":
             event_validator=event_validator,
             pipeline_step="ingestor_indexer",
         )
-
-        logger.info("ECS ingestor indexer task completed successfully")

--- a/catalogue_graph/src/ingestor/steps/ingestor_indexer.py
+++ b/catalogue_graph/src/ingestor/steps/ingestor_indexer.py
@@ -184,25 +184,6 @@ def event_validator(raw_input: str) -> IngestorIndexerLambdaEvent:
     return IngestorIndexerLambdaEvent.model_validate(event)
 
 
-def ecs_handler(arg_parser: ArgumentParser) -> None:
-    args, _ = arg_parser.parse_known_args()
-
-    execution_context = ExecutionContext(
-        trace_id=get_trace_id(),
-        pipeline_step="ingestor_indexer",
-    )
-
-    # This will automatically use `es_mode=private`
-    run_ecs_handler(
-        arg_parser=arg_parser,
-        handler=handler,
-        event_validator=event_validator,
-        execution_context=execution_context,
-    )
-
-    logger.info("ECS ingestor indexer task completed successfully")
-
-
 def local_handler(parser: ArgumentParser) -> None:
     add_pipeline_event_args(
         parser,
@@ -266,4 +247,12 @@ if __name__ == "__main__":
     if args.use_cli:
         local_handler(parser)
     else:
-        ecs_handler(parser)
+        # This will automatically use `es_mode=private`
+        run_ecs_handler(
+            arg_parser=parser,
+            handler=handler,
+            event_validator=event_validator,
+            pipeline_step="ingestor_indexer",
+        )
+
+        logger.info("ECS ingestor indexer task completed successfully")

--- a/catalogue_graph/src/ingestor/steps/ingestor_loader.py
+++ b/catalogue_graph/src/ingestor/steps/ingestor_loader.py
@@ -94,25 +94,6 @@ def event_validator(raw_input: str) -> IngestorLoaderLambdaEvent:
     return IngestorLoaderLambdaEvent.model_validate(event)
 
 
-def ecs_handler(arg_parser: ArgumentParser) -> None:
-    args, _ = arg_parser.parse_known_args()
-
-    execution_context = ExecutionContext(
-        trace_id=get_trace_id(),
-        pipeline_step="ingestor_loader",
-    )
-
-    # This will automatically use `es_mode=private`
-    run_ecs_handler(
-        arg_parser=arg_parser,
-        handler=handler,
-        event_validator=event_validator,
-        execution_context=execution_context,
-    )
-
-    logger.info("ECS ingestor loader task completed successfully")
-
-
 def lambda_handler(event: dict, context: typing.Any) -> dict:
     execution_context = ExecutionContext(
         trace_id=get_trace_id(context),
@@ -208,4 +189,11 @@ if __name__ == "__main__":
     if args.use_cli:
         local_handler(parser)
     else:
-        ecs_handler(parser)
+        # This will automatically use `es_mode=private`
+        run_ecs_handler(
+            arg_parser=parser,
+            handler=handler,
+            event_validator=event_validator,
+            pipeline_step="ingestor_loader",
+        )
+        logger.info("ECS ingestor loader task completed successfully")

--- a/catalogue_graph/src/ingestor/steps/ingestor_loader.py
+++ b/catalogue_graph/src/ingestor/steps/ingestor_loader.py
@@ -22,7 +22,7 @@ from utils.argparse import add_pipeline_event_args
 from utils.elasticsearch import ElasticsearchMode, get_client
 from utils.logger import ExecutionContext, get_trace_id, setup_logging
 from utils.reporting import LoaderReport
-from utils.steps import create_job_id, run_ecs_handler
+from utils.steps import create_job_id, ecs_handler
 from utils.types import IngestorType
 
 logger = structlog.get_logger(__name__)
@@ -190,7 +190,7 @@ if __name__ == "__main__":
         local_handler(parser)
     else:
         # This will automatically use `es_mode=private`
-        run_ecs_handler(
+        ecs_handler(
             arg_parser=parser,
             handler=handler,
             event_validator=event_validator,

--- a/catalogue_graph/src/ingestor/steps/ingestor_loader.py
+++ b/catalogue_graph/src/ingestor/steps/ingestor_loader.py
@@ -196,4 +196,3 @@ if __name__ == "__main__":
             event_validator=event_validator,
             pipeline_step="ingestor_loader",
         )
-        logger.info("ECS ingestor loader task completed successfully")

--- a/catalogue_graph/src/utils/steps.py
+++ b/catalogue_graph/src/utils/steps.py
@@ -10,7 +10,7 @@ import boto3
 import structlog
 from pydantic import BaseModel
 
-from utils.logger import ExecutionContext
+from utils.logger import ExecutionContext, get_trace_id
 
 logger = structlog.get_logger(__name__)
 
@@ -79,7 +79,7 @@ def run_ecs_handler[EventModel: BaseModel, ResultModel: BaseModel, **Params](
         Concatenate[EventModel, ExecutionContext, Params], ResultModel | None
     ],
     event_validator: Callable[[str], EventModel],
-    execution_context: ExecutionContext,
+    pipeline_step: str,
     *handler_args: Params.args,
     **handler_kwargs: Params.kwargs,
 ) -> None:
@@ -104,6 +104,10 @@ def run_ecs_handler[EventModel: BaseModel, ResultModel: BaseModel, **Params](
     step_output = StepFunctionOutput(task_token, stepfunctions_client)
 
     try:
+        execution_context = ExecutionContext(
+            trace_id=get_trace_id(),
+            pipeline_step=pipeline_step,
+        )
         result = handler(
             event,
             execution_context,

--- a/catalogue_graph/src/utils/steps.py
+++ b/catalogue_graph/src/utils/steps.py
@@ -73,7 +73,7 @@ class StepFunctionOutput:
             logger.error("Task error", error_output=error_output)
 
 
-def run_ecs_handler[EventModel: BaseModel, ResultModel: BaseModel, **Params](
+def ecs_handler[EventModel: BaseModel, ResultModel: BaseModel, **Params](
     arg_parser: ArgumentParser,
     handler: Callable[
         Concatenate[EventModel, ExecutionContext, Params], ResultModel | None

--- a/catalogue_graph/src/utils/steps.py
+++ b/catalogue_graph/src/utils/steps.py
@@ -115,7 +115,10 @@ def run_ecs_handler[EventModel: BaseModel, ResultModel: BaseModel, **Params](
             **handler_kwargs,
         )
         step_output.send_success(result)
-        logger.info(f"ECS task '{pipeline_step}' completed successfully")
+        logger.info(
+            "ECS task completed successfully",
+            pipeline_step=pipeline_step,
+        )
     except Exception as exc:
         step_output.send_failure(exc)
         raise

--- a/catalogue_graph/src/utils/steps.py
+++ b/catalogue_graph/src/utils/steps.py
@@ -85,7 +85,7 @@ def run_ecs_handler[EventModel: BaseModel, ResultModel: BaseModel, **Params](
 ) -> None:
     arg_parser.add_argument(
         "--event",
-        type=event_validator,
+        type=str,
         help="Raw event in JSON format.",
         required=True,
     )
@@ -98,7 +98,6 @@ def run_ecs_handler[EventModel: BaseModel, ResultModel: BaseModel, **Params](
 
     ecs_args = arg_parser.parse_args()
     task_token = ecs_args.task_token
-    event = ecs_args.event
 
     stepfunctions_client = boto3.client("stepfunctions") if task_token else None
     step_output = StepFunctionOutput(task_token, stepfunctions_client)
@@ -108,6 +107,7 @@ def run_ecs_handler[EventModel: BaseModel, ResultModel: BaseModel, **Params](
             trace_id=get_trace_id(),
             pipeline_step=pipeline_step,
         )
+        event = event_validator(ecs_args.event)
         result = handler(
             event,
             execution_context,
@@ -115,7 +115,7 @@ def run_ecs_handler[EventModel: BaseModel, ResultModel: BaseModel, **Params](
             **handler_kwargs,
         )
         step_output.send_success(result)
-
+        logger.info(f"ECS task '{pipeline_step}' completed successfully")
     except Exception as exc:
         step_output.send_failure(exc)
         raise

--- a/catalogue_graph/tests/utils/test_steps.py
+++ b/catalogue_graph/tests/utils/test_steps.py
@@ -61,10 +61,7 @@ def test_run_ecs_handler_reports_success(
             arg_parser=parser,
             handler=handler,
             event_validator=ExampleEvent.model_validate_json,
-            execution_context=ExecutionContext(
-                trace_id="test-trace-id",
-                pipeline_step="test_step",
-            ),
+            pipeline_step="test_step",
         )
 
     assert handler_calls == [ExampleEvent(message="hello")]
@@ -113,10 +110,7 @@ def test_run_ecs_handler_reports_failure(
             arg_parser=parser,
             handler=handler,
             event_validator=ExampleEvent.model_validate_json,
-            execution_context=ExecutionContext(
-                trace_id="test-trace-id",
-                pipeline_step="test_step",
-            ),
+            pipeline_step="test_step",
         )
 
     assert MockStepFunctionsClient.task_successes == []
@@ -165,10 +159,7 @@ def test_run_ecs_handler_handles_none_result(
             arg_parser=parser,
             handler=handler,
             event_validator=ExampleEvent.model_validate_json,
-            execution_context=ExecutionContext(
-                trace_id="test-trace-id",
-                pipeline_step="test_step",
-            ),
+            pipeline_step="test_step",
         )
 
     assert MockStepFunctionsClient.task_failures == []
@@ -210,10 +201,7 @@ def test_run_ecs_handler_without_task_token(
             arg_parser=parser,
             handler=handler,
             event_validator=ExampleEvent.model_validate_json,
-            execution_context=ExecutionContext(
-                trace_id="test-trace-id",
-                pipeline_step="test_step",
-            ),
+            pipeline_step="test_step",
         )
 
     assert MockStepFunctionsClient.task_successes == []
@@ -250,10 +238,7 @@ def test_run_ecs_handler_without_task_token_none_result(
             arg_parser=parser,
             handler=handler,
             event_validator=ExampleEvent.model_validate_json,
-            execution_context=ExecutionContext(
-                trace_id="test-trace-id",
-                pipeline_step="test_step",
-            ),
+            pipeline_step="test_step",
         )
 
     assert MockStepFunctionsClient.task_successes == []

--- a/catalogue_graph/tests/utils/test_steps.py
+++ b/catalogue_graph/tests/utils/test_steps.py
@@ -6,7 +6,7 @@ import sys
 from argparse import ArgumentParser
 
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from tests.mocks import MockStepFunctionsClient
 from utils.logger import ExecutionContext, setup_structlog
@@ -122,6 +122,44 @@ def test_ecs_handler_reports_failure(
     assert cause["message"] == "unexpected kaboom"
     assert cause["type"] == "RuntimeError"
 
+    assert "Sending task failure to Step Functions" in caplog.text
+
+
+def test_ecs_handler_reports_failure_on_invalid_event(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    invalid_payload = '{"not_a_valid_field": 123}'
+    token = "token-invalid"
+    parser = ArgumentParser(prog="test-handler")
+
+    def handler(
+        event: ExampleEvent,  # noqa: ARG001
+        execution_context: ExecutionContext | None = None,  # noqa: ARG001
+    ) -> ExampleResult:
+        raise AssertionError("handler should not be called")
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["prog", "--event", invalid_payload, "--task-token", token],
+    )
+
+    with (
+        caplog.at_level(logging.ERROR),
+        pytest.raises(ValidationError),
+    ):
+        ecs_handler(
+            arg_parser=parser,
+            handler=handler,
+            event_validator=ExampleEvent.model_validate_json,
+            pipeline_step="test_step",
+        )
+
+    assert MockStepFunctionsClient.task_successes == []
+    assert len(MockStepFunctionsClient.task_failures) == 1
+    failure = MockStepFunctionsClient.task_failures[0]
+    assert failure["taskToken"] == token
     assert "Sending task failure to Step Functions" in caplog.text
 
 

--- a/catalogue_graph/tests/utils/test_steps.py
+++ b/catalogue_graph/tests/utils/test_steps.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel
 
 from tests.mocks import MockStepFunctionsClient
 from utils.logger import ExecutionContext, setup_structlog
-from utils.steps import StepFunctionOutput, run_ecs_handler
+from utils.steps import StepFunctionOutput, ecs_handler
 
 
 class ExampleEvent(BaseModel):
@@ -27,7 +27,7 @@ def configure_structlog() -> None:
     setup_structlog()
 
 
-def test_run_ecs_handler_reports_success(
+def test_ecs_handler_reports_success(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -57,7 +57,7 @@ def test_run_ecs_handler_reports_success(
     )
 
     with caplog.at_level(logging.INFO):
-        run_ecs_handler(
+        ecs_handler(
             arg_parser=parser,
             handler=handler,
             event_validator=ExampleEvent.model_validate_json,
@@ -76,7 +76,7 @@ def test_run_ecs_handler_reports_success(
     assert "Sending task success to Step Functions" in caplog.text
 
 
-def test_run_ecs_handler_reports_failure(
+def test_ecs_handler_reports_failure(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -106,7 +106,7 @@ def test_run_ecs_handler_reports_failure(
         caplog.at_level(logging.ERROR),
         pytest.raises(RuntimeError, match="unexpected kaboom"),
     ):
-        run_ecs_handler(
+        ecs_handler(
             arg_parser=parser,
             handler=handler,
             event_validator=ExampleEvent.model_validate_json,
@@ -125,10 +125,10 @@ def test_run_ecs_handler_reports_failure(
     assert "Sending task failure to Step Functions" in caplog.text
 
 
-# run_ecs_handler tests
+# ecs_handler tests
 
 
-def test_run_ecs_handler_handles_none_result(
+def test_ecs_handler_handles_none_result(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -155,7 +155,7 @@ def test_run_ecs_handler_handles_none_result(
     )
 
     with caplog.at_level(logging.INFO):
-        run_ecs_handler(
+        ecs_handler(
             arg_parser=parser,
             handler=handler,
             event_validator=ExampleEvent.model_validate_json,
@@ -173,7 +173,7 @@ def test_run_ecs_handler_handles_none_result(
     assert "Sending task success to Step Functions" in caplog.text
 
 
-def test_run_ecs_handler_without_task_token(
+def test_ecs_handler_without_task_token(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -197,7 +197,7 @@ def test_run_ecs_handler_without_task_token(
     )
 
     with caplog.at_level(logging.INFO):
-        run_ecs_handler(
+        ecs_handler(
             arg_parser=parser,
             handler=handler,
             event_validator=ExampleEvent.model_validate_json,
@@ -210,7 +210,7 @@ def test_run_ecs_handler_without_task_token(
     assert "Task result" in caplog.text
 
 
-def test_run_ecs_handler_without_task_token_none_result(
+def test_ecs_handler_without_task_token_none_result(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -234,7 +234,7 @@ def test_run_ecs_handler_without_task_token_none_result(
     )
 
     with caplog.at_level(logging.INFO):
-        run_ecs_handler(
+        ecs_handler(
             arg_parser=parser,
             handler=handler,
             event_validator=ExampleEvent.model_validate_json,


### PR DESCRIPTION
## What does this change?

At the moment, when we pass an invalid event to an ECS task through a state machine step, the ECS task will fail but the step function will keep running. 

This PR moves event validation into the try/except block in `run_ecs_handler` so that the state machine fails and we are alerted. Construction of the `ExecutionContext` object is also moved into the block for the same reason.

## How to test

Run one of the ECS services locally (e.g. ingestor_loader) using an invalid event. Ensure that the `StepFunctionClient` logs a `Task error`.

## How can we measure success?

When something goes wrong in an ECS task triggered by a state machine, the state machine execution should stop and we should be alerted. 

## Have we considered potential risks?

Some code still inevitably executes outside of the try/except block (e.g. boto3 step function client construction), and so this situation can still occur (but is much less likely).