### PR TITLE
switch to POST from GET to get around response size limit

### DIFF
--- a/catalogue_graph/src/graph/sources/wikidata/sparql_client.py
+++ b/catalogue_graph/src/graph/sources/wikidata/sparql_client.py
@@ -100,7 +100,7 @@ class WikidataSparqlClient:
 
         try:
             results: list[dict] = r.json()["results"]["bindings"]
-        except (ValueError, KeyError) as e:
+        except (ValueError, KeyError, TypeError) as e:
             raise Exception(
                 f"SPARQL query returned invalid JSON (status {r.status_code}): "
                 f"{r.content[:500].decode('utf-8', errors='replace')}"

--- a/catalogue_graph/src/graph/sources/wikidata/sparql_client.py
+++ b/catalogue_graph/src/graph/sources/wikidata/sparql_client.py
@@ -69,9 +69,9 @@ class WikidataSparqlClient:
 
         # Use a semaphore to throttle the number of parallel requests
         with self.parallel_query_semaphore:
-            r = requests.get(
+            r = requests.post(
                 WIKIDATA_SPARQL_URL,
-                params={"format": "json", "query": query},
+                data={"format": "json", "query": query},
                 headers={"User-Agent": self._get_user_agent_header()},
             )
 
@@ -98,5 +98,11 @@ class WikidataSparqlClient:
         elif r.status_code != 200:
             raise Exception(r.content)
 
-        results: list[dict] = r.json()["results"]["bindings"]
+        try:
+            results: list[dict] = r.json()["results"]["bindings"]
+        except (ValueError, KeyError) as e:
+            raise Exception(
+                f"SPARQL query returned invalid JSON (status {r.status_code}): "
+                f"{r.content[:500].decode('utf-8', errors='replace')}"
+            ) from e
         return results

--- a/catalogue_graph/tests/conftest.py
+++ b/catalogue_graph/tests/conftest.py
@@ -43,6 +43,7 @@ def test(monkeypatch: MonkeyPatch) -> Generator[Any, Any, Any]:
     monkeypatch.setattr("boto3.client", mock_boto3_client)
     monkeypatch.setattr("requests.request", MockRequest.request)
     monkeypatch.setattr("requests.get", MockRequest.get)
+    monkeypatch.setattr("requests.post", MockRequest.post)
     monkeypatch.setattr("smart_open.open", MockSmartOpen.open)
     monkeypatch.setattr("elasticsearch.Elasticsearch", MockElasticsearchClient)
     monkeypatch.setattr("elasticsearch.helpers.bulk", MockElasticsearchClient.bulk)

--- a/catalogue_graph/tests/graph/sources/test_wikidata_concepts_source.py
+++ b/catalogue_graph/tests/graph/sources/test_wikidata_concepts_source.py
@@ -39,7 +39,7 @@ def _add_mock_wikidata_requests(
             load_fixture(f"wikidata_linked_loc/{query_type}_response.json")
         )
         MockRequest.mock_response(
-            method="GET", url=WIKIDATA_SPARQL_URL, params=params, json_data=response
+            method="POST", url=WIKIDATA_SPARQL_URL, body=params, json_data=response
         )
 
 

--- a/catalogue_graph/tests/graph/steps/test_extractor.py
+++ b/catalogue_graph/tests/graph/steps/test_extractor.py
@@ -59,10 +59,10 @@ LOC_NAMES_SOURCE_MOCK_RESPONSE: MockResponseInput = {
 }
 
 WIKIDATA_LINKED_LOC_SOURCE_MOCK_RESPONSE: MockResponseInput = {
-    "method": "GET",
+    "method": "POST",
     "url": WIKIDATA_SPARQL_URL,
     "status_code": 200,
-    "params": {
+    "body": {
         "format": "json",
         "query": "SELECT ?item WHERE { ?item wdt:P244 ?locId. }",
     },
@@ -71,10 +71,10 @@ WIKIDATA_LINKED_LOC_SOURCE_MOCK_RESPONSE: MockResponseInput = {
 }
 
 WIKIDATA_LINKED_MESH_SOURCE_MOCK_RESPONSE: MockResponseInput = {
-    "method": "GET",
+    "method": "POST",
     "url": WIKIDATA_SPARQL_URL,
     "status_code": 200,
-    "params": {
+    "body": {
         "format": "json",
         "query": "SELECT ?item WHERE { ?item wdt:P486 ?meshId. }",
     },

--- a/catalogue_graph/tests/mocks.py
+++ b/catalogue_graph/tests/mocks.py
@@ -281,11 +281,12 @@ class MockRequestExpectation(TypedDict):
     data: dict | str | None
 
 
-class MockResponseInput(TypedDict):
+class MockResponseInput(TypedDict, total=False):
     method: str
     url: str
     status_code: int
     params: dict | None
+    body: dict | str | None
     content_bytes: bytes | None
     json_data: dict | None
 
@@ -364,6 +365,16 @@ class MockRequest:
         params: dict | None = None,
     ) -> MockResponse:
         return MockRequest.request("GET", url, stream, data, headers, params)
+
+    @staticmethod
+    def post(
+        url: str,
+        stream: bool = False,
+        data: dict | None = None,
+        headers: dict | None = None,
+        params: dict | None = None,
+    ) -> MockResponse:
+        return MockRequest.request("POST", url, stream, data, headers, params)
 
 
 class MockBulkResponse:


### PR DESCRIPTION
## What does this change?

Following https://github.com/wellcomecollection/catalogue-pipeline/pull/3396 it emerges that the failure of `Wikidata Linked LoC Concept Nodes` step is due to a decoding error 
```
"Expecting property name enclosed in double quotes: line 1415 column 6 (char 32768)"
```
This could be due to the server truncating the response to a query whose result has increased in size, eg. because the wiki entities include additional data

## How to test

Run the step again 

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? -->

