### PR TITLE
Add test matcher/merger instances

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -44,8 +44,6 @@ steps:
       - "calm_indexer"
       - "matcher"
       - "merger"
-      - "matcher_test"
-      - "merger_test"
       - "mets_adapter"
       - "reindex_worker"
       - "sierra_indexer"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -44,6 +44,8 @@ steps:
       - "calm_indexer"
       - "matcher"
       - "merger"
+      - "matcher_test"
+      - "merger_test"
       - "mets_adapter"
       - "reindex_worker"
       - "sierra_indexer"

--- a/builds/deploy_catalogue_pipeline.sh
+++ b/builds/deploy_catalogue_pipeline.sh
@@ -78,6 +78,8 @@ then
   echo "Deploying λ pipeline services to catalogue-$PIPELINE_DATE"
   "$ROOT/builds/deploy_lambda_services.sh" \
     matcher:matcher \
-    merger:merger
+    matcher_test:matcher \
+    merger:merger \
+    merger_test:merger
 fi
 

--- a/pipeline/terraform/modules/pipeline/id_minter/main.tf
+++ b/pipeline/terraform/modules/pipeline/id_minter/main.tf
@@ -39,11 +39,6 @@ module "id_minter_lambda" {
   vpc_config      = var.vpc_config
 }
 
-moved {
-  from = module.id_generator_lambda
-  to   = module.id_generator_lambda[0]
-}
-
 module "id_generator_lambda" {
   source = "../../pipeline_lambda"
   count  = var.include_id_generator ? 1 : 0

--- a/pipeline/terraform/modules/pipeline/matcher/locals.tf
+++ b/pipeline/terraform/modules/pipeline/matcher/locals.tf
@@ -1,0 +1,30 @@
+locals {
+  namespace      = "catalogue-${var.pipeline_date}_${var.service_name}"
+  base_namespace = "catalogue-${var.pipeline_date}" // prod "catalogue-2025-10-02_works-graph" table doesn't reference service name, using base_namespace so table is preserved
+
+  graph_table_billing_mode = var.scale_up_matcher_db ? "PROVISIONED" : "PAY_PER_REQUEST"
+  lock_table_billing_mode  = var.scale_up_matcher_db ? "PROVISIONED" : "PAY_PER_REQUEST"
+
+  lock_timeout = 1 * 60
+
+  # The records in the locktable expire after local.lock_timeout
+  # The matcher is able to override locks that have expired
+  # Wait slightly longer to make sure locks are expired
+  queue_visibility_timeout_seconds = local.lock_timeout + 30
+
+  # Epistemic status of this comment: somewhat speculative.
+  #
+  # We want a lot of redrives here so we can handle cases where a bunch
+  # of works are being merged together in quick succession.
+  #
+  # Consider: ten works A, B, C, …, J are all going to be merged together,
+  # and they arrive at the matcher in that order.
+  #
+  # The matcher starts processing work A, and acquires a lock on it.
+  # The nine other works try to get a lock on A, fail, get redriven.
+  #
+  # When the visibility timeout expires, the matcher starts processing B
+  # and acquires a lock on A.  The eight other works try to get a lock on A,
+  # fail, get redriven.
+  max_receive_count = 10
+}

--- a/pipeline/terraform/modules/pipeline/matcher/locals.tf
+++ b/pipeline/terraform/modules/pipeline/matcher/locals.tf
@@ -1,7 +1,10 @@
 locals {
   namespace      = "catalogue-${var.pipeline_date}_${var.service_name}"
-  base_namespace = "catalogue-${var.pipeline_date}" // prod "catalogue-2025-10-02_works-graph" table doesn't reference service name, using base_namespace so table is preserved
 
+  # Preserve the existing production graph table name for the primary matcher
+  # service, but give non-prod matcher instances their own distinct namespace 
+  base_namespace = var.service_name == "matcher" ? "catalogue-${var.pipeline_date}" : local.namespace
+  
   graph_table_billing_mode = var.scale_up_matcher_db ? "PROVISIONED" : "PAY_PER_REQUEST"
   lock_table_billing_mode  = var.scale_up_matcher_db ? "PROVISIONED" : "PAY_PER_REQUEST"
 

--- a/pipeline/terraform/modules/pipeline/matcher/locals.tf
+++ b/pipeline/terraform/modules/pipeline/matcher/locals.tf
@@ -1,10 +1,10 @@
 locals {
-  namespace      = "catalogue-${var.pipeline_date}_${var.service_name}"
+  namespace = "catalogue-${var.pipeline_date}_${var.service_name}"
 
   # Preserve the existing production graph table name for the primary matcher
   # service, but give non-prod matcher instances their own distinct namespace 
   base_namespace = var.service_name == "matcher" ? "catalogue-${var.pipeline_date}" : local.namespace
-  
+
   graph_table_billing_mode = var.scale_up_matcher_db ? "PROVISIONED" : "PAY_PER_REQUEST"
   lock_table_billing_mode  = var.scale_up_matcher_db ? "PROVISIONED" : "PAY_PER_REQUEST"
 

--- a/pipeline/terraform/modules/pipeline/matcher/main.tf
+++ b/pipeline/terraform/modules/pipeline/matcher/main.tf
@@ -1,11 +1,3 @@
-locals {
-  namespace      = "catalogue-${var.pipeline_date}_${var.service_name}"
-  base_namespace = "catalogue-${var.pipeline_date}" // prod "catalogue-2025-10-02_works-graph" table doesn't reference service name, using base_namespace so table is preserved
-
-  graph_table_billing_mode = var.scale_up_matcher_db ? "PROVISIONED" : "PAY_PER_REQUEST"
-  lock_table_billing_mode  = var.scale_up_matcher_db ? "PROVISIONED" : "PAY_PER_REQUEST"
-}
-
 # ──────────────────────────────────────────────
 # Output topic
 # ──────────────────────────────────────────────
@@ -36,7 +28,7 @@ module "matcher_lambda" {
     dynamo_lock_table       = aws_dynamodb_table.lock_table.id
     dynamo_lock_table_index = "context-ids-index"
 
-    dynamo_lock_timeout = var.lock_timeout
+    dynamo_lock_timeout = local.lock_timeout
 
     es_index = var.es_works_identified_index
   }

--- a/pipeline/terraform/modules/pipeline/matcher/variables.tf
+++ b/pipeline/terraform/modules/pipeline/matcher/variables.tf
@@ -59,8 +59,3 @@ variable "scale_up_matcher_db" {
   default     = false
   description = "Whether to use provisioned capacity for DynamoDB tables"
 }
-
-variable "lock_timeout" {
-  type    = number
-  default = 60
-}

--- a/pipeline/terraform/modules/pipeline/merger/locals.tf
+++ b/pipeline/terraform/modules/pipeline/merger/locals.tf
@@ -7,6 +7,7 @@ locals {
     es_upstream_protocol = var.es_config.es_protocol
     es_upstream_apikey   = var.es_config.es_apikey
   }
+
   es_downstream_config = {
     es_downstream_host     = var.es_config.es_host
     es_downstream_port     = var.es_config.es_port

--- a/pipeline/terraform/modules/pipeline/service_id_minter.tf
+++ b/pipeline/terraform/modules/pipeline/service_id_minter.tf
@@ -48,8 +48,3 @@ module "id_minter_lambda" {
   alarm_topic_arn = local.monitoring_infra["chatbot_topic_arn"]
 }
 
-moved {
-  from = aws_cloudwatch_metric_alarm.id_minter_failures
-  to   = module.id_minter_lambda.aws_cloudwatch_metric_alarm.id_minter_failures
-}
-

--- a/pipeline/terraform/modules/pipeline/service_matcher.tf
+++ b/pipeline/terraform/modules/pipeline/service_matcher.tf
@@ -1,8 +1,8 @@
 module "matcher" {
   source = "./matcher"
 
-  pipeline_date             = var.pipeline_date
-  
+  pipeline_date = var.pipeline_date
+
   es_works_identified_index = local.es_works_identified_index
   scale_up_matcher_db       = var.reindexing_state.scale_up_matcher_db
 

--- a/pipeline/terraform/modules/pipeline/service_matcher_test.tf
+++ b/pipeline/terraform/modules/pipeline/service_matcher_test.tf
@@ -2,15 +2,15 @@
 # .buildkite/pipeline.yml -> matcher_test
 
 module "matcher_test" {
-  source = "./matcher"
-  service_name              = "matcher_test"
+  source       = "./matcher"
+  service_name = "matcher_test"
 
-  pipeline_date             = var.pipeline_date
+  pipeline_date = var.pipeline_date
 
   es_works_identified_index = "works-identified-2026-03-06"
   scale_up_matcher_db       = var.reindexing_state.scale_up_matcher_db
 
-  vpc_config = {  
+  vpc_config = {
     subnet_ids = local.network_config.subnets
     security_group_ids = [
       aws_security_group.egress.id,

--- a/pipeline/terraform/modules/pipeline/service_matcher_test.tf
+++ b/pipeline/terraform/modules/pipeline/service_matcher_test.tf
@@ -1,12 +1,16 @@
-module "matcher" {
+# when we destroy this infra, remember to remove the apps from the deployment matrix
+# .buildkite/pipeline.yml -> matcher_test
+
+module "matcher_test" {
   source = "./matcher"
+  service_name              = "matcher_test"
 
   pipeline_date             = var.pipeline_date
-  
-  es_works_identified_index = local.es_works_identified_index
+
+  es_works_identified_index = "works-identified-2026-03-06"
   scale_up_matcher_db       = var.reindexing_state.scale_up_matcher_db
 
-  vpc_config = {
+  vpc_config = {  
     subnet_ids = local.network_config.subnets
     security_group_ids = [
       aws_security_group.egress.id,
@@ -23,7 +27,7 @@ module "matcher" {
     batch_size                 = var.reindexing_state.scale_up_matcher_db ? 400 : 100
     maximum_concurrency        = var.reindexing_state.scale_up_matcher_db ? 40 : 2
     topic_arns = [
-      module.id_minter_lambda.id_minter_output_topic_arn,
+      module.id_minter_test.id_minter_output_topic_arn,
     ]
   }
 

--- a/pipeline/terraform/modules/pipeline/service_merger_test.tf
+++ b/pipeline/terraform/modules/pipeline/service_merger_test.tf
@@ -8,8 +8,9 @@ module "merger_test" {
   pipeline_date = var.pipeline_date
 
   es_works_identified_index   = "works-identified-2026-03-06"
-  es_works_denormalised_index = "works-denormalised-new-one"
-  es_images_initial_index     = "images-initial-new-one"
+  es_works_denormalised_index = "works-denormalised-2025-10-09"
+  es_images_initial_index     = "images-initial-2025-10-09"
+  
   queue_config = {
     visibility_timeout_seconds = 90
     max_receive_count          = 10

--- a/pipeline/terraform/modules/pipeline/service_merger_test.tf
+++ b/pipeline/terraform/modules/pipeline/service_merger_test.tf
@@ -1,11 +1,16 @@
-module "merger" {
-  source = "./merger"
+# when we destroy this infra, remember to remove the apps from the deployment matrix
+# .buildkite/pipeline.yml -> merger_test
 
+module "merger_test" {
+  source = "./merger"
+  service_name  = "merger_test"
+  
   pipeline_date = var.pipeline_date
 
-  es_works_identified_index   = local.es_works_identified_index
-  es_works_denormalised_index = local.es_works_denormalised_index
-  es_images_initial_index     = local.es_images_initial_index
+  es_works_identified_index   = "works-identified-2026-03-06"
+  es_works_denormalised_index = "works-denormalised-2026-05-19"
+  es_images_initial_index     = local.es_images_initial_index // same as prod
+  
   queue_config = {
     visibility_timeout_seconds = 90
     max_receive_count          = 10
@@ -13,9 +18,10 @@ module "merger" {
     batch_size                 = 50
     maximum_concurrency        = 30
     topic_arns = [
-      module.matcher.output_topic_arn,
+      module.matcher_test.output_topic_arn,
     ]
   }
+
   vpc_config = {
     subnet_ids = local.network_config.subnets
     security_group_ids = [
@@ -23,6 +29,7 @@ module "merger" {
       local.network_config.ec_privatelink_security_group_id,
     ]
   }
+  
   es_config = {
     es_host     = module.elastic.pipeline_storage_private_host
     es_port     = module.elastic.pipeline_storage_port

--- a/pipeline/terraform/modules/pipeline/service_merger_test.tf
+++ b/pipeline/terraform/modules/pipeline/service_merger_test.tf
@@ -2,15 +2,15 @@
 # .buildkite/pipeline.yml -> merger_test
 
 module "merger_test" {
-  source = "./merger"
-  service_name  = "merger_test"
-  
+  source       = "./merger"
+  service_name = "merger_test"
+
   pipeline_date = var.pipeline_date
 
   es_works_identified_index   = "works-identified-2026-03-06"
   es_works_denormalised_index = "works-denormalised-2025-10-09"
   es_images_initial_index     = "images-initial-2025-10-09"
-  
+
   queue_config = {
     visibility_timeout_seconds = 90
     max_receive_count          = 10
@@ -29,7 +29,7 @@ module "merger_test" {
       local.network_config.ec_privatelink_security_group_id,
     ]
   }
-  
+
   es_config = {
     es_host     = module.elastic.pipeline_storage_private_host
     es_port     = module.elastic.pipeline_storage_port

--- a/pipeline/terraform/modules/pipeline/service_merger_test.tf
+++ b/pipeline/terraform/modules/pipeline/service_merger_test.tf
@@ -8,9 +8,8 @@ module "merger_test" {
   pipeline_date = var.pipeline_date
 
   es_works_identified_index   = "works-identified-2026-03-06"
-  es_works_denormalised_index = "works-denormalised-2026-05-19"
-  es_images_initial_index     = local.es_images_initial_index // same as prod
-  
+  es_works_denormalised_index = "works-denormalised-new-one"
+  es_images_initial_index     = "images-initial-new-one"
   queue_config = {
     visibility_timeout_seconds = 90
     max_receive_count          = 10

--- a/pipeline/terraform/modules/pipeline/state_machine_id_minter_test.tf
+++ b/pipeline/terraform/modules/pipeline/state_machine_id_minter_test.tf
@@ -1,5 +1,5 @@
-# when we destroy this infra, remember to remove the lambda from the deployment matrix
-# .github/workflows/catalogue-graph-deploy.yml -> id-minter-test
+# when we destroy this infra, remember to remove the lambdas from the deployment matrix
+# .github/workflows/catalogue-graph-deploy.yml -> id-minter-test and id-generator-test
 
 locals {
   id_minter_v2_test_rds_instance = local.infra_critical.id_minter_rds["test"]


### PR DESCRIPTION
## What does this change?

Adds matcher/merger test instances that can run in parallel with prod.

**Sub-module refactoring:**
- Moves locals (lock timeout, billing mode, namespace) into `locals.tf` within each sub-module (`matcher/locals.tf`, `merger/locals.tf`)
- Removes `moved` blocks from `service_matcher.tf` — these were only needed for the initial migration and have now been applied
- The merger module takes explicit ES index name inputs and `es_config` directly, removing the `local.service_vpc_config` / `local.queue_config` / `local.es_config` indirection
- The matcher internalises `lock_timeout` instead of accepting it as a variable

**Test instances (dead-end pattern):**
- `service_matcher_test.tf` — `matcher_test` module reads from the test id_minter output topic, writes to its own DynamoDB tables, publishes to its own output topic. 
- `service_merger_test.tf` — `merger_test` module subscribes to `matcher_test` output topic, writes to dedicated denormalised index (nothing reads it downstream) and images-initial index
- Both are added to the Buildkite deployment matrix for auto-deploy from main

This allows us to iterate on matcher/merger code against real traffic without risking the prod pipeline.

Relates to https://github.com/wellcomecollection/platform/issues/6373

## How to test

The terraform plan for `pipeline/terraform/2025-10-02` shows **Plan: 38 to add, 0 to change, 0 to destroy.** 
All 38 resources to add are in `module.merger_test` and `module.matcher_test` 

## How can we measure success?

- Prod pipeline continues to operate without disruption after merge and apply
- Test matcher/merger instances deploy successfully and process messages from the test id_minter topic

## Have we considered potential risks?

- **Prod impact:** Mitigated — `moved` blocks have already been applied (plan shows 0 changes), and prod stays on `:prod` image tag
- **Cost:** Test instances use the same scaling config as prod but are dead-end (no downstream subscribers), so they add marginal Lambda and DynamoDB cost
- **Cleanup:** Comment in each test file reminds to remove from the Buildkite matrix when tearing down
