### PR TITLE
Remove deprecated @weco/ts-aws dependency

### DIFF
--- a/pipeline/matcher_merger/matcher/scripts/package.json
+++ b/pipeline/matcher_merger/matcher/scripts/package.json
@@ -10,7 +10,6 @@
     "@types/node": "^16.11.7",
     "@types/node-fetch": "2",
     "@types/yargs": "^17.0.5",
-    "@weco/ts-aws": "^0.1.0",
     "node-fetch": "2",
     "ts-graphviz": "^0.16.0",
     "ts-node": "^10.4.0",

--- a/pipeline/matcher_merger/matcher/scripts/yarn.lock
+++ b/pipeline/matcher_merger/matcher/scripts/yarn.lock
@@ -1599,14 +1599,6 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@weco/ts-aws@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@weco/ts-aws/-/ts-aws-0.1.0.tgz#0d9140061b73f0d10505218b4fa3ea908571b490"
-  integrity sha512-XJ8XRQ/07Q1BdXrKSAN9fegGsCidT4d4AxkeYUGpGClTABsmCvqUdwdNlR53LdwrB34RnbsRXoeyXlqdzRgwxw==
-  dependencies:
-    "@aws-sdk/client-secrets-manager" "^3.40.0"
-    "@aws-sdk/client-sts" "^3.22.0"
-
 acorn-walk@^8.1.1:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"


### PR DESCRIPTION
The @weco/ts-aws package is deprecated and unpublishable: the organisation lost access to the npm account that published it, so it can no longer be installed or updated. It is being removed everywhere.

## What changed

In the `pipeline/matcher_merger/matcher/scripts` workspace:

- Removed the `"@weco/ts-aws": "^0.1.0"` line from `package.json`. Nothing else in that file was changed.
- Removed the `@weco/ts-aws@^0.1.0` resolution block from `yarn.lock`.

This dependency was orphaned: no code in that scripts workspace imports it (the only .ts files there are elasticsearch.ts, getMatcherGraph.ts, graphAttributes.ts and models.ts, none of which reference the package). No code needed to be inlined or otherwise changed.

## Verification

- Grepped the whole repo and confirmed zero remaining references to @weco/ts-aws.
- Confirmed package.json is still valid JSON.
- The yarn.lock block was removed manually rather than by regenerating the lockfile, to avoid a full install against a private registry. Transitive-only lock entries that were previously pulled in by @weco/ts-aws were left in place; a future `yarn install` will prune any that are genuinely unused. No install or build was run.

Part of wellcomecollection/platform#6416