### PR TITLE
Transform MARC notes

### DIFF
--- a/catalogue_graph/src/adapters/transformers/builders/axiell_work_builder.py
+++ b/catalogue_graph/src/adapters/transformers/builders/axiell_work_builder.py
@@ -2,10 +2,12 @@ from adapters.transformers.builders.marc_xml_work_builder import MarcXmlWorkBuil
 from adapters.transformers.marc.last_transaction_time import (
     extract_last_transaction_time_to_datetime,
 )
+from adapters.transformers.marc.notes import extract_notes
 from adapters.transformers.marc.predecessor_identifier import (
     extract_calm_predecessor_id,
 )
 from models.pipeline.identifier import Id, WorkSourceIdentifier
+from models.pipeline.note import Note
 from utils.timezone import convert_datetime_to_utc_iso
 
 
@@ -31,3 +33,7 @@ class AxiellWorkBuilder(MarcXmlWorkBuilder):
         """Reads from MARC 005 (last transaction time) rather than the adapter row's last_modified."""
         last_modified = extract_last_transaction_time_to_datetime(self.record)
         return convert_datetime_to_utc_iso(last_modified)
+
+    @property
+    def notes(self) -> list[Note]:
+        return extract_notes(self.record)

--- a/catalogue_graph/src/adapters/transformers/builders/marc_xml_work_builder.py
+++ b/catalogue_graph/src/adapters/transformers/builders/marc_xml_work_builder.py
@@ -6,7 +6,6 @@ from adapters.transformers.builders.source_work_builder import SourceWorkBuilder
 from adapters.transformers.ebsco.parents import get_parents
 from adapters.transformers.marc.alternative_titles import extract_alternative_titles
 from adapters.transformers.marc.identifier import extract_id
-from adapters.transformers.marc.notes import extract_notes
 from adapters.transformers.marc.other_identifiers import extract_other_identifiers
 from adapters.transformers.marc.title import extract_title
 from models.pipeline.collection_path import CollectionPath
@@ -110,7 +109,7 @@ class MarcXmlWorkBuilder(SourceWorkBuilder):
 
     @property
     def notes(self) -> list[Note]:
-        return extract_notes(self.record)
+        return []
 
     @property
     def duration(self) -> int | None:

--- a/catalogue_graph/src/adapters/transformers/ebsco/description.py
+++ b/catalogue_graph/src/adapters/transformers/ebsco/description.py
@@ -19,7 +19,7 @@ from itertools import chain
 from pymarc.field import Field
 from pymarc.record import Record
 
-from adapters.transformers.ebsco.common import is_url
+from adapters.transformers.utils.html import format_as_html_link
 
 logger = logging.getLogger("transformer/description")
 
@@ -41,12 +41,4 @@ def get_plain_field_values(field: Field) -> Iterable[str]:
 
 
 def get_u_field_values(field: Field) -> Iterable[str]:
-    return (format_as_link(value) for value in field.get_subfields("u"))
-
-
-def format_as_link(maybe_url: str) -> str:
-    if is_url(maybe_url):
-        return f'<a href="{maybe_url}">{maybe_url}</a>'
-    else:
-        logger.warning("has MARC 520 $u which doesn't look like a URL: %s", maybe_url)
-        return maybe_url
+    return (format_as_html_link(value) for value in field.get_subfields("u"))

--- a/catalogue_graph/src/adapters/transformers/ebsco/holdings.py
+++ b/catalogue_graph/src/adapters/transformers/ebsco/holdings.py
@@ -9,7 +9,7 @@ from collections.abc import Iterator
 
 from pymarc.record import Record
 
-from adapters.transformers.ebsco.common import is_url
+from adapters.transformers.utils.html import is_url
 from models.pipeline.access_condition import (
     AccessCondition,
     LicensedResource,

--- a/catalogue_graph/src/adapters/transformers/marc/notes.py
+++ b/catalogue_graph/src/adapters/transformers/marc/notes.py
@@ -48,6 +48,11 @@ EXHIBITIONS_NOTE = IdLabel(id="exhibitions-note", label="Exhibitions note")
 AWARDS_NOTE = IdLabel(id="awards-note", label="Awards note")
 
 
+# TODO: The Scala notes transformer (MarcNotes.scala) had custom logic removing all references to Codebreakers.
+# Do we need to reimplement this logic here? To be confirmed once we start validating Python transformed source works
+# against Scala transformed source works.
+
+
 def _create_note_from_contents(
     field: Field,
     note_type: IdLabel,

--- a/catalogue_graph/src/adapters/transformers/marc/notes.py
+++ b/catalogue_graph/src/adapters/transformers/marc/notes.py
@@ -64,14 +64,14 @@ def _create_note_from_contents(
         if subfield_tag in suppressed:
             continue
 
-        # Subfield ǂu is rendered as an HTML link when it contains a valid URL.
+        # Subfield $u is rendered as an HTML link when it contains a valid URL.
         if subfield_tag == "u":
             trimmed = value.strip()
             if _is_url(trimmed):
                 parts.append(f'<a href="{trimmed}">{trimmed}</a>')
             else:
                 logger.warning(
-                    "Subfield ǂu which doesn't look like a URL",
+                    "Subfield $u which doesn't look like a URL",
                     contents=value,
                 )
                 parts.append(value)

--- a/catalogue_graph/src/adapters/transformers/marc/notes.py
+++ b/catalogue_graph/src/adapters/transformers/marc/notes.py
@@ -3,12 +3,12 @@ Extract notes from 5xx MARC fields.
 """
 
 from collections.abc import Callable
-from urllib.parse import urlparse
 
 import structlog
 from pymarc.field import Field
 from pymarc.record import Record
 
+from adapters.transformers.utils.html import format_as_html_link
 from models.pipeline.id_label import IdLabel
 from models.pipeline.note import Note
 
@@ -48,11 +48,6 @@ EXHIBITIONS_NOTE = IdLabel(id="exhibitions-note", label="Exhibitions note")
 AWARDS_NOTE = IdLabel(id="awards-note", label="Awards note")
 
 
-def _is_url(s: str) -> bool:
-    parsed = urlparse(s)
-    return parsed.scheme in ("http", "https") and bool(parsed.netloc)
-
-
 def _create_note_from_contents(
     field: Field,
     note_type: IdLabel,
@@ -66,15 +61,7 @@ def _create_note_from_contents(
 
         # Subfield $u is rendered as an HTML link when it contains a valid URL.
         if subfield_tag == "u":
-            trimmed = value.strip()
-            if _is_url(trimmed):
-                parts.append(f'<a href="{trimmed}">{trimmed}</a>')
-            else:
-                logger.warning(
-                    "Subfield $u which doesn't look like a URL",
-                    contents=value,
-                )
-                parts.append(value)
+            parts.append(format_as_html_link(value))
         else:
             parts.append(value)
     contents = " ".join(parts)

--- a/catalogue_graph/src/adapters/transformers/marc/notes.py
+++ b/catalogue_graph/src/adapters/transformers/marc/notes.py
@@ -1,20 +1,149 @@
 """
-Extract exhibition note from field
-585 - Exhibition Note
-https://www.loc.gov/marc/bibliographic/bd585.html
+Extract notes from 5xx MARC fields.
 """
 
+from collections.abc import Callable
+from urllib.parse import urlparse
+
+import structlog
+from pymarc.field import Field
 from pymarc.record import Record
 
-from adapters.transformers.marc.common import get_a_subfields
 from models.pipeline.id_label import IdLabel
 from models.pipeline.note import Note
 
-exhibitions_note_type = IdLabel(id="exhibitions-note", label="Exhibitions note")
+logger = structlog.get_logger(__name__)
+
+GLOBALLY_SUPPRESSED_SUBFIELDS = {"5"}
+
+GENERAL_NOTE = IdLabel(id="general-note", label="Notes")
+DISSERTATION_NOTE = IdLabel(id="dissertation-note", label="Dissertation note")
+BIBLIOGRAPHICAL_INFORMATION = IdLabel(
+    id="bibliographic-info", label="Bibliographic information"
+)
+CONTENTS_NOTE = IdLabel(id="contents", label="Contents")
+TERMS_OF_USE = IdLabel(id="terms-of-use", label="Terms of use")
+CREDITS_NOTE = IdLabel(id="credits", label="Creator/production credits")
+REFERENCES_NOTE = IdLabel(id="references-note", label="References note")
+LETTERING_NOTE = IdLabel(id="lettering-note", label="Lettering note")
+NUMBERING_NOTE = IdLabel(id="numbering-note", label="Numbering note")
+TIME_AND_PLACE_NOTE = IdLabel(id="time-and-place-note", label="Time and place note")
+CITE_AS_NOTE = IdLabel(id="reference", label="Reference")
+REPRODUCTION_NOTE = IdLabel(id="reproduction-note", label="Reproduction note")
+LOCATION_OF_ORIGINAL_NOTE = IdLabel(
+    id="location-of-original", label="Location of original"
+)
+LOCATION_OF_DUPLICATES_NOTE = IdLabel(
+    id="location-of-duplicates", label="Location of duplicates"
+)
+FUNDING_INFORMATION = IdLabel(id="funding-info", label="Funding information")
+COPYRIGHT_NOTE = IdLabel(id="copyright-note", label="Copyright note")
+RELATED_MATERIAL = IdLabel(id="related-material", label="Related material")
+BIOGRAPHICAL_NOTE = IdLabel(id="biographical-note", label="Biographical note")
+LANGUAGE_NOTE = IdLabel(id="language-note", label="Language note")
+OWNERSHIP_NOTE = IdLabel(id="ownership-note", label="Ownership note")
+BINDING_INFORMATION = IdLabel(id="binding-detail", label="Binding detail")
+PUBLICATIONS_NOTE = IdLabel(id="publication-note", label="Publications note")
+EXHIBITIONS_NOTE = IdLabel(id="exhibitions-note", label="Exhibitions note")
+AWARDS_NOTE = IdLabel(id="awards-note", label="Awards note")
+
+
+def _is_url(s: str) -> bool:
+    parsed = urlparse(s)
+    return parsed.scheme in ("http", "https") and bool(parsed.netloc)
+
+
+def _create_note_from_contents(
+    field: Field,
+    note_type: IdLabel,
+    suppressed_subfields: set[str] | None = None,
+) -> Note:
+    suppressed = GLOBALLY_SUPPRESSED_SUBFIELDS | (suppressed_subfields or set())
+    parts: list[str] = []
+    for subfield_tag, value in field:
+        if subfield_tag in suppressed:
+            continue
+
+        # Subfield ǂu is rendered as an HTML link when it contains a valid URL.
+        if subfield_tag == "u":
+            trimmed = value.strip()
+            if _is_url(trimmed):
+                parts.append(f'<a href="{trimmed}">{trimmed}</a>')
+            else:
+                logger.warning(
+                    "Subfield ǂu which doesn't look like a URL",
+                    contents=value,
+                )
+                parts.append(value)
+        else:
+            parts.append(value)
+    contents = " ".join(parts)
+    return Note(contents=contents, note_type=note_type)
+
+
+def _create_ownership_note(field: Field) -> Note | None:
+    # Only produce an ownership note when indicator 1 is "1" (not private).
+    if field.indicator1 == "1":
+        return _create_note_from_contents(field, OWNERSHIP_NOTE)
+    return None
+
+
+def _create_location_of_note(field: Field) -> Note | None:
+    # Use indicator 1 to distinguish location of originals vs duplicates.
+    if field.indicator1 == "2":
+        return _create_note_from_contents(field, LOCATION_OF_DUPLICATES_NOTE)
+    return _create_note_from_contents(field, LOCATION_OF_ORIGINAL_NOTE)
+
+
+def _note_from(note_type: IdLabel) -> Callable[[Field], Note | None]:
+    return lambda field: _create_note_from_contents(field, note_type)
+
+
+# Mapping of MARC tag to a function that creates a Note from the field
+_NOTES_FIELDS: dict[str, Callable[[Field], Note | None]] = {
+    "500": _note_from(GENERAL_NOTE),
+    "501": _note_from(GENERAL_NOTE),
+    "502": _note_from(DISSERTATION_NOTE),
+    "504": _note_from(BIBLIOGRAPHICAL_INFORMATION),
+    "505": _note_from(CONTENTS_NOTE),
+    "506": _note_from(TERMS_OF_USE),
+    "508": _note_from(CREDITS_NOTE),
+    "510": _note_from(REFERENCES_NOTE),
+    "511": _note_from(CREDITS_NOTE),
+    "514": _note_from(LETTERING_NOTE),
+    "515": _note_from(NUMBERING_NOTE),
+    "518": _note_from(TIME_AND_PLACE_NOTE),
+    "524": _note_from(CITE_AS_NOTE),
+    "525": _note_from(GENERAL_NOTE),
+    "533": _note_from(REPRODUCTION_NOTE),
+    "534": _note_from(REPRODUCTION_NOTE),
+    "535": _create_location_of_note,
+    "536": _note_from(FUNDING_INFORMATION),
+    "540": _note_from(TERMS_OF_USE),
+    "542": _note_from(COPYRIGHT_NOTE),
+    "544": _note_from(RELATED_MATERIAL),
+    "545": _note_from(BIOGRAPHICAL_NOTE),
+    "546": _note_from(LANGUAGE_NOTE),
+    "547": _note_from(GENERAL_NOTE),
+    "550": _note_from(GENERAL_NOTE),
+    "561": _create_ownership_note,
+    "562": _note_from(GENERAL_NOTE),
+    "563": _note_from(BINDING_INFORMATION),
+    "580": _note_from(GENERAL_NOTE),
+    "581": _note_from(PUBLICATIONS_NOTE),
+    "585": _note_from(EXHIBITIONS_NOTE),
+    "586": _note_from(AWARDS_NOTE),
+    "588": _note_from(GENERAL_NOTE),
+}
 
 
 def extract_notes(record: Record) -> list[Note]:
-    return [
-        Note(contents=a_value, note_type=exhibitions_note_type)
-        for a_value in get_a_subfields("585", record)
-    ]
+    notes: list[Note] = []
+    for field in record.get_fields(*_NOTES_FIELDS.keys()):
+        create = _NOTES_FIELDS.get(field.tag)
+        if create is None:
+            continue
+        note = create(field)
+        if note is not None and note.contents.strip():
+            notes.append(note)
+    return notes

--- a/catalogue_graph/src/adapters/transformers/utils/html.py
+++ b/catalogue_graph/src/adapters/transformers/utils/html.py
@@ -1,5 +1,9 @@
 from urllib.parse import urlparse
 
+import structlog
+
+logger = structlog.get_logger(__name__)
+
 
 def is_url(maybe_url: str) -> bool:
     """
@@ -17,3 +21,13 @@ def is_url(maybe_url: str) -> bool:
     # So we need to do a bit of extra checking to see if it really
     # looks like a URL.
     return bool(url.scheme in ["http", "https"] and url.netloc)
+
+
+def format_as_html_link(maybe_url: str) -> str:
+    """Format $u subfield contents as an HTML link if valid URL, otherwise return contents unchanged."""
+    trimmed = maybe_url.strip()
+    if is_url(trimmed):
+        return f'<a href="{trimmed}">{trimmed}</a>'
+
+    logger.warning("$u subfield doesn't look like a URL", value=maybe_url)
+    return maybe_url

--- a/catalogue_graph/tests/adapters/transformers/axiell/bdd/test_notes.py
+++ b/catalogue_graph/tests/adapters/transformers/axiell/bdd/test_notes.py
@@ -2,3 +2,4 @@ from pytest_bdd import scenarios
 
 scenarios("../../marc/features/exhibitions_note.feature")
 scenarios("../../marc/features/location_of_note.feature")
+scenarios("../../marc/features/ownership_note.feature")

--- a/catalogue_graph/tests/adapters/transformers/axiell/bdd/test_notes.py
+++ b/catalogue_graph/tests/adapters/transformers/axiell/bdd/test_notes.py
@@ -1,3 +1,4 @@
 from pytest_bdd import scenarios
 
 scenarios("../../marc/features/exhibitions_note.feature")
+scenarios("../../marc/features/location_of_note.feature")

--- a/catalogue_graph/tests/adapters/transformers/conftest.py
+++ b/catalogue_graph/tests/adapters/transformers/conftest.py
@@ -6,21 +6,9 @@ from pymarc.record import Field, Indicators, Record, Subfield
 # mypy: allow-untyped-calls
 
 
-@pytest.fixture
-def marc_record(request: pytest.FixtureRequest) -> Record:
-    """Create a MARC record with sensible defaults for transformer unit tests.
-
-    Tests can pass one or more pymarc Field objects via indirect parametrisation:
-        @pytest.mark.parametrize("marc_record", [(Field(...),)], indirect=True)
-
-    We also ensure mandatory fields exist unless explicitly supplied.
-    """
-
+def _record_with_fields(*fields: Field) -> Record:
     record = Record()
-
-    with suppress(AttributeError):
-        # request.param will typically be a tuple of Field objects
-        record.add_field(*request.param)
+    record.add_field(*fields)
 
     # Add mandatory fields if they are not mentioned in the params.
     if record.get("001") is None:
@@ -34,8 +22,25 @@ def marc_record(request: pytest.FixtureRequest) -> Record:
                 subfields=[Subfield(code="a", value="a title")],
             )
         )
-
     return record
+
+
+@pytest.fixture
+def marc_record(request: pytest.FixtureRequest) -> Record:
+    """Create a MARC record with sensible defaults for transformer unit tests.
+
+    Tests can pass one or more pymarc Field objects via indirect parametrisation:
+        @pytest.mark.parametrize("marc_record", [(Field(...),)], indirect=True)
+
+    We also ensure mandatory fields exist unless explicitly supplied.
+    """
+
+    fields = []
+    with suppress(AttributeError):
+        # request.param will typically be a tuple of Field objects
+        fields = request.param
+
+    return _record_with_fields(*fields)
 
 
 def _907_field(value: str) -> Field:

--- a/catalogue_graph/tests/adapters/transformers/marc/features/exhibitions_note.feature
+++ b/catalogue_graph/tests/adapters/transformers/marc/features/exhibitions_note.feature
@@ -1,5 +1,5 @@
 Feature: Extract Exhibitions notes from MARC 585 $a
-  notes are derived from every non-empty 585 $a subfield in order of appearance.
+  notes are derived from every non-empty 585 subfield in order of appearance.
 
   Background:
     Given a valid MARC record
@@ -23,6 +23,11 @@ Feature: Extract Exhibitions notes from MARC 585 $a
       And the MARC record has another 585 field with subfield "a" value "   "
       When I transform the MARC record
       Then there are no notes
+
+    Scenario: Globally suppressed subfield $5 is ignored
+      Given the MARC record has a 585 field with subfield "a" value "Some note" and subfield "5" value "Suppressed"
+      When I transform the MARC record
+      Then the only note has the contents "Some note"
 
   Rule: an exhibitions note is created for each valid 585 field
     Scenario: Single 585 $a

--- a/catalogue_graph/tests/adapters/transformers/marc/features/exhibitions_note.feature
+++ b/catalogue_graph/tests/adapters/transformers/marc/features/exhibitions_note.feature
@@ -9,11 +9,14 @@ Feature: Extract Exhibitions notes from MARC 585 $a
       When I transform the MARC record
       Then there are no notes
 
-    Scenario: Non-a subfields are ignored
-      Given the MARC record has a 585 field with subfield "b" value "Incorrect note"
-      And the MARC record has another 585 field with subfield "c" value "Another note"
+    Scenario: Subfield contents are concatenated
+      Given the MARC record has a 585 field with subfields:
+        | code | value        |
+        | a    | First note   |
+        | b    | Second note  |
+        | c    | Another note |
       When I transform the MARC record
-      Then there are no notes
+      Then the only note has the contents "First note Second note Another note"
 
     Scenario: Empty $a subfields are ignored
       Given the MARC record has a 585 field with subfield "a" value ""

--- a/catalogue_graph/tests/adapters/transformers/marc/features/location_of_note.feature
+++ b/catalogue_graph/tests/adapters/transformers/marc/features/location_of_note.feature
@@ -1,0 +1,45 @@
+Feature: Extract Location notes from MARC 535
+  Indicator 1 determines note type: "2" yields "Location of duplicates",
+  anything else yields "Location of original".
+
+  Background:
+    Given a valid MARC record
+
+  Rule: Indicator 1 determines the note type
+    Scenario: Default indicator produces Location of original
+      Given the MARC record has a 535 field with subfield "a" value "British Library, London."
+      When I transform the MARC record
+      Then the only note has the note_type.label "Location of original"
+      And the only note has the contents "British Library, London."
+
+    Scenario: Indicator 1 = "1" produces Location of original
+      Given the MARC record has a 535 field with indicators "1" "" with subfield "a" value "Wellcome Collection, London."
+      When I transform the MARC record
+      Then the only note has the note_type.label "Location of original"
+      And the only note has the contents "Wellcome Collection, London."
+
+    Scenario: Indicator 1 = "2" produces Location of duplicates
+      Given the MARC record has a 535 field with indicators "2" "" with subfield "a" value "National Archives, Kew."
+      When I transform the MARC record
+      Then the only note has the note_type.label "Location of duplicates"
+      And the only note has the contents "National Archives, Kew."
+
+  Rule: Standard note behaviour applies
+    Scenario: No 535 fields present
+      When I transform the MARC record
+      Then there are no notes
+
+    Scenario: Multiple 535 fields with different indicators
+      Given the MARC record has a 535 field with indicators "1" "" with subfield "a" value "Original held at Wellcome Collection."
+      And the MARC record has another 535 field with indicators "2" "" with subfield "a" value "Duplicate at British Library."
+      When I transform the MARC record
+      Then there are 2 notes
+      And the 1st note has the note_type.label "Location of original"
+      And the 1st note has the contents "Original held at Wellcome Collection."
+      And the 2nd note has the note_type.label "Location of duplicates"
+      And the 2nd note has the contents "Duplicate at British Library."
+
+    Scenario: Globally suppressed subfield $5 is excluded
+      Given the MARC record has a 535 field with subfield "a" value "Wellcome Collection." and subfield "5" value "UkLW"
+      When I transform the MARC record
+      Then the only note has the contents "Wellcome Collection."

--- a/catalogue_graph/tests/adapters/transformers/marc/features/ownership_note.feature
+++ b/catalogue_graph/tests/adapters/transformers/marc/features/ownership_note.feature
@@ -1,0 +1,27 @@
+Feature: Extract Ownership notes from MARC 561
+  An ownership note is only produced when indicator 1 is "1" (not private).
+
+  Background:
+    Given a valid MARC record
+
+  Rule: Indicator 1 must be "1" to produce a note
+    Scenario: Indicator 1 = "1" produces an ownership note
+      Given the MARC record has a 561 field with indicators "1" "" with subfield "a" value "Some ownership note."
+      When I transform the MARC record
+      Then the only note has the note_type.label "Ownership note"
+      And the only note has the contents "Some ownership note."
+
+    Scenario: No indicator produces no note
+      Given the MARC record has a 561 field with subfield "a" value "Private provenance."
+      When I transform the MARC record
+      Then there are no notes
+
+    Scenario: Indicator 1 = "0" produces no note
+      Given the MARC record has a 561 field with indicators "0" "" with subfield "a" value "Private provenance."
+      When I transform the MARC record
+      Then there are no notes
+
+    Scenario: Indicator 1 = " " produces no note
+      Given the MARC record has a 561 field with indicators " " "" with subfield "a" value "Some provenance."
+      When I transform the MARC record
+      Then there are no notes

--- a/catalogue_graph/tests/adapters/transformers/marc/test_description.py
+++ b/catalogue_graph/tests/adapters/transformers/marc/test_description.py
@@ -8,10 +8,9 @@ these tests are MARC-field level and can be shared across adapters.
 
 from __future__ import annotations
 
-import logging
-
 import pytest
 from pymarc.record import Field, Record, Subfield
+from structlog.testing import capture_logs
 
 from adapters.transformers.ebsco.description import extract_description
 
@@ -92,16 +91,18 @@ def test_make_link_from_url(marc_record: Record) -> None:
     ],
     indirect=True,
 )
-def test_only_urls_create_links(
-    marc_record: Record, caplog: pytest.LogCaptureFixture
-) -> None:
+def test_only_urls_create_links(marc_record: Record) -> None:
     """Non-URL URIs are treated as text, and a warning is logged."""
-    with caplog.at_level(logging.WARN):
+    with capture_logs() as cap_logs:
         assert (
             extract_description(marc_record)
             == "<p>summary source urn:isbn:9781455841653</p>"
         )
-    assert "doesn't look like a URL: urn:isbn:9781455841653" in caplog.text
+
+    assert any(
+        "$u subfield doesn't look like a URL" in log.get("event", "")
+        for log in cap_logs
+    )
 
 
 @pytest.mark.parametrize(

--- a/catalogue_graph/tests/adapters/transformers/marc/test_notes.py
+++ b/catalogue_graph/tests/adapters/transformers/marc/test_notes.py
@@ -6,6 +6,7 @@ from adapters.transformers.marc.notes import (
     BIBLIOGRAPHICAL_INFORMATION,
     BINDING_INFORMATION,
     BIOGRAPHICAL_NOTE,
+    CITE_AS_NOTE,
     CONTENTS_NOTE,
     COPYRIGHT_NOTE,
     CREDITS_NOTE,

--- a/catalogue_graph/tests/adapters/transformers/marc/test_notes.py
+++ b/catalogue_graph/tests/adapters/transformers/marc/test_notes.py
@@ -52,6 +52,7 @@ def test_extracts_notes_from_all_fields() -> None:
         ("511", "credits note b", CREDITS_NOTE),
         ("514", "Completeness:", LETTERING_NOTE),
         ("518", "time and place note", TIME_AND_PLACE_NOTE),
+        ("524", "cite as note", CITE_AS_NOTE),
         ("533", "reproduction a", REPRODUCTION_NOTE),
         ("534", "reproduction b", REPRODUCTION_NOTE),
         ("535", "location of original note", LOCATION_OF_ORIGINAL_NOTE),

--- a/catalogue_graph/tests/adapters/transformers/marc/test_notes.py
+++ b/catalogue_graph/tests/adapters/transformers/marc/test_notes.py
@@ -1,0 +1,259 @@
+from pymarc.record import Field, Indicators, Subfield
+
+from adapters.transformers.marc.notes import (
+    _NOTES_FIELDS,
+    AWARDS_NOTE,
+    BIBLIOGRAPHICAL_INFORMATION,
+    BINDING_INFORMATION,
+    BIOGRAPHICAL_NOTE,
+    CONTENTS_NOTE,
+    COPYRIGHT_NOTE,
+    CREDITS_NOTE,
+    DISSERTATION_NOTE,
+    EXHIBITIONS_NOTE,
+    FUNDING_INFORMATION,
+    GENERAL_NOTE,
+    LANGUAGE_NOTE,
+    LETTERING_NOTE,
+    LOCATION_OF_DUPLICATES_NOTE,
+    LOCATION_OF_ORIGINAL_NOTE,
+    OWNERSHIP_NOTE,
+    PUBLICATIONS_NOTE,
+    REFERENCES_NOTE,
+    RELATED_MATERIAL,
+    REPRODUCTION_NOTE,
+    TERMS_OF_USE,
+    TIME_AND_PLACE_NOTE,
+    extract_notes,
+)
+from models.pipeline.note import Note
+from tests.adapters.transformers.conftest import _record_with_fields
+
+
+def _simple_field(tag: str, content: str, indicator1: str = " ") -> Field:
+    return Field(
+        tag=tag,
+        indicators=Indicators(indicator1, " "),
+        subfields=[Subfield(code="a", value=content)],
+    )
+
+
+def test_extracts_notes_from_all_fields() -> None:
+    cases = [
+        ("500", "general note a", GENERAL_NOTE),
+        ("501", "general note b", GENERAL_NOTE),
+        ("502", "dissertation note", DISSERTATION_NOTE),
+        ("504", "bib info a", BIBLIOGRAPHICAL_INFORMATION),
+        ("505", "contents note", CONTENTS_NOTE),
+        ("506", "typical terms of use", TERMS_OF_USE),
+        ("508", "credits note a", CREDITS_NOTE),
+        ("510", "references a", REFERENCES_NOTE),
+        ("511", "credits note b", CREDITS_NOTE),
+        ("514", "Completeness:", LETTERING_NOTE),
+        ("518", "time and place note", TIME_AND_PLACE_NOTE),
+        ("533", "reproduction a", REPRODUCTION_NOTE),
+        ("534", "reproduction b", REPRODUCTION_NOTE),
+        ("535", "location of original note", LOCATION_OF_ORIGINAL_NOTE),
+        ("536", "funding information", FUNDING_INFORMATION),
+        ("540", "terms of use", TERMS_OF_USE),
+        ("542", "copyright a", COPYRIGHT_NOTE),
+        ("544", "related material a", RELATED_MATERIAL),
+        ("545", "bib info b", BIOGRAPHICAL_NOTE),
+        ("546", "Marriage certificate: German; Fraktur.", LANGUAGE_NOTE),
+        ("547", "general note c", GENERAL_NOTE),
+        ("562", "general note d", GENERAL_NOTE),
+        ("563", "binding info note", BINDING_INFORMATION),
+        ("581", "publications b", PUBLICATIONS_NOTE),
+        ("585", "exhibitions", EXHIBITIONS_NOTE),
+        ("586", "awards", AWARDS_NOTE),
+    ]
+    fields = [_simple_field(tag, content) for tag, content, _ in cases]
+    record = _record_with_fields(*fields)
+    expected = [Note(contents=content, note_type=nt) for _, content, nt in cases]
+    assert extract_notes(record) == expected
+
+
+def test_extracts_all_notes_when_duplicate_fields() -> None:
+    record = _record_with_fields(
+        _simple_field("500", "note a"),
+        _simple_field("500", "note b"),
+    )
+    assert extract_notes(record) == [
+        Note(contents="note a", note_type=GENERAL_NOTE),
+        Note(contents="note b", note_type=GENERAL_NOTE),
+    ]
+
+
+def test_does_not_extract_notes_from_non_note_fields() -> None:
+    record = _record_with_fields(
+        _simple_field("100", "not a note"),
+        _simple_field("530", "not a note"),
+    )
+    assert extract_notes(record) == []
+
+
+def test_preserves_html_in_notes_fields() -> None:
+    record = _record_with_fields(_simple_field("500", "<p>note</p>"))
+    assert extract_notes(record) == [
+        Note(contents="<p>note</p>", note_type=GENERAL_NOTE)
+    ]
+
+
+def test_concatenates_subfields_on_single_field_into_single_note() -> None:
+    field = Field(
+        tag="500",
+        indicators=Indicators(" ", " "),
+        subfields=[
+            Subfield(code="a", value="1st part."),
+            Subfield(code="b", value="2nd part."),
+            Subfield(code="c", value="3rd part."),
+        ],
+    )
+    record = _record_with_fields(field)
+    assert extract_notes(record) == [
+        Note(contents="1st part. 2nd part. 3rd part.", note_type=GENERAL_NOTE)
+    ]
+
+
+def test_does_not_concatenate_separate_fields() -> None:
+    record = _record_with_fields(
+        _simple_field("500", "1st note."),
+        _simple_field("500", "2nd note."),
+    )
+    assert extract_notes(record) == [
+        Note(contents="1st note.", note_type=GENERAL_NOTE),
+        Note(contents="2nd note.", note_type=GENERAL_NOTE),
+    ]
+
+
+def test_distinguishes_based_on_first_indicator_of_535() -> None:
+    record = _record_with_fields(
+        _simple_field("535", "The originals are in Oman", indicator1="1"),
+        _simple_field("535", "The duplicates are in Denmark", indicator1="2"),
+    )
+    assert extract_notes(record) == [
+        Note(
+            contents="The originals are in Oman",
+            note_type=LOCATION_OF_ORIGINAL_NOTE,
+        ),
+        Note(
+            contents="The duplicates are in Denmark",
+            note_type=LOCATION_OF_DUPLICATES_NOTE,
+        ),
+    ]
+
+
+def test_only_gets_ownership_note_if_561_first_indicator_is_1() -> None:
+    record = _record_with_fields(
+        _simple_field(
+            "561", "Provenance: one plate in the set of plates", indicator1="1"
+        ),
+        _simple_field("561", "Purchased from John Smith on 01/01/2001", indicator1="0"),
+        _simple_field("561", "Private contact details for John Smith"),
+    )
+    assert extract_notes(record) == [
+        Note(
+            contents="Provenance: one plate in the set of plates",
+            note_type=OWNERSHIP_NOTE,
+        )
+    ]
+
+
+def test_suppresses_subfield_5_universally() -> None:
+    fields_with_5 = [
+        Field(
+            tag=tag,
+            indicators=Indicators("1", " "),
+            subfields=[
+                Subfield(code="a", value="Main bit."),
+                Subfield(code="5", value="UkLW"),
+            ],
+        )
+        for tag in _NOTES_FIELDS
+    ]
+    fields_without_5 = [
+        Field(
+            tag=tag,
+            indicators=Indicators("1", " "),
+            subfields=[Subfield(code="a", value="Main bit.")],
+        )
+        for tag in _NOTES_FIELDS
+    ]
+    record_with_5 = _record_with_fields(*fields_with_5)
+    record_without_5 = _record_with_fields(*fields_without_5)
+    notes_with = sorted(
+        (n.contents, n.note_type.id) for n in extract_notes(record_with_5)
+    )
+    notes_without = sorted(
+        (n.contents, n.note_type.id) for n in extract_notes(record_without_5)
+    )
+    assert notes_with == notes_without
+
+
+def test_skips_notes_which_are_just_whitespace() -> None:
+    fields = [_simple_field("535", content) for content in ["\u00a0", "", "\t\n"]]
+    record = _record_with_fields(*fields)
+    assert extract_notes(record) == []
+
+
+def test_creates_clickable_link_for_subfield_u() -> None:
+    field = Field(
+        tag="540",
+        indicators=Indicators(" ", " "),
+        subfields=[
+            Subfield(
+                code="a",
+                value="The National Library of Medicine believes this item to be in the public domain.",
+            ),
+            Subfield(
+                code="u",
+                value="https://creativecommons.org/publicdomain/mark/1.0/",
+            ),
+            Subfield(code="5", value="DNLM"),
+        ],
+    )
+    record = _record_with_fields(field)
+    notes = extract_notes(record)
+    assert len(notes) == 1
+    assert notes[0].contents == (
+        "The National Library of Medicine believes this item to be in the public domain."
+        ' <a href="https://creativecommons.org/publicdomain/mark/1.0/">'
+        "https://creativecommons.org/publicdomain/mark/1.0/</a>"
+    )
+
+
+def test_does_not_create_link_if_subfield_u_is_not_a_url() -> None:
+    field = Field(
+        tag="540",
+        indicators=Indicators(" ", " "),
+        subfields=[
+            Subfield(
+                code="a",
+                value="The National Library of Medicine believes this item to be in the public domain.",
+            ),
+            Subfield(code="u", value="CC-0 license"),
+        ],
+    )
+    record = _record_with_fields(field)
+    notes = extract_notes(record)
+    assert len(notes) == 1
+    assert notes[0].contents == (
+        "The National Library of Medicine believes this item to be in the public domain."
+        " CC-0 license"
+    )
+
+
+def test_strips_whitespace_from_subfield_u() -> None:
+    field = Field(
+        tag="540",
+        indicators=Indicators(" ", " "),
+        subfields=[
+            Subfield(code="u", value="   https://example.com/works/a65fex5m   "),
+        ],
+    )
+    record = _record_with_fields(field)
+    notes = extract_notes(record)
+    assert len(notes) == 1
+    assert notes[0].contents == (
+        '<a href="https://example.com/works/a65fex5m">https://example.com/works/a65fex5m</a>'
+    )

--- a/catalogue_graph/tests/adapters/transformers/utils/test_html.py
+++ b/catalogue_graph/tests/adapters/transformers/utils/test_html.py
@@ -1,0 +1,22 @@
+from adapters.transformers.utils.html import format_as_html_link
+
+
+def test_formats_valid_url_as_link() -> None:
+    url = "https://example.com/page"
+    assert (
+        format_as_html_link(url)
+        == '<a href="https://example.com/page">https://example.com/page</a>'
+    )
+
+
+def test_strips_whitespace_before_checking() -> None:
+    url = "  https://example.com  "
+    assert (
+        format_as_html_link(url)
+        == '<a href="https://example.com">https://example.com</a>'
+    )
+
+
+def test_returns_non_url_unchanged() -> None:
+    not_a_url = "just some text"
+    assert format_as_html_link(not_a_url) == "just some text"


### PR DESCRIPTION
## What does this change?

https://github.com/wellcomecollection/platform/issues/6396

* Extract notes from 5xx MARC fields. This replaces an existing implementation, which was created as part of the Axiell transformer for exhibitions data.
* Move note extraction from the shared `MarcXmlWorkBuilder` class to `AxiellWorkBuilder`. At the moment, we do not extract any notes from EBSCO records, and this ensures that we do not accidentally start doing so.

This is a port of the Scala implementation (see `MarcNotes.scala`), minus the custom logic for removing references to Codebreakers, which may no longer be needed (to be confirmed later). 

Most notes are extracted using a standard handler, which concatenates all subfields of a given 5xx subfield (except for the suppressed subfield $5 - 'Institution to which field applies'). There are two special handlers:
* 535 notes are categorised as either location of duplicates or location of original, depending on ind1
* 561 notes are hidden if marked as private



## How to test

This change is covered by unit tests ported from Scala, plus BDD tests.

## How can we measure success?

The new note extraction logic should allow us to reproduce the `notes` field outputted by the CALM transformer in the Axiell transformer.

## Have we considered potential risks?

This change does not affect production and is low risk.
