### PR TITLE
increase ephemeral storage and timeout

### DIFF
--- a/catalogue_graph/infra/adapters/modules/adapter/lambda_trigger.tf
+++ b/catalogue_graph/infra/adapters/modules/adapter/lambda_trigger.tf
@@ -12,7 +12,11 @@ module "trigger_lambda" {
   }
 
   memory_size = 4096
-  timeout     = 300
+  timeout     = 900
+
+  ephemeral_storage = {
+    size = 1024
+  }
 
   environment = {
     variables = {

--- a/catalogue_graph/infra/adapters/modules/adapter/lambda_trigger.tf
+++ b/catalogue_graph/infra/adapters/modules/adapter/lambda_trigger.tf
@@ -12,7 +12,7 @@ module "trigger_lambda" {
   }
 
   memory_size = 4096
-  timeout     = 900
+  timeout     = 600
 
   ephemeral_storage = {
     size = 1024


### PR DESCRIPTION
## What does this change?

Increase ephemeral storage to 1024MB and timeout to 10 minutes.
See: https://wellcome.slack.com/archives/CQ720BG02/p1778810563534329
The EBSCO file has become too big for the lambda to handle 

## How to test

Run `terraform plan`

2 changes: axiell and folio adapter trigger lambdas
-> timeout and ephemeral storage


## How can we measure success?

Ebsco adapter trigger runs successfully 

## Have we considered potential risks?

Timeout is set lower than the schedule on axiell and folio to avoid overlapping runs 
