### PR TITLE
Move merger to modifiedTime-mapped images-initial; enable scheduled image-inferrer

### DIFF
--- a/pipeline/terraform/2025-10-02/main.tf
+++ b/pipeline/terraform/2025-10-02/main.tf
@@ -34,7 +34,11 @@ module "pipeline" {
         denormalised = "works_denormalised.2025-08-14"
       }
       images = {
-        // prod matcher_merger - prod inference manager
+        // prod matcher_merger - OLD SQS-driven inference manager.
+        // POST-CUTOVER: orphaned. The merger + Scala inferrer now write/read the
+        // modifiedTime-mapped images-initial-2026-06-15 (see the 2026-06-15 entry below),
+        // so nothing writes this index any more. Remove this `initial` entry to delete the
+        // old index once we're confident the new path is the source of truth.
         initial = "empty"
         // scala images ingestor - to be deleted when the service is removed
         augmented = "empty"
@@ -82,15 +86,20 @@ module "pipeline" {
         indexed = "images_indexed.2024-11-14"
       }
     }
-    // Shadow indexes for the new Python image-inferrer state machine, so it can
-    // run in isolation against real data without touching the live indexes.
-    // Date-only name (today's date) like the other test indexes.
-    //  - initial: the SOURCE index, with an explicit mapping that indexes
-    //    modifiedTime (the live images-initial uses the "empty"/dynamic:false
-    //    mapping, where modifiedTime is unqueryable). Populated by a one-off
-    //    reindex from images-initial-2025-10-02.
-    //  - augmented: the OUTPUT index (reuses the images_augmented.2026-04-29
-    //    mapping) so output can be compared against the Scala inferrer's prod output.
+    // Indexes for the new Python image-inferrer state machine.
+    // (Date-only name, chosen when these started as shadow indexes.)
+    //  - initial: now the PRODUCTION source index. The merger and both inferrers
+    //    write/read this; it has an explicit mapping that indexes modifiedTime, which
+    //    the find_work time-window query needs (the old images-initial-2025-10-02 used
+    //    the "empty"/dynamic:false mapping, where modifiedTime is unqueryable). No longer
+    //    a shadow index — keep it. (Will be a normal images-initial-<date> on the next
+    //    full pipeline reindex; the off-pipeline-date name is cosmetic until then.)
+    //  - augmented: parallel OUTPUT index kept in sync by the scheduled inferrer, for
+    //    comparison against the Scala inferrer's prod output (reuses the
+    //    images_augmented.2026-04-29 mapping). KEEP — deliberately retained. POST-CUTOVER,
+    //    when the new inferrer is switched to write the prod augmented index
+    //    (graph_index_dates.augmented) and the old service is retired, this stays as the
+    //    comparison/standby index unless we later decide otherwise.
     "2026-06-15" = {
       images = {
         initial   = "images_initial.2026-06-15"
@@ -100,6 +109,20 @@ module "pipeline" {
   }
 
   allow_delete_indices = false
+
+  # Image-inferrer cutover, run alongside the old SQS-driven service (not yet retired).
+  # The live images-initial-2025-10-02 uses the "empty"/dynamic:false mapping where modifiedTime is
+  # unqueryable, so the merger + Scala inferrer are moved onto the modifiedTime-mapped
+  # images-initial-2026-06-15 (the index the new state-machine inferrer already reads). The schedule
+  # is ENABLED so the new path runs every 15 min and keeps its shadow augmented index in sync; it
+  # keeps writing the shadow images-augmented-2026-06-15 (NOT prod), so the old service remains the
+  # source of truth for the prod augmented index that the API reads. The switch to the production
+  # augmented index (graph_index_dates.augmented = 2026-04-29) + retiring the old service is a
+  # separate later step. NB the augmented override must stay set explicitly — the module var
+  # defaults to "" which falls back to graph_index_dates.augmented (prod 2026-04-29).
+  enable_image_inferrer_schedule      = true
+  image_inferrer_initial_index_date   = "2026-06-15"
+  image_inferrer_augmented_index_date = "2026-06-15"
 
   # Base AMI for ECS instances
   ami_id = "resolve:ssm:arn:aws:ssm:eu-west-1:760097843905:parameter/imagebuilder/weco-al2023-ecs-optimised-x86_64/latest"

--- a/pipeline/terraform/modules/pipeline/locals.tf
+++ b/pipeline/terraform/modules/pipeline/locals.tf
@@ -29,12 +29,20 @@ data "aws_s3_bucket" "folio_adapter_bucket" {
 locals {
   namespace = "catalogue-${var.pipeline_date}"
 
+  // Resolved index dates for the image-inferrer path. Each var falls back to the steady-state
+  // default when empty, so a fresh pipeline is safe without overrides; an existing pipeline sets
+  // them explicitly during cutover (see the 2025-10-02 root). The merger, the Scala inferrer and
+  // the new state-machine inferrer all derive the initial index from one resolved value, so they
+  // can never diverge.
+  image_inferrer_initial_index_date   = var.image_inferrer_initial_index_date != "" ? var.image_inferrer_initial_index_date : var.pipeline_date
+  image_inferrer_augmented_index_date = var.image_inferrer_augmented_index_date != "" ? var.image_inferrer_augmented_index_date : var.graph_index_dates.augmented
+
   // Default index names for services that need to know where to write/read from
   // These presume that the indexes exist and are created by the index_config
   es_works_source_index       = "works-source-${var.pipeline_date}"
   es_works_identified_index   = "works-identified-${var.pipeline_date}"
   es_works_denormalised_index = "works-denormalised-${var.pipeline_date}"
-  es_images_initial_index     = "images-initial-${var.pipeline_date}"
+  es_images_initial_index     = "images-initial-${local.image_inferrer_initial_index_date}"
   es_images_augmented_index   = "images-augmented-${var.graph_index_dates.augmented}"
   es_images_index             = "images-indexed-${var.pipeline_date}"
 

--- a/pipeline/terraform/modules/pipeline/service_image_inferrer.tf
+++ b/pipeline/terraform/modules/pipeline/service_image_inferrer.tf
@@ -38,6 +38,11 @@ locals {
   inferrer_memory = floor(0.5 * (local.total_memory - local.manager_memory - local.aspect_ratio_memory - local.log_router_memory))
 }
 
+# OLD SQS-driven image inferrer. Being replaced by the scheduled state machine in
+# state_machine_image_inferrer.tf. POST-CUTOVER: remove this whole module (and its SNS
+# subscription to merger.images_output) once the new path writes the prod augmented index
+# and has been the sole inferrer for long enough to be trusted. Kept running in parallel
+# during the transition (it remains the source of truth for the prod augmented index).
 module "image_inferrer" {
   source = "../services_with_manager"
 

--- a/pipeline/terraform/modules/pipeline/state_machine_image_inferrer.tf
+++ b/pipeline/terraform/modules/pipeline/state_machine_image_inferrer.tf
@@ -68,8 +68,8 @@ locals {
         Output = {
           "pipeline_date" : var.pipeline_date,
           "index_dates" : {
-            "initial" : var.image_inferrer_initial_index_date,
-            "augmented" : var.image_inferrer_augmented_index_date
+            "initial" : local.image_inferrer_initial_index_date,
+            "augmented" : local.image_inferrer_augmented_index_date
           },
           # Window end is 5 minutes before the scheduled time (indexing lag);
           # the find-work step defaults the window start to end - 15 minutes.

--- a/pipeline/terraform/modules/pipeline/variables.tf
+++ b/pipeline/terraform/modules/pipeline/variables.tf
@@ -108,25 +108,26 @@ variable "enable_image_inferrer_schedule" {
 
 variable "image_inferrer_augmented_index_date" {
   type        = string
-  default     = "2026-06-15"
+  default     = ""
   description = <<-EOT
-    Augmented index date the Python image-inferrer state machine writes to. Defaults to a separate
-    shadow index (`images-augmented-2026-06-15`) so the new pipeline never overwrites the Scala
-    inferrer's prod output and its results can be compared. At cutover, set this to
-    `graph_index_dates.augmented`. A matching `index_config` entry must exist (see the 2025-10-02 root).
+    Augmented index date the Python image-inferrer state machine writes to. Empty (the default) falls
+    back to `graph_index_dates.augmented` — i.e. the production augmented index the images ingestor
+    reads — which is the steady-state cutover target. Set explicitly only to write a separate shadow
+    index (e.g. `2026-06-15`) for isolated comparison runs. A matching `index_config` entry must exist
+    (see the 2025-10-02 root).
   EOT
 }
 
 variable "image_inferrer_initial_index_date" {
   type        = string
-  default     = "2026-06-15"
+  default     = ""
   description = <<-EOT
-    Initial-images index date the Python image-inferrer state machine reads from. Defaults to a
-    shadow source index (`images-initial-2026-06-15`) whose mapping indexes `modifiedTime` (the live
-    images-initial uses an "empty"/dynamic:false mapping where modifiedTime is unqueryable). Populate
-    it via a one-off reindex from `images-initial-<pipeline_date>`. At cutover, set this to
-    `var.pipeline_date` once the live images-initial indexes `modifiedTime`. A matching `index_config`
-    entry must exist (see the 2025-10-02 root).
+    Initial-images index the merger writes and both inferrers read. Empty (the default) falls back to
+    `var.pipeline_date`, which is the steady-state once a fresh pipeline's images-initial is created
+    with a mapping that indexes `modifiedTime`. Set explicitly during the in-place migration on an
+    existing pipeline whose live images-initial uses the "empty"/dynamic:false mapping (where
+    `modifiedTime` is unqueryable): point it at a modifiedTime-mapped index (e.g. `2026-06-15`) that the
+    merger is moved onto. A matching `index_config` entry must exist (see the 2025-10-02 root).
   EOT
 }
 

--- a/reindexer/scripts/reindex_index.py
+++ b/reindexer/scripts/reindex_index.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""
+Reindex one Elasticsearch index into another on a pipeline-storage cluster, and verify
+doc counts.
+
+Both indices must live on the same ``pipeline_storage_<pipeline_date>`` cluster.
+
+By default the reindex runs with ``version_type=external`` and ``conflicts=proceed`` so it
+never overwrites a fresher write at the destination and is safe to re-run (e.g. to catch
+up after a writer has been moved onto the destination index). Pass ``--verify-field`` to
+also report how many docs have that field *indexed* (an ``exists`` query) in each index —
+useful when the point of the reindex is to populate a newly-mapped field (a
+``dynamic:false`` mapping leaves unmapped fields in ``_source`` but unqueryable, so the
+count is 0 until the docs are reindexed under a mapping that indexes the field).
+
+A write (``_reindex``) needs more than read-only privileges, so this connects with the
+deployment superuser credentials (``.../es_username`` + ``.../es_password``), not the
+``read_only`` user used by get_reindex_status.py.
+
+Usage (from reindexer/scripts/):
+    uv run reindex_index.py --source-index SRC --dest-index DST
+    uv run reindex_index.py --source-index SRC --dest-index DST --verify-field modifiedTime
+    uv run reindex_index.py --source-index SRC --dest-index DST --verify-only   # read-only counts
+    uv run reindex_index.py --source-index SRC --dest-index DST --no-wait        # fire and exit
+"""
+
+import time
+
+import click
+from elasticsearch import Elasticsearch
+
+from get_reindex_status import get_secret_string, get_session_with_role
+
+
+def get_superuser_es_client(pipeline_date: str) -> Elasticsearch:
+    """
+    Returns an Elasticsearch client for the pipeline-storage cluster authenticated as the
+    deployment superuser (required for _reindex, which writes).
+    """
+    session = get_session_with_role(
+        "arn:aws:iam::760097843905:role/platform-developer"
+    )
+
+    secret_prefix = f"elasticsearch/pipeline_storage_{pipeline_date}"
+
+    host = get_secret_string(session, secret_id=f"{secret_prefix}/public_host")
+    port = get_secret_string(session, secret_id=f"{secret_prefix}/port")
+    protocol = get_secret_string(session, secret_id=f"{secret_prefix}/protocol")
+    username = get_secret_string(session, secret_id=f"{secret_prefix}/es_username")
+    password = get_secret_string(session, secret_id=f"{secret_prefix}/es_password")
+
+    return Elasticsearch(
+        f"{protocol}://{host}:{port}",
+        basic_auth=(username, password),
+        request_timeout=120,
+    )
+
+
+def verify(
+    es_client: Elasticsearch,
+    *,
+    indices: list[str],
+    verify_field: str | None,
+) -> None:
+    """
+    Print the total doc count for each index, and (if verify_field is given) how many docs
+    have that field indexed/queryable via an ``exists`` query.
+    """
+    for index in indices:
+        if not es_client.indices.exists(index=index):
+            click.echo(f"  {index}: (does not exist)")
+            continue
+        total = es_client.count(index=index)["count"]
+        line = f"  {index}: total={total}"
+        if verify_field:
+            try:
+                queryable = es_client.count(
+                    index=index, query={"exists": {"field": verify_field}}
+                )["count"]
+                line += f", {verify_field}-indexed={queryable}"
+            except Exception as exc:  # noqa: BLE001 - report unmapped-field errors inline
+                line += f", {verify_field}-indexed=(error: {type(exc).__name__})"
+        click.echo(line)
+
+
+@click.command()
+@click.option("--pipeline-date", default="2025-10-02", show_default=True,
+              help="Selects the pipeline_storage_<date> cluster to connect to.")
+@click.option("--source-index", required=True, help="Index to reindex from.")
+@click.option("--dest-index", required=True, help="Index to reindex into.")
+@click.option("--version-type", default="external", show_default=True,
+              type=click.Choice(["external", "internal"]),
+              help="external = never clobber a fresher dest doc; safe to re-run.")
+@click.option("--conflicts", default="proceed", show_default=True,
+              type=click.Choice(["proceed", "abort"]))
+@click.option("--verify-field", default=None,
+              help="Also report how many docs have this field indexed (exists query).")
+@click.option("--wait/--no-wait", default=True, show_default=True,
+              help="Wait for the reindex task to finish and poll progress.")
+@click.option("--verify-only", is_flag=True, default=False,
+              help="Only print doc counts; do not run the reindex (read-only).")
+def main(
+    pipeline_date: str,
+    source_index: str,
+    dest_index: str,
+    version_type: str,
+    conflicts: str,
+    verify_field: str | None,
+    wait: bool,
+    verify_only: bool,
+) -> None:
+    es_client = get_superuser_es_client(pipeline_date)
+    indices = [source_index, dest_index]
+
+    click.echo("Before:")
+    verify(es_client, indices=indices, verify_field=verify_field)
+
+    if verify_only:
+        return
+
+    dest: dict = {"index": dest_index}
+    if version_type != "internal":
+        dest["version_type"] = version_type
+
+    click.echo(
+        f"\nReindexing {source_index} -> {dest_index} "
+        f"(version_type={version_type}, conflicts={conflicts})..."
+    )
+    response = es_client.reindex(
+        source={"index": source_index},
+        dest=dest,
+        conflicts=conflicts,
+        wait_for_completion=False,
+        request_timeout=120,
+    )
+    task_id = response["task"]
+    click.echo(f"  task: {task_id}")
+
+    if not wait:
+        click.echo("  --no-wait: not polling. Re-run with --verify-only to check progress.")
+        return
+
+    while True:
+        task = es_client.tasks.get(task_id=task_id)
+        status = task["task"]["status"]
+        click.echo(
+            "  progress: "
+            f"total={status['total']} created={status['created']} "
+            f"updated={status['updated']} version_conflicts={status['version_conflicts']} "
+            f"batches={status['batches']}"
+        )
+        if task["completed"]:
+            failures = task["response"].get("failures", [])
+            if failures:
+                click.echo(f"  FAILURES ({len(failures)}): {failures[:3]} ...")
+            break
+        time.sleep(5)
+
+    click.echo("\nAfter:")
+    verify(es_client, indices=indices, verify_field=verify_field)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What & why

Prepares the image-inferrer production cutover (follows #3413). The scheduled image-inference
state machine merged in #3413 has been validated but was dormant: it read/wrote **shadow** indices
and its schedule was disabled. Cutover needs the scheduled `find_work` step to discover images by a
`modifiedTime` time-window query — but the live merger-fed `images-initial-2025-10-02` uses the
`empty`/`dynamic:false` mapping, where `modifiedTime` is in `_source` but **not queryable**.

Rather than mutate a live index's mapping in place, this **moves the merger (and the still-live Scala
inferrer that reads alongside it) onto the already-existing, modifiedTime-mapped
`images-initial-2026-06-15`** — the exact index the new inferrer already reads — and **enables the
schedule** so the new path keeps its shadow augmented index continuously in sync.

This change is deliberately conservative: the old SQS-driven service is **not** retired and the
**production augmented index is not touched**. The old service remains the source of truth for the
prod augmented index the API reads; the new path writes only the shadow `images-augmented-2026-06-15`.

## What changes

- **`variables.tf`**: `image_inferrer_initial_index_date` / `image_inferrer_augmented_index_date`
  defaults `"2026-06-15"` → `""`.
- **`locals.tf`**: two resolved locals that fall back to `pipeline_date` /
  `graph_index_dates.augmented` when the var is empty (future pipelines safe without overrides).
  `es_images_initial_index` (merger write + Scala inferrer read) now derives from the resolved
  initial date — this is what moves the merger and Scala inferrer together.
- **`state_machine_image_inferrer.tf`**: `index_dates` read the resolved locals (single source of
  truth shared with the merger).
- **`2025-10-02/main.tf`**: explicit overrides — `enable_image_inferrer_schedule = true`,
  `image_inferrer_initial_index_date = "2026-06-15"`, `image_inferrer_augmented_index_date =
  "2026-06-15"` (augmented stays shadow on purpose). Comments updated: the `2026-06-15` initial index
  is now documented as **production** (no longer a shadow); post-cutover removal markers added to the
  orphaned old initial-index entry and the old service module.
- **`reindexer/scripts/reindex_index.py`** *(new)*: a general "reindex + verify any two indices"
  helper (`uv run`, superuser creds since `_reindex` writes; `version_type=external` +
  `conflicts=proceed`, so it's idempotent / safe to re-run). Used here to backfill
  `images-initial-2026-06-15` from `images-initial-2025-10-02`.

## Pipeline after this change

```mermaid
flowchart TD
    M[merger] -->|writes| INIT[("images-initial-2026-06-15<br/>modifiedTime mapped")]

    INIT -->|"SQS, by _id"| OLD["image_inferrer<br/>(old Scala service, still running)"]
    OLD -->|writes| AUGP[("images-augmented-2026-04-29<br/>PROD — source of truth")]
    AUGP --> ING[images ingestor] --> IDX[("images-indexed")] --> API[Catalogue API]

    SCHED["EventBridge schedule<br/>every 15 min (NOW ENABLED)"] --> SM["image_inferrer<br/>state machine"]
    INIT -->|"find_work: modifiedTime window"| SM
    SM -->|writes| AUGS[("images-augmented-2026-06-15<br/>SHADOW — kept in sync")]

    classDef prod fill:#e6ffe6,stroke:#2b8a3e;
    classDef shadow fill:#fff3bf,stroke:#b08900;
    class AUGP,IDX prod;
    class AUGS shadow;
```

Both inferrers share the inferrer EC2 ASG (`max = image_inferrer_max_concurrency = 10`). In steady
state the scheduled path sits at 0–1 instances per window, so contention with the old service (scales
0→1) is minimal; the state machine's `ECS.AmazonECSException` retrier + `RecordPartitionFailure`
tolerance turn a rare large-window race into a slowdown, not a failure.

## Apply / operational steps

These are run by hand (the reindex brackets the apply); `_reindex` is idempotent.

1. **Pre-apply backfill** — bring the shadow initial index current:
   ```
   cd reindexer/scripts
   uv run reindex_index.py --source-index images-initial-2025-10-02 \
     --dest-index images-initial-2026-06-15 --verify-field modifiedTime
   ```
2. **`terraform apply`** the `2025-10-02` stack. **Apply gate** — expect *only*:
   - merger + Scala-inferrer task-def `es_*_images_index` → `images-initial-2026-06-15`
   - `aws_scheduler_schedule.image_inferrer_schedule` state `DISABLED → ENABLED`
   - state-machine definition **unchanged** (both dates still resolve to `2026-06-15`)
   - **no** index-resource change, **no** service create/destroy. If anything else appears, stop.
3. **Post-apply catch-up** — rerun the same `reindex_index.py` command to copy anything merged during
   the apply window (old index now frozen; safe/idempotent).
4. **Verify** the `modifiedTime`-indexed count on `images-initial-2026-06-15` ≈ full doc count
   (`~137,884`; the empty-mapped index reports 0 today).

After this, the schedule keeps the shadow augmented index in sync automatically.

## Next steps (later PRs — NOT in this one)

1. **Switch augmented to prod**: set `image_inferrer_augmented_index_date = "2026-04-29"` (or drop the
   override to take the `""` → `graph_index_dates.augmented` fallback) so the new inferrer writes the
   production augmented index. (Re-augments modified images with the non-deterministic
   paletteEmbedding, hence deferred to a deliberate step.)
2. **Retire the old service**: remove `module.image_inferrer` (and its `merger.images_output`
   subscription) once the new path is trusted as sole inferrer.
3. **Cleanup**: remove the orphaned `images-initial-2025-10-02` `index_config` entry when ready to
   delete that index. (The shadow `images-augmented-2026-06-15` is **deliberately kept**.)

## Rollback

Pre-apply: nothing to undo (reindex is additive/idempotent). Post-apply: revert the stack overrides —
the merger/Scala inferrer return to `images-initial-2025-10-02` and the schedule goes back to
`DISABLED`. The old empty-mapped index is intact and the prod augmented path was never touched, so the
production path is unchanged throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
