### PR TITLE
Skip ingestor deletions step for by-id (ids) runs

### DIFF
--- a/pipeline/terraform/modules/pipeline/graph/state_machine_ingestor.tf
+++ b/pipeline/terraform/modules/pipeline/graph/state_machine_ingestor.tf
@@ -79,7 +79,12 @@ module "catalogue_graph_ingestor_state_machine" {
         Type = "Choice"
         Choices = [
           {
-            "Condition" : "{% $states.input.ingestor_type in ['concepts', 'images'] %}",
+            # Reconciliation deletions only make sense for a full/window-driven run. Skip them when
+            # the event carries `ids` (a targeted by-id re-ingest): the loader/indexer treat `ids` as
+            # "ingest these", but the deletions step treats the same `ids` as "delete these" (see
+            # ingestor_deletions.py), so without this guard a by-id run would index those ids and then
+            # immediately delete them from the live index.
+            "Condition" : "{% $states.input.ingestor_type in ['concepts', 'images'] and $count($states.input.ids) = 0 %}",
             "Next" : "Run deletions"
           }
         ]


### PR DESCRIPTION
## What does this change?

Guards the **deletions** step in the Python images/concepts ingestor state machine
(`graph-pipeline-ingestor-<date>`, `graph/state_machine_ingestor.tf`) so it only runs for
full/window-driven reconciliation runs, not for targeted by-id (`ids`) runs.

**The hazard.** The ingestor SM runs **loader → indexer → deletions**, and the *"Should run
deletions?"* Choice routed to deletions whenever `ingestor_type in ['concepts', 'images']`. `ids` is
a **shared field** on the base pipeline event, but the steps interpret it oppositely:

- **loader/indexer** (`ingestor/models/step_events.py:43`) treat `ids` as *"ingest **these** docs"*
  (the by-id mode, used for targeted re-indexing / local testing).
- **deletions** (`ingestor/steps/ingestor_deletions.py:72`) treats the *same* `event.ids` as
  *"**delete** these ids"*:
  `ids_to_delete = set(event.ids) if event.ids else get_ids_to_delete(event)` →
  `delete_documents(ids_to_delete)`.

Because the SM passes the same `$states.input` to every step, starting the SM with `ids` would index
those ids and then **immediately delete them** from the live index the Catalogue API serves. The 5%
`validate_fractional_change` safety gate doesn't protect a small id set (~0.02%).

**This is latent, not an active prod bug.** The parent `graph-pipeline-ingestors` SM never forwards
`ids` — it only passes `ingestor_type, pipeline_date, index_dates, window, pit_ids`
(`state_machine_ingestors.tf:17-21`), so the normal window-driven flow is unaffected. The documented
by-id test path, `ingestor/run_local.py`, runs **loader + indexer only** and never invokes deletions.
The hazard only triggers if an operator starts the **child** ingestor SM directly with an `ids` event
(e.g. testing a by-id re-ingest on real infrastructure) — where it is silent and destructive.

**The fix.** The deletions Choice condition now also requires `ids` to be absent:

```
{% $states.input.ingestor_type in ['concepts', 'images'] and $count($states.input.ids) = 0 %}
```

`$count(undefined) = 0`, so window/full runs are unchanged; a by-id run through the SM now behaves
like `run_local.py` (loader + indexer, no deletions), matching intent.

**Works is unaffected.** `IngestorDeletionsType = Literal["concepts", "images"]` (`utils/types.py:71`)
— works isn't a valid deletions type, and the Choice routes works to `Success`. Works deletion is
handled separately at the graph layer (`graph/steps/graph_remover_incremental.py`), not via an
ingest-event `ids` field.

## How to test

- `terraform fmt` is clean and `terraform validate` returns Success.
- `terraform plan` on the `2025-10-02` stack shows a **single in-place change** to the ingestor SM
  definition — exactly the `Condition` string gaining `and $count($states.input.ids) = 0` — and
  nothing else. (A find_work-lambda republish also appears in the plan, but that's pre-existing drift
  unrelated to this PR.)
- Confirm a by-id run through the child ingestor SM now skips the deletions step (routes loader →
  indexer → done), matching the behaviour of `ingestor/run_local.py`.
- Confirm window/full runs (no `ids` in the event) still route through deletions as before.

## How can we measure success?

- No regression in window/full reconciliation runs: deletions continue to run for `concepts`/`images`
  as they did before.
- A by-id re-ingest started directly against the child SM no longer deletes the ids it just indexed
  from the live index — i.e. no unexpected drops in the Catalogue API images/concepts indices following
  targeted re-ingests.

## Have we considered potential risks?

- **Scope is minimal:** one Choice condition in one Terraform-defined state machine; the plan confirms
  no other resources change.
- **Window/full runs unchanged:** `$count(undefined) = 0` means events without `ids` evaluate exactly
  as before, so normal reconciliation deletions are preserved.
- **By-id deletions intentionally removed from this path:** if a deliberate by-id *delete* is ever
  needed, it must now go through a dedicated path rather than the ingestor SM — this matches the
  documented by-id intent (`run_local.py` = loader + indexer only) and removes a silent, destructive
  failure mode.
- **Works unaffected:** works are never a valid deletions type and are routed to `Success`; works
  deletion remains handled at the graph layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
