### PR TITLE
Reduce Wikidata SPARQL chunk size to fix timeout failures

### DIFF
--- a/catalogue_graph/src/graph/sources/wikidata/linked_ontology_source.py
+++ b/catalogue_graph/src/graph/sources/wikidata/linked_ontology_source.py
@@ -15,7 +15,7 @@ from .sparql_query_builder import SparqlQueryBuilder, WikidataEdgeQueryType
 
 logger = structlog.get_logger(__name__)
 
-SPARQL_ITEMS_CHUNK_SIZE = 400
+SPARQL_ITEMS_CHUNK_SIZE = 200
 
 WIKIDATA_ID_PREFIX = "http://www.wikidata.org/entity/"
 


### PR DESCRIPTION
## What does this change?

Reduces `SPARQL_ITEMS_CHUNK_SIZE` from 400 to 200 in the Wikidata linked ontology source.

We've been seeing consistent failures in the Wikidata concepts transformer — the SPARQL client's backoff retries exhaust all attempts and the service dies. The root cause is that Wikidata's Blazegraph backend is under increasing load pressure and queries with 400 items (plus the label service) now regularly exceed the 60-second query deadline. Retrying the same oversized query doesn't help because the timeout is deterministic, not transient.

Halving the chunk size means each SPARQL query processes fewer items, keeping execution well within Wikidata's time budget. This trades some throughput for reliability.

## How to test

- Rerun the step and wait 👀

## How can we measure success?

- The Wikidata extraction steps complete reliably without exhausting backoff retries.
- No increase in 429 or 500 errors from the SPARQL endpoint in CloudWatch/logs.

## Have we considered potential risks?

- **Throughput**: Smaller chunks mean more HTTP round-trips, so total wall-clock time for a full extraction will increase slightly. Given the parallelism (4 concurrent queries), the impact should be modest.
- **Rate limits**: More requests could increase the chance of hitting Wikidata's per-minute rate limit, but each request is cheaper so we stay within the 60-second processing budget per 60 seconds.
- This is a safe, low-risk change — if it's insufficient we can reduce further or pursue query restructuring as a follow-up.
