### PR TITLE
Bump sbt to 1.10.10 and derive Docker image tag from build.properties

### DIFF
--- a/builds/run_sbt_task_in_docker.sh
+++ b/builds/run_sbt_task_in_docker.sh
@@ -59,4 +59,4 @@ docker run --tty --rm \
   --net host \
   --volume "$ROOT:$ROOT" \
   --workdir "$ROOT" \
-  "$ECR_REGISTRY/wellcome/sbt_wrapper:1.10.7" "$@"
+  "$ECR_REGISTRY/wellcome/sbt_wrapper:1.10.10" "$@"

--- a/builds/run_sbt_task_in_docker.sh
+++ b/builds/run_sbt_task_in_docker.sh
@@ -35,6 +35,7 @@ set -o nounset
 ECR_REGISTRY="760097843905.dkr.ecr.eu-west-1.amazonaws.com"
 
 ROOT=$(git rev-parse --show-toplevel)
+SBT_VERSION=$(sed -n 's/^sbt.version=//p' "$ROOT/project/build.properties")
 
 # Coursier cache location is platform-dependent
 # https://get-coursier.io/docs/cache.html#default-location
@@ -59,4 +60,4 @@ docker run --tty --rm \
   --net host \
   --volume "$ROOT:$ROOT" \
   --workdir "$ROOT" \
-  "$ECR_REGISTRY/wellcome/sbt_wrapper:1.10.10" "$@"
+  "$ECR_REGISTRY/wellcome/sbt_wrapper:$SBT_VERSION" "$@"

--- a/builds/run_sbt_task_in_docker.sh
+++ b/builds/run_sbt_task_in_docker.sh
@@ -59,4 +59,4 @@ docker run --tty --rm \
   --net host \
   --volume "$ROOT:$ROOT" \
   --workdir "$ROOT" \
-  "$ECR_REGISTRY/wellcome/sbt_wrapper" "$@"
+  "$ECR_REGISTRY/wellcome/sbt_wrapper:1.10.2" "$@"

--- a/builds/run_sbt_task_in_docker.sh
+++ b/builds/run_sbt_task_in_docker.sh
@@ -59,4 +59,4 @@ docker run --tty --rm \
   --net host \
   --volume "$ROOT:$ROOT" \
   --workdir "$ROOT" \
-  "$ECR_REGISTRY/wellcome/sbt_wrapper:1.10.2" "$@"
+  "$ECR_REGISTRY/wellcome/sbt_wrapper:1.10.7" "$@"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=1.10.7
+sbt.version=1.10.10
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=1.10.2
+sbt.version=1.10.7
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=1.10.7
+sbt.version=1.10.2
 

--- a/project/project/metals.sbt
+++ b/project/project/metals.sbt
@@ -3,6 +3,6 @@
 
 // This file enables sbt-bloop to create bloop config files.
 
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "2.0.17")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "2.0.19")
 
 // format: on

--- a/project/project/project/metals.sbt
+++ b/project/project/project/metals.sbt
@@ -3,6 +3,6 @@
 
 // This file enables sbt-bloop to create bloop config files.
 
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "2.0.17")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "2.0.19")
 
 // format: on


### PR DESCRIPTION
## What does this change?

Bumps sbt from 1.10.7 to 1.10.10, and updates sbt-bloop from 2.0.17 to 2.0.19.

Also updates `builds/run_sbt_task_in_docker.sh` to derive the sbt Docker image tag from `project/build.properties` rather than hardcoding it, avoiding version drift between the two.

Depends on https://github.com/wellcomecollection/platform-infrastructure/pull/489, which publishes the `sbt_wrapper:1.10.10` image to ECR.

See also: https://github.com/wellcomecollection/storage-service/pull/1179

## How to test

- CI should pass with the new sbt version.
- Verify locally: `./builds/run_sbt_task_in_docker.sh "compile"` should pull and run the `sbt_wrapper:1.10.10` image.

## How can we measure success?

CI builds succeed with sbt 1.10.10. The sbt wrapper script no longer needs manual updates when the version in `build.properties` changes.

## Have we considered potential risks?

Low risk — sbt patch version upgrades are backwards-compatible. The Docker image tag derivation uses `sed` on a well-known file format. If the platform-infrastructure PR hasn't been merged yet, CI docker runs will fail to pull the image until it's available.
