### PR TITLE
Bump cryptography to 48.0.1 in calm and window_generator test deps

### DIFF
--- a/calm_adapter/calm_deletion_check_initiator/src/test_requirements.txt
+++ b/calm_adapter/calm_deletion_check_initiator/src/test_requirements.txt
@@ -24,7 +24,7 @@ click==8.3.3
     # via -r requirements.txt
 coverage==7.13.5
     # via -r test_requirements.in
-cryptography==48.0.0
+cryptography==48.0.1
     # via moto
 docker==7.1.0
     # via -r test_requirements.in

--- a/common/window_generator/src/test_requirements.txt
+++ b/common/window_generator/src/test_requirements.txt
@@ -21,7 +21,7 @@ charset-normalizer==3.4.7
     # via requests
 click==8.1.8
     # via -r requirements.txt
-cryptography==46.0.7
+cryptography==48.0.1
     # via moto
 exceptiongroup==1.3.1
     # via pytest


### PR DESCRIPTION
## What does this change?

This bumps cryptography (a transitive dependency pulled in by moto) to 48.0.1 in two pip-compiled test requirement files:

- `calm_adapter/calm_deletion_check_initiator/src/test_requirements.txt`: 48.0.0 -> 48.0.1
- `common/window_generator/src/test_requirements.txt`: 46.0.7 -> 48.0.1

Each change is a minimal single-line bump of the cryptography pin and nothing else.

This branch supersedes two Dependabot PRs.

Closes #3418
Closes #3419

Dependabot's calm PR (#3418) did more than bump cryptography. It also downgraded boto3, moto, urllib3 and pytest (pytest 9.0.3 -> 4.4.2). Those downgrades are unrelated to the cryptography update and were deliberately not adopted here. Only the cryptography line was changed.

## How to test

Both test suites were installed into fresh venvs against cryptography 48.0.1 and pass:

- calm_deletion_check_initiator on Python 3.10: 3 passed
- window_generator on Python 3.9: 2 passed

## How can we measure success?

CI passes on both sub-projects with the updated pins. No further measurement needed for a dependency bump.

## Have we considered potential risks?

The change is limited to a single pinned line in each test requirements file, so it only affects the test toolchain and not runtime code. Keeping the bumps minimal avoids the unrelated boto3, moto, urllib3 and pytest downgrades that Dependabot's own calm PR would have introduced. Both test suites pass against the new pin.
