### PR TITLE
Retire image-inferrer cutover variables (augmented index + schedule gate)

### DIFF
--- a/pipeline/terraform/2025-10-02/main.tf
+++ b/pipeline/terraform/2025-10-02/main.tf
@@ -111,11 +111,9 @@ module "pipeline" {
   allow_delete_indices = false
 
   # Image-inferrer. The scheduled Python inferrer is the sole inferrer: it reads images-initial-2026-06-15
-  # and writes images-augmented-2026-06-15, which the graph READ-path (extractor + ingestor + remover)
-  # also reads. graph_index_dates.augmented = "2026-06-15" is the single source for both the write target
-  # and the read source. image_inferrer_initial_index_date stays overridden because this in-place pipeline's
-  # live images-initial used the old "empty"/dynamic:false mapping, so the merger and inferrer were moved
-  # onto the modifiedTime-mapped images-initial-2026-06-15 (it falls back to pipeline_date otherwise).
+  # and writes images-augmented-2026-06-15, which the graph read-path also reads.
+  # graph_index_dates.augmented = "2026-06-15" is the single source for both. image_inferrer_initial_index_date
+  # is overridden because it otherwise falls back to pipeline_date.
   image_inferrer_initial_index_date = "2026-06-15"
 
   # Base AMI for ECS instances

--- a/pipeline/terraform/2025-10-02/main.tf
+++ b/pipeline/terraform/2025-10-02/main.tf
@@ -116,7 +116,6 @@ module "pipeline" {
   # and the read source. image_inferrer_initial_index_date stays overridden because this in-place pipeline's
   # live images-initial used the old "empty"/dynamic:false mapping, so the merger and inferrer were moved
   # onto the modifiedTime-mapped images-initial-2026-06-15 (it falls back to pipeline_date otherwise).
-  enable_image_inferrer_schedule    = true
   image_inferrer_initial_index_date = "2026-06-15"
 
   # Base AMI for ECS instances

--- a/pipeline/terraform/2025-10-02/main.tf
+++ b/pipeline/terraform/2025-10-02/main.tf
@@ -17,7 +17,7 @@ module "pipeline" {
 
   graph_index_dates = {
     merged    = "2025-10-02"
-    augmented = "2026-04-29"
+    augmented = "2026-06-15"
     works     = "2026-03-03"
     concepts  = "2026-03-03"
     images    = "2026-04-29"
@@ -81,9 +81,9 @@ module "pipeline" {
     "2026-04-29" = {
       images = {
         // Old Scala inference manager output. The Scala service has been retired, so nothing writes this
-        // index now; the graph read-path already reads images-augmented-2026-06-15 (via
-        // graph_images_augmented_index_date). This index and this entry are pending removal in the
-        // index-cleanup PR.
+        // index now, and the graph read-path reads images-augmented-2026-06-15 (graph_index_dates.augmented).
+        // This index is orphaned; terraform still manages it under deletion_protection, so dropping it is a
+        // separate operational step. Remove this augmented entry once the index has been deleted.
         augmented = "images_augmented.2026-04-29"
         // prod graph/ingestor/indexer - prod API
         indexed = "images_indexed.2024-11-14"
@@ -98,9 +98,8 @@ module "pipeline" {
     //    a shadow index — keep it. (Will be a normal images-initial-<date> on the next
     //    full pipeline reindex; the off-pipeline-date name is cosmetic until then.)
     //  - augmented: the scheduled inferrer's output (reuses the images_augmented.2026-04-29 mapping).
-    //    As of Phase 2 this is the graph read-path SOURCE (graph_images_augmented_index_date =
-    //    "2026-06-15" below) — i.e. the production augmented index feeding the API. Must be at full
-    //    coverage before that switch is applied (see the graph_images_augmented_index_date note + PR).
+    //    This is the production augmented index feeding the API: both the inferrer's write target and
+    //    the graph read-path source, resolved from graph_index_dates.augmented = "2026-06-15".
     "2026-06-15" = {
       images = {
         initial   = "images_initial.2026-06-15"
@@ -111,18 +110,14 @@ module "pipeline" {
 
   allow_delete_indices = false
 
-  # Image-inferrer cutover. Phase 1 (applied): merger + Scala inferrer moved onto the modifiedTime-mapped
-  # images-initial-2026-06-15; the scheduled inferrer enabled, writing images-augmented-2026-06-15.
-  # Phase 2 (this change): the graph READ-path (extractor + ingestor + remover) is pointed at the new
-  # inferrer's output via graph_images_augmented_index_date below, so the API is now fed from
-  # images-augmented-2026-06-15. graph_index_dates.augmented stays "2026-04-29" on purpose: the old
-  # Scala service keeps writing that index as an untouched, live fallback (rollback = drop this override
-  # and the read-path returns to a still-current 2026-04-29). The new inferrer keeps writing
-  # images-augmented-2026-06-15 (image_inferrer_augmented_index_date), now the production augmented index.
-  enable_image_inferrer_schedule      = true
-  image_inferrer_initial_index_date   = "2026-06-15"
-  image_inferrer_augmented_index_date = "2026-06-15"
-  graph_images_augmented_index_date   = "2026-06-15"
+  # Image-inferrer. The scheduled Python inferrer is the sole inferrer: it reads images-initial-2026-06-15
+  # and writes images-augmented-2026-06-15, which the graph READ-path (extractor + ingestor + remover)
+  # also reads. graph_index_dates.augmented = "2026-06-15" is the single source for both the write target
+  # and the read source. image_inferrer_initial_index_date stays overridden because this in-place pipeline's
+  # live images-initial used the old "empty"/dynamic:false mapping, so the merger and inferrer were moved
+  # onto the modifiedTime-mapped images-initial-2026-06-15 (it falls back to pipeline_date otherwise).
+  enable_image_inferrer_schedule    = true
+  image_inferrer_initial_index_date = "2026-06-15"
 
   # Base AMI for ECS instances
   ami_id = "resolve:ssm:arn:aws:ssm:eu-west-1:760097843905:parameter/imagebuilder/weco-al2023-ecs-optimised-x86_64/latest"

--- a/pipeline/terraform/modules/pipeline/locals.tf
+++ b/pipeline/terraform/modules/pipeline/locals.tf
@@ -34,14 +34,7 @@ locals {
   // them explicitly during cutover (see the 2025-10-02 root). The merger, the Scala inferrer and
   // the new state-machine inferrer all derive the initial index from one resolved value, so they
   // can never diverge.
-  image_inferrer_initial_index_date   = var.image_inferrer_initial_index_date != "" ? var.image_inferrer_initial_index_date : var.pipeline_date
-  image_inferrer_augmented_index_date = var.image_inferrer_augmented_index_date != "" ? var.image_inferrer_augmented_index_date : var.graph_index_dates.augmented
-
-  // Augmented index the graph subsystem READ-path (extractor/ingestor/remover) sources from. Falls
-  // back to graph_index_dates.augmented (so read-path and the old Scala service's write target stay
-  // aligned) unless overridden to decouple them during the image-inferrer cutover. See the
-  // graph_images_augmented_index_date variable. Injected via subsystem_graph.tf's index_dates.
-  graph_images_augmented_index_date = var.graph_images_augmented_index_date != "" ? var.graph_images_augmented_index_date : var.graph_index_dates.augmented
+  image_inferrer_initial_index_date = var.image_inferrer_initial_index_date != "" ? var.image_inferrer_initial_index_date : var.pipeline_date
 
   // Default index names for services that need to know where to write/read from
   // These presume that the indexes exist and are created by the index_config

--- a/pipeline/terraform/modules/pipeline/state_machine_image_inferrer.tf
+++ b/pipeline/terraform/modules/pipeline/state_machine_image_inferrer.tf
@@ -69,7 +69,7 @@ locals {
           "pipeline_date" : var.pipeline_date,
           "index_dates" : {
             "initial" : local.image_inferrer_initial_index_date,
-            "augmented" : local.image_inferrer_augmented_index_date
+            "augmented" : var.graph_index_dates.augmented
           },
           # Window end is 5 minutes before the scheduled time (indexing lag);
           # the find-work step defaults the window start to end - 15 minutes.

--- a/pipeline/terraform/modules/pipeline/subsystem_graph.tf
+++ b/pipeline/terraform/modules/pipeline/subsystem_graph.tf
@@ -2,12 +2,9 @@ module "graph_pipeline" {
   source = "./graph"
 
   pipeline_date = var.pipeline_date
-  # The graph subsystem's augmented source can be decoupled from graph_index_dates.augmented (which
-  # the old Scala inferrer still writes) via graph_images_augmented_index_date — see that variable and
-  # local.graph_images_augmented_index_date. All other dates pass through unchanged.
   index_dates = {
     merged    = var.graph_index_dates.merged
-    augmented = local.graph_images_augmented_index_date
+    augmented = var.graph_index_dates.augmented
     works     = var.graph_index_dates.works
     concepts  = var.graph_index_dates.concepts
     images    = var.graph_index_dates.images

--- a/pipeline/terraform/modules/pipeline/variables.tf
+++ b/pipeline/terraform/modules/pipeline/variables.tf
@@ -102,8 +102,8 @@ variable "graph_index_dates" {
 
 variable "enable_image_inferrer_schedule" {
   type        = bool
-  default     = false
-  description = "Enable the scheduled image-inferrer state machine. Ships disabled until the new path is validated and we cut over from the SQS-driven service."
+  default     = true
+  description = "Whether the scheduled image-inferrer state machine is enabled. Defaults to true, since it is the sole image inferrer. Set to false as a kill-switch to pause scheduled inference, e.g. during an incident or a large reindex."
 }
 
 variable "image_inferrer_initial_index_date" {

--- a/pipeline/terraform/modules/pipeline/variables.tf
+++ b/pipeline/terraform/modules/pipeline/variables.tf
@@ -106,18 +106,6 @@ variable "enable_image_inferrer_schedule" {
   description = "Enable the scheduled image-inferrer state machine. Ships disabled until the new path is validated and we cut over from the SQS-driven service."
 }
 
-variable "image_inferrer_augmented_index_date" {
-  type        = string
-  default     = ""
-  description = <<-EOT
-    Augmented index date the Python image-inferrer state machine writes to. Empty (the default) falls
-    back to `graph_index_dates.augmented` — i.e. the production augmented index the images ingestor
-    reads — which is the steady-state cutover target. Set explicitly only to write a separate shadow
-    index (e.g. `2026-06-15`) for isolated comparison runs. A matching `index_config` entry must exist
-    (see the 2025-10-02 root).
-  EOT
-}
-
 variable "image_inferrer_initial_index_date" {
   type        = string
   default     = ""
@@ -128,20 +116,6 @@ variable "image_inferrer_initial_index_date" {
     existing pipeline whose live images-initial uses the "empty"/dynamic:false mapping (where
     `modifiedTime` is unqueryable): point it at a modifiedTime-mapped index (e.g. `2026-06-15`) that the
     merger is moved onto. A matching `index_config` entry must exist (see the 2025-10-02 root).
-  EOT
-}
-
-variable "graph_images_augmented_index_date" {
-  type        = string
-  default     = ""
-  description = <<-EOT
-    Augmented-images index that the graph subsystem READ-path (graph extractor, images ingestor,
-    incremental remover) uses as its source. Empty (the default) falls back to
-    `graph_index_dates.augmented`. Set explicitly to point the read-path at the new Python inferrer's
-    output (e.g. `2026-06-15`) independently of `graph_index_dates.augmented`. This override exists
-    because `graph_index_dates.augmented` still names the now-retired Scala inferrer's old output index,
-    which is pending removal; once that index is gone and `graph_index_dates.augmented` is set to the new
-    inferrer's output, this override can be dropped.
   EOT
 }
 


### PR DESCRIPTION
Stacked on #3432. Base this PR on `remove-old-scala-inferrer`, review and merge it after #3432, and apply its terraform after #3432's terraform.

This is the variable-collapse follow-up flagged in #3426 and again in #3432. With the old Scala image-inferrer gone, the variables that existed only to gate the cutover have outlived their purpose. This PR retires that cutover plumbing in two parts: the augmented-index overrides, and the schedule enable gate.

## What does this change?

### Augmented-index variables

Now that the old Scala image-inferrer is removed (#3432), the two cutover override variables that decoupled the augmented index during the migration are redundant. The new Python inferrer's write target and the graph read-path source can both resolve from a single `graph_index_dates.augmented`.

In `pipeline/terraform`:

- `2025-10-02/main.tf`: set `graph_index_dates.augmented = "2026-06-15"` (was `"2026-04-29"`), and remove the `image_inferrer_augmented_index_date = "2026-06-15"` and `graph_images_augmented_index_date = "2026-06-15"` overrides. Kept `image_inferrer_initial_index_date = "2026-06-15"`. Refreshed the cutover comment and the two `index_config` comments that referenced the removed variable.
- `modules/pipeline/variables.tf`: removed the `image_inferrer_augmented_index_date` and `graph_images_augmented_index_date` variable definitions. Kept `image_inferrer_initial_index_date` and `image_inferrer_max_concurrency`.
- `modules/pipeline/locals.tf`: removed the two resolving locals. Kept `image_inferrer_initial_index_date`, which still falls back to `pipeline_date`.
- `modules/pipeline/subsystem_graph.tf`: the graph module's `index_dates.augmented` now reads `var.graph_index_dates.augmented` directly (was `local.graph_images_augmented_index_date`).
- `modules/pipeline/state_machine_image_inferrer.tf`: the inferrer's ConstructEvent `index_dates.augmented` now reads `var.graph_index_dates.augmented` directly (was `local.image_inferrer_augmented_index_date`).

This is a net-zero change. Before this, both overrides were set to `"2026-06-15"`, so the read-path source and the inferrer write target already resolved to `images-augmented-2026-06-15`. Setting `graph_index_dates.augmented = "2026-06-15"` and dropping the overrides resolves to the same value through the default fallback. No index routing changes.

### Schedule enable gate

`enable_image_inferrer_schedule` was shipped disabled to gate the cutover from the old SQS-driven service. That service is gone and the scheduled Python inferrer is now the sole inferrer, so the steady state is enabled. This keeps the variable but changes what it means.

- `modules/pipeline/variables.tf`: flip the `enable_image_inferrer_schedule` default from `false` to `true`, and reword its description. It is no longer a cutover gate; it is now a kill-switch to pause scheduled inference, for example during an incident or a large reindex.
- `2025-10-02/main.tf`: remove the now-redundant `enable_image_inferrer_schedule = true` override, since the default now carries that value.

This is also net-zero. The override was already `true`, so the schedule resolves to `ENABLED` either way. Dropping the override and defaulting the variable to `true` lands on the same `state = "ENABLED"` for the inferrer's scheduling rule.

### Out of scope

This does not delete the orphaned `images-augmented-2026-04-29` index. Every index is an `elasticstack_elasticsearch_index` with `deletion_protection = !allow_delete_indices`, and `allow_delete_indices = false` on this stack, so removing the `index_config` entry would make `terraform apply` fail on the blocked destroy. Deleting that index is a separate operational step: flip `allow_delete_indices`, apply, flip back, or delete out of band. Its `index_config` entry is left in place on purpose, with a comment in `main.tf` noting this.

## How to test

This PR is stacked on #3432. Apply its terraform from the branch before merging, after #3432 has been applied and merged. Same ordering discipline as #3432.

1. Run `./run_terraform.sh plan` in `pipeline/terraform/2025-10-02/` and confirm it shows no functional changes. This is a net-zero variable collapse, so the variable and local plumbing simplification is plan-invisible. The augmented index keeps resolving to `images-augmented-2026-06-15` and the inferrer schedule rule stays `ENABLED`.
2. Apply, then merge.

Verification performed on this branch:

- `terraform fmt -check` is clean and `terraform validate` succeeds on the `2025-10-02` stack.
- A grep sweep confirms no remaining references to the two removed augmented-index variables or locals, and that the only remaining `enable_image_inferrer_schedule` references are the variable definition and its single use in the inferrer schedule rule.
- Not run: a live `terraform plan` against real state, which needs AWS credentials.

## How can we measure success?

`terraform plan` shows no functional resource changes. The image read-path and the inferrer write target continue to resolve to `images-augmented-2026-06-15`, with one variable now driving both instead of three, and the scheduled inferrer rule stays `ENABLED` with the schedule controlled by a single defaulted variable rather than a per-stack override.

## Have we considered potential risks?

Both changes are net-zero. The two removed augmented-index overrides were already set to `"2026-06-15"`, the same value `graph_index_dates.augmented` now carries, so routing is unchanged. The `enable_image_inferrer_schedule` override was already `true`, the same value the variable now defaults to, so the schedule stays `ENABLED`. The plan should confirm no functional resource changes before apply.

The orphaned `images-augmented-2026-04-29` index is deliberately left under terraform management. Removing its `index_config` entry while `allow_delete_indices = false` would break apply, so that cleanup is held back as a separate operational step.

Related: #3426, #3432.
