### PR TITLE
Improve AGENTS.md and agent workflows

### DIFF
--- a/.github/agents/address-review-comments.agent.md
+++ b/.github/agents/address-review-comments.agent.md
@@ -27,7 +27,7 @@ Set `GH_PROMPT_DISABLED=true` in the environment when invoking `gh`.
          comments(first:10){nodes{databaseId author{login} body}}
        }}}}}' -F owner=<owner> -F repo=<repo> -F num=<n>
    ```
-   Filter to `isResolved == false`.
+   Filter to `isResolved == false`. If the result is empty, report "no unresolved threads" and stop — don't invent work.
 3. **Build a todo list** with one item per unresolved thread so progress is visible.
 4. **For each thread (in file/line order):**
    1. Show the user the comment, the file + line, and the surrounding code.
@@ -38,10 +38,13 @@ Set `GH_PROMPT_DISABLED=true` in the environment when invoking `gh`.
         1. Make the edit.
         2. Run the relevant local checks for the touched area (e.g. for `catalogue_graph/`: `uv run pytest <scoped path>`, `uv run mypy <scoped path>`, `uv run ruff format`, `uv run ruff check --fix`; for Scala: the appropriate `builds/` script).
         3. `git add` only the files you changed for this comment, `git commit` with a short message referencing the comment intent, `git push`.
-        4. Resolve the thread (see snippet below).
+        4. If the formatter/linter touched files unrelated to this comment, show the user the extra diff with `git diff` and ask whether to include them — either as part of this commit, as a separate `chore: formatting` commit, or stashed/reverted. Don't silently bundle them in.
+        5. Resolve the thread (see snippet below).
       - **Decline:** Post a polite reply on the thread explaining the reasoning (reference the convention or constraint that motivates declining), then resolve the thread.
    5. Mark the todo item complete and move on.
 5. **Final summary.** Report which comments were applied (with commit SHAs) and which were declined (with one-line reasons).
+
+If `gh` GraphQL mutations on this repo hit the *Projects (classic) deprecated* error, see *Known repo quirks* in [AGENTS.md](/AGENTS.md) for the REST fallback.
 
 ## Resolving a thread
 

--- a/.github/agents/create-pr.agent.md
+++ b/.github/agents/create-pr.agent.md
@@ -60,5 +60,5 @@ If the user asks you to update a PR after pushing more commits:
 1. Re-read the current PR body (step 2 above).
 2. Re-run the diff/log against the base to see what's new.
 3. Extend the existing sections — add bullets for the new work, update *How to test* if test steps changed, leave unrelated content alone.
-4. Push the edit with `gh pr edit <n> --body-file …`.
+4. Push the edit via the REST PATCH workaround shown in *Working with the GitHub CLI* above — **not** `gh pr edit --body-file`, which fails on this repo (see *Known repo quirks* in [AGENTS.md](/AGENTS.md)).
 

--- a/.github/agents/review-pr.agent.md
+++ b/.github/agents/review-pr.agent.md
@@ -39,7 +39,7 @@ Set `GH_PROMPT_DISABLED=true` on every `gh` invocation.
 3. **Map the change.** Build a todo list of the meaningful units to review (e.g. "new `FolioRecordPipeline.transform`", "schema migration", "test changes for X"). Skip pure formatting / generated files unless the user wants them included.
 4. **Walk the diff with the reviewer**, one unit at a time. For each unit:
    1. Summarise what changed and why (per the author's description / commit message).
-   2. Read the affected files at the PR's `headRefName` (use `gh api repos/<o>/<r>/contents/<path>?ref=<head>` or check out via `git fetch origin pull/<n>/head:pr-<n>` into a **detached worktree** — never overwrite the user's working tree).
+   2. Read the affected files at the PR's `headRefName`. Prefer `gh api repos/<o>/<r>/contents/<path>?ref=<head>` (no working-tree impact). If you genuinely need a checkout, use a separate worktree — `git fetch origin pull/<n>/head && git worktree add ../pr-<n> FETCH_HEAD` — and never touch the user's existing working tree.
    3. Form an assessment: correctness, edge cases, security, tests, fit with repo conventions (`AGENTS.md`, `*.instructions.md`, repo-memory facts).
    4. **Verify before commenting.** For each potential issue:
       - Cite the file/line in the PR.
@@ -108,7 +108,7 @@ GH_PROMPT_DISABLED=true gh api graphql -f query='
 ' -F o=<o> -F r=<r> -F n=<n> | cat
 ```
 
-If `gh pr edit`-style mutations on this repo trip the *Projects (classic) deprecated* error, fall back to REST as described in `create-pr.agent.md` / `/memories/repo/`.
+If `gh pr edit`-style mutations on this repo trip the *Projects (classic) deprecated* error, fall back to REST as described in [create-pr.agent.md](/.github/agents/create-pr.agent.md) and *Known repo quirks* in [AGENTS.md](/AGENTS.md).
 
 ## Output format per drafted comment
 

--- a/.github/agents/review-pr.agent.md
+++ b/.github/agents/review-pr.agent.md
@@ -39,7 +39,7 @@ Set `GH_PROMPT_DISABLED=true` on every `gh` invocation.
 3. **Map the change.** Build a todo list of the meaningful units to review (e.g. "new `FolioRecordPipeline.transform`", "schema migration", "test changes for X"). Skip pure formatting / generated files unless the user wants them included.
 4. **Walk the diff with the reviewer**, one unit at a time. For each unit:
    1. Summarise what changed and why (per the author's description / commit message).
-   2. Read the affected files at the PR's `headRefName`. Prefer `gh api repos/<o>/<r>/contents/<path>?ref=<head>` (no working-tree impact). If you genuinely need a checkout, use a separate worktree — `git fetch origin pull/<n>/head && git worktree add ../pr-<n> FETCH_HEAD` — and never touch the user's existing working tree.
+   2. Read the affected files at the PR's `headRefName`. Prefer `gh api -H "Accept: application/vnd.github.raw" repos/<o>/<r>/contents/<path>?ref=<head>` so the response is the raw file contents (no working-tree impact). If you genuinely need a checkout, use a separate worktree — `git fetch origin pull/<n>/head && git worktree add ../pr-<n> FETCH_HEAD` — and never touch the user's existing working tree.
    3. Form an assessment: correctness, edge cases, security, tests, fit with repo conventions (`AGENTS.md`, `*.instructions.md`, repo-memory facts).
    4. **Verify before commenting.** For each potential issue:
       - Cite the file/line in the PR.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,27 @@ The Wellcome Collection catalogue pipeline: adapters that fetch records from
 source systems, a transformation pipeline that produces a common model, and
 ingestors that populate Elasticsearch indexes powering the catalogue API.
 
-Start with [README.md](README.md) and [docs/developers.md](docs/developers.md)
+Start with [README.md](/README.md) and [docs/developers.md](/docs/developers.md)
 for the high-level design. Don't duplicate that material here.
+
+> Links in this file use repo-root-absolute paths (`/foo`) so they resolve
+> correctly both here and via the [.github/copilot-instructions.md](/.github/copilot-instructions.md)
+> symlink.
+
+## Agent customization files
+
+This file is the single source of truth for agent guidance. Other agent-facing
+files extend it for tools that support more than a flat instructions file:
+
+- [.github/copilot-instructions.md](/.github/copilot-instructions.md) is a
+  symlink to this file — the GitHub-hosted Copilot coding agent reads it from
+  there. Edit `AGENTS.md`, not the symlink.
+- [.github/instructions/](/.github/instructions/) holds **path-scoped** rules
+  for VS Code Copilot (via `applyTo` frontmatter), e.g.
+  [catalogue-graph.instructions.md](/.github/instructions/catalogue-graph.instructions.md).
+  Put rules that only apply to a subtree here, not in AGENTS.md.
+- [.github/agents/](/.github/agents/) defines VS Code Copilot custom agent
+  modes: `address-review-comments`, `create-pr`, `review-pr`.
 
 ## Repository layout
 
@@ -20,8 +39,10 @@ is no workspace-wide build.
 - **Python** (UV, one project per directory with its own `pyproject.toml`):
   - `catalogue_graph/` — graph + ingestor pipeline, also contains the EBSCO,
     FOLIO, Axiell and OAI-PMH adapters under `src/adapters/` (largest Python
-    project; see [catalogue_graph/README.md](catalogue_graph/README.md))
+    project; see [catalogue_graph/README.md](/catalogue_graph/README.md))
   - `pipeline/inferrer/{aspect_ratio_inferrer,feature_inferrer,palette_inferrer,common}/`
+  - `sierra_adapter/` — Python maintenance scripts living alongside the Scala
+    adapter (own `pyproject.toml`, `uv.lock`, Python 3.13)
   - `reindexer/scripts/`, `scripts/{suppress_miro,miro_links,mimsy_dump,es_index_comparison}/`
 
 When working in a Python project, `cd` into that project's directory before
@@ -65,9 +86,23 @@ Scope `pytest`/`mypy` paths to the area you changed when the project is large
 ## CI
 
 GitHub Actions live in `.github/workflows/`; some Scala projects use Buildkite
-instead (badges in [README.md](README.md)). Python checks use the shared
+instead (badges in [README.md](/README.md)). Python checks use the shared
 `wellcomecollection/.github/.github/actions/python_check@main` action — match
 its commands locally (the four `uv run` commands above) to keep CI green.
+
+## Known repo quirks
+
+- **`gh pr edit --body-file` silently fails on this repo** with a *"GraphQL:
+  Projects (classic) is being deprecated …"* error (exit 1, but looks like a
+  warning). To update a PR description, use the REST API instead:
+  ```bash
+  jq -Rs '{body: .}' < body.md > body.json
+  GH_PROMPT_DISABLED=true gh api -X PATCH \
+    repos/wellcomecollection/catalogue-pipeline/pulls/<n> \
+    --input body.json -q '.html_url' | cat
+  ```
+  Always verify with `gh pr view <n> --json body -q .body | cat` afterwards.
+  Title-only changes via `gh pr edit --title` still work.
 
 ## Don'ts
 


### PR DESCRIPTION
## What does this change?

Audits and improves `AGENTS.md` and the three Copilot agent workflows (`address-review-comments`, `create-pr`, `review-pr`).

**AGENTS.md:**
- Adds `.github/copilot-instructions.md` as a symlink to `AGENTS.md`, so the GitHub-hosted Copilot coding agent (assign-to-issue / @copilot) picks up our repo guidance — it only reads `.github/copilot-instructions.md`, not `AGENTS.md`.
- Adds an "Agent customization files" section explaining how `AGENTS.md`, `.github/instructions/`, and `.github/agents/` relate to each other.
- Adds `sierra_adapter/` to the Python project list (it has its own `pyproject.toml`, `uv.lock`, Python 3.13).
- Adds a "Known repo quirks" section documenting the `gh pr edit --body-file` failure and the REST API workaround — previously this only lived in local agent memory.
- Converts relative links to repo-root-absolute paths (`/README.md`) so they resolve correctly from both the repo root and the `.github/` symlink location.

**Agent workflows:**
- **create-pr**: fixes a contradiction where "Updating after new commits" told the agent to use `gh pr edit --body-file` despite an earlier section warning it fails on this repo. Now routes through the REST PATCH workaround consistently.
- **review-pr**: replaces an incorrect "detached worktree" instruction with the correct `gh api contents` recommendation and a proper `git worktree add` fallback.
- **address-review-comments**: adds handling for empty unresolved threads (stop, don't invent work); adds a step requiring the agent to show the user any formatter-induced spillover and ask whether to bundle, split into a separate commit, or revert.
- All three agents now reference the committed "Known repo quirks" section in `AGENTS.md` instead of a local `/memories/repo/` note that other developers/agents wouldn't have.

## How to test

These are documentation/configuration files — no runtime code changes. Review the diffs for accuracy and clarity. You can verify:
- `ls -la .github/copilot-instructions.md` shows a symlink → `../AGENTS.md`
- `git ls-files --stage .github/copilot-instructions.md` shows mode `120000`
- Links in `AGENTS.md` resolve on github.com from both the root and the `.github/` directory

## How can we measure success?

- The GitHub-hosted Copilot agent follows repo conventions when assigned to issues on this repo.
- Agent workflows (`create-pr`, `review-pr`, `address-review-comments`) correctly use the REST API workaround for PR body updates instead of the broken `gh pr edit --body-file`.
- New contributors and agents can discover the agent-customization file structure from `AGENTS.md`.

## Have we considered potential risks?

- **Symlink on Windows**: a contributor with `core.symlinks=false` would see a text file containing the path `../AGENTS.md` instead of its contents — annoying but harmless, and no current contributors use Windows.
- **No runtime code changes**: zero risk to pipeline behaviour.
