### PR TITLE
Axiell normalise HTML text

### DIFF
--- a/catalogue_graph/pyproject.toml
+++ b/catalogue_graph/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "pymysql>=1.0.0",
     "cryptography>=48.0.1",
     "yoyo-migrations>=8.2.0",
+    "nh3"
 ]
 
 [tool.uv]

--- a/catalogue_graph/pyproject.toml
+++ b/catalogue_graph/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "pymysql>=1.0.0",
     "cryptography>=48.0.1",
     "yoyo-migrations>=8.2.0",
-    "nh3"
+    "nh3>=0.3"
 ]
 
 [tool.uv]

--- a/catalogue_graph/src/adapters/transformers/axiell/description.py
+++ b/catalogue_graph/src/adapters/transformers/axiell/description.py
@@ -1,0 +1,9 @@
+from pymarc.record import Record
+
+from adapters.transformers.marc.common import non_empty_subfields
+from adapters.transformers.utils.html import normalise_text
+
+
+def extract_description(record: Record) -> str | None:
+    description = " ".join(non_empty_subfields("520", "a", record))
+    return normalise_text(description) or None

--- a/catalogue_graph/src/adapters/transformers/axiell/notes.py
+++ b/catalogue_graph/src/adapters/transformers/axiell/notes.py
@@ -11,6 +11,7 @@ from adapters.transformers.marc.notes import (
     _create_note,
 )
 from adapters.transformers.marc.notes import extract_notes as base_extract_notes
+from adapters.transformers.utils.html import normalise_text
 from models.pipeline.id_label import IdLabel
 from models.pipeline.note import Note
 
@@ -40,5 +41,8 @@ def extract_notes(record: Record) -> list[Note]:
         notes.append(Note(contents=terms_of_use, note_type=TERMS_OF_USE))
 
     notes += extract_languages(record)[1]
+
+    for note in notes:
+        note.contents = normalise_text(note.contents)
 
     return notes

--- a/catalogue_graph/src/adapters/transformers/axiell/notes.py
+++ b/catalogue_graph/src/adapters/transformers/axiell/notes.py
@@ -45,4 +45,5 @@ def extract_notes(record: Record) -> list[Note]:
     for note in notes:
         note.contents = normalise_text(note.contents)
 
-    return notes
+    # Filter out any notes whose contents were fully removed by `normalise_text`
+    return [n for n in notes if n.contents]

--- a/catalogue_graph/src/adapters/transformers/axiell/physical_description.py
+++ b/catalogue_graph/src/adapters/transformers/axiell/physical_description.py
@@ -1,0 +1,14 @@
+from pymarc.field import Field
+from pymarc.record import Record
+
+from adapters.transformers.marc.common import non_empty_subfields
+from adapters.transformers.utils.html import normalise_text
+
+
+def _field_content(field: Field) -> str:
+    return " ".join(field.get_subfields("a", "b", "c", "e")).strip()
+
+
+def extract_physical_description(record: Record) -> str | None:
+    description = " ".join(non_empty_subfields("300", "a", record))
+    return normalise_text(description) or None

--- a/catalogue_graph/src/adapters/transformers/axiell/physical_description.py
+++ b/catalogue_graph/src/adapters/transformers/axiell/physical_description.py
@@ -1,12 +1,7 @@
-from pymarc.field import Field
 from pymarc.record import Record
 
 from adapters.transformers.marc.common import non_empty_subfields
 from adapters.transformers.utils.html import normalise_text
-
-
-def _field_content(field: Field) -> str:
-    return " ".join(field.get_subfields("a", "b", "c", "e")).strip()
 
 
 def extract_physical_description(record: Record) -> str | None:

--- a/catalogue_graph/src/adapters/transformers/builders/axiell_work_builder.py
+++ b/catalogue_graph/src/adapters/transformers/builders/axiell_work_builder.py
@@ -6,11 +6,15 @@ from adapters.transformers.axiell.catalogue_status import (
     extract_catalogue_status,
 )
 from adapters.transformers.axiell.contributors import extract_contributors
+from adapters.transformers.axiell.description import extract_description
 from adapters.transformers.axiell.format import extract_format
 from adapters.transformers.axiell.languages import extract_languages
 from adapters.transformers.axiell.notes import extract_notes
 from adapters.transformers.axiell.organisation_and_arrangement import (
     extract_work_type,
+)
+from adapters.transformers.axiell.physical_description import (
+    extract_physical_description,
 )
 from adapters.transformers.axiell.subjects import extract_subjects
 from adapters.transformers.builders.marc_xml_work_builder import MarcXmlWorkBuilder
@@ -20,7 +24,6 @@ from adapters.transformers.ebsco.production import (
 from adapters.transformers.marc.last_transaction_time import (
     extract_last_transaction_time_to_datetime,
 )
-from adapters.transformers.marc.physical_description import extract_physical_description
 from adapters.transformers.marc.predecessor_identifier import (
     extract_calm_predecessor_id,
 )
@@ -158,6 +161,10 @@ class AxiellWorkBuilder(MarcXmlWorkBuilder):
     @property
     def production(self) -> list[ProductionEvent]:
         return extract_production(self.record)
+
+    @property
+    def description(self) -> str | None:
+        return extract_description(self.record)
 
     @property
     def contributors(self) -> list[Contributor]:

--- a/catalogue_graph/src/adapters/transformers/utils/html.py
+++ b/catalogue_graph/src/adapters/transformers/utils/html.py
@@ -46,6 +46,8 @@ _TAGS: dict[AllowedTags, set[str]] = {
 
 def normalise_text(s: str, allowed_tags: AllowedTags = "basic") -> str:
     """Sanitise an HTML string, retaining only the tags permitted by allowed_tags."""
+    
+    # TODO: `rel="nofollow"` added to mirror Scala. Do we also want to add `noreferrer`? 
     cleaned = nh3.clean(s, tags=_TAGS[allowed_tags], link_rel="nofollow")
 
     lines = [line.rstrip() for line in cleaned.splitlines()]

--- a/catalogue_graph/src/adapters/transformers/utils/html.py
+++ b/catalogue_graph/src/adapters/transformers/utils/html.py
@@ -1,8 +1,63 @@
+import html
+from typing import Literal
 from urllib.parse import urlparse
 
+import nh3
 import structlog
 
 logger = structlog.get_logger(__name__)
+
+
+type AllowedTags = Literal["basic", "none", "italics_only"]
+
+BASIC_TAGS = {
+    "a",
+    "b",
+    "blockquote",
+    "br",
+    "cite",
+    "code",
+    "dd",
+    "dl",
+    "dt",
+    "em",
+    "i",
+    "li",
+    "ol",
+    "p",
+    "pre",
+    "q",
+    "small",
+    "span",
+    "strike",
+    "strong",
+    "sub",
+    "sup",
+    "u",
+    "ul",
+}
+
+_TAGS: dict[AllowedTags, set[str]] = {
+    "basic": BASIC_TAGS,
+    "none": set(),
+    "italics_only": {"i"},
+}
+
+
+def normalise_text(s: str, allowed_tags: AllowedTags = "basic") -> str:
+    cleaned = nh3.clean(s, tags=_TAGS[allowed_tags], link_rel="nofollow")
+
+    lines = [line.rstrip() for line in cleaned.splitlines()]
+
+    result: list[str] = []
+    for line in lines:
+        if not result and line == "":
+            continue
+        if result and result[-1] == "" and line == "":
+            continue
+        result.append(line)
+
+    return html.unescape("\n".join(result)).strip()
 
 
 def is_url(maybe_url: str) -> bool:

--- a/catalogue_graph/src/adapters/transformers/utils/html.py
+++ b/catalogue_graph/src/adapters/transformers/utils/html.py
@@ -46,8 +46,8 @@ _TAGS: dict[AllowedTags, set[str]] = {
 
 def normalise_text(s: str, allowed_tags: AllowedTags = "basic") -> str:
     """Sanitise an HTML string, retaining only the tags permitted by allowed_tags."""
-    
-    # TODO: `rel="nofollow"` added to mirror Scala. Do we also want to add `noreferrer`? 
+
+    # TODO: `rel="nofollow"` added to mirror Scala. Do we also want to add `noreferrer`?
     cleaned = nh3.clean(s, tags=_TAGS[allowed_tags], link_rel="nofollow")
 
     lines = [line.rstrip() for line in cleaned.splitlines()]

--- a/catalogue_graph/src/adapters/transformers/utils/html.py
+++ b/catalogue_graph/src/adapters/transformers/utils/html.py
@@ -45,12 +45,14 @@ _TAGS: dict[AllowedTags, set[str]] = {
 
 
 def normalise_text(s: str, allowed_tags: AllowedTags = "basic") -> str:
+    """Sanitise an HTML string, retaining only the tags permitted by allowed_tags."""
     cleaned = nh3.clean(s, tags=_TAGS[allowed_tags], link_rel="nofollow")
 
     lines = [line.rstrip() for line in cleaned.splitlines()]
 
     result: list[str] = []
     for line in lines:
+        # Strip consecutive blank lines
         if not result and line == "":
             continue
         if result and result[-1] == "" and line == "":

--- a/catalogue_graph/src/adapters/transformers/utils/html.py
+++ b/catalogue_graph/src/adapters/transformers/utils/html.py
@@ -48,7 +48,15 @@ def normalise_text(s: str, allowed_tags: AllowedTags = "basic") -> str:
     """Sanitise an HTML string, retaining only the tags permitted by allowed_tags."""
 
     # TODO: `rel="nofollow"` added to mirror Scala. Do we also want to add `noreferrer`?
-    cleaned = nh3.clean(s, tags=_TAGS[allowed_tags], link_rel="nofollow")
+    cleaned = nh3.clean(
+        s,
+        tags=_TAGS[allowed_tags],
+        #  `"*": set()` clears generic attributes
+        attributes={"a": {"href"}, "blockquote": {"cite"}, "q": {"cite"}, "*": set()},
+        url_schemes={"ftp", "http", "https", "mailto"},
+        url_relative="deny",
+        link_rel="nofollow",
+    )
 
     lines = [line.rstrip() for line in cleaned.splitlines()]
 

--- a/catalogue_graph/src/adapters/transformers/utils/html.py
+++ b/catalogue_graph/src/adapters/transformers/utils/html.py
@@ -48,6 +48,7 @@ def normalise_text(s: str, allowed_tags: AllowedTags = "basic") -> str:
     """Sanitise an HTML string, retaining only the tags permitted by allowed_tags."""
 
     # TODO: `rel="nofollow"` added to mirror Scala. Do we also want to add `noreferrer`?
+    # The attributes/url_schemes configuration matches jsoup's defaults to mirror Scala pipeline
     cleaned = nh3.clean(
         s,
         tags=_TAGS[allowed_tags],

--- a/catalogue_graph/tests/adapters/transformers/axiell/bdd/features/description.feature
+++ b/catalogue_graph/tests/adapters/transformers/axiell/bdd/features/description.feature
@@ -1,0 +1,38 @@
+Feature: Description extraction from Axiell MARC records
+  Description is derived from MARC 520 $a (Summary, etc.).
+  Multiple 520 fields are joined with spaces.
+  HTML is sanitised via normalise_text.
+  - https://www.loc.gov/marc/bibliographic/bd520.html
+
+  Background:
+    Given a valid MARC record
+
+  Scenario: No 520 field — description is absent
+    When I transform the MARC record
+    Then the work's description is absent
+
+  Scenario: Single 520 field
+    Given the MARC record has a 520 field with subfield "a" value "A collection of correspondence."
+    When I transform the MARC record
+    Then the work's description is "A collection of correspondence."
+
+  Scenario: Multiple 520 fields are joined by space
+    Given the MARC record has a 520 field with subfield "a" value "First summary."
+    And the MARC record has another 520 field with subfield "a" value "Second summary."
+    When I transform the MARC record
+    Then the work's description is "First summary. Second summary."
+
+  Scenario: Permitted HTML tags are retained
+    Given the MARC record has a 520 field with subfield "a" value "Contains <em>important</em> material."
+    When I transform the MARC record
+    Then the work's description is "Contains <em>important</em> material."
+
+  Scenario: Disallowed HTML tags are stripped but text is kept
+    Given the MARC record has a 520 field with subfield "a" value "See <div>attached</div> list."
+    When I transform the MARC record
+    Then the work's description is "See attached list."
+
+  Scenario: Whitespace-only 520 $a produces no description
+    Given the MARC record has a 520 field with subfield "a" value "   "
+    When I transform the MARC record
+    Then the work's description is absent

--- a/catalogue_graph/tests/adapters/transformers/axiell/bdd/features/physical_description.feature
+++ b/catalogue_graph/tests/adapters/transformers/axiell/bdd/features/physical_description.feature
@@ -16,19 +16,9 @@ Feature: Physical description extraction from Axiell MARC records
     Given the MARC record has a 300 field with subfield "a" value "42 leaves"
     When I transform the MARC record
     Then the work's physical_description is "42 leaves"
-
-  Scenario: Single 300 field with multiple subfields joined by space
-    Given the MARC record has a 300 field with subfields:
-      | code | value              |
-      | a    | 1 folder           |
-      | b    | ill.               |
-      | c    | 30 cm              |
-      | e    | + 1 map            |
-    When I transform the MARC record
-    Then the work's physical_description is "1 folder ill. 30 cm + 1 map"
-
-  Scenario: Multiple 300 fields are joined with <br/>
+    
+  Scenario: Multiple 300 fields are joined by space
     Given the MARC record has a 300 field with subfield "a" value "42 leaves"
     And the MARC record has another 300 field with subfield "a" value "1 map"
     When I transform the MARC record
-    Then the work's physical_description is "42 leaves<br/>1 map"
+    Then the work's physical_description is "42 leaves 1 map"

--- a/catalogue_graph/tests/adapters/transformers/axiell/bdd/features/physical_description.feature
+++ b/catalogue_graph/tests/adapters/transformers/axiell/bdd/features/physical_description.feature
@@ -1,8 +1,6 @@
 Feature: Physical description extraction from Axiell MARC records
-  Physical description is derived from MARC 300 (Physical Description).
-  Subfields $a (extent), $b (other physical details), $c (dimensions), and
-  $e (accompanying material) are joined with a space. Multiple 300 fields are
-  joined with "<br/>".
+  Physical description is derived from MARC 300 $a (Physical Description, extent).
+  Multiple 300 fields are joined with spaces.
   - https://www.loc.gov/marc/bibliographic/bd300.html
 
   Background:

--- a/catalogue_graph/tests/adapters/transformers/axiell/bdd/test_description.py
+++ b/catalogue_graph/tests/adapters/transformers/axiell/bdd/test_description.py
@@ -1,0 +1,3 @@
+from pytest_bdd import scenarios
+
+scenarios("features/description.feature")

--- a/catalogue_graph/tests/adapters/transformers/axiell/test_notes.py
+++ b/catalogue_graph/tests/adapters/transformers/axiell/test_notes.py
@@ -98,3 +98,16 @@ def test_540_text_content_not_emitted_as_terms_of_use() -> None:
     record.add_field(_field("540", "a", "Reproductions may be made for personal use."))
     notes = extract_notes(record)
     assert not any(n.note_type == TERMS_OF_USE for n in notes)
+
+
+def test_note_stripped_to_empty_by_normalise_text_is_excluded() -> None:
+    """A note whose content normalise_text reduces to an empty string is not returned.
+
+    An HTML comment is non-empty (so it passes the base extract_notes whitespace
+    filter) but nh3 strips it entirely, leaving nothing after normalise_text.
+    """
+    record = Record()
+    record.add_field(Field(tag="001", data="test_id"))
+    record.add_field(_field("500", "a", "<!-- only a comment -->"))
+    notes = extract_notes(record)
+    assert notes == []

--- a/catalogue_graph/tests/adapters/transformers/utils/test_html.py
+++ b/catalogue_graph/tests/adapters/transformers/utils/test_html.py
@@ -1,4 +1,4 @@
-from adapters.transformers.utils.html import format_as_html_link
+from adapters.transformers.utils.html import format_as_html_link, normalise_text
 
 
 def test_formats_valid_url_as_link() -> None:
@@ -20,3 +20,73 @@ def test_strips_whitespace_before_checking() -> None:
 def test_returns_non_url_unchanged() -> None:
     not_a_url = "just some text"
     assert format_as_html_link(not_a_url) == "just some text"
+
+
+def test_normalise_preserves_basic_text_tags() -> None:
+    s = "Some text with some <em>basic text tags</em> inside."
+    assert normalise_text(s) == s
+
+
+def test_normalise_strips_non_basic_text_tags() -> None:
+    assert (
+        normalise_text("<div>Tags should be <ins>stripped</ins></div>")
+        == "Tags should be stripped"
+    )
+
+
+def test_normalise_removes_script_tags_and_inner_content() -> None:
+    s = 'Nothing here...<script>window.alert("NASTY");</script> Nothing.'
+    assert normalise_text(s) == "Nothing here... Nothing."
+
+
+def test_normalise_does_not_error_on_missing_closing_tags() -> None:
+    assert (
+        normalise_text("Someone forgot <em>to close something..")
+        == "Someone forgot <em>to close something..</em>"
+    )
+
+
+def test_normalise_preserves_newlines_and_left_whitespace() -> None:
+    s = "Text\n  * that spans\n  * multiple lines\n(and includes some <b>left whitespace</b>)"
+    assert normalise_text(s) == s
+
+
+def test_normalise_retains_links_stripping_non_href_attributes() -> None:
+    s = 'A <a href="http://example.location" target="_blank">link</a>'
+    assert (
+        normalise_text(s)
+        == 'A <a href="http://example.location" rel="nofollow">link</a>'
+    )
+
+
+def test_normalise_does_not_escape_symbols() -> None:
+    s = "Ampersand & some other symbols like >."
+    assert normalise_text(s) == s
+
+
+def test_normalise_strips_full_html_document_removing_recurring_empty_lines() -> None:
+    s = """
+      <!doctype html>
+      <html lang="en">
+      <head>
+        <meta charset="utf-8">
+      </head>
+      <div>
+        <h1>The document:</h1>
+        <div>
+          <p>
+            This contains text with <em>a few</em> <b>different</b> tags, some of
+            of which are <span>preserved</span>, others <ins>not</ins>.
+          </p>
+        </div>
+      </div>
+    """
+    assert (
+        normalise_text(s)
+        == """The document:
+
+          <p>
+            This contains text with <em>a few</em> <b>different</b> tags, some of
+            of which are <span>preserved</span>, others not.
+          </p>"""
+    )

--- a/catalogue_graph/tests/adapters/transformers/utils/test_html.py
+++ b/catalogue_graph/tests/adapters/transformers/utils/test_html.py
@@ -64,6 +64,76 @@ def test_normalise_does_not_escape_symbols() -> None:
     assert normalise_text(s) == s
 
 
+def test_normalise_strips_hreflang_from_links() -> None:
+    s = '<a href="https://example.com" hreflang="en">link</a>'
+    assert normalise_text(s) == '<a href="https://example.com" rel="nofollow">link</a>'
+
+
+def test_normalise_strips_generic_lang_attribute() -> None:
+    assert normalise_text('<p lang="en">text</p>') == "<p>text</p>"
+
+
+def test_normalise_strips_generic_title_attribute() -> None:
+    assert normalise_text('<span title="tooltip">text</span>') == "<span>text</span>"
+
+
+def test_normalise_allows_cite_on_blockquote() -> None:
+    s = '<blockquote cite="https://example.com">quote</blockquote>'
+    assert normalise_text(s) == s
+
+
+def test_normalise_allows_cite_on_q() -> None:
+    s = '<q cite="https://example.com">quote</q>'
+    assert normalise_text(s) == s
+
+
+def test_normalise_strips_relative_href() -> None:
+    assert (
+        normalise_text('<a href="/relative/path">link</a>')
+        == '<a rel="nofollow">link</a>'
+    )
+
+
+def test_normalise_strips_anchor_href() -> None:
+    assert normalise_text('<a href="#section">link</a>') == '<a rel="nofollow">link</a>'
+
+
+def test_normalise_allows_ftp_href() -> None:
+    s = '<a href="ftp://files.example.com">FTP</a>'
+    assert (
+        normalise_text(s) == '<a href="ftp://files.example.com" rel="nofollow">FTP</a>'
+    )
+
+
+def test_normalise_allows_mailto_href() -> None:
+    s = '<a href="mailto:user@example.com">email</a>'
+    assert (
+        normalise_text(s)
+        == '<a href="mailto:user@example.com" rel="nofollow">email</a>'
+    )
+
+
+def test_normalise_strips_javascript_href() -> None:
+    assert (
+        normalise_text('<a href="javascript:alert(1)">xss</a>')
+        == '<a rel="nofollow">xss</a>'
+    )
+
+
+def test_normalise_strips_magnet_href() -> None:
+    assert (
+        normalise_text('<a href="magnet:?xt=urn:example">magnet</a>')
+        == '<a rel="nofollow">magnet</a>'
+    )
+
+
+def test_normalise_strips_irc_href() -> None:
+    assert (
+        normalise_text('<a href="irc://irc.example.com/channel">IRC</a>')
+        == '<a rel="nofollow">IRC</a>'
+    )
+
+
 def test_normalise_strips_full_html_document_removing_recurring_empty_lines() -> None:
     s = """
       <!doctype html>

--- a/catalogue_graph/uv.lock
+++ b/catalogue_graph/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.12.*"
 
 [[package]]
@@ -133,6 +133,7 @@ dependencies = [
     { name = "cryptography" },
     { name = "elasticsearch" },
     { name = "lxml" },
+    { name = "nh3" },
     { name = "oai-pmh-client" },
     { name = "polars" },
     { name = "pyarrow" },
@@ -180,6 +181,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=48.0.1" },
     { name = "elasticsearch", specifier = ">=8.11,<8.13" },
     { name = "lxml", specifier = ">=6.0.0" },
+    { name = "nh3" },
     { name = "oai-pmh-client", git = "https://github.com/wellcomecollection/oai-pmh.git?tag=v1.0.1" },
     { name = "polars" },
     { name = "pyarrow", specifier = "~=23.0" },
@@ -458,7 +460,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/44/69/9b804adb5fd0671f367781560eb5eb586c4d495277c93bde4307b9e28068/greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd", size = 274079, upload-time = "2025-08-07T13:15:45.033Z" },
     { url = "https://files.pythonhosted.org/packages/46/e9/d2a80c99f19a153eff70bc451ab78615583b8dac0754cfb942223d2c1a0d/greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb", size = 640997, upload-time = "2025-08-07T13:42:56.234Z" },
     { url = "https://files.pythonhosted.org/packages/3b/16/035dcfcc48715ccd345f3a93183267167cdd162ad123cd93067d86f27ce4/greenlet-3.2.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f28588772bb5fb869a8eb331374ec06f24a83a9c25bfa1f38b6993afe9c1e968", size = 655185, upload-time = "2025-08-07T13:45:27.624Z" },
-    { url = "https://files.pythonhosted.org/packages/31/da/0386695eef69ffae1ad726881571dfe28b41970173947e7c558d9998de0f/greenlet-3.2.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5c9320971821a7cb77cfab8d956fa8e39cd07ca44b6070db358ceb7f8797c8c9", size = 649926, upload-time = "2025-08-07T13:53:15.251Z" },
     { url = "https://files.pythonhosted.org/packages/68/88/69bf19fd4dc19981928ceacbc5fd4bb6bc2215d53199e367832e98d1d8fe/greenlet-3.2.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c60a6d84229b271d44b70fb6e5fa23781abb5d742af7b808ae3f6efd7c9c60f6", size = 651839, upload-time = "2025-08-07T13:18:30.281Z" },
     { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
@@ -827,6 +828,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
+]
+
+[[package]]
+name = "nh3"
+version = "0.3.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/1b/ef84624f14954d270f74060a19fc550dd4f06656399447569afb584d8c06/nh3-0.3.6.tar.gz", hash = "sha256:f3736c9dd3d1856f80cd031715b84ca75cda2bbb1ac802c3da26bfce590838d7", size = 24684, upload-time = "2026-06-22T00:47:02.008Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/ab/a7653bce9a3b204be6a6931767a9e23595807bb84790ce6685e4d7e5bd08/nh3-0.3.6-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:a43ebd7543555c3ac1bc353023d0794e75cb76f6f18f19c32e95441496c0cc25", size = 1443564, upload-time = "2026-06-22T00:46:36.66Z" },
+    { url = "https://files.pythonhosted.org/packages/41/21/e1084ab18eb589506335c7c7576f2d4643e9a0c0e33983ef0e549a256b96/nh3-0.3.6-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e1b160831c9cdb06a6c79c2f9cdb11386602938f9af260d1c457a85add4f6f69", size = 838002, upload-time = "2026-06-22T00:46:38.101Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/94/f48d08e6f72a406300fa11d8acd929fea1a80d4bf750fa292cb10785f126/nh3-0.3.6-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d14bf7982e7a77c0c775634c29c07ce08b38a046df73e1c1f139b3e82f18a38e", size = 823045, upload-time = "2026-06-22T00:46:39.495Z" },
+    { url = "https://files.pythonhosted.org/packages/25/bb/431615ba1d1d3eb63cde0f974f2114edf863a8a3f6049a12fed23fc241d3/nh3-0.3.6-cp38-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:44673b27010051ab5a5e438a86ec31bbda61d4a77d7e900af6b7be3037c1abae", size = 1093171, upload-time = "2026-06-22T00:46:41.21Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/24/a0d80182a18919665fefd19c1c06f1d1df1c9a6455d0252de40c034a0bc3/nh3-0.3.6-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e6b7beece07525dc6e6b0fc2f104442de2ba328360ad00e50cbe2e1fd620447d", size = 1049217, upload-time = "2026-06-22T00:46:42.804Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/13/6f1e302ca674ac74362e150848ad56a1be5145391204f74facdb8e94df12/nh3-0.3.6-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:455469a29951edc92bc48b47ac2281c3f2609e6c4f6a047056449f8c2c23facf", size = 917372, upload-time = "2026-06-22T00:46:44.495Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/67/314f6151bad77a93d751978a344033e1fc890822f05f0416079338e34231/nh3-0.3.6-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:905f877dc66dd7aea4a76e54bcb26acb5ff8216f720c0017ccf63e0e6035698e", size = 806699, upload-time = "2026-06-22T00:46:45.99Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a6/bfaa00046e58603507dcfc266c4778e3ab7adf68a5dedd73b6274b8d9314/nh3-0.3.6-cp38-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:25c733bee928530556b1db0ea46c52cf5aa686146e38e60a6fc7cb801ef91cec", size = 835165, upload-time = "2026-06-22T00:46:47.617Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a8/fb2c38845efb703a9173bffdfc745fc64d2b0e55cfc73a3647d2f028250c/nh3-0.3.6-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2f90d9a0cfdbee218994fdaaeeb5a0fde62d08f35e4eef0378ec1e2200172fd0", size = 858282, upload-time = "2026-06-22T00:46:49.276Z" },
+    { url = "https://files.pythonhosted.org/packages/68/17/06e72a18ee9b572914447338237ca7eb164c0df901f141bc10d1282247a2/nh3-0.3.6-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:82ca5bf427ad1b216b65ede1a2e2d87dc49bec417ceba0f297213107d3cd9d78", size = 1014328, upload-time = "2026-06-22T00:46:51.026Z" },
+    { url = "https://files.pythonhosted.org/packages/11/f9/3966c61455668c08853bf5e33b4bed93c421f3194ce4de896dc248d6f6ce/nh3-0.3.6-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:f5ed5fe84aee7f39db95c214a7421bf0499fbf500fec6d86a4e29bfc37971438", size = 1098207, upload-time = "2026-06-22T00:46:52.674Z" },
+    { url = "https://files.pythonhosted.org/packages/19/d3/479cb4ae440424825735d60525b53e3c77fd60fd6e6afc0e984f00eb0178/nh3-0.3.6-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:082675ff87b9385ec430ffe6d5847ba7456cc39b73720cd4add472f9f4cffd56", size = 1056961, upload-time = "2026-06-22T00:46:54.335Z" },
+    { url = "https://files.pythonhosted.org/packages/17/0c/6cdb5ee1e127be50dc8391e54bddc1f64e87bf4bfad0c55633320e2e02db/nh3-0.3.6-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:36d06341bd501240d320f5942481ed5e6846136b666e1ba4faf802b78ebc875f", size = 1033829, upload-time = "2026-06-22T00:46:56.258Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/55/9de666ad975d6ccd77d799ea0add55ee2347aa81286ce21b2a97c070746b/nh3-0.3.6-cp38-abi3-win32.whl", hash = "sha256:5276ef17bdba9ad8040575c74072008b13aae429436e9d0429e718bb5f90f4da", size = 609081, upload-time = "2026-06-22T00:46:57.665Z" },
+    { url = "https://files.pythonhosted.org/packages/82/fa/2b5d684e3edf1e81bfd02d298c78c3e3da77ca1d8a2be3183a79544a7548/nh3-0.3.6-cp38-abi3-win_amd64.whl", hash = "sha256:f338ac7d594c067679f1e99b4f5ec3906842979560f9d8f15d6bdfa39a353b10", size = 624461, upload-time = "2026-06-22T00:46:59.163Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/e5/7cafee2f0413ca4cb0ef3bd111e94d408a48810008b283ad8aee00dd1809/nh3-0.3.6-cp38-abi3-win_arm64.whl", hash = "sha256:69f365963f63a1e9bff53bdbb3c542c7c2efed3e163c9d5d83a772a2ac468c21", size = 603060, upload-time = "2026-06-22T00:47:00.596Z" },
 ]
 
 [[package]]

--- a/catalogue_graph/uv.lock
+++ b/catalogue_graph/uv.lock
@@ -181,7 +181,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=48.0.1" },
     { name = "elasticsearch", specifier = ">=8.11,<8.13" },
     { name = "lxml", specifier = ">=6.0.0" },
-    { name = "nh3" },
+    { name = "nh3", specifier = ">=0.3" },
     { name = "oai-pmh-client", git = "https://github.com/wellcomecollection/oai-pmh.git?tag=v1.0.1" },
     { name = "polars" },
     { name = "pyarrow", specifier = "~=23.0" },


### PR DESCRIPTION
## What does this change?

https://github.com/wellcomecollection/platform/issues/6337

Port HTML normalisation (sanitisation) logic from the CALM transformer (`NormaliseText.scala`) to the Axiell transformer. Sanitisation is done using the [nh3](https://pypi.org/project/nh3/) package, which is based on [ammonia](https://github.com/rust-ammonia/ammonia).

To mirror the Scala logic, a `rel="nofollow"` is added to all HTML links, but we should also consider adding `noreferrer`, since it's good practice. 

## How to test

Unit tests were ported from Scala. Validation against CALM showed that the relevant fields (description, physical description, notes) now match.

## How can we measure success?

HTML sanitisation parity between CALM transformer and Axiell transformer.

## Have we considered potential risks?

This change is low risk, reproducing functionality of the existing CALM transformer.
