### PR TITLE
Predecessor validation tweaks

### DIFF
--- a/.github/workflows/catalogue-graph-deploy.yml
+++ b/.github/workflows/catalogue-graph-deploy.yml
@@ -22,7 +22,7 @@ permissions:
   contents: read
   id-token: write
 
-jobs: 
+jobs:
   retag-unified-pipeline-task-image:
     runs-on: ubuntu-latest
     steps:
@@ -71,7 +71,7 @@ jobs:
 
   deploy-unified-pipeline-lambdas:
     runs-on: ubuntu-latest
-    needs: [retag-unified-pipeline-lambda-image]
+    needs: [ retag-unified-pipeline-lambda-image ]
     strategy:
       matrix:
         lambda_name:
@@ -101,6 +101,7 @@ jobs:
           - id-minter
           - id-minter-test # remove when we're done testing canonical ids inheritance
           - id-generator
+          - id-generator-test # remove when we're done testing canonical ids inheritance
           # Transformer lambdas
           - transformer
           # Graph subsystem lambdas

--- a/catalogue_graph/src/core/transformer.py
+++ b/catalogue_graph/src/core/transformer.py
@@ -1,4 +1,3 @@
-import json
 from collections.abc import Generator, Iterable
 from itertools import batched
 from typing import Any, TypeVar

--- a/catalogue_graph/src/core/transformer.py
+++ b/catalogue_graph/src/core/transformer.py
@@ -85,7 +85,7 @@ class ElasticBaseTransformer[T: BaseModel](BaseTransformer):
         self, records: Iterable[T], index_name: str
     ) -> Generator[dict[str, Any]]:
         for record in records:
-            source = json.loads(record.model_dump_json(exclude_none=True))
+            source = record.model_dump(exclude_none=True, mode="json")
             yield {
                 "_index": index_name,
                 "_id": self._get_document_id(record),

--- a/catalogue_graph/src/core/transformer.py
+++ b/catalogue_graph/src/core/transformer.py
@@ -1,3 +1,4 @@
+import json
 from collections.abc import Generator, Iterable
 from itertools import batched
 from typing import Any, TypeVar
@@ -84,10 +85,11 @@ class ElasticBaseTransformer[T: BaseModel](BaseTransformer):
         self, records: Iterable[T], index_name: str
     ) -> Generator[dict[str, Any]]:
         for record in records:
+            source = json.loads(record.model_dump_json(exclude_none=True))
             yield {
                 "_index": index_name,
                 "_id": self._get_document_id(record),
-                "_source": record.model_dump(),
+                "_source": source,
             }
 
     def stream_to_index(self, es_client: Elasticsearch, index_name: str) -> None:

--- a/catalogue_graph/tests/core/test_transformer.py
+++ b/catalogue_graph/tests/core/test_transformer.py
@@ -1,0 +1,33 @@
+from core.transformer import ElasticBaseTransformer
+from models.pipeline.identifier import Id, SourceIdentifier
+from models.pipeline.serialisable import SerialisableModel
+
+
+class StubDocument(SerialisableModel):
+    source_identifier: SourceIdentifier
+    predecessor_identifier: SourceIdentifier | None = None
+
+
+def test_generate_bulk_load_actions_excludes_none_fields() -> None:
+    """Null fields (e.g. predecessorIdentifier) must not appear in _source."""
+
+    class StubTransformer(ElasticBaseTransformer[StubDocument]):
+        def _get_document_id(self, record: StubDocument) -> str:
+            return str(record.source_identifier)
+
+    transformer = StubTransformer()
+    doc = StubDocument(
+        source_identifier=SourceIdentifier(
+            identifier_type=Id(id="test-type"),
+            ontology_type="Work",
+            value="abc123",
+        ),
+        predecessor_identifier=None,
+    )
+
+    actions = list(transformer._generate_bulk_load_actions([doc], "test-index"))
+
+    assert len(actions) == 1
+    source = actions[0]["_source"]
+    assert "predecessorIdentifier" not in source
+    assert "sourceIdentifier" in source

--- a/pipeline/terraform/modules/pipeline/state_machine_id_minter_test.tf
+++ b/pipeline/terraform/modules/pipeline/state_machine_id_minter_test.tf
@@ -5,7 +5,7 @@ locals {
   id_minter_v2_test_rds_instance = local.infra_critical.id_minter_rds["test"]
 
   id_minter_test_vpc_config = {
-    subnet_ids         = local.network_config.subnets
+    subnet_ids = local.network_config.subnets
     security_group_ids = [
       aws_security_group.egress.id,
       local.id_minter_v2_test_rds_instance.ingress_security_group_id,
@@ -25,8 +25,8 @@ locals {
   rds_test_master_secret_name = regex(
     "arn:aws:secretsmanager:[^:]+:[^:]+:secret:(.+)-.{6}$",
     local.id_minter_v2_test_rds_instance.master_user_secret_arn
-  )[
-  0
+    )[
+    0
   ]
 
   id_minter_test_secret_env_vars = merge(
@@ -44,9 +44,9 @@ locals {
     QueryLanguage = "JSONata"
     Comment       = "Invoke the id_minter Lambda"
     StartAt       = "ConstructEvent"
-    States        = {
+    States = {
       ConstructEvent = {
-        Type   = "Pass",
+        Type = "Pass",
         Output = {
           "pipeline_date" : var.pipeline_date,
           # window end time is 5 minutes before the scheduled time
@@ -57,14 +57,14 @@ locals {
         Next = "InvokeIdMinter"
       }
       InvokeIdMinter = {
-        Type      = "Task"
-        Resource  = "arn:aws:states:::lambda:invoke"
+        Type     = "Task"
+        Resource = "arn:aws:states:::lambda:invoke"
         Arguments = {
           FunctionName = module.id_minter_test.id_minter_lambda_arn
           Payload      = "{% $states.input %}"
         }
         Output = "{% $states.result.Payload %}"
-        Retry  = [
+        Retry = [
           {
             ErrorEquals     = ["Lambda.ServiceException", "Lambda.AWSLambdaException", "Lambda.SdkClientException"]
             IntervalSeconds = 2
@@ -138,10 +138,10 @@ resource "aws_iam_role" "run_id_minter_test_role" {
   name = "run-id-minter-test-role-${var.pipeline_date}"
 
   assume_role_policy = jsonencode({
-    Version   = "2012-10-17"
+    Version = "2012-10-17"
     Statement = [
       {
-        Effect    = "Allow"
+        Effect = "Allow"
         Principal = {
           Service = "scheduler.amazonaws.com"
         }
@@ -155,7 +155,7 @@ resource "aws_iam_role_policy" "run_id_minter_test_policy" {
   role = aws_iam_role.run_id_minter_test_role.id
 
   policy = jsonencode({
-    Version   = "2012-10-17"
+    Version = "2012-10-17"
     Statement = [
       {
         Effect   = "Allow"

--- a/pipeline/terraform/modules/pipeline/state_machine_id_minter_test.tf
+++ b/pipeline/terraform/modules/pipeline/state_machine_id_minter_test.tf
@@ -25,9 +25,7 @@ locals {
   rds_test_master_secret_name = regex(
     "arn:aws:secretsmanager:[^:]+:[^:]+:secret:(.+)-.{6}$",
     local.id_minter_v2_test_rds_instance.master_user_secret_arn
-    )[
-    0
-  ]
+    )[0]
 
   id_minter_test_secret_env_vars = merge(
     {

--- a/pipeline/terraform/modules/pipeline/state_machine_id_minter_test.tf
+++ b/pipeline/terraform/modules/pipeline/state_machine_id_minter_test.tf
@@ -25,7 +25,7 @@ locals {
   rds_test_master_secret_name = regex(
     "arn:aws:secretsmanager:[^:]+:[^:]+:secret:(.+)-.{6}$",
     local.id_minter_v2_test_rds_instance.master_user_secret_arn
-    )[0]
+  )[0]
 
   id_minter_test_secret_env_vars = merge(
     {

--- a/pipeline/terraform/modules/pipeline/state_machine_id_minter_test.tf
+++ b/pipeline/terraform/modules/pipeline/state_machine_id_minter_test.tf
@@ -5,7 +5,7 @@ locals {
   id_minter_v2_test_rds_instance = local.infra_critical.id_minter_rds["test"]
 
   id_minter_test_vpc_config = {
-    subnet_ids = local.network_config.subnets
+    subnet_ids         = local.network_config.subnets
     security_group_ids = [
       aws_security_group.egress.id,
       local.id_minter_v2_test_rds_instance.ingress_security_group_id,
@@ -25,7 +25,9 @@ locals {
   rds_test_master_secret_name = regex(
     "arn:aws:secretsmanager:[^:]+:[^:]+:secret:(.+)-.{6}$",
     local.id_minter_v2_test_rds_instance.master_user_secret_arn
-  )[0]
+  )[
+  0
+  ]
 
   id_minter_test_secret_env_vars = merge(
     {
@@ -42,9 +44,9 @@ locals {
     QueryLanguage = "JSONata"
     Comment       = "Invoke the id_minter Lambda"
     StartAt       = "ConstructEvent"
-    States = {
+    States        = {
       ConstructEvent = {
-        Type = "Pass",
+        Type   = "Pass",
         Output = {
           "pipeline_date" : var.pipeline_date,
           # window end time is 5 minutes before the scheduled time
@@ -55,14 +57,14 @@ locals {
         Next = "InvokeIdMinter"
       }
       InvokeIdMinter = {
-        Type     = "Task"
-        Resource = "arn:aws:states:::lambda:invoke"
+        Type      = "Task"
+        Resource  = "arn:aws:states:::lambda:invoke"
         Arguments = {
           FunctionName = module.id_minter_test.id_minter_lambda_arn
           Payload      = "{% $states.input %}"
         }
         Output = "{% $states.result.Payload %}"
-        Retry = [
+        Retry  = [
           {
             ErrorEquals     = ["Lambda.ServiceException", "Lambda.AWSLambdaException", "Lambda.SdkClientException"]
             IntervalSeconds = 2
@@ -81,7 +83,7 @@ module "id_minter_test" {
 
   pipeline_date        = var.pipeline_date
   namespace            = "test"
-  include_id_generator = false
+  include_id_generator = true
 
   vpc_config      = local.id_minter_test_vpc_config
   env_vars        = local.id_minter_test_env_vars
@@ -136,10 +138,10 @@ resource "aws_iam_role" "run_id_minter_test_role" {
   name = "run-id-minter-test-role-${var.pipeline_date}"
 
   assume_role_policy = jsonencode({
-    Version = "2012-10-17"
+    Version   = "2012-10-17"
     Statement = [
       {
-        Effect = "Allow"
+        Effect    = "Allow"
         Principal = {
           Service = "scheduler.amazonaws.com"
         }
@@ -153,11 +155,13 @@ resource "aws_iam_role_policy" "run_id_minter_test_policy" {
   role = aws_iam_role.run_id_minter_test_role.id
 
   policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect   = "Allow"
-      Action   = "states:StartExecution"
-      Resource = module.id_minter_test_state_machine.state_machine_arn
-    }]
+    Version   = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "states:StartExecution"
+        Resource = module.id_minter_test_state_machine.state_machine_arn
+      }
+    ]
   })
 }


### PR DESCRIPTION
## What does this change?

* **Transformer tweak**: When indexing transformed documents to the `works-source` index, drop nulls for parity with the Scala pipeline and with the Python ingestor service. Keeping fields will null values causes downstream issues in the ID minter.
* **ID minter tweak**: Temporarily deploy an ID generator Lambda for the test ID minter database (`identifiers-v2-serverless-test`). During my [Folio predecessor testing](https://github.com/wellcomecollection/platform/issues/6349), the ID pool in the testing database ran out of free IDs, and adding this Lambda allows for easy top ups. 

