### PR TITLE
Set publish = false on image-based pipeline lambdas

### DIFF
--- a/catalogue_graph/infra/adapters/modules/adapter/lambda_trigger.tf
+++ b/catalogue_graph/infra/adapters/modules/adapter/lambda_trigger.tf
@@ -5,7 +5,9 @@ module "trigger_lambda" {
   description  = "Lambda function to trigger adapter ingestion"
   package_type = "Image"
   image_uri    = "${var.repository_url}:prod"
-  publish      = true
+  # CI deploys via `update-function-code --publish` and nothing consumes a
+  # versioned ARN, so Terraform publishing only caused a perpetual version diff.
+  publish = false
 
   image_config = {
     command = ["adapters.steps.${local.steps_namespace}.trigger.lambda_handler"]

--- a/pipeline/terraform/modules/pipeline/state_machine_transformers.tf
+++ b/pipeline/terraform/modules/pipeline/state_machine_transformers.tf
@@ -9,7 +9,9 @@ module "transformer_lambda" {
   description  = "Lambda function to transform EBSCO/Axiell data"
   package_type = "Image"
   image_uri    = "${data.aws_ecr_repository.unified_pipeline_lambda.repository_url}:prod"
-  publish      = true
+  # CI deploys via `update-function-code --publish` and nothing consumes a
+  # versioned ARN, so Terraform publishing only caused a perpetual version diff.
+  publish = false
 
   image_config = {
     command = ["adapters.steps.transformer.lambda_handler"]

--- a/pipeline/terraform/modules/pipeline_lambda/main.tf
+++ b/pipeline/terraform/modules/pipeline_lambda/main.tf
@@ -7,7 +7,10 @@ module "pipeline_step" {
   timeout      = var.timeout
   memory_size  = var.memory_size
   description  = var.description
-  publish      = true
+  # Versions are not consumed anywhere (state machines invoke the unqualified
+  # ARN), and CI deploys via `update-function-code --publish` out of band, so
+  # letting Terraform also publish only produced a perpetual version diff.
+  publish = false
 
   vpc_config = var.vpc_config
 


### PR DESCRIPTION
## What does this change?

Sets `publish = false` on the image-based Lambda definitions, so Terraform stops cutting new Lambda versions on every apply.

One commit, the same one-line change in three places:

- `pipeline/terraform/modules/pipeline_lambda/main.tf`: the wrapper used by every dated pipeline lambda (transformer, id-minter, matcher, merger, graph lambdas, image-inference-find-work, and their `*-test` variants).
- `pipeline/terraform/modules/pipeline/state_machine_transformers.tf`: the transformer lambda (direct `terraform-aws-lambda` call, `:prod` tag).
- `catalogue_graph/infra/adapters/modules/adapter/lambda_trigger.tf`: the adapter trigger lambdas (ebsco/folio/axiell).

**Why**

Running `terraform plan` on the pipeline stacks showed a permanent diff on these image-based lambdas. The `version`, `qualified_arn`, and `qualified_invoke_arn` attributes always showed "known after apply", and the diff came back after every apply.

The cause is that these lambdas are deployed by CI, not Terraform. CI builds the image, retags it onto the mutable `env.<date>` / `prod` tags, then calls `aws lambda update-function-code --image-uri ... --publish` directly on the live function. That `--publish` keeps cutting new Lambda versions out of band, so Terraform's own `publish = true` was perpetually trying to re-publish to catch up.

The `terraform-aws-lambda` module already has `ignore_changes = [image_uri, filename, s3_object_version]`, which confirms Terraform is not meant to manage the image at all.

**What this does**

Setting `publish = false` stops Terraform publishing versions. CI keeps publishing them, so rollback-by-version still works.

Nothing in the repo consumes a qualified/versioned ARN or a Lambda alias: state machines invoke the unqualified function ARN, and the `state_machine` module grants `lambda:InvokeFunction` on the bare ARN. So invocation is unaffected and `$LATEST` always serves the current code.

## How to test

This has not been applied yet.

Run `terraform plan` per stack and confirm the only change is a one-time in-place `publish = true -> false` per lambda, with no recreation and no destroy.

- Pipeline stacks: `./run_terraform.sh apply` in each `pipeline/terraform/<date>` stack. The `2025-10-02` stack plans `0 to add, 16 to change, 0 to destroy`, every change being only `publish = true -> false`.
- Adapters stack: a normal apply in the `catalogue_graph` adapters stack (separate state, same one-line change).

## How can we measure success?

The permanent `terraform plan` diff on these lambdas is gone. After applying, subsequent plans on the affected stacks no longer show `version` / `qualified_arn` / `qualified_invoke_arn` as "known after apply".

## Have we considered potential risks?

- No recreation, no destroy, no downtime. Each affected stack shows a one-time in-place `publish = true -> false` per lambda.
- Existing published versions in AWS are retained, not deleted.
- Invocation is unaffected. Nothing consumes a versioned/qualified ARN or alias; state machines invoke the unqualified ARN and IAM grants are on the bare ARN, so `$LATEST` keeps serving current code.
- Rollback-by-version still works because CI continues to publish versions.
