### PR TITLE
Point image graph read-path at the new inferrer's augmented index

### DIFF
--- a/pipeline/terraform/2025-10-02/main.tf
+++ b/pipeline/terraform/2025-10-02/main.tf
@@ -80,7 +80,10 @@ module "pipeline" {
     },
     "2026-04-29" = {
       images = {
-        // prod inference manager - prod graph/ingestor/indexer
+        // OLD Scala inference manager output (its write target = local.es_images_augmented_index =
+        // images-augmented-${graph_index_dates.augmented}). POST-PHASE-2 the graph read-path no longer
+        // reads this (graph_images_augmented_index_date points it at 2026-06-15); the old service keeps
+        // writing it as a live rollback fallback. Remove when the old service is retired.
         augmented = "images_augmented.2026-04-29"
         // prod graph/ingestor/indexer - prod API
         indexed = "images_indexed.2024-11-14"
@@ -94,12 +97,10 @@ module "pipeline" {
     //    the "empty"/dynamic:false mapping, where modifiedTime is unqueryable). No longer
     //    a shadow index — keep it. (Will be a normal images-initial-<date> on the next
     //    full pipeline reindex; the off-pipeline-date name is cosmetic until then.)
-    //  - augmented: parallel OUTPUT index kept in sync by the scheduled inferrer, for
-    //    comparison against the Scala inferrer's prod output (reuses the
-    //    images_augmented.2026-04-29 mapping). KEEP — deliberately retained. POST-CUTOVER,
-    //    when the new inferrer is switched to write the prod augmented index
-    //    (graph_index_dates.augmented) and the old service is retired, this stays as the
-    //    comparison/standby index unless we later decide otherwise.
+    //  - augmented: the scheduled inferrer's output (reuses the images_augmented.2026-04-29 mapping).
+    //    As of Phase 2 this is the graph read-path SOURCE (graph_images_augmented_index_date =
+    //    "2026-06-15" below) — i.e. the production augmented index feeding the API. Must be at full
+    //    coverage before that switch is applied (see the graph_images_augmented_index_date note + PR).
     "2026-06-15" = {
       images = {
         initial   = "images_initial.2026-06-15"
@@ -110,19 +111,21 @@ module "pipeline" {
 
   allow_delete_indices = false
 
-  # Image-inferrer cutover, run alongside the old SQS-driven service (not yet retired).
-  # The live images-initial-2025-10-02 uses the "empty"/dynamic:false mapping where modifiedTime is
-  # unqueryable, so the merger + Scala inferrer are moved onto the modifiedTime-mapped
-  # images-initial-2026-06-15 (the index the new state-machine inferrer already reads). The schedule
-  # is ENABLED so the new path runs every 15 min and keeps its shadow augmented index in sync; it
-  # keeps writing the shadow images-augmented-2026-06-15 (NOT prod), so the old service remains the
-  # source of truth for the prod augmented index that the API reads. The switch to the production
-  # augmented index (graph_index_dates.augmented = 2026-04-29) + retiring the old service is a
-  # separate later step. NB the augmented override must stay set explicitly — the module var
-  # defaults to "" which falls back to graph_index_dates.augmented (prod 2026-04-29).
+  # Image-inferrer cutover. Phase 1 (applied): merger + Scala inferrer moved onto the modifiedTime-mapped
+  # images-initial-2026-06-15; the scheduled inferrer enabled, writing images-augmented-2026-06-15.
+  # Phase 2 (this change): the graph READ-path (extractor + ingestor + remover) is pointed at the new
+  # inferrer's output via graph_images_augmented_index_date below, so the API is now fed from
+  # images-augmented-2026-06-15. graph_index_dates.augmented stays "2026-04-29" on purpose: the old
+  # Scala service keeps writing that index as an untouched, live fallback (rollback = drop this override
+  # and the read-path returns to a still-current 2026-04-29). The new inferrer keeps writing
+  # images-augmented-2026-06-15 (image_inferrer_augmented_index_date), now the production augmented index.
+  # PREREQUISITE before apply: images-augmented-2026-06-15 must be at full coverage — it was short by
+  # ~5,709 historical images the scheduled find_work window hasn't reached; close that backlog first by
+  # reindexing images-augmented-2026-04-29 -> images-augmented-2026-06-15 (external_gte; see PR).
   enable_image_inferrer_schedule      = true
   image_inferrer_initial_index_date   = "2026-06-15"
   image_inferrer_augmented_index_date = "2026-06-15"
+  graph_images_augmented_index_date   = "2026-06-15"
 
   # Base AMI for ECS instances
   ami_id = "resolve:ssm:arn:aws:ssm:eu-west-1:760097843905:parameter/imagebuilder/weco-al2023-ecs-optimised-x86_64/latest"

--- a/pipeline/terraform/2025-10-02/main.tf
+++ b/pipeline/terraform/2025-10-02/main.tf
@@ -119,9 +119,6 @@ module "pipeline" {
   # Scala service keeps writing that index as an untouched, live fallback (rollback = drop this override
   # and the read-path returns to a still-current 2026-04-29). The new inferrer keeps writing
   # images-augmented-2026-06-15 (image_inferrer_augmented_index_date), now the production augmented index.
-  # PREREQUISITE before apply: images-augmented-2026-06-15 must be at full coverage — it was short by
-  # ~5,709 historical images the scheduled find_work window hasn't reached; close that backlog first by
-  # reindexing images-augmented-2026-04-29 -> images-augmented-2026-06-15 (external_gte; see PR).
   enable_image_inferrer_schedule      = true
   image_inferrer_initial_index_date   = "2026-06-15"
   image_inferrer_augmented_index_date = "2026-06-15"

--- a/pipeline/terraform/modules/pipeline/locals.tf
+++ b/pipeline/terraform/modules/pipeline/locals.tf
@@ -37,6 +37,12 @@ locals {
   image_inferrer_initial_index_date   = var.image_inferrer_initial_index_date != "" ? var.image_inferrer_initial_index_date : var.pipeline_date
   image_inferrer_augmented_index_date = var.image_inferrer_augmented_index_date != "" ? var.image_inferrer_augmented_index_date : var.graph_index_dates.augmented
 
+  // Augmented index the graph subsystem READ-path (extractor/ingestor/remover) sources from. Falls
+  // back to graph_index_dates.augmented (so read-path and the old Scala service's write target stay
+  // aligned) unless overridden to decouple them during the image-inferrer cutover. See the
+  // graph_images_augmented_index_date variable. Injected via subsystem_graph.tf's index_dates.
+  graph_images_augmented_index_date = var.graph_images_augmented_index_date != "" ? var.graph_images_augmented_index_date : var.graph_index_dates.augmented
+
   // Default index names for services that need to know where to write/read from
   // These presume that the indexes exist and are created by the index_config
   es_works_source_index       = "works-source-${var.pipeline_date}"

--- a/pipeline/terraform/modules/pipeline/subsystem_graph.tf
+++ b/pipeline/terraform/modules/pipeline/subsystem_graph.tf
@@ -2,7 +2,16 @@ module "graph_pipeline" {
   source = "./graph"
 
   pipeline_date = var.pipeline_date
-  index_dates   = var.graph_index_dates
+  # The graph subsystem's augmented source can be decoupled from graph_index_dates.augmented (which
+  # the old Scala inferrer still writes) via graph_images_augmented_index_date — see that variable and
+  # local.graph_images_augmented_index_date. All other dates pass through unchanged.
+  index_dates = {
+    merged    = var.graph_index_dates.merged
+    augmented = local.graph_images_augmented_index_date
+    works     = var.graph_index_dates.works
+    concepts  = var.graph_index_dates.concepts
+    images    = var.graph_index_dates.images
+  }
 
   ecs_cluster_arn = aws_ecs_cluster.cluster.arn
 

--- a/pipeline/terraform/modules/pipeline/variables.tf
+++ b/pipeline/terraform/modules/pipeline/variables.tf
@@ -131,6 +131,21 @@ variable "image_inferrer_initial_index_date" {
   EOT
 }
 
+variable "graph_images_augmented_index_date" {
+  type        = string
+  default     = ""
+  description = <<-EOT
+    Augmented-images index that the graph subsystem READ-path (graph extractor, images ingestor,
+    incremental remover) uses as its source. Empty (the default) falls back to
+    `graph_index_dates.augmented`, keeping the read-path and the old Scala inferrer's write target
+    (`local.es_images_augmented_index`, also derived from `graph_index_dates.augmented`) on the same
+    index. Set explicitly to decouple them — i.e. to cut the read-path over to the new Python inferrer's
+    output (e.g. `2026-06-15`) while the old SQS-driven service keeps writing
+    `graph_index_dates.augmented` as an untouched, live fallback (so a rollback is just reverting this
+    var). The target index must be at full coverage before the switch.
+  EOT
+}
+
 variable "image_inferrer_max_concurrency" {
   type        = number
   default     = 10


### PR DESCRIPTION
## What does this change?

This is Phase 2 of the image-inferrer cutover.

Phase 1 (merged + applied, PRs #3413 / #3423) moved the merger and the old Scala inferrer onto the `modifiedTime`-mapped `images-initial-2026-06-15`, and enabled the new scheduled state-machine inferrer, which writes `images-augmented-2026-06-15`.

Phase 2 points the graph subsystem's READ-path (graph extractor, images ingestor, incremental remover) at that new index, so the production API is fed from the new inferrer's output.

It does this by adding a module variable `graph_images_augmented_index_date` that decouples the augmented index the graph READS from `graph_index_dates.augmented`, which the old Scala inferrer still WRITES (via `local.es_images_augmented_index`). On the `2025-10-02` stack the new var is set to `"2026-06-15"`. `graph_index_dates.augmented` stays `"2026-04-29"`, so the old service keeps writing that index as an untouched, live rollback fallback.

Four files change, all Terraform:

- `modules/pipeline/variables.tf`: new `graph_images_augmented_index_date` variable, default `""` (empty falls back to `graph_index_dates.augmented`).
- `modules/pipeline/locals.tf`: resolved `local.graph_images_augmented_index_date` (var if set, else `graph_index_dates.augmented`).
- `modules/pipeline/subsystem_graph.tf`: constructs the graph module's `index_dates` with `augmented` overridden by the resolved local. All other dates (`merged`, `works`, `concepts`, `images`) pass through unchanged.
- `2025-10-02/main.tf`: sets the override (`graph_images_augmented_index_date = "2026-06-15"`) and updates the surrounding comments to describe the Phase 2 state.

### Evidence this is safe (gathered during this work)

1. Per-doc parity (read-only). I diffed the 24 most-recently-modified images between `images-augmented-2026-06-15` (new) and `images-augmented-2026-04-29` (old). `features` max abs diff was `1.8e-8` (float32 epsilon); `aspectRatio` and `averageColorHex` were identical. Only `paletteEmbedding` differs, and the palette encoder is non-deterministic by design (unseeded noise), so neither value is "more correct".
2. End-to-end through the real ingestor. After the deletions-guard fix (PR #3425), I ran the images ingestor state machine by-id for those 24 images, sourcing `images-augmented-2026-06-15` and writing the live prod `images-indexed-2026-04-29`. The execution succeeded and deletions were correctly skipped. The resulting prod indexed docs were identical to before except `paletteEmbedding` (expected) and `display.aspectRatio` differing only in float64-vs-float32 precision (e.g. `1.7021277` vs `1.702127659574468`, the same value). `features` had parity and all work-data / display / query fields were identical. Left in place (benign).

## How to test

- `terraform fmt` and `terraform validate` are clean.
- `terraform plan` on the `2025-10-02` stack shows 0 add, 2 change, 0 destroy: only the graph incremental-trigger state machine's `index_dates.augmented` flips `2026-04-29` to `2026-06-15`. The old Scala `image_inferrer` task definition is NOT in the plan, so its write target stays `2026-04-29`. (A `find_work` lambda republish also appears, but that's pre-existing drift unrelated to this PR.)
- Coverage of `images-augmented-2026-06-15` now matches `images-augmented-2026-04-29` after the backfill (see the risks section): the new index holds 137,879 docs and a full id scroll confirmed 0 ids missing from it.
- Post-apply: the ingestor/extractor read the new index; `images-indexed-2026-04-29` (the API index) stays complete; spot-check that a sample of images render in wellcomecollection.org search; the image count in the API index does not drop.

## How can we measure success?

- `terraform plan` shows only the trigger-SM augmented flip (plus the unrelated lambda drift), and `fmt` / `validate` are clean.
- Post-apply, the API index `images-indexed-2026-04-29` stays complete (no drop in image count) and search results render correctly, with the graph read-path now sourced from `images-augmented-2026-06-15`.
- Per-doc and end-to-end parity is already demonstrated (see the evidence above): only the intentionally non-deterministic `paletteEmbedding` and float-precision `aspectRatio` differ.

## Have we considered potential risks?

Coverage prerequisite (DONE). The read-path switch was gated on `images-augmented-2026-06-15` reaching full coverage of the old augmented index. At prep time the new index was short by ~5,709 historical images, because the scheduled `find_work` window only moves forward in time and never reaches the historical tail, so this backlog was never going to close on its own. This gate is now closed:

- On 2026-06-24 I backfilled the gap with `reindexer/scripts/reindex_index.py`, reindexing `images-augmented-2026-04-29` (old Scala inferrer, full coverage) into `images-augmented-2026-06-15` (new Python inferrer) with `version_type=external` and `conflicts=proceed`.
- Why `external` / `proceed` is the right and safe choice here: the two indices version their docs differently. The old index uses an internal `_version` (a small counter, e.g. `2`), while the new index versions by the `modifiedTime` epoch (around `1.7e12`). Because the reindex carries each old doc's version across to the destination, every doc that already exists in the new index loses the version comparison and the existing new-inferrer doc is preserved. So only the genuine gaps get filled, the new inferrer's own docs are never clobbered, and if the new inferrer ever reprocesses a backfilled doc its `modifiedTime`-epoch version wins.
- Result: `created=5,704`, `updated=0`, `version_conflicts=132,157`, 0 failures. The new index went from 132,175 to 137,879 docs. I then ran a full id scroll over both indices and confirmed 0 ids are missing from the new index.
- Net effect: `images-augmented-2026-06-15` now covers the old augmented index, so the read-path switch (`graph_images_augmented_index_date = "2026-06-15"`) is safe to apply. The PR stays a draft because we are not applying the cutover yet.

- Rollback is just dropping the `graph_images_augmented_index_date` override: the read-path returns to `images-augmented-2026-04-29`, which the old Scala service has kept current. There's no stale-fallback problem, which is why we decoupled via a new var rather than moving `graph_index_dates.augmented`.
- Blast radius is verified by the `terraform plan` above: 0 add, 2 change, 0 destroy, and the old Scala `image_inferrer` task definition is untouched.

### Follow-ups (out of scope for this PR)

- After bake-in, retire the old Scala `image_inferrer` service (P5) and remove the orphaned `images-augmented-2026-04-29` `index_config` entry.
- Once the old Scala service is gone, we should be able to collapse the cutover var exceptions added here and just set `graph_index_dates.augmented = "2026-06-15"`. The old service (`service_image_inferrer.tf`) is the only consumer of `local.es_images_augmented_index`, which is the reason `graph_index_dates.augmented` was pinned to the old `2026-04-29` index. With it retired, both the graph read-path (`graph_images_augmented_index_date`) and the new inferrer's write target (`image_inferrer_augmented_index_date`) fall back to `graph_index_dates.augmented`, so setting that to `2026-06-15` lets both overrides be dropped. (Note this is only the *augmented* overrides. `image_inferrer_initial_index_date` is a separate concern tied to the merger / initial-index mapping and would not be removed by this.)
- The date-only `2026-06-15` index names become normal on the next full pipeline reindex (the off-pipeline-date name is cosmetic until then).
