### PR TITLE
add folio transformer trigger

### DIFF
--- a/pipeline/terraform/modules/pipeline/iam.tf
+++ b/pipeline/terraform/modules/pipeline/iam.tf
@@ -2,6 +2,7 @@ locals {
   adapter_buckets = {
     ebsco  = local.ebsco_adapter_bucket
     axiell = local.axiell_adapter_bucket
+    folio  = local.folio_adapter_bucket
   }
 }
 
@@ -95,6 +96,18 @@ data "aws_iam_policy_document" "read_axiell_transformer_pipeline_storage_secrets
       "arn:aws:secretsmanager:eu-west-1:760097843905:secret:elasticsearch/pipeline_storage_${var.pipeline_date}/port*",
       "arn:aws:secretsmanager:eu-west-1:760097843905:secret:elasticsearch/pipeline_storage_${var.pipeline_date}/protocol*",
       "arn:aws:secretsmanager:eu-west-1:760097843905:secret:elasticsearch/pipeline_storage_${var.pipeline_date}/transformer_axiell/api_key*"
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "read_folio_transformer_pipeline_storage_secrets" {
+  statement {
+    actions = ["secretsmanager:GetSecretValue"]
+    resources = [
+      "arn:aws:secretsmanager:eu-west-1:760097843905:secret:elasticsearch/pipeline_storage_${var.pipeline_date}/private_host*",
+      "arn:aws:secretsmanager:eu-west-1:760097843905:secret:elasticsearch/pipeline_storage_${var.pipeline_date}/port*",
+      "arn:aws:secretsmanager:eu-west-1:760097843905:secret:elasticsearch/pipeline_storage_${var.pipeline_date}/protocol*",
+      "arn:aws:secretsmanager:eu-west-1:760097843905:secret:elasticsearch/pipeline_storage_${var.pipeline_date}/transformer_folio/api_key*"
     ]
   }
 }

--- a/pipeline/terraform/modules/pipeline/iam.tf
+++ b/pipeline/terraform/modules/pipeline/iam.tf
@@ -112,6 +112,28 @@ data "aws_iam_policy_document" "read_folio_transformer_pipeline_storage_secrets"
   }
 }
 
+# Combined policy documents for the transformer lambda role to stay within
+# the 10 inline policies per role limit.
+data "aws_iam_policy_document" "all_adapter_s3tables_read" {
+  source_policy_documents = values(data.aws_iam_policy_document.adapter_s3tables_read)[*].json
+}
+
+data "aws_iam_policy_document" "all_adapter_buckets_read" {
+  source_policy_documents = values(data.aws_iam_policy_document.adapter_bucket_read)[*].json
+}
+
+data "aws_iam_policy_document" "all_adapter_buckets_write" {
+  source_policy_documents = values(data.aws_iam_policy_document.adapter_bucket_write)[*].json
+}
+
+data "aws_iam_policy_document" "all_transformer_pipeline_storage_secrets" {
+  source_policy_documents = [
+    data.aws_iam_policy_document.read_ebsco_transformer_pipeline_storage_secrets.json,
+    data.aws_iam_policy_document.read_axiell_transformer_pipeline_storage_secrets.json,
+    data.aws_iam_policy_document.read_folio_transformer_pipeline_storage_secrets.json,
+  ]
+}
+
 data "aws_iam_policy_document" "adapter_bucket_write" {
   for_each = local.adapter_buckets
 

--- a/pipeline/terraform/modules/pipeline/iam.tf
+++ b/pipeline/terraform/modules/pipeline/iam.tf
@@ -112,8 +112,7 @@ data "aws_iam_policy_document" "read_folio_transformer_pipeline_storage_secrets"
   }
 }
 
-# Combined policy documents for the transformer lambda role to stay within
-# the 10 inline policies per role limit.
+# Combined policy documents for the transformer lambda role to access S3 buckets and table, ES source index
 data "aws_iam_policy_document" "all_adapter_s3tables_read" {
   source_policy_documents = values(data.aws_iam_policy_document.adapter_s3tables_read)[*].json
 }

--- a/pipeline/terraform/modules/pipeline/locals.tf
+++ b/pipeline/terraform/modules/pipeline/locals.tf
@@ -22,6 +22,10 @@ data "aws_s3_bucket" "axiell_adapter_bucket" {
   bucket = "wellcomecollection-platform-axiell-adapter"
 }
 
+data "aws_s3_bucket" "folio_adapter_bucket" {
+  bucket = "wellcomecollection-platform-folio-adapter"
+}
+
 locals {
   namespace = "catalogue-${var.pipeline_date}"
 
@@ -103,6 +107,9 @@ locals {
 
   # Axiell adapter bucket
   axiell_adapter_bucket = data.aws_s3_bucket.axiell_adapter_bucket.bucket
+
+  # Folio adapter bucket
+  folio_adapter_bucket = data.aws_s3_bucket.folio_adapter_bucket.bucket
 
   # Mets adapter VHS
   mets_adapter_read_policy = data.terraform_remote_state.mets_adapter.outputs.mets_dynamo_read_policy

--- a/pipeline/terraform/modules/pipeline/state_machine_transformers.tf
+++ b/pipeline/terraform/modules/pipeline/state_machine_transformers.tf
@@ -76,6 +76,11 @@ resource "aws_iam_role_policy" "transformer_axiell_lambda_pipeline_storage_secre
   policy = data.aws_iam_policy_document.read_axiell_transformer_pipeline_storage_secrets.json
 }
 
+resource "aws_iam_role_policy" "transformer_folio_lambda_pipeline_storage_secret_read" {
+  role   = module.transformer_lambda.lambda_role.name
+  policy = data.aws_iam_policy_document.read_folio_transformer_pipeline_storage_secrets.json
+}
+
 # State Machine Definition
 locals {
   transformer_state_machine_definition = jsonencode({
@@ -147,6 +152,11 @@ locals {
       adapter_detail_type  = "axiell.adapter.completed"
       reindex_target_value = "axiell"
     }
+    folio = {
+      adapter_source       = "folio.adapter"
+      adapter_detail_type  = "folio.adapter.completed"
+      reindex_target_value = "folio"
+    }
   }
 }
 
@@ -163,6 +173,7 @@ module "transformer_state_machine" {
   policies_to_attach = {
     "read_ebsco_adapter_bucket"  = data.aws_iam_policy_document.adapter_bucket_read["ebsco"].json
     "read_axiell_adapter_bucket" = data.aws_iam_policy_document.adapter_bucket_read["axiell"].json
+    "read_folio_adapter_bucket"  = data.aws_iam_policy_document.adapter_bucket_read["folio"].json
   }
 }
 

--- a/pipeline/terraform/modules/pipeline/state_machine_transformers.tf
+++ b/pipeline/terraform/modules/pipeline/state_machine_transformers.tf
@@ -35,12 +35,12 @@ module "transformer_lambda" {
   }
 }
 
+# "all_adapter" -> see transformer_types below
+
 # Attach read-only Iceberg access policies to transformer lambda
 resource "aws_iam_role_policy" "transformer_lambda_iceberg_read" {
-  for_each = local.transformer_types
-
   role   = module.transformer_lambda.lambda_role.name
-  policy = data.aws_iam_policy_document.adapter_s3tables_read[each.key].json
+  policy = data.aws_iam_policy_document.all_adapter_s3tables_read.json
 }
 
 # Give the transformer Lambda permission to write to the reconciler table
@@ -51,34 +51,20 @@ resource "aws_iam_role_policy" "transformer_lambda_iceberg_reconciler_write" {
 
 # Attach S3 read policies to transformer lambda
 resource "aws_iam_role_policy" "transformer_lambda_s3_read" {
-  for_each = local.transformer_types
-
   role   = module.transformer_lambda.lambda_role.name
-  policy = data.aws_iam_policy_document.adapter_bucket_read[each.key].json
+  policy = data.aws_iam_policy_document.all_adapter_buckets_read.json
 }
 
 # Attach S3 write policies to transformer lambda
 resource "aws_iam_role_policy" "transformer_lambda_s3_write" {
-  for_each = local.transformer_types
-
   role   = module.transformer_lambda.lambda_role.name
-  policy = data.aws_iam_policy_document.adapter_bucket_write[each.key].json
+  policy = data.aws_iam_policy_document.all_adapter_buckets_write.json
 }
 
 # Allow transformer to read pipeline storage secrets
 resource "aws_iam_role_policy" "transformer_lambda_pipeline_storage_secret_read" {
   role   = module.transformer_lambda.lambda_role.name
-  policy = data.aws_iam_policy_document.read_ebsco_transformer_pipeline_storage_secrets.json
-}
-
-resource "aws_iam_role_policy" "transformer_axiell_lambda_pipeline_storage_secret_read" {
-  role   = module.transformer_lambda.lambda_role.name
-  policy = data.aws_iam_policy_document.read_axiell_transformer_pipeline_storage_secrets.json
-}
-
-resource "aws_iam_role_policy" "transformer_folio_lambda_pipeline_storage_secret_read" {
-  role   = module.transformer_lambda.lambda_role.name
-  policy = data.aws_iam_policy_document.read_folio_transformer_pipeline_storage_secrets.json
+  policy = data.aws_iam_policy_document.all_transformer_pipeline_storage_secrets.json
 }
 
 # State Machine Definition


### PR DESCRIPTION
## What does this change?

See https://wellcome.slack.com/archives/C02ANCYL90E/p1781170153492379

## How to test

~~Plan: 16 to add, 0 to change, 0 to destroy.~~
~~All related to folio/transofrmer/trigger~~

EDIT to get around the inline policy limit:
Plan: 15 to add, 1 to change, 7 to destroy.

Destroy: (replaced below)
- axiell_lambda_pipeline_storage_secret_read
- iceberg_read["axiell"]
- iceberg_read["ebsco"]
- lambda_s3_read["axiell"]
- lambda_s3_read["ebsco"]
- lambda_s3_write["axiell"]
- lambda_s3_write["ebsco"]

Change:
- transformer_lambda_pipeline_storage_secret_read
-> add transformer_axiell (as destroyed above) and transformer_folio secret read

Create:
- lambda_iceberg_read
-> for all S3 tables
- transformer_lambda_s3_write
- transformer_lambda_s3_read
-> for all S3 buckets
- 10 resources added to enable transformer_trigger["folio"] 
- transformer state_machine.aws_iam_policy  to read from folio-adapter S3 bucket
- the above policy's attachment

## How can we measure success?

When the folio adapter produces a changeset, the transformer gets triggered via catalogue-pipeline-adapter-event-bus

## Have we considered potential risks?

Writing to the wrong/production source index
See https://github.com/wellcomecollection/catalogue-pipeline/blob/ea022016dac6b3e104bc34f52e52d0cb3d086fef/catalogue_graph/src/adapters/extractors/oai_pmh/folio/config.py#L113: folio transformer is configured to write to the test source index, as is axiell transformer https://github.com/wellcomecollection/catalogue-pipeline/blob/ea022016dac6b3e104bc34f52e52d0cb3d086fef/catalogue_graph/src/adapters/extractors/oai_pmh/axiell/config.py#L110
