### PR TITLE
Remove orphan indices

### DIFF
--- a/pipeline/terraform/2025-10-02/main.tf
+++ b/pipeline/terraform/2025-10-02/main.tf
@@ -29,7 +29,6 @@ module "pipeline" {
         source       = "works_source.2026-03-25"
         identified   = "works_identified.2023-05-26"
         denormalised = "works_denormalised.2025-08-14"
-        indexed      = "works_indexed.2024-11-14"
       }
       images = {
         initial   = "empty"
@@ -39,17 +38,10 @@ module "pipeline" {
     }
     "2025-10-09" = {
       works = {
-        indexed      = "works_indexed.2024-11-14"
         denormalised = "works_denormalised.2025-08-14"
       }
       images = {
         initial = "empty"
-      }
-      concepts = { indexed = "concepts_indexed.2025-06-17" }
-    },
-    "2025-11-20" = {
-      works = {
-        indexed = "works_indexed.2024-11-14"
       }
     },
     "2026-01-12" = {

--- a/pipeline/terraform/2025-10-02/main.tf
+++ b/pipeline/terraform/2025-10-02/main.tf
@@ -27,19 +27,19 @@ module "pipeline" {
     (local.pipeline_date) = {
       works = {
         // prod transformers - prod id_minter
-        source       = "works_source.2026-03-25"
+        source = "works_source.2026-03-25"
         // prod id_minter - prod matcher_merger
-        identified   = "works_identified.2023-05-26"
+        identified = "works_identified.2023-05-26"
         // prod matcher_merger - prod graph/ingestor/indexer
         denormalised = "works_denormalised.2025-08-14"
       }
       images = {
         // prod matcher_merger - prod inference manager
-        initial   = "empty"
+        initial = "empty"
         // scala images ingestor - to be deleted when the service is removed
         augmented = "empty"
         // scala images ingestor - to be deleted when the service is removed
-        indexed   = "images_indexed.2024-11-14"
+        indexed = "images_indexed.2024-11-14"
       }
     }
     "2025-10-09" = {
@@ -79,7 +79,7 @@ module "pipeline" {
         // prod inference manager - prod graph/ingestor/indexer
         augmented = "images_augmented.2026-04-29"
         // prod graph/ingestor/indexer - prod API
-        indexed   = "images_indexed.2024-11-14"
+        indexed = "images_indexed.2024-11-14"
       }
     }
   }

--- a/pipeline/terraform/2025-10-02/main.tf
+++ b/pipeline/terraform/2025-10-02/main.tf
@@ -28,7 +28,7 @@ module "pipeline" {
       works = {
         // prod transformers - prod id_minter
         source       = "works_source.2026-03-25"
-        // prod id_minter - prod matcher_merger 
+        // prod id_minter - prod matcher_merger
         identified   = "works_identified.2023-05-26"
         // prod matcher_merger - prod graph/ingestor/indexer
         denormalised = "works_denormalised.2025-08-14"

--- a/pipeline/terraform/2025-10-02/main.tf
+++ b/pipeline/terraform/2025-10-02/main.tf
@@ -26,45 +26,59 @@ module "pipeline" {
   index_config = {
     (local.pipeline_date) = {
       works = {
+        // prod transformers - prod id_minter
         source       = "works_source.2026-03-25"
+        // prod id_minter - prod matcher_merger 
         identified   = "works_identified.2023-05-26"
+        // prod matcher_merger - prod graph/ingestor/indexer
         denormalised = "works_denormalised.2025-08-14"
       }
       images = {
+        // prod matcher_merger - prod inference manager
         initial   = "empty"
+        // scala images ingestor - to be deleted when the service is removed
         augmented = "empty"
+        // scala images ingestor - to be deleted when the service is removed
         indexed   = "images_indexed.2024-11-14"
       }
     }
     "2025-10-09" = {
       works = {
+        // test matcher_merger - WCSTP dev
         denormalised = "works_denormalised.2025-08-14"
       }
       images = {
+        // test matcher_merger - WCSTP dev
         initial = "empty"
       }
     },
     "2026-01-12" = {
       works = {
+        // test transformers - WCSTP dev
         source = "works_source.2026-03-25"
       }
     },
     "2026-03-03" = {
       works = {
+        // prod graph/ingestor/indexer - prod API
         indexed = "works_indexed.2024-11-14"
       }
       concepts = {
+        // prod graph/ingestor/indexer - prod API
         indexed = "concepts_indexed.2025-06-17"
       }
     },
     "2026-03-06" = {
       works = {
+        // test id_minter - test matcher_merger - WCSTP dev
         identified = "works_identified.2023-05-26"
       }
     },
     "2026-04-29" = {
       images = {
+        // prod inference manager - prod graph/ingestor/indexer
         augmented = "images_augmented.2026-04-29"
+        // prod graph/ingestor/indexer - prod API
         indexed   = "images_indexed.2024-11-14"
       }
     }


### PR DESCRIPTION
## What does this change?

https://github.com/wellcomecollection/platform/issues/6372
- Removes indices unused by production apps or WCSTP test pipeline 
- Adds comments to clarify where the index is used

NOTE: 
`concepts-indexed-2026-02-16` and `images-indexed-dev` were not added in TF, will have to be deleted manually

NOTEE:
This is to be applied in 3 steps: 
1. `allow_delete_indices = true`, apply
2. TF changes from this PR, apply
3. `allow_delete_indices = false`, apply

## How to test

Check that all 8 indices used in production persist, with the correct date:
works-source-2025-10-02
works-identified-2025-10-02
works-denormalised-2025-10-02
works-indexed-2026-03-03
images-initial-2025-10-02
images-augmented-2026-04-29
images-indexed-2026-04-29
concepts-indexed-2026-03-03

Run `./run_terraform.sh plan` in `pipeline/terraform/2025-10-02`
```
Plan: 15 to add, 15 to change, 19 to destroy.
```
15 changes: execution_role + task_role + execution_role_policy for each transformer (these don't actually appear in the apply later IIRC)
15 to destroy + 15 to add: 6 api key and 9 secret versions, due to the change in resources (deleted indices)
4 to destroy: the 4 unused indices

## How can we measure success?

Nothing break 🙏

## Have we considered potential risks?

Deleting indices is not trivial, but the added comments provide assurance that all necessary items are accounted for

