### PR TITLE
Enable the test id minter schedule

### DIFF
--- a/pipeline/terraform/modules/pipeline/state_machine_id_minter_test.tf
+++ b/pipeline/terraform/modules/pipeline/state_machine_id_minter_test.tf
@@ -129,7 +129,7 @@ resource "aws_scheduler_schedule" "id_minter_test_schedule" {
     JSON
   }
 
-  state = "DISABLED"
+  state = "ENABLED"
 }
 
 resource "aws_iam_role" "run_id_minter_test_role" {


### PR DESCRIPTION
## What does this change?

Enables the test id minter schedule for https://github.com/wellcomecollection/platform/issues/6349.

## How to test

- [ ] Enable the schedule, does it invoke the test state machine as expected?

## How can we measure success?

A running state machine will reveal any issues with the test setup more quickly, even if we're not using the output, that it runs successfully of not is useful data.

## Have we considered potential risks?

Cost is minimal.
