### PR TITLE
Deduplicate item licenses in works/images ingestor

### DIFF
--- a/catalogue_graph/src/ingestor/transformers/work_aggregate_transformer.py
+++ b/catalogue_graph/src/ingestor/transformers/work_aggregate_transformer.py
@@ -85,11 +85,16 @@ class AggregateWorkTransformer(WorkBaseTransformer):
 
     @property
     def licenses(self) -> Generator[AggregatableField]:
+        aggregatable = []
         for item in self.data.items:
             for loc in item.locations:
                 display_license = DisplayLicense.from_location(loc)
                 if display_license is not None:
-                    yield AggregatableField(**display_license.model_dump())
+                    aggregatable.append(
+                        AggregatableField(**display_license.model_dump())
+                    )
+
+        yield from get_unique(aggregatable)
 
     @property
     def availabilities(self) -> Generator[AggregatableField]:

--- a/catalogue_graph/tests/ingestor/test_aggregatable_values.py
+++ b/catalogue_graph/tests/ingestor/test_aggregatable_values.py
@@ -8,7 +8,9 @@ from ingestor.transformers.work_aggregate_transformer import (
     AggregateWorkTransformer,
 )
 from models.pipeline.concept import Subject
-from models.pipeline.id_label import Language
+from models.pipeline.id_label import Id, Language
+from models.pipeline.item import Item
+from models.pipeline.location import DigitalLocation, LocationType
 from tests.test_utils import (
     load_json_fixture,
 )
@@ -68,3 +70,21 @@ def test_concept_aggregation_deduplication() -> None:
 
     # Deduplicate concepts with the same label
     assert len(list(AggregateWorkTransformer(extracted).subjects)) == 1
+
+
+def test_license_deduplication() -> None:
+    extracted = get_work_fixture()
+
+    cc_by_nc_location = DigitalLocation(
+        url="https://example.com/1",
+        location_type=LocationType(id="iiif-presentation"),
+        license=Id(id="cc-by-nc"),
+        access_conditions=[],
+    )
+    item_a = Item(id={"type": "Unidentifiable"}, locations=[cc_by_nc_location])
+    item_b = Item(id={"type": "Unidentifiable"}, locations=[cc_by_nc_location])
+    extracted.work.data.items = [item_a, item_b]
+
+    licenses = list(AggregateWorkTransformer(extracted).licenses)
+    assert len(licenses) == 1
+    assert licenses[0].id == "cc-by-nc"

--- a/catalogue_graph/tests/ingestor/test_aggregatable_values.py
+++ b/catalogue_graph/tests/ingestor/test_aggregatable_values.py
@@ -9,6 +9,7 @@ from ingestor.transformers.work_aggregate_transformer import (
 )
 from models.pipeline.concept import Subject
 from models.pipeline.id_label import Id, Language
+from models.pipeline.identifier import Unidentifiable
 from models.pipeline.item import Item
 from models.pipeline.location import DigitalLocation, LocationType
 from tests.test_utils import (
@@ -81,8 +82,8 @@ def test_license_deduplication() -> None:
         license=Id(id="cc-by-nc"),
         access_conditions=[],
     )
-    item_a = Item(id={"type": "Unidentifiable"}, locations=[cc_by_nc_location])
-    item_b = Item(id={"type": "Unidentifiable"}, locations=[cc_by_nc_location])
+    item_a = Item(id=Unidentifiable(), locations=[cc_by_nc_location])
+    item_b = Item(id=Unidentifiable(), locations=[cc_by_nc_location])
     extracted.work.data.items = [item_a, item_b]
 
     licenses = list(AggregateWorkTransformer(extracted).licenses)


### PR DESCRIPTION
## What does this change?

In the Python works/images ingestor, we currently do not deduplicate item licenses when populating the `aggregatableValues` field. This means that if two items have the same license, we end up storing it twice. For example, in work `jduevp4d`, we have:

```
{
  ...
  "aggregatableValues": {
    "locations.license": [
      {
        "id": "cc-by",
        "label": "Attribution 4.0 International (CC BY 4.0)"
      },
      {
        "id": "cc-by",
        "label": "Attribution 4.0 International (CC BY 4.0)"
      }
    ],
    ...
  },
  ...
}
```

This PR implements a fix.

## How to test

The change is covered by a unit test.

## How can we measure success?

No duplicate licenses in aggregatable values. 

## Have we considered potential risks?

I can't think of any risks.
