### PR TITLE
Wikidata source refactoring

### DIFF
--- a/catalogue_graph/src/graph/sources/wikidata/linked_ontology_edge_source.py
+++ b/catalogue_graph/src/graph/sources/wikidata/linked_ontology_edge_source.py
@@ -1,0 +1,56 @@
+from collections.abc import Generator
+
+from .linked_ontology_source import (
+    HAS_PARENT_EDGE_TYPES,
+    PEOPLE_RELATIONSHIP_EDGE_TYPES,
+    WikidataLinkedOntologySource,
+)
+from .sparql_query_builder import WikidataEdgeQueryType
+
+
+class WikidataLinkedOntologyEdgeSource(WikidataLinkedOntologySource):
+    """Streams Wikidata edges linked to a selected ontology."""
+
+    def _stream_all_edges_by_type(
+        self, edge_type: WikidataEdgeQueryType
+    ) -> Generator[dict]:
+        # Only keep edges whose start node was extracted by the current transformer
+        # (e.g. "wikidata_linked_loc_concepts"), discarding edges from unrelated node types.
+        # (This makes the Wikidata edge transformer dependent on the node transformer,
+        # so we need to make sure that the node transformer always runs first.)
+        for edge in super()._stream_all_edges_by_type(edge_type):
+            if self._is_id_valid_for_transformer(
+                edge["from_id"], self.event.transformer_type
+            ):
+                yield edge
+
+    def stream_raw(self) -> Generator[tuple[dict, WikidataEdgeQueryType]]:
+        """
+        Stream edges for the selected `linked_ontology` and `node_type`. Yield tuples of (edge_dict, edge_type).
+        """
+
+        # SAME_AS edges map a Wikidata ID to its equivalent in the linked ontology (LoC/MeSH).
+        for edge in self._stream_all_edges_by_type(self.same_as_edge_type):
+            # Only include edges where the target ID belongs to the current `node_type` in the linked ontology.
+            # For example, when processing "loc_names", skip edges pointing to LoC IDs classified as locations/concepts.
+            # This also filters out invalid linked IDs (of which there are several thousand).
+            if self._is_id_valid_for_transformer(
+                edge["to_id"], self.linked_transformer
+            ):
+                yield edge, self.same_as_edge_type
+
+        edge_types: list[WikidataEdgeQueryType] = [
+            *HAS_PARENT_EDGE_TYPES,
+            "has_industry",
+            "has_founder",
+        ]
+        if self.node_type == "names":
+            edge_types += ["has_field_of_work", *PEOPLE_RELATIONSHIP_EDGE_TYPES]
+
+        # Remaining edges are internal to Wikidata (both endpoints are Wikidata nodes).
+        for edge_type in edge_types:
+            for edge in self._stream_all_edges_by_type(edge_type):
+                # Keep only edges whose target is a known Wikidata node (extracted by any wikidata transformer,
+                # regardless of `node_type`).
+                if self._is_id_valid_for_ontology(edge["to_id"], "wikidata"):
+                    yield edge, edge_type

--- a/catalogue_graph/src/graph/sources/wikidata/linked_ontology_node_source.py
+++ b/catalogue_graph/src/graph/sources/wikidata/linked_ontology_node_source.py
@@ -1,0 +1,55 @@
+from collections.abc import Generator
+
+from .linked_ontology_source import HAS_PARENT_EDGE_TYPES, WikidataLinkedOntologySource
+from .sparql_query_builder import SparqlQueryBuilder
+
+
+class WikidataLinkedOntologyNodeSource(WikidataLinkedOntologySource):
+    """Streams Wikidata nodes linked to a selected ontology."""
+
+    def _stream_filtered_wikidata_ids(self) -> Generator[str]:
+        """Streams all Wikidata IDs to be processed as nodes given the selected `node_type`."""
+        seen = set()
+
+        # Retrieve all SAME_AS edges connecting Wikidata IDs with IDs from the linked ontology.
+        for edge in self._stream_all_edges_by_type(self.same_as_edge_type):
+            wikidata_id, linked_id = edge["from_id"], edge["to_id"]
+            is_linked_id_valid = self._is_id_valid_for_ontology(
+                linked_id, self.linked_ontology
+            )
+
+            # Deduplicate, since a given Wikidata ID can appear in more than one edge.
+            if is_linked_id_valid and wikidata_id not in seen:
+                # Add Wikidata ID to `seen` regardless of whether it's classified under the selected node type
+                # to make sure it is not processed again as a parent below.
+                seen.add(wikidata_id)
+
+                # Verify that the linked ID is valid by checking that it was processed by the relevant transformer.
+                if self._is_id_valid_for_transformer(
+                    linked_id, self.linked_transformer
+                ):
+                    yield wikidata_id
+
+        # Yield all unseen parents of the nodes yielded above. All parents are categorised as _concepts_,
+        # no matter whether their children are concepts, names, or locations.
+        if self.node_type == "concepts":
+            for edge_type in HAS_PARENT_EDGE_TYPES:
+                for edge in self._stream_all_edges_by_type(edge_type):
+                    parent_wikidata_id = edge["to_id"]
+                    if parent_wikidata_id not in seen:
+                        seen.add(parent_wikidata_id)
+                        yield parent_wikidata_id
+
+    def stream_raw(self) -> Generator[dict]:
+        """
+        Extract nodes via the following steps:
+            1. Stream raw edges and extract Wikidata IDs from them.
+            2. Split the extracted IDs into chunks. For each chunk, run a SPARQL query to retrieve all the corresponding
+            Wikidata fields required to create a node.
+        """
+
+        def build_items_query(wikidata_ids: list[str]) -> str:
+            return SparqlQueryBuilder.get_items_query(wikidata_ids, self.node_type)
+
+        all_ids = self._stream_filtered_wikidata_ids()
+        yield from self.client.run_query_in_parallel(all_ids, build_items_query)

--- a/catalogue_graph/src/graph/sources/wikidata/linked_ontology_source.py
+++ b/catalogue_graph/src/graph/sources/wikidata/linked_ontology_source.py
@@ -1,25 +1,25 @@
-from collections.abc import Callable, Generator, Iterator
+from abc import ABC, abstractmethod
+from collections.abc import Generator
 from functools import lru_cache
-from typing import cast
+from typing import Any, cast
 
 import structlog
 
 from core.source import BaseSource
 from models.events import ExtractorEvent
-from utils.ontology import get_extracted_ids, is_id_in_ontology
-from utils.streaming import process_stream_in_parallel
+from utils.ontology import (
+    is_id_extracted_for_ontology,
+    is_id_extracted_for_transformer,
+)
 from utils.types import NodeType, OntologyType, TransformerType
 
-from .sparql_client import SPARQL_MAX_PARALLEL_QUERIES, WikidataSparqlClient
+from .sparql_client import WikidataSparqlClient
 from .sparql_query_builder import SparqlQueryBuilder, WikidataEdgeQueryType
 
 logger = structlog.get_logger(__name__)
 
-SPARQL_ITEMS_CHUNK_SIZE = 400
-
-WIKIDATA_ID_PREFIX = "http://www.wikidata.org/entity/"
-
-PEOPLE_RELATIONSHIP_TYPES: list[WikidataEdgeQueryType] = [
+HAS_PARENT_EDGE_TYPES: list[WikidataEdgeQueryType] = ["instance_of", "subclass_of"]
+PEOPLE_RELATIONSHIP_EDGE_TYPES: list[WikidataEdgeQueryType] = [
     "has_father",
     "has_mother",
     "has_sibling",
@@ -27,18 +27,7 @@ PEOPLE_RELATIONSHIP_TYPES: list[WikidataEdgeQueryType] = [
     "has_child",
 ]
 
-
-def _parallelise_sparql_requests(
-    items: Iterator, run_sparql_query: Callable[[list], list]
-) -> Generator:
-    """Accept an `items` generator and a `run_sparql_query` method. Split `items` into chunks and apply
-    `run_sparql_query` to each chunk. Return a single generator of results."""
-    yield from process_stream_in_parallel(
-        items,
-        run_sparql_query,
-        SPARQL_ITEMS_CHUNK_SIZE,
-        SPARQL_MAX_PARALLEL_QUERIES,
-    )
+WIKIDATA_ID_PREFIX = "http://www.wikidata.org/entity/"
 
 
 def extract_wikidata_id(item: dict, key: str = "item") -> str | None:
@@ -60,10 +49,10 @@ def extract_wikidata_id(item: dict, key: str = "item") -> str | None:
     return None
 
 
-class WikidataLinkedOntologySource(BaseSource):
+class WikidataLinkedOntologySource(BaseSource, ABC):
     """
     A source for streaming selected Wikidata nodes/edges. There are _many_ Wikidata items, so we cannot store all of
-    them in the graph. Instead, we only include items which reference an id from a selected linked ontology
+    them in the graph. Instead, we only include items which reference an ID from a selected linked ontology
     (LoC or MeSH) and their parents.
 
     Wikidata puts strict limits on the resources which can be consumed by a single query, and queries which include
@@ -82,14 +71,18 @@ class WikidataLinkedOntologySource(BaseSource):
         self.linked_ontology = cast(OntologyType, self.linked_transformer.split("_")[0])
         self.node_type = cast(NodeType, self.linked_transformer.split("_")[-1])
 
+        self.same_as_edge_type = cast(
+            WikidataEdgeQueryType, f"same_as_{self.linked_ontology}"
+        )
+
     @lru_cache
     def _get_all_ids(self) -> list[str]:
         """
-        Return all Wikidata ids corresponding to Wikidata items referencing the selected linked ontology.
-        All ids are returned, no matter whether we categorise them as concepts, names, or locations.
+        Return the IDs of all Wikidata items which reference a node from the selected linked ontology.
+        All IDs are returned, regardless of whether we categorise them as concepts, names, or locations.
         """
         logger.info(
-            "Retrieving Wikidata ids linked to ontology",
+            "Retrieving Wikidata IDs linked to ontology",
             linked_ontology=self.linked_ontology,
         )
         ids_query = SparqlQueryBuilder.get_all_ids_query(self.linked_ontology)
@@ -100,38 +93,35 @@ class WikidataLinkedOntologySource(BaseSource):
         all_ids = set(extract_wikidata_id(item) for item in id_items)
         all_valid_ids = [i for i in all_ids if i is not None]
 
-        logger.info("Retrieved Wikidata ids", count=len(all_valid_ids))
+        logger.info("Retrieved Wikidata IDs", count=len(all_valid_ids))
         return list(all_valid_ids)
-
-    def _get_wikidata_items(self, wikidata_ids: list[str]) -> list:
-        query = SparqlQueryBuilder.get_items_query(wikidata_ids, self.node_type)
-        return self.client.run_query(query)
 
     def _stream_all_edges_by_type(
         self, edge_type: WikidataEdgeQueryType
     ) -> Generator[dict]:
         """
-        Given an `edge_type`, return a generator of all edges starting from all Wikidata items linking to the selected
-        ontology.
+        Return a generator of all edges of the given `edge_type` for Wikidata items referencing the selected ontology.
 
         Edges are extracted via the following steps:
-            1. Run a SPARQL query which retrieves _all_ Wikidata items referencing an id from the linked ontology.
-            2. Split the returned ids into chunks. For each chunk, run a second SPARQL query to retrieve the requested
-            edges for all ids in the chunk. (It is possible to modify the query in step 1 to return the edges directly,
-            but this makes the query unreliable - sometimes it times out or returns invalid JSON. Getting the edges
-            in chunks is much slower, but it works every time.)
+            1. Run a SPARQL query which retrieves _all_ Wikidata items referencing an ID from the linked ontology.
+            2. Split the returned IDs into chunks and run a second SPARQL query per chunk to retrieve the requested
+            edges. (It is possible to modify the query in step 1 to return the edges directly, but this makes the
+            query unreliable - sometimes it times out or returns invalid JSON. Getting the edges in chunks is much
+            slower, but it works every time.)
         """
+        logger.info("Streaming edges from Wikidata", edge_type=edge_type)
 
-        def get_edges(wikidata_ids: list[str]) -> list[dict]:
-            query = SparqlQueryBuilder.get_edge_query(wikidata_ids, edge_type)
-            return self.client.run_query(query)
+        def build_edge_query(wikidata_ids: list[str]) -> str:
+            return SparqlQueryBuilder.get_edge_query(wikidata_ids, edge_type)
 
         all_ids = self._get_all_ids()
-        for raw_mapping in _parallelise_sparql_requests(iter(all_ids), get_edges):
+        for raw_mapping in self.client.run_query_in_parallel(
+            iter(all_ids), build_edge_query
+        ):
             from_id = extract_wikidata_id(raw_mapping, "fromItem")
 
-            # The 'toItem' ids of SAME_AS edges are MeSH/LoC ids, so we take the raw value instead of extracting
-            # the ids via the `extract_wikidata_id` function
+            # The 'toItem' IDs of SAME_AS edges are MeSH/LoC IDs, so we take the raw value instead of extracting
+            # the IDs via the `extract_wikidata_id` function
             if edge_type in ("same_as_mesh", "same_as_loc"):
                 to_id = raw_mapping["toItem"]["value"]
             else:
@@ -140,145 +130,19 @@ class WikidataLinkedOntologySource(BaseSource):
             if from_id is not None and to_id is not None:
                 yield {"from_id": from_id, "to_id": to_id}
 
-    def _stream_all_same_as_edges(self) -> Generator[dict]:
-        if self.linked_ontology == "loc":
-            yield from self._stream_all_edges_by_type("same_as_loc")
-        elif self.linked_ontology == "mesh":
-            yield from self._stream_all_edges_by_type("same_as_mesh")
-
-    def _stream_all_has_parent_edges(self) -> Generator[dict]:
-        yield from self._stream_all_edges_by_type("instance_of")
-        yield from self._stream_all_edges_by_type("subclass_of")
-
-    def _stream_all_has_founder_edges(self) -> Generator[dict]:
-        yield from self._stream_all_edges_by_type("has_founder")
-
-    def _stream_all_has_industry_edges(self) -> Generator[dict]:
-        yield from self._stream_all_edges_by_type("has_industry")
-
-    def is_valid_wikidata_id(self, wikidata_id: str) -> bool:
-        return is_id_in_ontology(
-            wikidata_id, "wikidata", self.event.pipeline_date, self.event.environment
+    def _is_id_valid_for_ontology(self, item_id: str, ontology: OntologyType) -> bool:
+        """Return `True` if the given ID is valid for the specified ontology."""
+        return is_id_extracted_for_ontology(
+            item_id, ontology, self.event.pipeline_date, self.event.environment
         )
 
-    def is_valid_linked_id(self, linked_id: str) -> bool:
-        return is_id_in_ontology(
-            linked_id,
-            self.linked_ontology,
-            self.event.pipeline_date,
-            self.event.environment,
+    def _is_id_valid_for_transformer(
+        self, item_id: str, transformer_type: TransformerType
+    ) -> bool:
+        """Return `True` if the given ID was extracted by the specified transformer."""
+        return is_id_extracted_for_transformer(
+            item_id, transformer_type, self.event.pipeline_date, self.event.environment
         )
 
-    def _stream_filtered_wikidata_ids(self) -> Generator[str]:
-        """Streams all wikidata ids to be processed as nodes given the selected `node_type`."""
-        seen = set()
-
-        # Stream all SAME_AS edges and extract Wikidata ids from them, making sure to deduplicate
-        # (a given Wikidata id can appear in more than one edge).
-        for edge in self._stream_all_same_as_edges():
-            wikidata_id, linked_id = edge["from_id"], edge["to_id"]
-            if self.is_valid_linked_id(linked_id) and wikidata_id not in seen:
-                # Add Wikidata id to `seen` no matter if it's part of the selected node type
-                # to make sure it is not processed again as a parent below.
-                seen.add(wikidata_id)
-
-                if linked_id in get_extracted_ids(
-                    self.linked_transformer,
-                    self.event.pipeline_date,
-                    self.event.environment,
-                ):
-                    yield wikidata_id
-
-        # Stream HAS_PARENT edges and extract Wikidata ids of all parents (children are streamed above). Filter out
-        # all parent ids which reference a linked ontology ids. All remaining ids belong to items which do not
-        # reference a MeSH/LoC id. We categorise all of them as _concepts_, no matter whether the children are
-        # categorised as concepts, names, or locations.
-        if self.node_type == "concepts":
-            for edge in self._stream_all_has_parent_edges():
-                parent_wikidata_id = edge["to_id"]
-                if parent_wikidata_id not in seen:
-                    seen.add(parent_wikidata_id)
-                    yield parent_wikidata_id
-
-    def _stream_raw_edges(self) -> Generator[dict]:
-        """
-        Stream SAME_AS edges followed by HAS_PARENT edges for the selected `linked_ontology` and `node_type`.
-        """
-        logger.info("Streaming SAME_AS edges")
-        streamed_wikidata_ids = set()
-        for edge in self._stream_all_same_as_edges():
-            # Filter for mappings which are part of the selected `node_type`, as determined by the linked ontology.
-            # For example, if we are streaming Wikidata 'names' edges linked to LoC ids but the LoC id linked to some
-            # Wikidata id is classified as a 'location', we skip it. This filtering process also removes mappings which
-            # include invalid LoC ids (of which there are several thousand).
-
-            if edge["to_id"] in get_extracted_ids(
-                self.linked_transformer,
-                self.event.pipeline_date,
-                self.event.environment,
-            ):
-                streamed_wikidata_ids.add(edge["from_id"])
-                yield {**edge, "type": "SAME_AS"}
-
-        logger.info("Streaming HAS_PARENT edges")
-        for edge in self._stream_all_has_parent_edges():
-            # Only include an edge if its `from_id` was already streamed in a SAME_AS edge, indicating that
-            # the child item belongs under the selected `node_type`.
-            if edge["from_id"] in streamed_wikidata_ids:
-                streamed_wikidata_ids.add(edge["to_id"])
-                yield {**edge, "type": "HAS_PARENT"}
-
-        logger.info("Streaming HAS_INDUSTRY edges")
-        for edge in self._stream_all_has_industry_edges():
-            if edge["from_id"] in streamed_wikidata_ids and self.is_valid_wikidata_id(
-                edge["to_id"]
-            ):
-                yield {**edge, "type": "HAS_INDUSTRY"}
-
-        logger.info("Streaming HAS_FOUNDER edges")
-        for edge in self._stream_all_has_founder_edges():
-            if edge["from_id"] in streamed_wikidata_ids and self.is_valid_wikidata_id(
-                edge["to_id"]
-            ):
-                yield {**edge, "type": "HAS_FOUNDER"}
-
-        # The following edges only apply to people (SourceName) nodes
-        if self.node_type == "names":
-            logger.info("Streaming HAS_FIELD_OF_WORK edges")
-            for edge in self._stream_all_edges_by_type("has_field_of_work"):
-                # Only include an edge if its `to_id` has a corresponding concept node in the graph
-                if edge[
-                    "from_id"
-                ] in streamed_wikidata_ids and self.is_valid_wikidata_id(edge["to_id"]):
-                    yield {**edge, "type": "HAS_FIELD_OF_WORK"}
-
-            logger.info("Streaming RELATED_TO edges")
-            for relationship_type in PEOPLE_RELATIONSHIP_TYPES:
-                for edge in self._stream_all_edges_by_type(relationship_type):
-                    if (
-                        edge["from_id"] in streamed_wikidata_ids
-                        and edge["to_id"] in streamed_wikidata_ids
-                    ):
-                        yield {
-                            **edge,
-                            "type": "RELATED_TO",
-                            "subtype": relationship_type,
-                        }
-
-    def _stream_raw_nodes(self) -> Generator[dict]:
-        """
-        Extract nodes via the following steps:
-            1. Stream raw edges and extract Wikidata ids from them.
-            2. Split the extracted ids into chunks. For each chunk, run a SPARQL query to retrieve all the corresponding
-            Wikidata fields required to create a node.
-        """
-        all_ids = self._stream_filtered_wikidata_ids()
-        yield from _parallelise_sparql_requests(all_ids, self._get_wikidata_items)
-
-    def stream_raw(self) -> Generator[dict]:
-        if self.event.entity_type == "nodes":
-            return self._stream_raw_nodes()
-        elif self.event.entity_type == "edges":
-            return self._stream_raw_edges()
-        else:
-            raise ValueError(f"Invalid entity type: {self.event.entity_type}")
+    @abstractmethod
+    def stream_raw(self) -> Generator[Any]: ...

--- a/catalogue_graph/src/graph/sources/wikidata/sparql_client.py
+++ b/catalogue_graph/src/graph/sources/wikidata/sparql_client.py
@@ -2,12 +2,14 @@ import os
 import threading
 import time
 import typing
+from collections.abc import Callable, Generator, Iterator
 
 import backoff
 import requests
 import structlog
 
 from config import WIKIDATA_SPARQL_URL
+from utils.streaming import process_stream_in_parallel
 
 logger = structlog.get_logger(__name__)
 
@@ -17,6 +19,7 @@ logger = structlog.get_logger(__name__)
 SPARQL_MAX_PARALLEL_QUERIES = 4
 SPARQL_REQUESTS_BACKOFF_RETRIES = int(os.environ.get("REQUESTS_BACKOFF_RETRIES", "5"))
 SPARQL_REQUESTS_BACKOFF_INTERVAL = 30
+SPARQL_ITEMS_CHUNK_SIZE = 400
 
 
 def on_request_backoff(backoff_details: typing.Any) -> None:
@@ -106,3 +109,23 @@ class WikidataSparqlClient:
                 f"{r.content[:500].decode('utf-8', errors='replace')}"
             ) from e
         return results
+
+    def run_query_in_parallel(
+        self, items: Iterator, build_query: Callable[[list[str]], str]
+    ) -> Generator:
+        """
+        Accept an `items` generator and a `build_query` function that constructs a SPARQL query string
+        for a given chunk of IDs. Split `items` into chunks, build a query for each chunk, run it via
+        `self.run_query`, and return a single generator of results.
+        """
+
+        def run_sparql_query(chunk: list[str]) -> list[dict]:
+            query = build_query(chunk)
+            return self.run_query(query)
+
+        yield from process_stream_in_parallel(
+            items,
+            run_sparql_query,
+            SPARQL_ITEMS_CHUNK_SIZE,
+            SPARQL_MAX_PARALLEL_QUERIES,
+        )

--- a/catalogue_graph/src/graph/sources/wikidata/sparql_query_builder.py
+++ b/catalogue_graph/src/graph/sources/wikidata/sparql_query_builder.py
@@ -148,32 +148,25 @@ class SparqlQueryBuilder:
         """
         ids_clause = " ".join([f"wd:{wikidata_id}" for wikidata_id in sorted(item_ids)])
 
-        if edge_type == "same_as_loc":
-            property_path = "p:P244/ps:P244"
-        elif edge_type == "same_as_mesh":
-            property_path = "p:P486/ps:P486"
-        elif edge_type == "instance_of":
-            property_path = "wdt:P31"
-        elif edge_type == "subclass_of":
-            property_path = "wdt:P279"
-        elif edge_type == "has_field_of_work":
-            property_path = "wdt:P101"
-        elif edge_type == "has_founder":
-            property_path = "wdt:P112"
-        elif edge_type == "has_industry":
-            property_path = "wdt:P452"
-        elif edge_type == "has_father":
-            property_path = "wdt:P22"
-        elif edge_type == "has_mother":
-            property_path = "wdt:P25"
-        elif edge_type == "has_sibling":
-            property_path = "wdt:P3373"
-        elif edge_type == "has_spouse":
-            property_path = "wdt:P26"
-        elif edge_type == "has_child":
-            property_path = "wdt:P40"
-        else:
+        edge_type_to_property_path: dict[WikidataEdgeQueryType, str] = {
+            "same_as_loc": "p:P244/ps:P244",
+            "same_as_mesh": "p:P486/ps:P486",
+            "instance_of": "wdt:P31",
+            "subclass_of": "wdt:P279",
+            "has_field_of_work": "wdt:P101",
+            "has_founder": "wdt:P112",
+            "has_industry": "wdt:P452",
+            "has_father": "wdt:P22",
+            "has_mother": "wdt:P25",
+            "has_sibling": "wdt:P3373",
+            "has_spouse": "wdt:P26",
+            "has_child": "wdt:P40",
+        }
+
+        if edge_type not in edge_type_to_property_path:
             raise ValueError(f"Unknown edge type: {edge_type}")
+
+        property_path = edge_type_to_property_path[edge_type]
 
         query = f"""
             SELECT DISTINCT ?fromItem ?toItem

--- a/catalogue_graph/src/graph/transformers/wikidata/base_transformer.py
+++ b/catalogue_graph/src/graph/transformers/wikidata/base_transformer.py
@@ -1,0 +1,18 @@
+from graph.sources.wikidata.linked_ontology_edge_source import (
+    WikidataLinkedOntologyEdgeSource,
+)
+from graph.sources.wikidata.linked_ontology_node_source import (
+    WikidataLinkedOntologyNodeSource,
+)
+from graph.transformers.graph_transformer import GraphBaseTransformer
+from models.events import ExtractorEvent
+from utils.types import TransformerType
+
+
+class WikidataBaseTransformer(GraphBaseTransformer):
+    def __init__(self, linked_transformer: TransformerType, event: ExtractorEvent):
+        super().__init__()
+        if event.entity_type == "nodes":
+            self.source = WikidataLinkedOntologyNodeSource(linked_transformer, event)
+        else:
+            self.source = WikidataLinkedOntologyEdgeSource(linked_transformer, event)

--- a/catalogue_graph/src/graph/transformers/wikidata/concepts_transformer.py
+++ b/catalogue_graph/src/graph/transformers/wikidata/concepts_transformer.py
@@ -1,8 +1,9 @@
 from collections.abc import Generator
 
-from graph.sources.wikidata.linked_ontology_source import WikidataLinkedOntologySource
-from graph.transformers.graph_transformer import GraphBaseTransformer
-from models.events import ExtractorEvent
+from graph.sources.wikidata.linked_ontology_source import (
+    HAS_PARENT_EDGE_TYPES,
+)
+from graph.sources.wikidata.sparql_query_builder import WikidataEdgeQueryType
 from models.graph_edge import (
     BaseEdge,
     SourceConceptHasFieldOfWork,
@@ -12,15 +13,12 @@ from models.graph_edge import (
     SourceConceptSameAsAttributes,
 )
 from models.graph_node import SourceConcept
-from utils.types import TransformerType
 
+from .base_transformer import WikidataBaseTransformer
 from .raw_concept import RawWikidataConcept
 
 
-class WikidataConceptsTransformer(GraphBaseTransformer):
-    def __init__(self, linked_transformer: TransformerType, event: ExtractorEvent):
-        self.source = WikidataLinkedOntologySource(linked_transformer, event)
-
+class WikidataConceptsTransformer(WikidataBaseTransformer):
     def transform_node(self, raw_node: dict) -> SourceConcept | None:
         raw_concept = RawWikidataConcept(raw_node)
 
@@ -35,36 +33,36 @@ class WikidataConceptsTransformer(GraphBaseTransformer):
             description=raw_concept.description,
         )
 
-    def extract_edges(self, raw_node: dict) -> Generator[BaseEdge]:
-        if raw_node["type"] == "SAME_AS":
+    def extract_edges(
+        self, raw_edge: tuple[dict, WikidataEdgeQueryType]
+    ) -> Generator[BaseEdge]:
+        edge, edge_type = raw_edge
+        if edge_type in ("same_as_loc", "same_as_mesh"):
             edge_attributes = SourceConceptSameAsAttributes(source="wikidata")
             yield SourceConceptSameAs(
-                from_id=raw_node["from_id"],
-                to_id=raw_node["to_id"],
+                from_id=edge["from_id"],
+                to_id=edge["to_id"],
                 attributes=edge_attributes,
             )
             yield SourceConceptSameAs(
-                from_id=raw_node["to_id"],
-                to_id=raw_node["from_id"],
+                from_id=edge["to_id"],
+                to_id=edge["from_id"],
                 attributes=edge_attributes,
             )
-        elif raw_node["type"] == "HAS_PARENT":
+        elif edge_type in HAS_PARENT_EDGE_TYPES:
             yield SourceConceptHasParent(
-                from_id=raw_node["from_id"],
-                to_id=raw_node["to_id"],
+                from_id=edge["from_id"],
+                to_id=edge["to_id"],
             )
-        elif raw_node["type"] == "HAS_FOUNDER":
+        elif edge_type == "has_founder":
             yield SourceConceptHasFounder(
-                from_id=raw_node["from_id"],
-                to_id=raw_node["to_id"],
+                from_id=edge["from_id"],
+                to_id=edge["to_id"],
             )
-        elif (
-            raw_node["type"] == "HAS_INDUSTRY"
-            or raw_node["type"] == "HAS_FIELD_OF_WORK"
-        ):
+        elif edge_type in ("has_industry", "has_field_of_work"):
             yield SourceConceptHasFieldOfWork(
-                from_id=raw_node["from_id"],
-                to_id=raw_node["to_id"],
+                from_id=edge["from_id"],
+                to_id=edge["to_id"],
             )
         else:
-            raise ValueError(f"Unknown edge type {raw_node['type']}")
+            raise ValueError(f"Unknown edge type {edge_type}")

--- a/catalogue_graph/src/graph/transformers/wikidata/locations_transformer.py
+++ b/catalogue_graph/src/graph/transformers/wikidata/locations_transformer.py
@@ -1,16 +1,10 @@
-from graph.sources.wikidata.linked_ontology_source import WikidataLinkedOntologySource
-from models.events import ExtractorEvent
 from models.graph_node import SourceLocation
-from utils.types import TransformerType
 
 from .concepts_transformer import WikidataConceptsTransformer
 from .raw_concept import RawWikidataLocation
 
 
 class WikidataLocationsTransformer(WikidataConceptsTransformer):
-    def __init__(self, linked_transformer: TransformerType, event: ExtractorEvent):
-        self.source = WikidataLinkedOntologySource(linked_transformer, event)
-
     def transform_node(self, raw_node: dict) -> SourceLocation | None:
         raw_concept = RawWikidataLocation(raw_node)
 

--- a/catalogue_graph/src/graph/transformers/wikidata/names_transformer.py
+++ b/catalogue_graph/src/graph/transformers/wikidata/names_transformer.py
@@ -1,23 +1,21 @@
 from collections.abc import Generator
 
-from graph.sources.wikidata.linked_ontology_source import WikidataLinkedOntologySource
-from models.events import ExtractorEvent
+from graph.sources.wikidata.linked_ontology_source import (
+    PEOPLE_RELATIONSHIP_EDGE_TYPES,
+)
+from graph.sources.wikidata.sparql_query_builder import WikidataEdgeQueryType
 from models.graph_edge import (
     BaseEdge,
     SourceNameRelatedTo,
     SourceNameRelatedToAttributes,
 )
 from models.graph_node import SourceName
-from utils.types import TransformerType
 
 from .concepts_transformer import WikidataConceptsTransformer
 from .raw_concept import RawWikidataName
 
 
 class WikidataNamesTransformer(WikidataConceptsTransformer):
-    def __init__(self, linked_transformer: TransformerType, event: ExtractorEvent):
-        self.source = WikidataLinkedOntologySource(linked_transformer, event)
-
     def transform_node(self, raw_node: dict) -> SourceName | None:
         raw_concept = RawWikidataName(raw_node)
 
@@ -32,15 +30,16 @@ class WikidataNamesTransformer(WikidataConceptsTransformer):
             place_of_birth=raw_concept.place_of_birth,
         )
 
-    def extract_edges(self, raw_node: dict) -> Generator[BaseEdge]:
-        if raw_node["type"] == "RELATED_TO":
-            attributes = SourceNameRelatedToAttributes(
-                relationship_type=raw_node["subtype"]
-            )
+    def extract_edges(
+        self, raw_edge: tuple[dict, WikidataEdgeQueryType]
+    ) -> Generator[BaseEdge]:
+        edge, edge_type = raw_edge
+        if edge_type in PEOPLE_RELATIONSHIP_EDGE_TYPES:
+            attributes = SourceNameRelatedToAttributes(relationship_type=edge_type)
             yield SourceNameRelatedTo(
-                from_id=raw_node["from_id"],
-                to_id=raw_node["to_id"],
+                from_id=edge["from_id"],
+                to_id=edge["to_id"],
                 attributes=attributes,
             )
         else:
-            yield from super().extract_edges(raw_node)
+            yield from super().extract_edges(raw_edge)

--- a/catalogue_graph/src/utils/ontology.py
+++ b/catalogue_graph/src/utils/ontology.py
@@ -40,7 +40,7 @@ def get_transformers_from_ontology(ontology: OntologyType) -> list[TransformerTy
 
 
 @lru_cache
-def get_extracted_ids(
+def get_ids_for_transformer(
     transformer: TransformerType, pipeline_date: str, environment: Environment
 ) -> set[str]:
     """Return all ids extracted as part of the specified transformer."""
@@ -59,15 +59,25 @@ def get_extracted_ids(
     return ids
 
 
-def is_id_in_ontology(
+def is_id_extracted_for_transformer(
+    item_id: str,
+    transformer: TransformerType,
+    pipeline_date: str,
+    environment: Environment,
+) -> bool:
+    """Return 'True' if the given ID was extracted by the specified transformer."""
+    return item_id in get_ids_for_transformer(transformer, pipeline_date, environment)
+
+
+def is_id_extracted_for_ontology(
     item_id: str,
     item_ontology: OntologyType,
     pipeline_date: str,
     environment: Environment,
 ) -> bool:
-    """Return 'True' if the given ID exists in the catalogue graph under the specified ontology."""
+    """Return 'True' if the given ID was extracted by any transformer under the specified ontology."""
     transformers = get_transformers_from_ontology(item_ontology)
     return any(
-        item_id in get_extracted_ids(t, pipeline_date, environment)
+        item_id in get_ids_for_transformer(t, pipeline_date, environment)
         for t in transformers
     )

--- a/catalogue_graph/tests/graph/sources/test_linked_ontology_edge_source.py
+++ b/catalogue_graph/tests/graph/sources/test_linked_ontology_edge_source.py
@@ -81,8 +81,9 @@ def _patch_stream_and_validators(
     monkeypatch.setattr(
         source,
         "_is_id_valid_for_transformer",
-        lambda item_id, transformer: item_id
-        in valid_for_transformer.get(transformer, set()),
+        lambda item_id, transformer: (
+            item_id in valid_for_transformer.get(transformer, set())
+        ),
     )
     monkeypatch.setattr(
         source,

--- a/catalogue_graph/tests/graph/sources/test_linked_ontology_edge_source.py
+++ b/catalogue_graph/tests/graph/sources/test_linked_ontology_edge_source.py
@@ -1,0 +1,243 @@
+"""Unit tests for WikidataLinkedOntologyEdgeSource filtering logic."""
+
+from collections.abc import Generator
+
+import pytest
+
+from graph.sources.wikidata.linked_ontology_edge_source import (
+    WikidataLinkedOntologyEdgeSource,
+)
+from graph.sources.wikidata.linked_ontology_source import WikidataLinkedOntologySource
+from graph.sources.wikidata.sparql_query_builder import WikidataEdgeQueryType
+from models.events import ExtractorEvent
+
+
+@pytest.fixture
+def concepts_source() -> WikidataLinkedOntologyEdgeSource:
+    return WikidataLinkedOntologyEdgeSource(
+        linked_transformer="loc_concepts",
+        event=ExtractorEvent(
+            pipeline_date="test",
+            environment="prod",
+            transformer_type="wikidata_linked_loc_concepts",
+            entity_type="edges",
+        ),
+    )
+
+
+@pytest.fixture
+def names_source() -> WikidataLinkedOntologyEdgeSource:
+    return WikidataLinkedOntologyEdgeSource(
+        linked_transformer="loc_names",
+        event=ExtractorEvent(
+            pipeline_date="test",
+            environment="prod",
+            transformer_type="wikidata_linked_loc_names",
+            entity_type="edges",
+        ),
+    )
+
+
+def _collect_streamed_edge_types(
+    source: WikidataLinkedOntologyEdgeSource,
+    monkeypatch: pytest.MonkeyPatch,
+) -> set[WikidataEdgeQueryType]:
+    """Call stream_raw with a no-op _stream_all_edges_by_type and return which edge types were requested."""
+    streamed: list[WikidataEdgeQueryType] = []
+
+    def mock_stream(
+        self: WikidataLinkedOntologyEdgeSource, edge_type: WikidataEdgeQueryType
+    ) -> Generator[dict]:
+        streamed.append(edge_type)
+        yield from []
+
+    monkeypatch.setattr(
+        WikidataLinkedOntologyEdgeSource, "_stream_all_edges_by_type", mock_stream
+    )
+    monkeypatch.setattr(source, "_is_id_valid_for_transformer", lambda *a: False)
+    monkeypatch.setattr(source, "_is_id_valid_for_ontology", lambda *a: True)
+
+    list(source.stream_raw())
+    return set(streamed)
+
+
+def _patch_stream_and_validators(
+    source: WikidataLinkedOntologySource,
+    monkeypatch: pytest.MonkeyPatch,
+    edges_by_type: dict[WikidataEdgeQueryType, list[dict]],
+    valid_for_transformer: dict[str, set[str]],
+    valid_for_ontology: dict[str, set[str]],
+) -> None:
+    """Patch _stream_all_edges_by_type and validators on a WikidataLinkedOntologySource."""
+
+    def mock_stream(
+        self: WikidataLinkedOntologySource, edge_type: WikidataEdgeQueryType
+    ) -> Generator[dict]:
+        yield from edges_by_type.get(edge_type, [])
+
+    monkeypatch.setattr(
+        WikidataLinkedOntologySource, "_stream_all_edges_by_type", mock_stream
+    )
+    monkeypatch.setattr(
+        source,
+        "_is_id_valid_for_transformer",
+        lambda item_id, transformer: item_id
+        in valid_for_transformer.get(transformer, set()),
+    )
+    monkeypatch.setattr(
+        source,
+        "_is_id_valid_for_ontology",
+        lambda item_id, ontology: item_id in valid_for_ontology.get(ontology, set()),
+    )
+
+
+def test_filters_edges_by_from_id(
+    concepts_source: WikidataLinkedOntologyEdgeSource,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only edges whose from_id is valid for the transformer are yielded."""
+    _patch_stream_and_validators(
+        concepts_source,
+        monkeypatch,
+        edges_by_type={
+            "instance_of": [
+                {"from_id": "Q1", "to_id": "Q2"},
+                {"from_id": "Q9", "to_id": "Q2"},  # Q9 not valid for transformer
+                {"from_id": "Q3", "to_id": "Q2"},
+            ],
+        },
+        valid_for_transformer={"wikidata_linked_loc_concepts": {"Q1", "Q3"}},
+        valid_for_ontology={"wikidata": {"Q1", "Q2", "Q3", "Q9"}},
+    )
+
+    result = list(concepts_source.stream_raw())
+    assert result == [
+        ({"from_id": "Q1", "to_id": "Q2"}, "instance_of"),
+        ({"from_id": "Q3", "to_id": "Q2"}, "instance_of"),
+    ]
+
+
+def test_no_edges_when_none_match_transformer(
+    concepts_source: WikidataLinkedOntologyEdgeSource,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Zero edges emitted when no from_ids are valid."""
+    _patch_stream_and_validators(
+        concepts_source,
+        monkeypatch,
+        edges_by_type={
+            "instance_of": [{"from_id": "Q99", "to_id": "Q2"}],
+        },
+        valid_for_transformer={},
+        valid_for_ontology={"wikidata": {"Q2"}},
+    )
+
+    assert list(concepts_source.stream_raw()) == []
+
+
+def test_same_as_edges_filtered_by_linked_transformer(
+    concepts_source: WikidataLinkedOntologyEdgeSource,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SAME_AS edges are only yielded if to_id is valid for the linked_transformer."""
+    _patch_stream_and_validators(
+        concepts_source,
+        monkeypatch,
+        edges_by_type={
+            "same_as_loc": [
+                {"from_id": "Q1", "to_id": "sh001"},  # valid concept
+                {"from_id": "Q1", "to_id": "n001"},  # name, not a concept
+            ],
+        },
+        valid_for_transformer={
+            "wikidata_linked_loc_concepts": {"Q1"},
+            "loc_names": {"n001"},
+            "loc_concepts": {"sh001"},
+        },
+        valid_for_ontology={"wikidata": {"Q1"}, "loc": {"n001", "sh001"}},
+    )
+
+    result = list(concepts_source.stream_raw())
+    assert result == [
+        ({"from_id": "Q1", "to_id": "sh001"}, "same_as_loc"),
+    ]
+
+
+def test_same_as_edge_type_derived_from_linked_ontology(
+    concepts_source: WikidataLinkedOntologyEdgeSource,
+) -> None:
+    """same_as_edge_type is 'same_as_loc' for a loc-linked source."""
+    assert concepts_source.same_as_edge_type == "same_as_loc"
+
+
+def test_internal_edges_filtered_by_wikidata_ontology(
+    concepts_source: WikidataLinkedOntologyEdgeSource,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Internal edges are only yielded if to_id is a known wikidata node."""
+    _patch_stream_and_validators(
+        concepts_source,
+        monkeypatch,
+        edges_by_type={
+            "instance_of": [
+                {"from_id": "Q1", "to_id": "Q2"},  # Q2 is known
+                {"from_id": "Q1", "to_id": "Q99"},  # Q99 is unknown
+            ],
+        },
+        valid_for_transformer={"wikidata_linked_loc_concepts": {"Q1"}},
+        valid_for_ontology={"wikidata": {"Q1", "Q2"}},
+    )
+
+    result = list(concepts_source.stream_raw())
+    assert result == [
+        ({"from_id": "Q1", "to_id": "Q2"}, "instance_of"),
+    ]
+
+
+def test_concepts_edge_types_exclude_names_only(
+    concepts_source: WikidataLinkedOntologyEdgeSource,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Concepts source does not stream has_field_of_work or people relationship edges."""
+    streamed = _collect_streamed_edge_types(concepts_source, monkeypatch)
+    names_only_types = {
+        "has_field_of_work",
+        "has_father",
+        "has_mother",
+        "has_sibling",
+        "has_spouse",
+        "has_child",
+    }
+    assert names_only_types.isdisjoint(streamed)
+
+
+def test_names_edge_types_include_field_of_work_and_relationships(
+    names_source: WikidataLinkedOntologyEdgeSource,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Names source includes has_field_of_work and people relationship edge types."""
+    streamed = _collect_streamed_edge_types(names_source, monkeypatch)
+    names_only_types = {
+        "has_field_of_work",
+        "has_father",
+        "has_mother",
+        "has_sibling",
+        "has_spouse",
+        "has_child",
+    }
+    assert names_only_types.issubset(streamed)
+
+
+def test_both_concepts_and_names_include_parent_and_founder_types(
+    concepts_source: WikidataLinkedOntologyEdgeSource,
+    names_source: WikidataLinkedOntologyEdgeSource,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both concepts and names always include parent, has_industry, and has_founder types."""
+    common_types = {"instance_of", "subclass_of", "has_industry", "has_founder"}
+    assert common_types.issubset(
+        _collect_streamed_edge_types(concepts_source, monkeypatch)
+    )
+    assert common_types.issubset(
+        _collect_streamed_edge_types(names_source, monkeypatch)
+    )

--- a/catalogue_graph/tests/graph/sources/test_linked_ontology_node_source.py
+++ b/catalogue_graph/tests/graph/sources/test_linked_ontology_node_source.py
@@ -1,0 +1,245 @@
+"""Unit tests for WikidataLinkedOntologyNodeSource._stream_filtered_wikidata_ids."""
+
+import pytest
+
+from graph.sources.wikidata.linked_ontology_node_source import (
+    WikidataLinkedOntologyNodeSource,
+)
+from models.events import ExtractorEvent
+from tests.graph.sources.test_linked_ontology_edge_source import (
+    _patch_stream_and_validators,
+)
+
+
+@pytest.fixture
+def concepts_source() -> WikidataLinkedOntologyNodeSource:
+    return WikidataLinkedOntologyNodeSource(
+        linked_transformer="loc_concepts",
+        event=ExtractorEvent(
+            pipeline_date="test",
+            environment="prod",
+            transformer_type="wikidata_linked_loc_concepts",
+            entity_type="nodes",
+        ),
+    )
+
+
+@pytest.fixture
+def names_source() -> WikidataLinkedOntologyNodeSource:
+    return WikidataLinkedOntologyNodeSource(
+        linked_transformer="loc_names",
+        event=ExtractorEvent(
+            pipeline_date="test",
+            environment="prod",
+            transformer_type="wikidata_linked_loc_names",
+            entity_type="nodes",
+        ),
+    )
+
+
+def test_yields_ids_with_valid_linked_ids(
+    concepts_source: WikidataLinkedOntologyNodeSource,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only Wikidata IDs whose linked_id passes both ontology and transformer checks are yielded."""
+    _patch_stream_and_validators(
+        concepts_source,
+        monkeypatch,
+        edges_by_type={
+            "same_as_loc": [
+                {"from_id": "Q1", "to_id": "sh001"},  # valid concept
+                {"from_id": "Q2", "to_id": "n001"},  # not valid for transformer
+                {"from_id": "Q3", "to_id": "sh002"},  # valid concept
+            ],
+        },
+        valid_for_transformer={"loc_concepts": {"sh001", "sh002"}},
+        valid_for_ontology={"loc": {"sh001", "n001", "sh002"}},
+    )
+
+    result = list(concepts_source._stream_filtered_wikidata_ids())
+    assert result == ["Q1", "Q3"]
+
+
+def test_skips_ids_with_invalid_linked_ontology_id(
+    concepts_source: WikidataLinkedOntologyNodeSource,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """IDs whose linked_id is not valid for the ontology at all are skipped."""
+    _patch_stream_and_validators(
+        concepts_source,
+        monkeypatch,
+        edges_by_type={
+            "same_as_loc": [
+                {"from_id": "Q1", "to_id": "invalid_id"},
+            ],
+        },
+        valid_for_transformer={"loc_concepts": set()},
+        valid_for_ontology={"loc": set()},  # nothing valid in ontology
+    )
+
+    assert list(concepts_source._stream_filtered_wikidata_ids()) == []
+
+
+def test_no_ids_when_no_edges(
+    concepts_source: WikidataLinkedOntologyNodeSource,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Zero IDs emitted when there are no SAME_AS edges."""
+    _patch_stream_and_validators(
+        concepts_source,
+        monkeypatch,
+        edges_by_type={},
+        valid_for_transformer={},
+        valid_for_ontology={},
+    )
+
+    assert list(concepts_source._stream_filtered_wikidata_ids()) == []
+
+
+def test_deduplicates_wikidata_ids(
+    concepts_source: WikidataLinkedOntologyNodeSource,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A Wikidata ID appearing in multiple edges is only yielded once."""
+    _patch_stream_and_validators(
+        concepts_source,
+        monkeypatch,
+        edges_by_type={
+            "same_as_loc": [
+                {"from_id": "Q1", "to_id": "sh001"},
+                {"from_id": "Q1", "to_id": "sh002"},  # duplicate Q1
+            ],
+        },
+        valid_for_transformer={"loc_concepts": {"sh001", "sh002"}},
+        valid_for_ontology={"loc": {"sh001", "sh002"}},
+    )
+
+    result = list(concepts_source._stream_filtered_wikidata_ids())
+    assert result == ["Q1"]
+
+
+def test_seen_but_not_yielded_ids_are_not_duplicated_as_parents(
+    concepts_source: WikidataLinkedOntologyNodeSource,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """IDs valid in the ontology but not for the transformer are 'seen' and won't reappear as parents."""
+    _patch_stream_and_validators(
+        concepts_source,
+        monkeypatch,
+        edges_by_type={
+            "same_as_loc": [
+                {"from_id": "Q1", "to_id": "sh001"},  # valid concept
+                {"from_id": "Q2", "to_id": "n001"},  # not valid for transformer
+            ],
+            "instance_of": [
+                {"from_id": "Q1", "to_id": "Q2"},  # Q2 not yielded as parent
+            ],
+        },
+        valid_for_transformer={"loc_concepts": {"sh001"}},
+        valid_for_ontology={"loc": {"sh001", "n001"}},
+    )
+
+    result = list(concepts_source._stream_filtered_wikidata_ids())
+    assert result == ["Q1"]
+    assert "Q2" not in result
+
+
+def test_concepts_yield_unseen_parents(
+    concepts_source: WikidataLinkedOntologyNodeSource,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Parent IDs not already seen via SAME_AS are yielded for concepts."""
+    _patch_stream_and_validators(
+        concepts_source,
+        monkeypatch,
+        edges_by_type={
+            "same_as_loc": [
+                {"from_id": "Q1", "to_id": "sh001"},
+            ],
+            "instance_of": [
+                {"from_id": "Q1", "to_id": "Q10"},  # new parent
+            ],
+            "subclass_of": [
+                {"from_id": "Q1", "to_id": "Q11"},  # another new parent
+            ],
+        },
+        valid_for_transformer={"loc_concepts": {"sh001"}},
+        valid_for_ontology={"loc": {"sh001"}},
+    )
+
+    result = list(concepts_source._stream_filtered_wikidata_ids())
+    assert result == ["Q1", "Q10", "Q11"]
+
+
+def test_concepts_do_not_duplicate_parent_already_in_same_as(
+    concepts_source: WikidataLinkedOntologyNodeSource,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A parent ID already seen during SAME_AS processing is not yielded again."""
+    _patch_stream_and_validators(
+        concepts_source,
+        monkeypatch,
+        edges_by_type={
+            "same_as_loc": [
+                {"from_id": "Q1", "to_id": "sh001"},
+                {"from_id": "Q2", "to_id": "sh002"},
+            ],
+            "instance_of": [
+                {"from_id": "Q1", "to_id": "Q2"},  # Q2 already seen
+            ],
+        },
+        valid_for_transformer={"loc_concepts": {"sh001", "sh002"}},
+        valid_for_ontology={"loc": {"sh001", "sh002"}},
+    )
+
+    result = list(concepts_source._stream_filtered_wikidata_ids())
+    assert result == ["Q1", "Q2"]
+
+
+def test_parent_ids_are_deduplicated(
+    concepts_source: WikidataLinkedOntologyNodeSource,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The same parent appearing in multiple edges is only yielded once."""
+    _patch_stream_and_validators(
+        concepts_source,
+        monkeypatch,
+        edges_by_type={
+            "same_as_loc": [
+                {"from_id": "Q1", "to_id": "sh001"},
+            ],
+            "instance_of": [
+                {"from_id": "Q1", "to_id": "Q10"},
+                {"from_id": "Q2", "to_id": "Q10"},  # Q10 already seen as parent
+            ],
+        },
+        valid_for_transformer={"loc_concepts": {"sh001"}},
+        valid_for_ontology={"loc": {"sh001"}},
+    )
+
+    result = list(concepts_source._stream_filtered_wikidata_ids())
+    assert result.count("Q10") == 1
+
+
+def test_names_do_not_yield_parents(
+    names_source: WikidataLinkedOntologyNodeSource,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Names node source does not stream parent nodes."""
+    _patch_stream_and_validators(
+        names_source,
+        monkeypatch,
+        edges_by_type={
+            "same_as_loc": [
+                {"from_id": "Q100", "to_id": "n001"},
+            ],
+            "instance_of": [
+                {"from_id": "Q100", "to_id": "Q200"},
+            ],
+        },
+        valid_for_transformer={"loc_names": {"n001"}},
+        valid_for_ontology={"loc": {"n001"}},
+    )
+
+    result = list(names_source._stream_filtered_wikidata_ids())
+    assert result == ["Q100"]

--- a/catalogue_graph/tests/graph/sources/test_wikidata_concepts_source.py
+++ b/catalogue_graph/tests/graph/sources/test_wikidata_concepts_source.py
@@ -2,11 +2,16 @@ import json
 from typing import Literal
 
 from config import WIKIDATA_SPARQL_URL
-from graph.sources.wikidata.linked_ontology_source import WikidataLinkedOntologySource
+from graph.sources.wikidata.linked_ontology_edge_source import (
+    WikidataLinkedOntologyEdgeSource,
+)
+from graph.sources.wikidata.linked_ontology_node_source import (
+    WikidataLinkedOntologyNodeSource,
+)
 from models.events import ExtractorEvent
 from tests.mocks import MockRequest
 from tests.test_utils import add_mock_transformer_outputs_for_ontologies, load_fixture
-from utils.ontology import get_extracted_ids, is_id_in_ontology
+from utils.ontology import get_ids_for_transformer, is_id_extracted_for_ontology
 
 
 def _add_mock_wikidata_requests(
@@ -55,37 +60,35 @@ def test_wikidata_concepts_source_edges() -> None:
         transformer_type="wikidata_linked_loc_concepts",
         entity_type="edges",
     )
-    loc_concepts_source = WikidataLinkedOntologySource(
+    loc_concepts_source = WikidataLinkedOntologyEdgeSource(
         linked_transformer="loc_concepts", event=source_event
     )
     stream_result = list(loc_concepts_source.stream_raw())
 
-    assert len(stream_result) == 7
+    assert len(stream_result) == 5
 
     same_as_edges = set()
     has_parent_edges = set()
     has_industry_edges = set()
     has_founder_edges = set()
-    for edge in stream_result:
-        if edge["type"] == "SAME_AS":
+    for edge, edge_type in stream_result:
+        if edge_type == "same_as_loc":
             same_as_edges.add((edge["from_id"], edge["to_id"]))
-        elif edge["type"] == "HAS_PARENT":
+        elif edge_type in ("instance_of", "subclass_of"):
             has_parent_edges.add((edge["from_id"], edge["to_id"]))
-        elif edge["type"] == "HAS_INDUSTRY":
+        elif edge_type == "has_industry":
             has_industry_edges.add((edge["from_id"], edge["to_id"]))
-        elif edge["type"] == "HAS_FOUNDER":
+        elif edge_type == "has_founder":
             has_founder_edges.add((edge["from_id"], edge["to_id"]))
         else:
-            raise ValueError(f"Unknown edge type {edge['type']}")
+            raise ValueError(f"Unknown edge type {edge_type}")
 
     assert len(same_as_edges) == 2
     assert ("Q1", "sh00000001") in same_as_edges
     assert ("Q2", "sh00000001") in same_as_edges
 
-    assert len(has_parent_edges) == 3
-    assert ("Q1", "Q4") in has_parent_edges
+    assert len(has_parent_edges) == 1
     assert ("Q2", "Q1") in has_parent_edges
-    assert ("Q2", "Q3") in has_parent_edges
 
     assert len(has_founder_edges) == 1
     assert ("Q1", "Q101") in has_founder_edges
@@ -104,7 +107,7 @@ def test_wikidata_concepts_source_nodes() -> None:
         transformer_type="wikidata_linked_loc_concepts",
         entity_type="nodes",
     )
-    mesh_concepts_source = WikidataLinkedOntologySource(
+    mesh_concepts_source = WikidataLinkedOntologyNodeSource(
         linked_transformer="loc_concepts", event=source_event
     )
 
@@ -121,9 +124,17 @@ def test_wikidata_concepts_source_nodes() -> None:
 def test_wikidata_linked_ontology_id_checker() -> None:
     add_mock_transformer_outputs_for_ontologies(["loc"], "1900-01-01")
 
-    assert is_id_in_ontology("sh00000001", "loc", "1900-01-01", "prod")
-    assert not is_id_in_ontology("sh00000001000", "loc", "1900-01-01", "prod")
+    assert is_id_extracted_for_ontology("sh00000001", "loc", "1900-01-01", "prod")
+    assert not is_id_extracted_for_ontology(
+        "sh00000001000", "loc", "1900-01-01", "prod"
+    )
 
-    assert "sh00000001" not in get_extracted_ids("loc_locations", "1900-01-01", "prod")
-    assert "tgrefwdw" not in get_extracted_ids("loc_locations", "1900-01-01", "prod")
-    assert "sh00000015" in get_extracted_ids("loc_locations", "1900-01-01", "prod")
+    assert "sh00000001" not in get_ids_for_transformer(
+        "loc_locations", "1900-01-01", "prod"
+    )
+    assert "tgrefwdw" not in get_ids_for_transformer(
+        "loc_locations", "1900-01-01", "prod"
+    )
+    assert "sh00000015" in get_ids_for_transformer(
+        "loc_locations", "1900-01-01", "prod"
+    )

--- a/catalogue_graph/tests/graph/sources/test_wikidata_names_source.py
+++ b/catalogue_graph/tests/graph/sources/test_wikidata_names_source.py
@@ -1,4 +1,9 @@
-from graph.sources.wikidata.linked_ontology_source import WikidataLinkedOntologySource
+from graph.sources.wikidata.linked_ontology_edge_source import (
+    WikidataLinkedOntologyEdgeSource,
+)
+from graph.sources.wikidata.linked_ontology_node_source import (
+    WikidataLinkedOntologyNodeSource,
+)
 from models.events import ExtractorEvent
 from tests.graph.sources.test_wikidata_concepts_source import (
     _add_mock_wikidata_requests,
@@ -19,7 +24,7 @@ def test_wikidata_names_source_edges() -> None:
         transformer_type="wikidata_linked_loc_names",
         entity_type="edges",
     )
-    mesh_concepts_source = WikidataLinkedOntologySource(
+    mesh_concepts_source = WikidataLinkedOntologyEdgeSource(
         linked_transformer="loc_names", event=source_event
     )
     stream_result = list(mesh_concepts_source.stream_raw())
@@ -29,17 +34,23 @@ def test_wikidata_names_source_edges() -> None:
     has_field_of_work_edges = set()
     related_to_edges = set()
     has_industry_edges = set()
-    for edge in stream_result:
-        if edge["type"] == "SAME_AS":
+    for edge, edge_type in stream_result:
+        if edge_type in ("same_as_loc", "same_as_mesh"):
             same_as_edges.add((edge["from_id"], edge["to_id"]))
-        elif edge["type"] == "HAS_FIELD_OF_WORK":
+        elif edge_type == "has_field_of_work":
             has_field_of_work_edges.add((edge["from_id"], edge["to_id"]))
-        elif edge["type"] == "RELATED_TO":
-            related_to_edges.add((edge["from_id"], edge["to_id"], edge["subtype"]))
-        elif edge["type"] == "HAS_INDUSTRY":
+        elif edge_type in (
+            "has_father",
+            "has_mother",
+            "has_sibling",
+            "has_spouse",
+            "has_child",
+        ):
+            related_to_edges.add((edge["from_id"], edge["to_id"], edge_type))
+        elif edge_type == "has_industry":
             has_industry_edges.add((edge["from_id"], edge["to_id"]))
         else:
-            raise ValueError(f"Unknown edge type {edge['type']}")
+            raise ValueError(f"Unknown edge type {edge_type}")
 
     assert len(same_as_edges) == 2
     assert ("Q100", "n00000001") in same_as_edges
@@ -66,7 +77,7 @@ def test_wikidata_names_source_nodes() -> None:
         transformer_type="wikidata_linked_loc_names",
         entity_type="nodes",
     )
-    mesh_concepts_source = WikidataLinkedOntologySource(
+    mesh_concepts_source = WikidataLinkedOntologyNodeSource(
         linked_transformer="loc_names", event=source_event
     )
     stream_result = list(mesh_concepts_source.stream_raw())

--- a/catalogue_graph/tests/graph/transformers/wikidata/test_wikidata_concepts_transformer.py
+++ b/catalogue_graph/tests/graph/transformers/wikidata/test_wikidata_concepts_transformer.py
@@ -45,7 +45,9 @@ def test_wikidata_concepts_nodes_transformer() -> None:
 
 
 def test_wikidata_concepts_edges_transformer() -> None:
-    add_mock_transformer_outputs_for_ontologies(["loc"])
+    add_mock_transformer_outputs_for_ontologies(
+        ["loc", "wikidata_linked_loc", "wikidata_linked_mesh"]
+    )
     _add_mock_wikidata_requests("edges", "concepts")
 
     source_event = ExtractorEvent(
@@ -57,7 +59,7 @@ def test_wikidata_concepts_edges_transformer() -> None:
     transformer = WikidataConceptsTransformer("loc_concepts", source_event)
 
     edges = list(transformer._stream_entities(entity_type="edges"))
-    assert len(list(edges)) == 9
+    assert len(list(edges)) == 7
 
     assert edges[0] == SourceConceptSameAs(
         from_type="SourceConcept",


### PR DESCRIPTION
## What does this change?

https://github.com/wellcomecollection/platform/issues/6379

Due to https://github.com/wellcomecollection/catalogue-pipeline/pull/3297, the Wikidata extractor service now filters out Wikidata nodes which do not have an English label. This causes an issue in the downstream Wikidata edge extractor, which assumes that no filtering occurs and outputs edges whose start nodes do not exist in the graph. 

The fix involves checking that the start node of each edge returned by the Wikidata API exists in the graph (by reading the bulk load file outputted by the Wikidata node extractor).

This PR also improves unit test coverage and refactors surrounding code to make it easier to understand:
* Split the logic in the `WikidataLinkedOntologySource` class into three classes, with separate subclasses dedicated to extracting nodes and edges
* Add a `WikidataBaseTransformer` superclass, selecting the correct source class at construction time based on the selected `entity_type`. 
* Move the `_parallelise_sparql_requests` function to the `WikidataSparqlClient` class

## How to test

Run the Wikidata edge/node extractor locally and compare outputs with existing production outputs. Outputted files should largely be the same, but the file outputted by the new edge extractor shouldn't include edges whose node IDs aren't outputted by the node extractor. 

## How can we measure success?

The Wikidata extractor does not emit edges with missing IDs and is easier to maintain.

## Have we considered potential risks?

Since the Wikidata edge extractor now checks IDs outputted by the node extractor, it is dependent on it. This shouldn't be an issue, since the deployed state machine always runs the node extractor first. 
