### PR TITLE
write works-source-2026-01-12 api key for folio transf

### DIFF
--- a/pipeline/terraform/modules/pipeline/elastic/main.tf
+++ b/pipeline/terraform/modules/pipeline/elastic/main.tf
@@ -151,6 +151,10 @@ locals {
       read  = []
       write = ["works-source-2026-01-12"]
     }
+    transformer_folio = {
+      read  = []
+      write = ["works-source-2026-01-12"]
+    }
     id_minter = {
       read  = [for idx in local.works_source_list : idx.name]
       write = [for idx in local.works_identified_list : idx.name]


### PR DESCRIPTION
## What does this change?

Following https://github.com/wellcomecollection/catalogue-pipeline/pull/3409
The creation of the actual api_key was omitted so the folio transformer fails with
```
"An error occurred (ResourceNotFoundException) when calling the GetSecretValue operation: Secrets Manager can't find the specified secret."
```

## How to test

TF plan
Plan: 3 to add, 15 to change, 0 to destroy.
15 to change are the usual scaling_service stuff, 3 for each of sierra/miro/tei/mets/calm transformer. These are not eventually applied
3 to add: 
```
Terraform will perform the following actions:

  # module.pipeline.module.elastic.module.pipeline_services["transformer_folio"].elasticstack_elasticsearch_security_api_key.pipeline_service will be created
  + resource "elasticstack_elasticsearch_security_api_key" "pipeline_service" {
      + api_key              = (sensitive value)
      + encoded              = (sensitive value)
      + expiration_timestamp = (known after apply)
      + id                   = (known after apply)
      + metadata             = (known after apply)
      + name                 = "transformer_folio-2025-10-02"
      + role_descriptors     = jsonencode(
            {
              + write = {
                  + indices = [
                      + {
                          + allow_restricted_indices = false
                          + names                    = [
                              + "works-source-2026-01-12",
                            ]
                          + privileges               = [
                              + "all",
                            ]
                        },
                    ]
                }
            }
        )
    }

  # module.pipeline.module.elastic.module.pipeline_services["transformer_folio"].module.pipeline_service_api_key_secrets.aws_secretsmanager_secret.secret["elasticsearch/pipeline_storage_2025-10-02/transformer_folio/api_key"] will be created
  + resource "aws_secretsmanager_secret" "secret" {
      + arn                            = (known after apply)
      + description                    = "(managed by Terraform)"
      + force_overwrite_replica_secret = false
      + id                             = (known after apply)
      + name                           = "elasticsearch/pipeline_storage_2025-10-02/transformer_folio/api_key"
      + name_prefix                    = (known after apply)
      + policy                         = (known after apply)
      + recovery_window_in_days        = 0
      + region                         = "eu-west-1"
      + tags_all                       = (known after apply)

      + replica (known after apply)
    }

  # module.pipeline.module.elastic.module.pipeline_services["transformer_folio"].module.pipeline_service_api_key_secrets.aws_secretsmanager_secret_version.secret["elasticsearch/pipeline_storage_2025-10-02/transformer_folio/api_key"] will be created
  + resource "aws_secretsmanager_secret_version" "secret" {
      + arn                  = (known after apply)
      + has_secret_string_wo = (known after apply)
      + id                   = (known after apply)
      + region               = "eu-west-1"
      + secret_id            = (known after apply)
      + secret_string        = (sensitive value)
      + version_id           = (known after apply)
      + version_stages       = (known after apply)
    }
```

## How can we measure success?

The folio transformer can read the secret used to write to ES

## Have we considered potential risks?

Same pattern as existing ES client

