### PR TITLE
Switch graph extractor from runTask.sync to waitForTaskToken

### DIFF
--- a/catalogue_graph/src/utils/steps.py
+++ b/catalogue_graph/src/utils/steps.py
@@ -37,7 +37,7 @@ class StepFunctionOutput:
     def _dump_result(self, result: ResultModel | None) -> str:
         if result is not None:
             return result.model_dump_json()
-        return "Result is None"
+        return "{}"
 
     def send_success(self, result: ResultModel | None) -> None:
         output = self._dump_result(result)

--- a/catalogue_graph/tests/utils/test_steps.py
+++ b/catalogue_graph/tests/utils/test_steps.py
@@ -204,7 +204,7 @@ def test_ecs_handler_handles_none_result(
     assert MockStepFunctionsClient.task_successes == [
         {
             "taskToken": token,
-            "output": "Result is None",
+            "output": "{}",
         }
     ]
 
@@ -322,7 +322,7 @@ def test_step_function_output_send_success_none_result_records() -> None:
     assert MockStepFunctionsClient.task_successes == [
         {
             "taskToken": "token-456",
-            "output": "Result is None",
+            "output": "{}",
         }
     ]
 

--- a/pipeline/terraform/modules/pipeline/graph/ecs_task_extractor.tf
+++ b/pipeline/terraform/modules/pipeline/graph/ecs_task_extractor.tf
@@ -34,3 +34,21 @@ resource "aws_iam_role_policy" "graph_extractor_ecs_read_pipeline_secrets_policy
   role   = module.extractor_ecs_task.task_role_name
   policy = data.aws_iam_policy_document.allow_pipeline_storage_secret_read_denormalised_read_only.json
 }
+
+data "aws_iam_policy_document" "allow_extractor_task_token" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "states:SendTaskSuccess",
+      "states:SendTaskFailure",
+    ]
+    resources = [
+      module.catalogue_graph_extractor_state_machine.state_machine_arn,
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "allow_extractor_task_token_policy" {
+  role   = module.extractor_ecs_task.task_role_name
+  policy = data.aws_iam_policy_document.allow_extractor_task_token.json
+}

--- a/pipeline/terraform/modules/pipeline/graph/state_machine_extractor.tf
+++ b/pipeline/terraform/modules/pipeline/graph/state_machine_extractor.tf
@@ -9,7 +9,7 @@ module "catalogue_graph_extractor_state_machine" {
     States = {
       Extract = {
         Type     = "Task"
-        Resource = "arn:aws:states:::ecs:runTask.sync"
+        Resource = "arn:aws:states:::ecs:runTask.waitForTaskToken"
         Output   = "{% $states.input %}"
         Retry    = local.state_function_default_retry,
         Next     = "Success"
@@ -34,6 +34,7 @@ module "catalogue_graph_extractor_state_machine" {
                 Command = [
                   "/app/src/graph/steps/extractor.py",
                   "--event", "{% $string($states.input) %}",
+                  "--task-token", "{% $states.context.Task.Token %}"
                 ],
               }
             ]


### PR DESCRIPTION
## What does this change?

Switches the graph extractor Step Functions state machine from `ecs:runTask.sync` to `ecs:runTask.waitForTaskToken`.

### Problem

The graph extractor was failing in production with `States.TaskFailed`, despite the extractor app container completing successfully (exit code 0). The root cause is the `.sync` integration pattern: Step Functions monitors the ECS task and treats **any** non-zero container exit code as a failure — including the non-essential `log_router` (fluentbit) sidecar, which gets SIGKILL'd (exit code 137) when the essential app container exits. This is normal ECS shutdown behaviour, but `.sync` doesn't distinguish between essential and non-essential containers.

Evidence from a failed execution (`1613e839-c103-4d30-be33-23643f9babee`):
- `graph-extractor-2025-10-02`: ExitCode **0** (success)
- `log_router`: ExitCode **137** (SIGKILL — killed during task shutdown)
- StopCode: `EssentialContainerExited`
- Step Functions error: `States.TaskFailed`

### Fix

With `.waitForTaskToken`, the app itself calls `SendTaskSuccess`/`SendTaskFailure` to report its outcome, so sidecar exit codes are irrelevant. This is already the pattern used by the graph ingestor and all adapters.

### Changes

1. **`state_machine_extractor.tf`**: `runTask.sync` → `runTask.waitForTaskToken`, added `--task-token` to the command override
2. **`ecs_task_extractor.tf`**: Added IAM policy granting the extractor task role `states:SendTaskSuccess` and `states:SendTaskFailure` (matching the ingestor loader pattern)
3. **`src/utils/steps.py`**: Fixed `_dump_result` to return `"{}"` instead of `"Result is None"` when the handler returns `None` — `SendTaskSuccess` requires valid JSON output

No other Python changes needed — the extractor already uses `ecs_handler`, which handles the `--task-token` argument automatically.

## How to test

1. Run a graph extractor execution via the Step Functions console
2. Confirm the execution succeeds (previously it would fail with `States.TaskFailed`)
3. Check CloudWatch logs to verify the extractor logs "Sending task success to Step Functions"

## How can we measure success?

Graph extractor Step Functions executions should no longer fail spuriously due to sidecar exit codes. The `graph-extractor-2025-10-02` state machine should show consistent successes when the extractor workload completes normally.

## Have we considered potential risks?

With `.waitForTaskToken`, if the task crashes without calling `SendTaskSuccess`/`SendTaskFailure` (e.g. OOM kill), Step Functions will wait indefinitely rather than detecting the failure. This is the same behaviour as the existing ingestor and adapter state machines, which also don't set `HeartbeatSeconds`. The retry policy already handles `Ecs.TaskFailedToStartException` and similar infrastructure errors. Adding `HeartbeatSeconds` as a safety net could be a follow-up improvement across all `waitForTaskToken` tasks.
