### PR TITLE
Do not fail the OAI-PMH loader when there are no pending windows

### DIFF
--- a/catalogue_graph/src/adapters/steps/oai_pmh/loader.py
+++ b/catalogue_graph/src/adapters/steps/oai_pmh/loader.py
@@ -136,10 +136,7 @@ def execute_loader(
         runtime: Loader runtime with clients and configuration.
 
     Returns:
-        OAIPMHLoaderResponse with harvest results.
-
-    Raises:
-        RuntimeError: If no windows were ready to harvest.
+        OAIPMHLoaderResponse with harvest results (empty when nothing was pending).
     """
     window = request.window
     harvester = build_harvester(request, runtime)
@@ -151,9 +148,13 @@ def execute_loader(
     )
 
     if not summaries:
-        raise RuntimeError(
-            "No pending windows to harvest for "
-            f"{window.start_time.isoformat()} -> {window.end_time.isoformat()}"
+        # Every candidate window in the range was already harvested (or the range
+        # produced none): a caught-up no-op, not an error. Return an empty response so
+        # the state machine routes straight to success instead of failing and retrying.
+        logger.info(
+            "No pending windows to harvest",
+            window_start=window.start_time.isoformat(),
+            window_end=window.end_time.isoformat(),
         )
 
     return OAIPMHLoaderResponse.from_summaries(summaries, job_id=request.job_id)

--- a/catalogue_graph/tests/adapters/extractors/oai_pmh/test_loader.py
+++ b/catalogue_graph/tests/adapters/extractors/oai_pmh/test_loader.py
@@ -10,7 +10,6 @@ from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-import pytest
 from lxml import etree
 
 from adapters.extractors.oai_pmh.models.step_events import (
@@ -147,17 +146,21 @@ class TestExecuteLoader:
             assert response.changed_record_count == 0
             assert adapter_store_client.get_all_records().num_rows == 0
 
-    def test_errors_when_no_windows(
+    def test_no_pending_windows_returns_empty_response(
         self,
         loader_runtime: LoaderRuntime,
     ) -> None:
+        """A caught-up range (no pending windows) is a no-op, not an error: the loader
+        returns an empty response so the state machine routes straight to success."""
         req = _create_loader_event()
 
         with patch.object(WindowHarvestManager, "harvest_range") as mock_harvest:
             mock_harvest.return_value = []
 
-            with pytest.raises(RuntimeError):
-                loader.execute_loader(req, runtime=loader_runtime)
+            response = loader.execute_loader(req, runtime=loader_runtime)
+
+        assert response.changeset_ids == []
+        assert response.changed_record_count == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this change?

When the OAI-PMH adapter is caught up, `harvest_range` returns no window summaries. `execute_loader` raised `RuntimeError` in that case, which exits the ECS loader task non-zero, fails the "Run loader" Step Functions state, and after 3 retries fails the whole execution. That is a caught-up no-op reported as a fatal error, and it fires whenever a manual run (or an extra run) finds nothing new to harvest.

This returns the empty loader response instead, with an info log. `OAIPMHLoaderResponse.from_summaries([], ...)` yields `changeset_ids=[]` and `changed_record_count=0`, and the state machine's "Should enrich?" and "Should publish event?" choices already gate on `changeset_ids` being non-empty, so an empty response routes straight to Success. No state-machine change is needed.

Shared by all OAI-PMH adapters (Axiell, EBSCO, FOLIO).

## How to test

Inside `catalogue_graph/`:

```
uv run ruff check . && uv run ruff format --check .
uv run mypy .
uv run pytest tests/adapters/extractors/oai_pmh
```

`test_no_pending_windows_returns_empty_response` (renamed from `test_errors_when_no_windows`) asserts the empty response. On this branch: ruff clean, `mypy .` clean (557 files), oai_pmh loader + reloader tests pass (101).

## How can we measure success?

Manual and scheduled runs that find nothing to harvest complete as SUCCEEDED with an empty changeset, instead of FAILED after retries.

## Have we considered potential risks?

An empty summaries list only means every candidate window was already harvested, or the range produced no windows: genuinely nothing to do. Real harvest failures do not come back as an empty list; they surface as a failed summary or an exception raised from inside `harvest_range`, both of which still propagate. So converting empty to success is correct semantics, not a blanket swallow. A Step Functions `Catch` on the state was rejected because it would also swallow genuine loader errors.
