### PR TITLE
Add FolioInstance and AxiellGuid identifier types with merger tests

### DIFF
--- a/builds/deploy_catalogue_pipeline.sh
+++ b/builds/deploy_catalogue_pipeline.sh
@@ -78,8 +78,8 @@ then
   echo "Deploying λ pipeline services to catalogue-$PIPELINE_DATE"
   "$ROOT/builds/deploy_lambda_services.sh" \
     matcher:matcher \
-    matcher_test:matcher \
+    matcher:matcher_test \
     merger:merger \
-    merger_test:merger
+    merger:merger_test 
 fi
 

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/IdentifierType.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/IdentifierType.scala
@@ -46,6 +46,11 @@ object IdentifierType extends Enum[IdentifierType] {
     val label = "Sierra system number"
   }
 
+  case object FolioInstance extends IdentifierType {
+    val id = "folio-instance"
+    val label = "Folio instance"
+  }
+
   case object SierraIdentifier extends IdentifierType {
     val id = "sierra-identifier"
     val label = "Sierra identifier"
@@ -89,6 +94,11 @@ object IdentifierType extends Enum[IdentifierType] {
   case object CalmRecordIdentifier extends IdentifierType {
     val id = "calm-record-id"
     val label = "Calm RecordIdentifier"
+  }
+
+  case object AxiellGuid extends IdentifierType {
+    val id = "axiell-guid"
+    val label = "Axiell Guid"
   }
 
   case object ISBN extends IdentifierType {

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/generators/IdentifiersGenerators.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/generators/IdentifiersGenerators.scala
@@ -127,6 +127,20 @@ trait IdentifiersGenerators extends RandomGenerators {
       ontologyType = "Work"
     )
 
+  def createFolioSourceIdentifier: SourceIdentifier =
+    SourceIdentifier(
+      value = randomAlphanumeric(10),
+      identifierType = IdentifierType.FolioInstance,
+      ontologyType = "Work"
+    )
+
+  def createAxiellSourceIdentifier: SourceIdentifier =
+    SourceIdentifier(
+      value = randomAlphanumeric(10),
+      identifierType = IdentifierType.AxiellGuid,
+      ontologyType = "Work"
+    )
+
   def createDigcodeIdentifier(digcode: String): SourceIdentifier =
     SourceIdentifier(
       value = digcode,

--- a/pipeline/matcher_merger/merger/src/test/scala/weco/pipeline/merger/MergerIntegrationTest.scala
+++ b/pipeline/matcher_merger/merger/src/test/scala/weco/pipeline/merger/MergerIntegrationTest.scala
@@ -863,4 +863,42 @@ class MergerIntegrationTest
       }
     }
   }
+
+  Scenario("A single Folio work with nothing linked to it") {
+    withContext {
+      implicit context =>
+        Given("A single Folio work")
+        val work = identifiedWork(
+          sourceIdentifier = createFolioSourceIdentifier
+        )
+
+        When("the work is processed by the matcher/merger")
+        processWork(work)
+
+        Then("the work is returned unchanged")
+        val mergedWork = context.getMerged(work)
+        mergedWork.data shouldBe work.data
+        mergedWork.state should beSimilarTo(work.state)
+        mergedWork.state.mergedTime should beRecent()
+    }
+  }
+
+  Scenario("A single Axiell work with nothing linked to it") {
+    withContext {
+      implicit context =>
+        Given("A single Axiell work")
+        val work = identifiedWork(
+          sourceIdentifier = createAxiellSourceIdentifier
+        )
+
+        When("the work is processed by the matcher/merger")
+        processWork(work)
+
+        Then("the work is returned unchanged")
+        val mergedWork = context.getMerged(work)
+        mergedWork.data shouldBe work.data
+        mergedWork.state should beSimilarTo(work.state)
+        mergedWork.state.mergedTime should beRecent()
+    }
+  }
 }

--- a/pipeline/matcher_merger/merger/src/test/scala/weco/pipeline/merger/services/PlatformMergerTest.scala
+++ b/pipeline/matcher_merger/merger/src/test/scala/weco/pipeline/merger/services/PlatformMergerTest.scala
@@ -1139,4 +1139,32 @@ class PlatformMergerTest
       }
     }
   }
+
+  it("passes a Folio work through the merger unchanged") {
+    val folioWork = identifiedWork(
+      sourceIdentifier = createFolioSourceIdentifier
+    )
+
+    val result = merger.merge(works = Seq(folioWork))
+
+    val mergedWorks = result.mergedWorksWithTime(now)
+    mergedWorks.size shouldBe 1
+
+    val mergedWork = mergedWorks.head.asInstanceOf[Work.Visible[Merged]]
+    mergedWork.data shouldBe folioWork.data
+  }
+
+  it("passes an Axiell work through the merger unchanged") {
+    val axiellWork = identifiedWork(
+      sourceIdentifier = createAxiellSourceIdentifier
+    )
+
+    val result = merger.merge(works = Seq(axiellWork))
+
+    val mergedWorks = result.mergedWorksWithTime(now)
+    mergedWorks.size shouldBe 1
+
+    val mergedWork = mergedWorks.head.asInstanceOf[Work.Visible[Merged]]
+    mergedWork.data shouldBe axiellWork.data
+  }
 }


### PR DESCRIPTION
## What does this change?

We're adding support for two new source systems — **Folio** and **Axiell** — to the catalogue pipeline.

This PR introduces two new `IdentifierType` enum values in the Scala internal model:

- `FolioInstance` (id: `folio-instance`) — for records from the Folio library system
- `AxiellGuid` (id: `axiell-guid`) — for records from the Axiell collections management system

It also adds merger tests (`PlatformMergerTest` and `MergerIntegrationTest`) confirming that works with these new identifier types pass through the matcher/merger unchanged. These types are currently no-op in the merger — no special merge rules are applied, so works simply pass through as-is.

## How to test

Run the merger tests:

```
./builds/run_sbt_tests.sh pipeline/merger
```

The new tests in `PlatformMergerTest` and `MergerIntegrationTest` verify that single works with Folio or Axiell identifiers emerge from the merger unmodified.

## How can we measure success?

The pipeline will be able to process records from Folio and Axiell source systems without errors. Once adapters for these systems begin sending records, we should see them flow through the matcher/merger stage successfully.

## Have we considered potential risks?

Low risk — this is an additive change that introduces new enum values and tests. No existing behaviour is modified. The new identifier types have no merge rules, so they cannot inadvertently merge with other works.
