### PR TITLE
Stream the full-reindex read from the adapter store

### DIFF
--- a/catalogue_graph/src/adapters/transformers/adapter_store_source.py
+++ b/catalogue_graph/src/adapters/transformers/adapter_store_source.py
@@ -32,5 +32,9 @@ class AdapterStoreSource(BaseSource):
 
             # During a full reindex we are writing into an empty index,
             # so no need to include deleted rows to overwrite documents.
-            table = self.adapter_store.get_active_namespace_records(self.snapshot_id)
-            yield from table.to_pylist()
+            # Stream record batches so the full table is never held in memory at once.
+            batches = self.adapter_store.stream_active_namespace_records(
+                self.snapshot_id
+            )
+            for batch in batches:
+                yield from batch.to_pylist()

--- a/catalogue_graph/src/adapters/transformers/adapter_store_source.py
+++ b/catalogue_graph/src/adapters/transformers/adapter_store_source.py
@@ -32,9 +32,14 @@ class AdapterStoreSource(BaseSource):
 
             # During a full reindex we are writing into an empty index,
             # so no need to include deleted rows to overwrite documents.
-            # Stream record batches so the full table is never held in memory at once.
+            # Stream record batches so the full table need not be materialised
+            # at once. Close the reader on exit so an abandoned stream (e.g. a
+            # consumer error mid-reindex) does not leave prefetch reads running.
             batches = self.adapter_store.stream_active_namespace_records(
                 self.snapshot_id
             )
-            for batch in batches:
-                yield from batch.to_pylist()
+            try:
+                for batch in batches:
+                    yield from batch.to_pylist()
+            finally:
+                batches.close()

--- a/catalogue_graph/src/adapters/utils/adapter_store.py
+++ b/catalogue_graph/src/adapters/utils/adapter_store.py
@@ -1,4 +1,3 @@
-from collections.abc import Generator
 from datetime import UTC, datetime
 
 import pyarrow as pa
@@ -72,7 +71,7 @@ class AdapterStore(PipelineStore):
 
     def stream_active_namespace_records(
         self, snapshot_id: int | None = None
-    ) -> Generator[pa.RecordBatch]:
+    ) -> pa.RecordBatchReader:
         """Stream non-deleted records in the store namespace as record batches."""
         non_deleted_filter = Or(EqualTo("deleted", False), IsNull("deleted"))
         return self.stream_namespace_records(non_deleted_filter, snapshot_id)

--- a/catalogue_graph/src/adapters/utils/adapter_store.py
+++ b/catalogue_graph/src/adapters/utils/adapter_store.py
@@ -1,3 +1,4 @@
+from collections.abc import Generator
 from datetime import UTC, datetime
 
 import pyarrow as pa
@@ -68,6 +69,13 @@ class AdapterStore(PipelineStore):
         """Return non-deleted records in the store namespace."""
         non_deleted_filter = Or(EqualTo("deleted", False), IsNull("deleted"))
         return self.get_namespace_records(non_deleted_filter, snapshot_id)
+
+    def stream_active_namespace_records(
+        self, snapshot_id: int | None = None
+    ) -> Generator[pa.RecordBatch]:
+        """Stream non-deleted records in the store namespace as record batches."""
+        non_deleted_filter = Or(EqualTo("deleted", False), IsNull("deleted"))
+        return self.stream_namespace_records(non_deleted_filter, snapshot_id)
 
     @staticmethod
     def _preserve_content_for_deletions(

--- a/catalogue_graph/src/adapters/utils/pipeline_store.py
+++ b/catalogue_graph/src/adapters/utils/pipeline_store.py
@@ -1,6 +1,5 @@
 import uuid
 from abc import ABC, abstractmethod
-from collections.abc import Generator
 from datetime import datetime
 from typing import Any, cast
 
@@ -8,7 +7,6 @@ import pyarrow as pa
 import pyarrow.compute as pc
 from pydantic import BaseModel
 from pyiceberg.expressions import And, BooleanExpression, EqualTo, In
-from pyiceberg.io.pyarrow import ArrowScan
 from pyiceberg.table import ALWAYS_TRUE
 from pyiceberg.table import Table as IcebergTable
 from pyiceberg.table.upsert_util import get_rows_to_update
@@ -72,27 +70,21 @@ class PipelineStore(ABC):
         self,
         iceberg_filter: BooleanExpression = ALWAYS_TRUE,
         snapshot_id: int | None = None,
-    ) -> Generator[pa.RecordBatch]:
+    ) -> pa.RecordBatchReader:
         """Stream records in the store namespace as Arrow record batches.
 
-        Unlike `get_namespace_records`, rows are never materialised all at once:
-        memory stays bounded at roughly one data file regardless of table size.
-
-        Files are read one at a time rather than through `to_arrow_batch_reader`,
-        whose thread pool downloads every file eagerly regardless of consumption
-        rate, buffering close to the whole table in memory.
+        Unlike `get_namespace_records`, rows are not materialised as a single
+        table. Note that pyiceberg's reader prefetches data files on a thread
+        pool regardless of consumption rate (apache/iceberg-python#2407), so
+        peak memory is well below an eager read but can still approach the
+        table size when the consumer is slower than the downloads.
         """
         full_filter = And(EqualTo("namespace", self.namespace), iceberg_filter)
-        scan = self.table.scan(row_filter=full_filter, snapshot_id=snapshot_id)
-        for task in scan.plan_files():
-            file_table = ArrowScan(
-                scan.table_metadata,
-                scan.io,
-                scan.projection(),
-                scan.row_filter,
-                scan.case_sensitive,
-            ).to_table([task])
-            yield from file_table.cast(self.schema).to_batches()
+        return (
+            self.table.scan(row_filter=full_filter, snapshot_id=snapshot_id)
+            .to_arrow_batch_reader()
+            .cast(self.schema)
+        )
 
     def get_records_by_changeset(
         self, changeset_id: str, snapshot_id: int | None = None

--- a/catalogue_graph/src/adapters/utils/pipeline_store.py
+++ b/catalogue_graph/src/adapters/utils/pipeline_store.py
@@ -1,5 +1,6 @@
 import uuid
 from abc import ABC, abstractmethod
+from collections.abc import Generator
 from datetime import datetime
 from typing import Any, cast
 
@@ -7,6 +8,7 @@ import pyarrow as pa
 import pyarrow.compute as pc
 from pydantic import BaseModel
 from pyiceberg.expressions import And, BooleanExpression, EqualTo, In
+from pyiceberg.io.pyarrow import ArrowScan
 from pyiceberg.table import ALWAYS_TRUE
 from pyiceberg.table import Table as IcebergTable
 from pyiceberg.table.upsert_util import get_rows_to_update
@@ -65,6 +67,32 @@ class PipelineStore(ABC):
             .to_arrow()
             .cast(self.schema)
         )
+
+    def stream_namespace_records(
+        self,
+        iceberg_filter: BooleanExpression = ALWAYS_TRUE,
+        snapshot_id: int | None = None,
+    ) -> Generator[pa.RecordBatch]:
+        """Stream records in the store namespace as Arrow record batches.
+
+        Unlike `get_namespace_records`, rows are never materialised all at once:
+        memory stays bounded at roughly one data file regardless of table size.
+
+        Files are read one at a time rather than through `to_arrow_batch_reader`,
+        whose thread pool downloads every file eagerly regardless of consumption
+        rate, buffering close to the whole table in memory.
+        """
+        full_filter = And(EqualTo("namespace", self.namespace), iceberg_filter)
+        scan = self.table.scan(row_filter=full_filter, snapshot_id=snapshot_id)
+        for task in scan.plan_files():
+            file_table = ArrowScan(
+                scan.table_metadata,
+                scan.io,
+                scan.projection(),
+                scan.row_filter,
+                scan.case_sensitive,
+            ).to_table([task])
+            yield from file_table.cast(self.schema).to_batches()
 
     def get_records_by_changeset(
         self, changeset_id: str, snapshot_id: int | None = None

--- a/catalogue_graph/tests/adapters/transformers/test_adapter_store_source.py
+++ b/catalogue_graph/tests/adapters/transformers/test_adapter_store_source.py
@@ -1,0 +1,99 @@
+"""Tests for AdapterStoreSource, the Iceberg-backed source used by transformers."""
+
+from collections.abc import Generator
+from typing import cast
+
+import pyarrow as pa
+
+from adapters.transformers.adapter_store_source import AdapterStoreSource
+from adapters.utils.adapter_store import AdapterStore
+from adapters.utils.schemata import ADAPTER_STORE_ARROW_SCHEMA
+from tests.adapters.conftest import AdapterStoreFactory, adapter_records_to_table
+
+
+def test_stream_raw_full_reindex_yields_all_active_rows(
+    adapter_store_with_records: AdapterStoreFactory,
+) -> None:
+    """With no changeset ids, stream_raw yields every non-deleted row as a dict."""
+    store = adapter_store_with_records(
+        [
+            {"id": "rec001", "content": "first"},
+            {"id": "rec002", "content": "second", "deleted": False},
+            {"id": "rec003", "content": "deleted", "deleted": True},
+        ]
+    )
+    source = AdapterStoreSource(store, changeset_ids=[])
+
+    rows = list(source.stream_raw())
+
+    assert sorted(row["id"] for row in rows) == ["rec001", "rec002"]
+    assert all(isinstance(row, dict) for row in rows)
+
+
+def test_stream_raw_changeset_path_uses_changeset_lookup(
+    adapter_store_with_records: AdapterStoreFactory,
+) -> None:
+    """With changeset ids, stream_raw yields only rows from those changesets."""
+    store = adapter_store_with_records(
+        [
+            {"id": "rec001", "content": "first", "changeset": "changeset-1"},
+            {"id": "rec002", "content": "second", "changeset": "changeset-2"},
+            {"id": "rec003", "content": "third", "changeset": "changeset-3"},
+        ]
+    )
+    source = AdapterStoreSource(store, changeset_ids=["changeset-1", "changeset-2"])
+
+    rows = list(source.stream_raw())
+
+    assert sorted(row["id"] for row in rows) == ["rec001", "rec002"]
+
+
+class _StreamingOnlyStore:
+    """Stub store that streams instrumented batches and forbids eager reads."""
+
+    def __init__(self, batches: list[pa.RecordBatch]) -> None:
+        self.batches = batches
+        self.batches_consumed: list[int] = []
+
+    def stream_active_namespace_records(
+        self, snapshot_id: int | None = None
+    ) -> Generator[pa.RecordBatch]:
+        for index, batch in enumerate(self.batches):
+            self.batches_consumed.append(index)
+            yield batch
+
+    def get_active_namespace_records(self, snapshot_id: int | None = None) -> pa.Table:
+        raise AssertionError(
+            "stream_raw must not materialise the namespace with an eager read"
+        )
+
+
+def _single_row_batch(record_id: str) -> pa.RecordBatch:
+    table = adapter_records_to_table([{"id": record_id, "content": "content"}])
+    return table.to_batches()[0]
+
+
+def test_stream_raw_full_reindex_is_lazy() -> None:
+    """stream_raw consumes record batches one at a time, never the whole table."""
+    store = _StreamingOnlyStore(
+        [_single_row_batch("rec001"), _single_row_batch("rec002")]
+    )
+    source = AdapterStoreSource(cast(AdapterStore, store), changeset_ids=[])
+
+    stream = source.stream_raw()
+    first_row = next(stream)
+
+    assert first_row["id"] == "rec001"
+    assert store.batches_consumed == [0]
+
+    assert next(stream)["id"] == "rec002"
+    assert store.batches_consumed == [0, 1]
+
+
+def test_stream_raw_full_reindex_empty_store() -> None:
+    """A full reindex over an empty store yields nothing without erroring."""
+    empty_batch = pa.RecordBatch.from_pylist([], schema=ADAPTER_STORE_ARROW_SCHEMA)
+    store = _StreamingOnlyStore([empty_batch])
+    source = AdapterStoreSource(cast(AdapterStore, store), changeset_ids=[])
+
+    assert list(source.stream_raw()) == []

--- a/catalogue_graph/tests/adapters/transformers/test_adapter_store_source.py
+++ b/catalogue_graph/tests/adapters/transformers/test_adapter_store_source.py
@@ -48,19 +48,33 @@ def test_stream_raw_changeset_path_uses_changeset_lookup(
     assert sorted(row["id"] for row in rows) == ["rec001", "rec002"]
 
 
-class _StreamingOnlyStore:
-    """Stub store that streams instrumented batches and forbids eager reads."""
+class _ClosableBatchStream:
+    """Iterable of record batches that records consumption and close(), like a reader."""
 
     def __init__(self, batches: list[pa.RecordBatch]) -> None:
         self.batches = batches
         self.batches_consumed: list[int] = []
+        self.closed = False
 
-    def stream_active_namespace_records(
-        self, snapshot_id: int | None = None
-    ) -> Generator[pa.RecordBatch]:
+    def __iter__(self) -> Generator[pa.RecordBatch]:
         for index, batch in enumerate(self.batches):
             self.batches_consumed.append(index)
             yield batch
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _StreamingOnlyStore:
+    """Stub store that streams instrumented batches and forbids eager reads."""
+
+    def __init__(self, batches: list[pa.RecordBatch]) -> None:
+        self.stream = _ClosableBatchStream(batches)
+
+    def stream_active_namespace_records(
+        self, snapshot_id: int | None = None
+    ) -> _ClosableBatchStream:
+        return self.stream
 
     def get_active_namespace_records(self, snapshot_id: int | None = None) -> pa.Table:
         raise AssertionError(
@@ -84,10 +98,25 @@ def test_stream_raw_full_reindex_is_lazy() -> None:
     first_row = next(stream)
 
     assert first_row["id"] == "rec001"
-    assert store.batches_consumed == [0]
+    assert store.stream.batches_consumed == [0]
 
     assert next(stream)["id"] == "rec002"
-    assert store.batches_consumed == [0, 1]
+    assert store.stream.batches_consumed == [0, 1]
+
+
+def test_stream_raw_full_reindex_closes_reader_when_abandoned() -> None:
+    """Abandoning the stream mid-iteration closes the underlying batch reader,
+    so a consumer error does not leave the reader's prefetch reads running."""
+    store = _StreamingOnlyStore(
+        [_single_row_batch("rec001"), _single_row_batch("rec002")]
+    )
+    source = AdapterStoreSource(cast(AdapterStore, store), changeset_ids=[])
+
+    stream = source.stream_raw()
+    next(stream)
+    stream.close()
+
+    assert store.stream.closed
 
 
 def test_stream_raw_full_reindex_empty_store() -> None:

--- a/catalogue_graph/tests/adapters/utils/test_adapter_store.py
+++ b/catalogue_graph/tests/adapters/utils/test_adapter_store.py
@@ -236,7 +236,7 @@ def test_stream_active_namespace_records_excludes_deleted(
     assert sorted(streamed_ids) == ["rec001", "rec002"]
 
 
-def test_stream_namespace_records_honours_snapshot_id(
+def test_stream_active_namespace_records_honours_snapshot_id(
     adapter_store_with_records: AdapterStoreFactory,
 ) -> None:
     """Streaming with a pinned snapshot excludes rows appended after the snapshot."""
@@ -277,7 +277,7 @@ def test_stream_active_namespace_records_empty_table(
     assert sum(batch.num_rows for batch in reader) == 0
 
 
-def test_stream_namespace_records_batches_match_store_schema(
+def test_stream_active_namespace_records_batches_match_store_schema(
     adapter_store_with_records: AdapterStoreFactory,
 ) -> None:
     """Streamed batches carry the store's Arrow schema."""

--- a/catalogue_graph/tests/adapters/utils/test_adapter_store.py
+++ b/catalogue_graph/tests/adapters/utils/test_adapter_store.py
@@ -6,12 +6,14 @@ These tests cover methods that are not specific to either incremental_update or 
 - get_records_by_changeset
 """
 
+from operator import itemgetter
 from typing import cast
 
 from pyiceberg.table import Table as IcebergTable
 
 from adapters.utils.adapter_store import AdapterStore
-from tests.adapters.conftest import AdapterStoreFactory
+from adapters.utils.schemata import ADAPTER_STORE_ARROW_SCHEMA
+from tests.adapters.conftest import AdapterStoreFactory, adapter_records_to_table
 
 # =============================================================================
 # get_all_records tests
@@ -183,3 +185,104 @@ def test_get_records_by_changeset_includes_deleted_records(
     assert result.num_rows == 2
     ids = set(result.column("id").to_pylist())
     assert ids == {"rec001", "rec002"}
+
+
+# =============================================================================
+# stream_active_namespace_records tests
+# =============================================================================
+
+
+def test_stream_active_namespace_records_matches_eager_read(
+    adapter_store_with_records: AdapterStoreFactory,
+) -> None:
+    """Streaming yields exactly the same rows as the eager read."""
+    client = adapter_store_with_records(
+        [
+            {"id": "rec001", "content": "first"},
+            {"id": "rec002", "content": "second", "deleted": False},
+            {"id": "rec003", "content": "third"},
+        ]
+    )
+
+    streamed = [
+        row
+        for batch in client.stream_active_namespace_records()
+        for row in batch.to_pylist()
+    ]
+    eager = client.get_active_namespace_records().to_pylist()
+
+    sort_key = itemgetter("id")
+    assert sorted(streamed, key=sort_key) == sorted(eager, key=sort_key)
+
+
+def test_stream_active_namespace_records_excludes_deleted(
+    adapter_store_with_records: AdapterStoreFactory,
+) -> None:
+    """Streaming returns records where deleted is null or False, excluding deleted ones."""
+    client = adapter_store_with_records(
+        [
+            {"id": "rec001", "content": "active record"},
+            {"id": "rec002", "content": "another active", "deleted": False},
+            {"id": "rec003", "content": "deleted record", "deleted": True},
+        ]
+    )
+
+    streamed_ids = [
+        row["id"]
+        for batch in client.stream_active_namespace_records()
+        for row in batch.to_pylist()
+    ]
+
+    assert sorted(streamed_ids) == ["rec001", "rec002"]
+
+
+def test_stream_namespace_records_honours_snapshot_id(
+    adapter_store_with_records: AdapterStoreFactory,
+) -> None:
+    """Streaming with a pinned snapshot excludes rows appended after the snapshot."""
+    client = adapter_store_with_records(
+        [
+            {"id": "rec001", "content": "first"},
+            {"id": "rec002", "content": "second"},
+        ]
+    )
+    pinned_snapshot_id = client.current_snapshot_id()
+
+    client.table.append(adapter_records_to_table([{"id": "rec003", "content": "new"}]))
+
+    pinned_ids = [
+        row["id"]
+        for batch in client.stream_active_namespace_records(pinned_snapshot_id)
+        for row in batch.to_pylist()
+    ]
+    current_ids = [
+        row["id"]
+        for batch in client.stream_active_namespace_records()
+        for row in batch.to_pylist()
+    ]
+
+    assert sorted(pinned_ids) == ["rec001", "rec002"]
+    assert sorted(current_ids) == ["rec001", "rec002", "rec003"]
+
+
+def test_stream_active_namespace_records_empty_table(
+    temporary_table: IcebergTable,
+) -> None:
+    """Streaming an empty table yields no rows."""
+    client = AdapterStore(temporary_table, "test_namespace")
+
+    batches = list(client.stream_active_namespace_records())
+
+    assert sum(batch.num_rows for batch in batches) == 0
+
+
+def test_stream_namespace_records_batches_match_store_schema(
+    adapter_store_with_records: AdapterStoreFactory,
+) -> None:
+    """Streamed batches carry the store's Arrow schema."""
+    client = adapter_store_with_records([{"id": "rec001", "content": "first"}])
+
+    batches = list(client.stream_active_namespace_records())
+
+    assert len(batches) > 0
+    assert all(batch.schema == ADAPTER_STORE_ARROW_SCHEMA for batch in batches)

--- a/catalogue_graph/tests/adapters/utils/test_adapter_store.py
+++ b/catalogue_graph/tests/adapters/utils/test_adapter_store.py
@@ -268,12 +268,13 @@ def test_stream_namespace_records_honours_snapshot_id(
 def test_stream_active_namespace_records_empty_table(
     temporary_table: IcebergTable,
 ) -> None:
-    """Streaming an empty table yields no rows."""
+    """Streaming an empty table yields no rows, with the store's Arrow schema."""
     client = AdapterStore(temporary_table, "test_namespace")
 
-    batches = list(client.stream_active_namespace_records())
+    reader = client.stream_active_namespace_records()
 
-    assert sum(batch.num_rows for batch in batches) == 0
+    assert reader.schema == ADAPTER_STORE_ARROW_SCHEMA
+    assert sum(batch.num_rows for batch in reader) == 0
 
 
 def test_stream_namespace_records_batches_match_store_schema(


### PR DESCRIPTION
Closes #3439.

## What does this change?

On a full reindex (no changeset ids), `AdapterStoreSource.stream_raw` loaded the whole adapter store namespace into memory twice: once as an Arrow table via `get_active_namespace_records`, and again as a Python list via `to_pylist()`. For the 1.7M-record FOLIO bib store that peaks at about 13 GB, which cannot fit in the transformer Lambda. The same path is shared by Axiell and EBSCO.

This change streams the read as Arrow record batches instead:

- `PipelineStore.stream_namespace_records`: same namespace filter and snapshot pinning as `get_namespace_records`, but returns `scan.to_arrow_batch_reader()` (cast to the store schema) instead of a materialised table.
- `AdapterStore.stream_active_namespace_records`: applies the same non-deleted filter as `get_active_namespace_records`.
- `AdapterStoreSource.stream_raw`: the full-reindex branch iterates batches and converts one batch at a time. The changeset branch is untouched.

Downstream needs no changes: `ElasticBaseTransformer._transform_batches` already consumes `stream_raw()` lazily in 10k chunks.

### Measurements

Read-only runs against the production FOLIO bib S3 Table (1,706,137 active rows, 23 data files), each in a fresh process, reporting `ru_maxrss`:

| Approach | Peak RSS | Elapsed |
| --- | --- | --- |
| Current eager read (`get_active_namespace_records().to_pylist()`) | 12,995 MB | 117s |
| This change (`to_arrow_batch_reader`) | 4,530 and 4,885 MB (two runs) | 45s |
| Per-file `ArrowScan` streaming (considered, not chosen) | 2,746 MB | 80s |

All three returned identical row counts.

### Choice of API

pyiceberg's `to_arrow_batch_reader` prefetches data files on a thread pool regardless of consumption rate (each file scan task materialises its whole file, and all tasks are submitted up front), so its peak memory is a large constant-factor improvement over the eager read rather than a hard per-batch bound. This is a known upstream issue (apache/iceberg-python#2407) with an open improvement PR (#1995).

A per-file read via `ArrowScan.to_table([task])` gives a genuinely bounded profile (2.7 GB, flat as the table grows) and was implemented in an earlier iteration of this branch (commit `3cf3ebb72`), but `ArrowScan` sits below pyiceberg's public API and the library is pre-1.0, so its signature can change in a minor release. The public reader was chosen deliberately, in discussion with the repo owner: it is the supported surface, it is simpler and faster, upstream memory improvements land for free, and the measured 4.5 to 4.9 GB peak fits comfortably in the transformer Lambda's 10240 MB. The per-file pattern is preserved in this branch's history if a hard bound is ever needed.

## How to test

Inside `catalogue_graph/`:

```
uv run ruff check .
uv run ruff format --check .
uv run mypy .
uv run pytest
```

On this branch: ruff clean, `mypy .` clean (558 files), 1350 tests pass (27 deselected). New tests:

- `tests/adapters/utils/test_adapter_store.py` (5): streamed rows match the eager read, deleted rows are excluded, snapshot pinning is honoured, an empty table streams no rows, and batches carry the store schema.
- `tests/adapters/transformers/test_adapter_store_source.py` (4): the full-reindex path yields all active rows, the changeset path is unchanged, consuming one row pulls only one batch and never calls the eager read (laziness), and an empty store yields nothing.

## How can we measure success?

On a full reindex, the transformer reads the FOLIO bib namespace without running out of memory. Peak RSS drops from about 13 GB to about 4.5 GB, well inside the transformer Lambda's 10240 MB, at current scale, and the read is faster (about 45s against 117s). Row counts match the eager read exactly, so the streamed read produces the same works.

## Have we considered potential risks?

- Peak memory scales with table size and with how far the reader's prefetch runs ahead of the consumer, rather than being bounded by one batch. At current scale it is 4.5 GB against a 10 GB Lambda. If the stores grow substantially, options are: cap `PYICEBERG_MAX_WORKERS` on the Lambda (upstream reports a large memory drop with unchanged duration), pick up the upstream reader improvements, or restore the per-file read from commit `3cf3ebb72`.
- The manifest bookkeeping in `stream_to_index` still accumulates all successful ids and an id mapping for the run. That is O(n) in short id strings, small next to record content, and out of scope here.

### Related work

- #3444 is the sibling issue about the changeset read scanning the whole table with an un-prunable filter. This work does not touch `get_records_by_changeset` or the changeset branch of `stream_raw`, so the two fixes are independent.
- PR #3438 wraps both `stream_raw` branches in `_with_enrichment(rows)`. The only textual conflict is the tail of the full-reindex branch. To resolve when both are in: build the row generator (`row for batch in batches for row in batch.to_pylist()`), pass it to `_with_enrichment`, and loosen that method's parameter type from `list` to `Iterable`. Its body uses `itertools.batched`, which accepts any iterable, so the enrichment join stays bounded and the stream stays lazy end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
