### PR TITLE
Extract Title in folio transformer

### DIFF
--- a/catalogue_graph/src/adapters/transformers/folio_transformer.py
+++ b/catalogue_graph/src/adapters/transformers/folio_transformer.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from pymarc.record import Record
 
 from adapters.transformers.folio.predecessor_identifier import extract_predecessor_id
+from adapters.transformers.marc.title import extract_title
 from adapters.transformers.marcxml_transformer import MarcXmlTransformer
 from adapters.utils.adapter_store import AdapterStore
 from models.pipeline.identifier import Id
@@ -31,7 +32,9 @@ class FolioTransformer(MarcXmlTransformer):
     def transform_record(
         self, marc_record: Record, source_modified_time: datetime
     ) -> VisibleSourceWork:
-        work_data = WorkData()
+        work_data = WorkData(
+            title=extract_title(marc_record),
+        )
         work_state = self.source_work_state(
             marc_record=marc_record,
             source_modified_time=source_modified_time,

--- a/catalogue_graph/tests/adapters/transformers/folio/BDD/conftest.py
+++ b/catalogue_graph/tests/adapters/transformers/folio/BDD/conftest.py
@@ -24,6 +24,7 @@ def do_transform(marc_record: Record) -> VisibleSourceWork:
         marc_record, source_modified_time=datetime(2020, 1, 1)
     )
 
+
 @then("transforming the record raises ValueError")
 def check_transform_raises_error(marc_record: Record) -> None:
     transformer = FolioTransformerForTests()

--- a/catalogue_graph/tests/adapters/transformers/folio/BDD/conftest.py
+++ b/catalogue_graph/tests/adapters/transformers/folio/BDD/conftest.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 from datetime import datetime
 
+import pytest
 from pymarc.record import Record
-from pytest_bdd import when
+from pytest_bdd import then, when
 
 from models.pipeline.source.work import VisibleSourceWork
 from tests.adapters.transformers.folio.folio_test_transformer import (
@@ -22,3 +23,11 @@ def do_transform(marc_record: Record) -> VisibleSourceWork:
     return transformer.transform_record(
         marc_record, source_modified_time=datetime(2020, 1, 1)
     )
+
+@then("transforming the record raises ValueError")
+def check_transform_raises_error(marc_record: Record) -> None:
+    transformer = FolioTransformerForTests()
+    with pytest.raises(ValueError):
+        transformer.transform_record(
+            marc_record, source_modified_time=datetime(2020, 1, 1)
+        )

--- a/catalogue_graph/tests/adapters/transformers/folio/BDD/features/minimal_record.feature
+++ b/catalogue_graph/tests/adapters/transformers/folio/BDD/features/minimal_record.feature
@@ -5,6 +5,7 @@ Feature: The bare minimum MARC record for an item
   Scenario: A minimal MARC record from Folio
     Given a MARC record with field 001 "abc123"
     And the MARC record has a 907 field with subfield "a" value "b12345679"
+    And the MARC record has a 245 field with subfield "a" value "Some Title"
     When I transform the MARC record
     Then the work is visible
     And the work has the identifier "Work[folio-instance/abc123]"

--- a/catalogue_graph/tests/adapters/transformers/folio/BDD/features/minimal_record.feature
+++ b/catalogue_graph/tests/adapters/transformers/folio/BDD/features/minimal_record.feature
@@ -10,3 +10,9 @@ Feature: The bare minimum MARC record for an item
     Then the work is visible
     And the work has the identifier "Work[folio-instance/abc123]"
     And the work has the predecessor identifier "Work[sierra-system-number/b12345679]"
+    And the work's title is Some Title
+
+  Scenario: A MARC record with an empty title field should fail
+    Given a MARC record with field 001 "abc123"
+    And the MARC record has a 245 field with subfield "a" value ""
+    Then transforming the record raises ValueError


### PR DESCRIPTION
## What does this change?

Extracts the title field from MARC records in the Folio transformer. This adds title extraction to the FOLIO adapter's transformation pipeline by:
- Importing the existing `extract_title` function from the MARC transformer module
- Using the extracted title when creating `WorkData` during FOLIO record transformation
- Updating the minimal record BDD test to include a 245 MARC field (title field) with a test value
- Adding error handling to validate that empty title fields raise `ValueError`

## How to test

Run the Folio transformer tests:

```bash
cd catalogue_graph
uv run pytest tests/adapters/transformers/folio/ -v
```

The test suite includes:
- **Minimal record scenario**: Validates that the title field is properly extracted and available in the transformed work data
- **Empty title scenario**: Confirms that a MARC record with an empty 245 field raises `ValueError` as expected

## How can we measure success?

- FOLIO records now have titles extracted from the MARC 245 field
- Existing Folio transformer tests pass with the new title extraction in place
- Both happy path and error path are covered: records with valid titles extract correctly, and empty titles are rejected with appropriate errors
- BDD test scenarios confirm the transformer correctly processes records with title fields and handles edge cases

## Have we considered potential risks?

- The `extract_title` function is already tested and used in other MARC-based transformers (e.g., Sierra, METS)
- This change integrates existing, proven functionality into the Folio transformer
- No changes to external APIs or schemas
- The change is additive — only adds title data to records that didn't previously have it extracted
- Error handling for malformed/empty titles follows the same pattern as existing transformers
