### PR TITLE
Read small changesets by record id in the transformer

### DIFF
--- a/catalogue_graph/src/adapters/transformers/adapter_store_source.py
+++ b/catalogue_graph/src/adapters/transformers/adapter_store_source.py
@@ -22,8 +22,7 @@ class AdapterStoreSource(BaseSource):
 
     def stream_raw(self) -> Generator[dict[str, Any]]:
         if self.changeset_ids:
-            # Changeset reads include soft-deleted rows (needed to overwrite
-            # documents downstream); get_records_by_changesets preserves that.
+            # Includes soft-deleted rows, needed to overwrite documents downstream.
             table = self.adapter_store.get_records_by_changesets(
                 self.changeset_ids, self.snapshot_id
             )

--- a/catalogue_graph/src/adapters/transformers/adapter_store_source.py
+++ b/catalogue_graph/src/adapters/transformers/adapter_store_source.py
@@ -8,6 +8,14 @@ from core.source import BaseSource
 
 logger = structlog.get_logger(__name__)
 
+# Measured on the production FOLIO table (1.7M rows): for small changesets an
+# In("id", ...) content read prunes to the few data files overlapping the id
+# range (~1.5 GB peak vs ~1.8 GB for the un-prunable changeset scan, and
+# seconds vs a full-table read). For large changesets id-filtered reads
+# re-read the same overlapping files repeatedly and can exceed the Lambda
+# timeout, so we fall back to the eager changeset read.
+SMALL_CHANGESET_THRESHOLD = 1000
+
 
 class AdapterStoreSource(BaseSource):
     def __init__(
@@ -22,11 +30,7 @@ class AdapterStoreSource(BaseSource):
 
     def stream_raw(self) -> Generator[dict[str, Any]]:
         if self.changeset_ids:
-            for changeset_id in self.changeset_ids:
-                table = self.adapter_store.get_records_by_changeset(
-                    changeset_id, self.snapshot_id
-                )
-                yield from table.to_pylist()
+            yield from self._stream_changeset_records()
         else:
             logger.info("No changeset_id provided; performing full reindex of records.")
 
@@ -43,3 +47,27 @@ class AdapterStoreSource(BaseSource):
                     yield from batch.to_pylist()
             finally:
                 batches.close()
+
+    def _stream_changeset_records(self) -> Generator[dict[str, Any]]:
+        # Resolve the snapshot once so the id lookup and the content read see
+        # identical rows even when the caller did not pin a snapshot.
+        snapshot_id = self.snapshot_id
+        if snapshot_id is None:
+            snapshot_id = self.adapter_store.current_snapshot_id()
+
+        ids = self.adapter_store.get_changeset_record_ids(
+            self.changeset_ids, snapshot_id
+        )
+        if not ids:
+            return
+        if len(ids) <= SMALL_CHANGESET_THRESHOLD:
+            # Changeset reads include soft-deleted rows (needed to overwrite
+            # documents downstream); get_records_by_ids preserves that.
+            table = self.adapter_store.get_records_by_ids(ids, snapshot_id)
+            yield from table.to_pylist()
+        else:
+            for changeset_id in self.changeset_ids:
+                table = self.adapter_store.get_records_by_changeset(
+                    changeset_id, snapshot_id
+                )
+                yield from table.to_pylist()

--- a/catalogue_graph/src/adapters/transformers/adapter_store_source.py
+++ b/catalogue_graph/src/adapters/transformers/adapter_store_source.py
@@ -55,15 +55,19 @@ class AdapterStoreSource(BaseSource):
         if snapshot_id is None:
             snapshot_id = self.adapter_store.current_snapshot_id()
 
-        ids = self.adapter_store.get_changeset_record_ids(
+        ids, min_last_modified = self.adapter_store.get_changeset_record_ids(
             self.changeset_ids, snapshot_id
         )
         if not ids:
             return
         if len(ids) <= SMALL_CHANGESET_THRESHOLD:
             # Changeset reads include soft-deleted rows (needed to overwrite
-            # documents downstream); get_records_by_ids preserves that.
-            table = self.adapter_store.get_records_by_ids(ids, snapshot_id)
+            # documents downstream); get_records_by_ids preserves that. The
+            # last_modified bound is derived from the changeset's own rows, so
+            # it excludes nothing and lets file stats skip old compacted files.
+            table = self.adapter_store.get_records_by_ids(
+                ids, snapshot_id, updated_since=min_last_modified
+            )
             yield from table.to_pylist()
         else:
             for changeset_id in self.changeset_ids:

--- a/catalogue_graph/src/adapters/transformers/adapter_store_source.py
+++ b/catalogue_graph/src/adapters/transformers/adapter_store_source.py
@@ -8,14 +8,6 @@ from core.source import BaseSource
 
 logger = structlog.get_logger(__name__)
 
-# Measured on the production FOLIO table (1.7M rows): for small changesets an
-# In("id", ...) content read prunes to the few data files overlapping the id
-# range (~1.5 GB peak vs ~1.8 GB for the un-prunable changeset scan, and
-# seconds vs a full-table read). For large changesets id-filtered reads
-# re-read the same overlapping files repeatedly and can exceed the Lambda
-# timeout, so we fall back to the eager changeset read.
-SMALL_CHANGESET_THRESHOLD = 1000
-
 
 class AdapterStoreSource(BaseSource):
     def __init__(
@@ -30,7 +22,12 @@ class AdapterStoreSource(BaseSource):
 
     def stream_raw(self) -> Generator[dict[str, Any]]:
         if self.changeset_ids:
-            yield from self._stream_changeset_records()
+            # Changeset reads include soft-deleted rows (needed to overwrite
+            # documents downstream); get_records_by_changesets preserves that.
+            table = self.adapter_store.get_records_by_changesets(
+                self.changeset_ids, self.snapshot_id
+            )
+            yield from table.to_pylist()
         else:
             logger.info("No changeset_id provided; performing full reindex of records.")
 
@@ -47,31 +44,3 @@ class AdapterStoreSource(BaseSource):
                     yield from batch.to_pylist()
             finally:
                 batches.close()
-
-    def _stream_changeset_records(self) -> Generator[dict[str, Any]]:
-        # Resolve the snapshot once so the id lookup and the content read see
-        # identical rows even when the caller did not pin a snapshot.
-        snapshot_id = self.snapshot_id
-        if snapshot_id is None:
-            snapshot_id = self.adapter_store.current_snapshot_id()
-
-        ids, min_last_modified = self.adapter_store.get_changeset_record_ids(
-            self.changeset_ids, snapshot_id
-        )
-        if not ids:
-            return
-        if len(ids) <= SMALL_CHANGESET_THRESHOLD:
-            # Changeset reads include soft-deleted rows (needed to overwrite
-            # documents downstream); get_records_by_ids preserves that. The
-            # last_modified bound is derived from the changeset's own rows, so
-            # it excludes nothing and lets file stats skip old compacted files.
-            table = self.adapter_store.get_records_by_ids(
-                ids, snapshot_id, updated_since=min_last_modified
-            )
-            yield from table.to_pylist()
-        else:
-            for changeset_id in self.changeset_ids:
-                table = self.adapter_store.get_records_by_changeset(
-                    changeset_id, snapshot_id
-                )
-                yield from table.to_pylist()

--- a/catalogue_graph/src/adapters/transformers/adapter_store_source.py
+++ b/catalogue_graph/src/adapters/transformers/adapter_store_source.py
@@ -23,10 +23,13 @@ class AdapterStoreSource(BaseSource):
     def stream_raw(self) -> Generator[dict[str, Any]]:
         if self.changeset_ids:
             # Includes soft-deleted rows, needed to overwrite documents downstream.
+            # Convert one batch at a time so the Python dicts never hold the
+            # whole (possibly multi-changeset) table alongside the Arrow copy.
             table = self.adapter_store.get_records_by_changesets(
                 self.changeset_ids, self.snapshot_id
             )
-            yield from table.to_pylist()
+            for batch in table.to_batches():
+                yield from batch.to_pylist()
         else:
             logger.info("No changeset_id provided; performing full reindex of records.")
 

--- a/catalogue_graph/src/adapters/utils/pipeline_store.py
+++ b/catalogue_graph/src/adapters/utils/pipeline_store.py
@@ -95,7 +95,12 @@ class PipelineStore(ABC):
     def get_records_by_changeset(
         self, changeset_id: str, snapshot_id: int | None = None
     ) -> pa.Table:
-        """Return rows written under the specified changeset ID."""
+        """Return rows written under the specified changeset ID.
+
+        This is the plain, unbounded changeset scan, kept as the reference
+        read (and parity-test oracle) for `get_records_by_changesets`, which
+        prunes data files and should be preferred by production callers.
+        """
         return self.get_namespace_records(
             EqualTo("changeset", changeset_id), snapshot_id
         )
@@ -118,13 +123,14 @@ class PipelineStore(ABC):
 
         changeset_filter = In("changeset", changeset_ids)
         min_last_modified = self._get_min_last_modified(changeset_filter, snapshot_id)
+        if min_last_modified is None:
+            # No rows match at this snapshot; skip the un-prunable content scan.
+            return self.schema.empty_table()
 
-        row_filter: BooleanExpression = changeset_filter
-        if min_last_modified is not None:
-            row_filter = And(
-                changeset_filter,
-                GreaterThanOrEqual("last_modified", min_last_modified.isoformat()),
-            )
+        row_filter = And(
+            changeset_filter,
+            GreaterThanOrEqual("last_modified", min_last_modified.isoformat()),
+        )
         return self.get_namespace_records(row_filter, snapshot_id)
 
     def _get_min_last_modified(
@@ -141,10 +147,9 @@ class PipelineStore(ABC):
             selected_fields=("last_modified",),
         ).to_arrow()
 
-        timestamps = cast(
-            list[datetime], timestamp_table.column("last_modified").to_pylist()
+        return cast(
+            datetime | None, pc.min(timestamp_table.column("last_modified")).as_py()
         )
-        return min(timestamps, default=None)
 
     def normalise_table(self, table: pa.Table) -> pa.Table:
         """Enforce that the table conforms to the required schema and filter for records in the selected namespace"""

--- a/catalogue_graph/src/adapters/utils/pipeline_store.py
+++ b/catalogue_graph/src/adapters/utils/pipeline_store.py
@@ -1,7 +1,7 @@
 import uuid
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import Any, NamedTuple, cast
+from typing import Any, cast
 
 import pyarrow as pa
 import pyarrow.compute as pc
@@ -16,14 +16,6 @@ from pyiceberg.expressions import (
 from pyiceberg.table import ALWAYS_TRUE
 from pyiceberg.table import Table as IcebergTable
 from pyiceberg.table.upsert_util import get_rows_to_update
-
-
-class ChangesetRecordIds(NamedTuple):
-    """The record IDs written under a set of changesets, with the minimum
-    `last_modified` across them (a file-pruning bound for id-based reads)."""
-
-    ids: list[str]
-    min_last_modified: datetime | None
 
 
 class PipelineStoreUpdate(BaseModel):
@@ -108,61 +100,57 @@ class PipelineStore(ABC):
             EqualTo("changeset", changeset_id), snapshot_id
         )
 
-    def get_records_by_ids(
-        self,
-        ids: list[str],
-        snapshot_id: int | None = None,
-        updated_since: datetime | None = None,
+    def get_records_by_changesets(
+        self, changeset_ids: list[str], snapshot_id: int | None = None
     ) -> pa.Table:
-        """Return rows with the specified record IDs, including soft-deleted rows.
+        """Return rows written under any of the specified changeset IDs,
+        including soft-deleted rows.
 
-        Unlike a changeset filter, an `id` filter prunes data files on the
-        id-sorted table, so this read is cheap when `ids` spans few files.
-
-        `updated_since` is a pruning bound, not a selection filter: callers must
-        ensure every target row's `last_modified` is at or after it (e.g. the
-        minimum across a changeset's rows). It lets file-level column stats
-        skip old compacted files whose id ranges overlap the target ids but
-        which cannot contain the recently written rows.
+        The changeset filter cannot prune data files on the id-sorted table,
+        so a first pass projects only `last_modified` to find the changesets'
+        minimum, and the content read applies it as a `last_modified >=`
+        bound. The bound is exact by construction (every target row is at or
+        after the minimum of the set), so it can never exclude a row; it only
+        lets file-level column stats skip files that predate the changesets.
+        Worst case (an old bound) it prunes nothing and the read behaves like
+        a plain changeset scan.
         """
-        row_filter: BooleanExpression = In("id", ids)
-        if updated_since is not None:
+        # Resolve the snapshot once so the bound lookup and the content read
+        # see identical rows even when the caller did not pin a snapshot.
+        if snapshot_id is None:
+            snapshot_id = self.current_snapshot_id()
+
+        changeset_filter = In("changeset", changeset_ids)
+        min_last_modified = self._get_min_last_modified(changeset_filter, snapshot_id)
+
+        row_filter: BooleanExpression = changeset_filter
+        if min_last_modified is not None:
             row_filter = And(
-                row_filter,
-                GreaterThanOrEqual("last_modified", updated_since.isoformat()),
+                changeset_filter,
+                GreaterThanOrEqual("last_modified", min_last_modified.isoformat()),
             )
         return self.get_namespace_records(row_filter, snapshot_id)
 
-    def get_changeset_record_ids(
-        self, changeset_ids: list[str], snapshot_id: int | None = None
-    ) -> ChangesetRecordIds:
-        """Return the IDs of rows written under any of the specified changesets,
-        with the minimum `last_modified` across them (for use as a pruning
-        bound in `get_records_by_ids`).
+    def _get_min_last_modified(
+        self, iceberg_filter: BooleanExpression, snapshot_id: int | None
+    ) -> datetime | None:
+        """Return the minimum `last_modified` of the matching rows, or None if
+        there are none.
 
-        Projects only the `id` and `last_modified` columns, so the scan avoids
-        reading row content and stays cheap even though the changeset filter
-        cannot prune data files on the id-sorted table.
+        Projects only the `last_modified` column, so the scan avoids reading
+        row content even when the filter cannot prune data files.
         """
-        full_filter = And(
-            EqualTo("namespace", self.namespace), In("changeset", changeset_ids)
-        )
-        id_table = self.table.scan(
+        full_filter = And(EqualTo("namespace", self.namespace), iceberg_filter)
+        timestamp_table = self.table.scan(
             row_filter=full_filter,
             snapshot_id=snapshot_id,
-            selected_fields=("id", "last_modified"),
+            selected_fields=("last_modified",),
         ).to_arrow()
 
         timestamps = cast(
-            list[datetime | None], id_table.column("last_modified").to_pylist()
+            list[datetime], timestamp_table.column("last_modified").to_pylist()
         )
-        # A null last_modified would make the pruning bound exclude that row,
-        # so only supply a bound when every row carries a timestamp.
-        non_null = [t for t in timestamps if t is not None]
-        min_last_modified = (
-            min(non_null) if len(non_null) == len(timestamps) and non_null else None
-        )
-        return ChangesetRecordIds(self._extract_ids(id_table), min_last_modified)
+        return min(timestamps, default=None)
 
     def normalise_table(self, table: pa.Table) -> pa.Table:
         """Enforce that the table conforms to the required schema and filter for records in the selected namespace"""

--- a/catalogue_graph/src/adapters/utils/pipeline_store.py
+++ b/catalogue_graph/src/adapters/utils/pipeline_store.py
@@ -1,15 +1,29 @@
 import uuid
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import Any, cast
+from typing import Any, NamedTuple, cast
 
 import pyarrow as pa
 import pyarrow.compute as pc
 from pydantic import BaseModel
-from pyiceberg.expressions import And, BooleanExpression, EqualTo, In
+from pyiceberg.expressions import (
+    And,
+    BooleanExpression,
+    EqualTo,
+    GreaterThanOrEqual,
+    In,
+)
 from pyiceberg.table import ALWAYS_TRUE
 from pyiceberg.table import Table as IcebergTable
 from pyiceberg.table.upsert_util import get_rows_to_update
+
+
+class ChangesetRecordIds(NamedTuple):
+    """The record IDs written under a set of changesets, with the minimum
+    `last_modified` across them (a file-pruning bound for id-based reads)."""
+
+    ids: list[str]
+    min_last_modified: datetime | None
 
 
 class PipelineStoreUpdate(BaseModel):
@@ -95,31 +109,60 @@ class PipelineStore(ABC):
         )
 
     def get_records_by_ids(
-        self, ids: list[str], snapshot_id: int | None = None
+        self,
+        ids: list[str],
+        snapshot_id: int | None = None,
+        updated_since: datetime | None = None,
     ) -> pa.Table:
         """Return rows with the specified record IDs, including soft-deleted rows.
 
         Unlike a changeset filter, an `id` filter prunes data files on the
         id-sorted table, so this read is cheap when `ids` spans few files.
+
+        `updated_since` is a pruning bound, not a selection filter: callers must
+        ensure every target row's `last_modified` is at or after it (e.g. the
+        minimum across a changeset's rows). It lets file-level column stats
+        skip old compacted files whose id ranges overlap the target ids but
+        which cannot contain the recently written rows.
         """
-        return self.get_namespace_records(In("id", ids), snapshot_id)
+        row_filter: BooleanExpression = In("id", ids)
+        if updated_since is not None:
+            row_filter = And(
+                row_filter,
+                GreaterThanOrEqual("last_modified", updated_since.isoformat()),
+            )
+        return self.get_namespace_records(row_filter, snapshot_id)
 
     def get_changeset_record_ids(
         self, changeset_ids: list[str], snapshot_id: int | None = None
-    ) -> list[str]:
-        """Return the IDs of rows written under any of the specified changesets.
+    ) -> ChangesetRecordIds:
+        """Return the IDs of rows written under any of the specified changesets,
+        with the minimum `last_modified` across them (for use as a pruning
+        bound in `get_records_by_ids`).
 
-        Projects only the `id` column, so the scan avoids reading row content
-        and stays cheap even though the changeset filter cannot prune data
-        files on the id-sorted table.
+        Projects only the `id` and `last_modified` columns, so the scan avoids
+        reading row content and stays cheap even though the changeset filter
+        cannot prune data files on the id-sorted table.
         """
         full_filter = And(
             EqualTo("namespace", self.namespace), In("changeset", changeset_ids)
         )
         id_table = self.table.scan(
-            row_filter=full_filter, snapshot_id=snapshot_id, selected_fields=("id",)
+            row_filter=full_filter,
+            snapshot_id=snapshot_id,
+            selected_fields=("id", "last_modified"),
         ).to_arrow()
-        return self._extract_ids(id_table)
+
+        timestamps = cast(
+            list[datetime | None], id_table.column("last_modified").to_pylist()
+        )
+        # A null last_modified would make the pruning bound exclude that row,
+        # so only supply a bound when every row carries a timestamp.
+        non_null = [t for t in timestamps if t is not None]
+        min_last_modified = (
+            min(non_null) if len(non_null) == len(timestamps) and non_null else None
+        )
+        return ChangesetRecordIds(self._extract_ids(id_table), min_last_modified)
 
     def normalise_table(self, table: pa.Table) -> pa.Table:
         """Enforce that the table conforms to the required schema and filter for records in the selected namespace"""

--- a/catalogue_graph/src/adapters/utils/pipeline_store.py
+++ b/catalogue_graph/src/adapters/utils/pipeline_store.py
@@ -107,16 +107,12 @@ class PipelineStore(ABC):
         including soft-deleted rows.
 
         The changeset filter cannot prune data files on the id-sorted table,
-        so a first pass projects only `last_modified` to find the changesets'
-        minimum, and the content read applies it as a `last_modified >=`
-        bound. The bound is exact by construction (every target row is at or
-        after the minimum of the set), so it can never exclude a row; it only
-        lets file-level column stats skip files that predate the changesets.
-        Worst case (an old bound) it prunes nothing and the read behaves like
-        a plain changeset scan.
+        so the content read is bounded by the changesets' minimum
+        `last_modified` (found with a cheap single-column scan). Every target
+        row is at or after that minimum, so the bound excludes nothing; it
+        only lets file stats skip files that predate the changesets.
         """
-        # Resolve the snapshot once so the bound lookup and the content read
-        # see identical rows even when the caller did not pin a snapshot.
+        # Resolve the snapshot once so both phases read the same rows.
         if snapshot_id is None:
             snapshot_id = self.current_snapshot_id()
 
@@ -134,11 +130,9 @@ class PipelineStore(ABC):
     def _get_min_last_modified(
         self, iceberg_filter: BooleanExpression, snapshot_id: int | None
     ) -> datetime | None:
-        """Return the minimum `last_modified` of the matching rows, or None if
-        there are none.
-
-        Projects only the `last_modified` column, so the scan avoids reading
-        row content even when the filter cannot prune data files.
+        """Return the minimum `last_modified` of the matching rows (None if
+        none). Projects a single column, so the scan stays cheap even when
+        the filter cannot prune data files.
         """
         full_filter = And(EqualTo("namespace", self.namespace), iceberg_filter)
         timestamp_table = self.table.scan(

--- a/catalogue_graph/src/adapters/utils/pipeline_store.py
+++ b/catalogue_graph/src/adapters/utils/pipeline_store.py
@@ -94,6 +94,33 @@ class PipelineStore(ABC):
             EqualTo("changeset", changeset_id), snapshot_id
         )
 
+    def get_records_by_ids(
+        self, ids: list[str], snapshot_id: int | None = None
+    ) -> pa.Table:
+        """Return rows with the specified record IDs, including soft-deleted rows.
+
+        Unlike a changeset filter, an `id` filter prunes data files on the
+        id-sorted table, so this read is cheap when `ids` spans few files.
+        """
+        return self.get_namespace_records(In("id", ids), snapshot_id)
+
+    def get_changeset_record_ids(
+        self, changeset_ids: list[str], snapshot_id: int | None = None
+    ) -> list[str]:
+        """Return the IDs of rows written under any of the specified changesets.
+
+        Projects only the `id` column, so the scan avoids reading row content
+        and stays cheap even though the changeset filter cannot prune data
+        files on the id-sorted table.
+        """
+        full_filter = And(
+            EqualTo("namespace", self.namespace), In("changeset", changeset_ids)
+        )
+        id_table = self.table.scan(
+            row_filter=full_filter, snapshot_id=snapshot_id, selected_fields=("id",)
+        ).to_arrow()
+        return self._extract_ids(id_table)
+
     def normalise_table(self, table: pa.Table) -> pa.Table:
         """Enforce that the table conforms to the required schema and filter for records in the selected namespace"""
         table = table.cast(self.schema)

--- a/catalogue_graph/src/adapters/utils/pipeline_store.py
+++ b/catalogue_graph/src/adapters/utils/pipeline_store.py
@@ -129,7 +129,7 @@ class PipelineStore(ABC):
 
         row_filter = And(
             changeset_filter,
-            GreaterThanOrEqual("last_modified", min_last_modified.isoformat()),
+            GreaterThanOrEqual("last_modified", min_last_modified),
         )
         return self.get_namespace_records(row_filter, snapshot_id)
 

--- a/catalogue_graph/tests/adapters/transformers/test_adapter_store_source.py
+++ b/catalogue_graph/tests/adapters/transformers/test_adapter_store_source.py
@@ -1,23 +1,14 @@
 """Tests for AdapterStoreSource, the Iceberg-backed source used by transformers."""
 
 from collections.abc import Generator
-from typing import Any, cast
+from typing import cast
 
 import pyarrow as pa
-import pytest
 
-from adapters.transformers import adapter_store_source
 from adapters.transformers.adapter_store_source import AdapterStoreSource
 from adapters.utils.adapter_store import AdapterStore
 from adapters.utils.schemata import ADAPTER_STORE_ARROW_SCHEMA
 from tests.adapters.conftest import AdapterStoreFactory, adapter_records_to_table
-
-
-def _forbid(method_name: str) -> Any:
-    def _raise(*args: Any, **kwargs: Any) -> None:
-        raise AssertionError(f"{method_name} must not be called on this path")
-
-    return _raise
 
 
 def test_stream_raw_full_reindex_yields_all_active_rows(
@@ -57,29 +48,7 @@ def test_stream_raw_changeset_path_uses_changeset_lookup(
     assert sorted(row["id"] for row in rows) == ["rec001", "rec002"]
 
 
-def test_stream_raw_small_changeset_avoids_changeset_content_read(
-    adapter_store_with_records: AdapterStoreFactory,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A small changeset is read by record id, never via the un-prunable
-    changeset-filtered content scan."""
-    store = adapter_store_with_records(
-        [
-            {"id": "rec001", "content": "first", "changeset": "changeset-1"},
-            {"id": "rec002", "content": "second", "changeset": "changeset-2"},
-        ]
-    )
-    monkeypatch.setattr(
-        store, "get_records_by_changeset", _forbid("get_records_by_changeset")
-    )
-    source = AdapterStoreSource(store, changeset_ids=["changeset-1"])
-
-    rows = list(source.stream_raw())
-
-    assert [row["id"] for row in rows] == ["rec001"]
-
-
-def test_stream_raw_small_changeset_includes_deleted_rows_with_content(
+def test_stream_raw_changeset_path_includes_deleted_rows_with_content(
     adapter_store_with_records: AdapterStoreFactory,
 ) -> None:
     """Deleted rows in a changeset are streamed with their preserved content,
@@ -104,38 +73,12 @@ def test_stream_raw_small_changeset_includes_deleted_rows_with_content(
     assert rows["rec002"]["content"] == "deleted with content preserved"
 
 
-def test_stream_raw_falls_back_for_large_changesets(
+def test_stream_raw_empty_changeset_yields_nothing(
     adapter_store_with_records: AdapterStoreFactory,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Above the threshold, stream_raw uses the eager changeset read instead of
-    an id-filtered read."""
-    store = adapter_store_with_records(
-        [
-            {"id": "rec001", "content": "first", "changeset": "changeset-1"},
-            {"id": "rec002", "content": "second", "changeset": "changeset-1"},
-        ]
-    )
-    monkeypatch.setattr(adapter_store_source, "SMALL_CHANGESET_THRESHOLD", 1)
-    monkeypatch.setattr(store, "get_records_by_ids", _forbid("get_records_by_ids"))
-    source = AdapterStoreSource(store, changeset_ids=["changeset-1"])
-
-    rows = list(source.stream_raw())
-
-    assert sorted(row["id"] for row in rows) == ["rec001", "rec002"]
-
-
-def test_stream_raw_empty_changeset_yields_no_content_read(
-    adapter_store_with_records: AdapterStoreFactory,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A changeset matching no rows yields nothing and performs no content read."""
+    """A changeset matching no rows yields an empty stream."""
     store = adapter_store_with_records(
         [{"id": "rec001", "content": "first", "changeset": "changeset-1"}]
-    )
-    monkeypatch.setattr(store, "get_records_by_ids", _forbid("get_records_by_ids"))
-    monkeypatch.setattr(
-        store, "get_records_by_changeset", _forbid("get_records_by_changeset")
     )
     source = AdapterStoreSource(store, changeset_ids=["nonexistent"])
 

--- a/catalogue_graph/tests/adapters/transformers/test_adapter_store_source.py
+++ b/catalogue_graph/tests/adapters/transformers/test_adapter_store_source.py
@@ -1,14 +1,23 @@
 """Tests for AdapterStoreSource, the Iceberg-backed source used by transformers."""
 
 from collections.abc import Generator
-from typing import cast
+from typing import Any, cast
 
 import pyarrow as pa
+import pytest
 
+from adapters.transformers import adapter_store_source
 from adapters.transformers.adapter_store_source import AdapterStoreSource
 from adapters.utils.adapter_store import AdapterStore
 from adapters.utils.schemata import ADAPTER_STORE_ARROW_SCHEMA
 from tests.adapters.conftest import AdapterStoreFactory, adapter_records_to_table
+
+
+def _forbid(method_name: str) -> Any:
+    def _raise(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError(f"{method_name} must not be called on this path")
+
+    return _raise
 
 
 def test_stream_raw_full_reindex_yields_all_active_rows(
@@ -46,6 +55,91 @@ def test_stream_raw_changeset_path_uses_changeset_lookup(
     rows = list(source.stream_raw())
 
     assert sorted(row["id"] for row in rows) == ["rec001", "rec002"]
+
+
+def test_stream_raw_small_changeset_avoids_changeset_content_read(
+    adapter_store_with_records: AdapterStoreFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A small changeset is read by record id, never via the un-prunable
+    changeset-filtered content scan."""
+    store = adapter_store_with_records(
+        [
+            {"id": "rec001", "content": "first", "changeset": "changeset-1"},
+            {"id": "rec002", "content": "second", "changeset": "changeset-2"},
+        ]
+    )
+    monkeypatch.setattr(
+        store, "get_records_by_changeset", _forbid("get_records_by_changeset")
+    )
+    source = AdapterStoreSource(store, changeset_ids=["changeset-1"])
+
+    rows = list(source.stream_raw())
+
+    assert [row["id"] for row in rows] == ["rec001"]
+
+
+def test_stream_raw_small_changeset_includes_deleted_rows_with_content(
+    adapter_store_with_records: AdapterStoreFactory,
+) -> None:
+    """Deleted rows in a changeset are streamed with their preserved content,
+    so downstream documents can be overwritten."""
+    store = adapter_store_with_records(
+        [
+            {"id": "rec001", "content": "active", "changeset": "changeset-1"},
+            {
+                "id": "rec002",
+                "content": "deleted with content preserved",
+                "deleted": True,
+                "changeset": "changeset-1",
+            },
+        ]
+    )
+    source = AdapterStoreSource(store, changeset_ids=["changeset-1"])
+
+    rows = {row["id"]: row for row in source.stream_raw()}
+
+    assert sorted(rows) == ["rec001", "rec002"]
+    assert rows["rec002"]["deleted"] is True
+    assert rows["rec002"]["content"] == "deleted with content preserved"
+
+
+def test_stream_raw_falls_back_for_large_changesets(
+    adapter_store_with_records: AdapterStoreFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Above the threshold, stream_raw uses the eager changeset read instead of
+    an id-filtered read."""
+    store = adapter_store_with_records(
+        [
+            {"id": "rec001", "content": "first", "changeset": "changeset-1"},
+            {"id": "rec002", "content": "second", "changeset": "changeset-1"},
+        ]
+    )
+    monkeypatch.setattr(adapter_store_source, "SMALL_CHANGESET_THRESHOLD", 1)
+    monkeypatch.setattr(store, "get_records_by_ids", _forbid("get_records_by_ids"))
+    source = AdapterStoreSource(store, changeset_ids=["changeset-1"])
+
+    rows = list(source.stream_raw())
+
+    assert sorted(row["id"] for row in rows) == ["rec001", "rec002"]
+
+
+def test_stream_raw_empty_changeset_yields_no_content_read(
+    adapter_store_with_records: AdapterStoreFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A changeset matching no rows yields nothing and performs no content read."""
+    store = adapter_store_with_records(
+        [{"id": "rec001", "content": "first", "changeset": "changeset-1"}]
+    )
+    monkeypatch.setattr(store, "get_records_by_ids", _forbid("get_records_by_ids"))
+    monkeypatch.setattr(
+        store, "get_records_by_changeset", _forbid("get_records_by_changeset")
+    )
+    source = AdapterStoreSource(store, changeset_ids=["nonexistent"])
+
+    assert list(source.stream_raw()) == []
 
 
 class _ClosableBatchStream:

--- a/catalogue_graph/tests/adapters/utils/test_adapter_store.py
+++ b/catalogue_graph/tests/adapters/utils/test_adapter_store.py
@@ -6,6 +6,7 @@ These tests cover methods that are not specific to either incremental_update or 
 - get_records_by_changeset
 """
 
+from datetime import UTC, datetime
 from operator import itemgetter
 from typing import cast
 
@@ -205,7 +206,7 @@ def test_get_changeset_record_ids_returns_ids_for_requested_changesets(
         ]
     )
 
-    ids = client.get_changeset_record_ids(["changeset-a", "changeset-b"])
+    ids = client.get_changeset_record_ids(["changeset-a", "changeset-b"]).ids
 
     assert sorted(ids) == ["rec001", "rec002", "rec003"]
 
@@ -226,7 +227,7 @@ def test_get_changeset_record_ids_includes_deleted_records(
         ]
     )
 
-    ids = client.get_changeset_record_ids(["changeset-a"])
+    ids = client.get_changeset_record_ids(["changeset-a"]).ids
 
     assert sorted(ids) == ["rec001", "rec002"]
 
@@ -247,7 +248,7 @@ def test_get_changeset_record_ids_scoped_to_namespace(
         ]
     )
 
-    ids = client.get_changeset_record_ids(["changeset-a"])
+    ids = client.get_changeset_record_ids(["changeset-a"]).ids
 
     assert ids == ["rec001"]
 
@@ -260,7 +261,10 @@ def test_get_changeset_record_ids_nonexistent_changeset_returns_empty(
         [{"id": "rec001", "content": "first", "changeset": "changeset-a"}]
     )
 
-    assert client.get_changeset_record_ids(["nonexistent"]) == []
+    result = client.get_changeset_record_ids(["nonexistent"])
+
+    assert result.ids == []
+    assert result.min_last_modified is None
 
 
 def test_get_changeset_record_ids_pins_snapshot(
@@ -278,8 +282,10 @@ def test_get_changeset_record_ids_pins_snapshot(
         )
     )
 
-    pinned_ids = client.get_changeset_record_ids(["changeset-a"], pinned_snapshot_id)
-    current_ids = client.get_changeset_record_ids(["changeset-a"])
+    pinned_ids = client.get_changeset_record_ids(
+        ["changeset-a"], pinned_snapshot_id
+    ).ids
+    current_ids = client.get_changeset_record_ids(["changeset-a"]).ids
 
     assert pinned_ids == ["rec001"]
     assert sorted(current_ids) == ["rec001", "rec002"]
@@ -308,7 +314,7 @@ def test_get_records_by_ids_matches_changeset_read_including_deleted(
         ]
     )
 
-    ids = client.get_changeset_record_ids(["changeset-a"])
+    ids = client.get_changeset_record_ids(["changeset-a"]).ids
     by_ids = client.get_records_by_ids(ids).to_pylist()
     by_changeset = client.get_records_by_changeset("changeset-a").to_pylist()
 
@@ -328,6 +334,77 @@ def test_get_records_by_ids_empty_ids_returns_empty(
     )
 
     assert client.get_records_by_ids([]).num_rows == 0
+
+
+def test_get_changeset_record_ids_returns_min_last_modified(
+    adapter_store_with_records: AdapterStoreFactory,
+) -> None:
+    """The minimum last_modified across the changeset's rows is returned."""
+    earlier = datetime(2026, 7, 1, 9, 0, tzinfo=UTC)
+    later = datetime(2026, 7, 1, 10, 0, tzinfo=UTC)
+    client = adapter_store_with_records(
+        [
+            {
+                "id": "rec001",
+                "content": "first",
+                "changeset": "changeset-a",
+                "last_modified": later,
+            },
+            {
+                "id": "rec002",
+                "content": "second",
+                "changeset": "changeset-a",
+                "last_modified": earlier,
+            },
+        ]
+    )
+
+    result = client.get_changeset_record_ids(["changeset-a"])
+
+    assert result.min_last_modified == earlier
+
+
+def test_get_records_by_ids_with_updated_since_bound_returns_all_target_rows(
+    adapter_store_with_records: AdapterStoreFactory,
+) -> None:
+    """Using the changeset's own minimum last_modified as the bound returns
+    exactly the same rows as the unbounded id read."""
+    earlier = datetime(2026, 7, 1, 9, 0, tzinfo=UTC)
+    later = datetime(2026, 7, 1, 10, 0, tzinfo=UTC)
+    client = adapter_store_with_records(
+        [
+            {
+                "id": "rec001",
+                "content": "first",
+                "changeset": "changeset-a",
+                "last_modified": earlier,
+            },
+            {
+                "id": "rec002",
+                "content": "deleted",
+                "deleted": True,
+                "changeset": "changeset-a",
+                "last_modified": later,
+            },
+            {
+                "id": "rec003",
+                "content": "older row outside the changeset",
+                "changeset": "changeset-b",
+                "last_modified": datetime(2026, 1, 1, tzinfo=UTC),
+            },
+        ]
+    )
+
+    ids, min_last_modified = client.get_changeset_record_ids(["changeset-a"])
+    bounded = client.get_records_by_ids(ids, updated_since=min_last_modified)
+    unbounded = client.get_records_by_ids(ids)
+
+    sort_key = itemgetter("id")
+    assert sorted(bounded.to_pylist(), key=sort_key) == sorted(
+        unbounded.to_pylist(), key=sort_key
+    )
+    bounded_ids = cast(list[str], bounded.column("id").to_pylist())
+    assert sorted(bounded_ids) == ["rec001", "rec002"]
 
 
 # =============================================================================

--- a/catalogue_graph/tests/adapters/utils/test_adapter_store.py
+++ b/catalogue_graph/tests/adapters/utils/test_adapter_store.py
@@ -188,6 +188,149 @@ def test_get_records_by_changeset_includes_deleted_records(
 
 
 # =============================================================================
+# get_changeset_record_ids tests
+# =============================================================================
+
+
+def test_get_changeset_record_ids_returns_ids_for_requested_changesets(
+    adapter_store_with_records: AdapterStoreFactory,
+) -> None:
+    """Only ids from the requested changesets are returned."""
+    client = adapter_store_with_records(
+        [
+            {"id": "rec001", "content": "first", "changeset": "changeset-a"},
+            {"id": "rec002", "content": "second", "changeset": "changeset-a"},
+            {"id": "rec003", "content": "third", "changeset": "changeset-b"},
+            {"id": "rec004", "content": "fourth", "changeset": "changeset-c"},
+        ]
+    )
+
+    ids = client.get_changeset_record_ids(["changeset-a", "changeset-b"])
+
+    assert sorted(ids) == ["rec001", "rec002", "rec003"]
+
+
+def test_get_changeset_record_ids_includes_deleted_records(
+    adapter_store_with_records: AdapterStoreFactory,
+) -> None:
+    """Deleted rows in a changeset are included (no filtering by deleted flag)."""
+    client = adapter_store_with_records(
+        [
+            {"id": "rec001", "content": "active", "changeset": "changeset-a"},
+            {
+                "id": "rec002",
+                "content": "deleted",
+                "deleted": True,
+                "changeset": "changeset-a",
+            },
+        ]
+    )
+
+    ids = client.get_changeset_record_ids(["changeset-a"])
+
+    assert sorted(ids) == ["rec001", "rec002"]
+
+
+def test_get_changeset_record_ids_scoped_to_namespace(
+    adapter_store_with_records: AdapterStoreFactory,
+) -> None:
+    """Only ids in the store's namespace are returned for a shared changeset id."""
+    client = adapter_store_with_records(
+        [
+            {"id": "rec001", "content": "mine", "changeset": "changeset-a"},
+            {
+                "id": "rec002",
+                "content": "other",
+                "changeset": "changeset-a",
+                "namespace": "other_namespace",
+            },
+        ]
+    )
+
+    ids = client.get_changeset_record_ids(["changeset-a"])
+
+    assert ids == ["rec001"]
+
+
+def test_get_changeset_record_ids_nonexistent_changeset_returns_empty(
+    adapter_store_with_records: AdapterStoreFactory,
+) -> None:
+    """A changeset with no rows returns an empty id list."""
+    client = adapter_store_with_records(
+        [{"id": "rec001", "content": "first", "changeset": "changeset-a"}]
+    )
+
+    assert client.get_changeset_record_ids(["nonexistent"]) == []
+
+
+def test_get_changeset_record_ids_pins_snapshot(
+    adapter_store_with_records: AdapterStoreFactory,
+) -> None:
+    """Ids are read at the pinned snapshot, excluding later appends."""
+    client = adapter_store_with_records(
+        [{"id": "rec001", "content": "first", "changeset": "changeset-a"}]
+    )
+    pinned_snapshot_id = client.current_snapshot_id()
+
+    client.table.append(
+        adapter_records_to_table(
+            [{"id": "rec002", "content": "later", "changeset": "changeset-a"}]
+        )
+    )
+
+    pinned_ids = client.get_changeset_record_ids(["changeset-a"], pinned_snapshot_id)
+    current_ids = client.get_changeset_record_ids(["changeset-a"])
+
+    assert pinned_ids == ["rec001"]
+    assert sorted(current_ids) == ["rec001", "rec002"]
+
+
+# =============================================================================
+# get_records_by_ids tests
+# =============================================================================
+
+
+def test_get_records_by_ids_matches_changeset_read_including_deleted(
+    adapter_store_with_records: AdapterStoreFactory,
+) -> None:
+    """The id-based read returns the same rows as the changeset read, including
+    a deleted row with its preserved content."""
+    client = adapter_store_with_records(
+        [
+            {"id": "rec001", "content": "active", "changeset": "changeset-a"},
+            {
+                "id": "rec002",
+                "content": "deleted with content preserved",
+                "deleted": True,
+                "changeset": "changeset-a",
+            },
+            {"id": "rec003", "content": "other changeset", "changeset": "changeset-b"},
+        ]
+    )
+
+    ids = client.get_changeset_record_ids(["changeset-a"])
+    by_ids = client.get_records_by_ids(ids).to_pylist()
+    by_changeset = client.get_records_by_changeset("changeset-a").to_pylist()
+
+    sort_key = itemgetter("id")
+    assert sorted(by_ids, key=sort_key) == sorted(by_changeset, key=sort_key)
+    deleted_row = next(row for row in by_ids if row["id"] == "rec002")
+    assert deleted_row["deleted"] is True
+    assert deleted_row["content"] == "deleted with content preserved"
+
+
+def test_get_records_by_ids_empty_ids_returns_empty(
+    adapter_store_with_records: AdapterStoreFactory,
+) -> None:
+    """An empty id list returns an empty table without erroring."""
+    client = adapter_store_with_records(
+        [{"id": "rec001", "content": "first", "changeset": "changeset-a"}]
+    )
+
+    assert client.get_records_by_ids([]).num_rows == 0
+
+
+# =============================================================================
 # stream_active_namespace_records tests
 # =============================================================================
 

--- a/catalogue_graph/tests/adapters/utils/test_adapter_store.py
+++ b/catalogue_graph/tests/adapters/utils/test_adapter_store.py
@@ -189,14 +189,14 @@ def test_get_records_by_changeset_includes_deleted_records(
 
 
 # =============================================================================
-# get_changeset_record_ids tests
+# get_records_by_changesets tests
 # =============================================================================
 
 
-def test_get_changeset_record_ids_returns_ids_for_requested_changesets(
+def test_get_records_by_changesets_returns_rows_for_requested_changesets(
     adapter_store_with_records: AdapterStoreFactory,
 ) -> None:
-    """Only ids from the requested changesets are returned."""
+    """Only rows from the requested changesets are returned."""
     client = adapter_store_with_records(
         [
             {"id": "rec001", "content": "first", "changeset": "changeset-a"},
@@ -206,140 +206,17 @@ def test_get_changeset_record_ids_returns_ids_for_requested_changesets(
         ]
     )
 
-    ids = client.get_changeset_record_ids(["changeset-a", "changeset-b"]).ids
+    result = client.get_records_by_changesets(["changeset-a", "changeset-b"])
 
+    ids = cast(list[str], result.column("id").to_pylist())
     assert sorted(ids) == ["rec001", "rec002", "rec003"]
 
 
-def test_get_changeset_record_ids_includes_deleted_records(
+def test_get_records_by_changesets_matches_per_changeset_reads(
     adapter_store_with_records: AdapterStoreFactory,
 ) -> None:
-    """Deleted rows in a changeset are included (no filtering by deleted flag)."""
-    client = adapter_store_with_records(
-        [
-            {"id": "rec001", "content": "active", "changeset": "changeset-a"},
-            {
-                "id": "rec002",
-                "content": "deleted",
-                "deleted": True,
-                "changeset": "changeset-a",
-            },
-        ]
-    )
-
-    ids = client.get_changeset_record_ids(["changeset-a"]).ids
-
-    assert sorted(ids) == ["rec001", "rec002"]
-
-
-def test_get_changeset_record_ids_scoped_to_namespace(
-    adapter_store_with_records: AdapterStoreFactory,
-) -> None:
-    """Only ids in the store's namespace are returned for a shared changeset id."""
-    client = adapter_store_with_records(
-        [
-            {"id": "rec001", "content": "mine", "changeset": "changeset-a"},
-            {
-                "id": "rec002",
-                "content": "other",
-                "changeset": "changeset-a",
-                "namespace": "other_namespace",
-            },
-        ]
-    )
-
-    ids = client.get_changeset_record_ids(["changeset-a"]).ids
-
-    assert ids == ["rec001"]
-
-
-def test_get_changeset_record_ids_nonexistent_changeset_returns_empty(
-    adapter_store_with_records: AdapterStoreFactory,
-) -> None:
-    """A changeset with no rows returns an empty id list."""
-    client = adapter_store_with_records(
-        [{"id": "rec001", "content": "first", "changeset": "changeset-a"}]
-    )
-
-    result = client.get_changeset_record_ids(["nonexistent"])
-
-    assert result.ids == []
-    assert result.min_last_modified is None
-
-
-def test_get_changeset_record_ids_pins_snapshot(
-    adapter_store_with_records: AdapterStoreFactory,
-) -> None:
-    """Ids are read at the pinned snapshot, excluding later appends."""
-    client = adapter_store_with_records(
-        [{"id": "rec001", "content": "first", "changeset": "changeset-a"}]
-    )
-    pinned_snapshot_id = client.current_snapshot_id()
-
-    client.table.append(
-        adapter_records_to_table(
-            [{"id": "rec002", "content": "later", "changeset": "changeset-a"}]
-        )
-    )
-
-    pinned_ids = client.get_changeset_record_ids(
-        ["changeset-a"], pinned_snapshot_id
-    ).ids
-    current_ids = client.get_changeset_record_ids(["changeset-a"]).ids
-
-    assert pinned_ids == ["rec001"]
-    assert sorted(current_ids) == ["rec001", "rec002"]
-
-
-# =============================================================================
-# get_records_by_ids tests
-# =============================================================================
-
-
-def test_get_records_by_ids_matches_changeset_read_including_deleted(
-    adapter_store_with_records: AdapterStoreFactory,
-) -> None:
-    """The id-based read returns the same rows as the changeset read, including
-    a deleted row with its preserved content."""
-    client = adapter_store_with_records(
-        [
-            {"id": "rec001", "content": "active", "changeset": "changeset-a"},
-            {
-                "id": "rec002",
-                "content": "deleted with content preserved",
-                "deleted": True,
-                "changeset": "changeset-a",
-            },
-            {"id": "rec003", "content": "other changeset", "changeset": "changeset-b"},
-        ]
-    )
-
-    ids = client.get_changeset_record_ids(["changeset-a"]).ids
-    by_ids = client.get_records_by_ids(ids).to_pylist()
-    by_changeset = client.get_records_by_changeset("changeset-a").to_pylist()
-
-    sort_key = itemgetter("id")
-    assert sorted(by_ids, key=sort_key) == sorted(by_changeset, key=sort_key)
-    deleted_row = next(row for row in by_ids if row["id"] == "rec002")
-    assert deleted_row["deleted"] is True
-    assert deleted_row["content"] == "deleted with content preserved"
-
-
-def test_get_records_by_ids_empty_ids_returns_empty(
-    adapter_store_with_records: AdapterStoreFactory,
-) -> None:
-    """An empty id list returns an empty table without erroring."""
-    client = adapter_store_with_records(
-        [{"id": "rec001", "content": "first", "changeset": "changeset-a"}]
-    )
-
-    assert client.get_records_by_ids([]).num_rows == 0
-
-
-def test_get_changeset_record_ids_returns_min_last_modified(
-    adapter_store_with_records: AdapterStoreFactory,
-) -> None:
-    """The minimum last_modified across the changeset's rows is returned."""
+    """The bounded multi-changeset read returns exactly the union of the
+    plain per-changeset reads, with rows carrying mixed timestamps."""
     earlier = datetime(2026, 7, 1, 9, 0, tzinfo=UTC)
     later = datetime(2026, 7, 1, 10, 0, tzinfo=UTC)
     client = adapter_store_with_records(
@@ -356,55 +233,123 @@ def test_get_changeset_record_ids_returns_min_last_modified(
                 "changeset": "changeset-a",
                 "last_modified": earlier,
             },
-        ]
-    )
-
-    result = client.get_changeset_record_ids(["changeset-a"])
-
-    assert result.min_last_modified == earlier
-
-
-def test_get_records_by_ids_with_updated_since_bound_returns_all_target_rows(
-    adapter_store_with_records: AdapterStoreFactory,
-) -> None:
-    """Using the changeset's own minimum last_modified as the bound returns
-    exactly the same rows as the unbounded id read."""
-    earlier = datetime(2026, 7, 1, 9, 0, tzinfo=UTC)
-    later = datetime(2026, 7, 1, 10, 0, tzinfo=UTC)
-    client = adapter_store_with_records(
-        [
             {
-                "id": "rec001",
-                "content": "first",
-                "changeset": "changeset-a",
-                "last_modified": earlier,
-            },
-            {
-                "id": "rec002",
-                "content": "deleted",
-                "deleted": True,
-                "changeset": "changeset-a",
+                "id": "rec003",
+                "content": "third",
+                "changeset": "changeset-b",
                 "last_modified": later,
             },
             {
-                "id": "rec003",
-                "content": "older row outside the changeset",
-                "changeset": "changeset-b",
+                "id": "rec004",
+                "content": "old row outside the requested changesets",
+                "changeset": "changeset-c",
                 "last_modified": datetime(2026, 1, 1, tzinfo=UTC),
             },
         ]
     )
 
-    ids, min_last_modified = client.get_changeset_record_ids(["changeset-a"])
-    bounded = client.get_records_by_ids(ids, updated_since=min_last_modified)
-    unbounded = client.get_records_by_ids(ids)
+    combined = client.get_records_by_changesets(["changeset-a", "changeset-b"])
+    per_changeset = (
+        client.get_records_by_changeset("changeset-a").to_pylist()
+        + client.get_records_by_changeset("changeset-b").to_pylist()
+    )
 
     sort_key = itemgetter("id")
-    assert sorted(bounded.to_pylist(), key=sort_key) == sorted(
-        unbounded.to_pylist(), key=sort_key
+    assert sorted(combined.to_pylist(), key=sort_key) == sorted(
+        per_changeset, key=sort_key
     )
-    bounded_ids = cast(list[str], bounded.column("id").to_pylist())
-    assert sorted(bounded_ids) == ["rec001", "rec002"]
+
+
+def test_get_records_by_changesets_includes_deleted_records(
+    adapter_store_with_records: AdapterStoreFactory,
+) -> None:
+    """Deleted rows in a changeset are returned with their preserved content."""
+    client = adapter_store_with_records(
+        [
+            {"id": "rec001", "content": "active", "changeset": "changeset-a"},
+            {
+                "id": "rec002",
+                "content": "deleted with content preserved",
+                "deleted": True,
+                "changeset": "changeset-a",
+            },
+        ]
+    )
+
+    rows = {
+        row["id"]: row
+        for row in client.get_records_by_changesets(["changeset-a"]).to_pylist()
+    }
+
+    assert sorted(rows) == ["rec001", "rec002"]
+    assert rows["rec002"]["deleted"] is True
+    assert rows["rec002"]["content"] == "deleted with content preserved"
+
+
+def test_get_records_by_changesets_scoped_to_namespace(
+    adapter_store_with_records: AdapterStoreFactory,
+) -> None:
+    """Only rows in the store's namespace are returned for a shared changeset id."""
+    client = adapter_store_with_records(
+        [
+            {"id": "rec001", "content": "mine", "changeset": "changeset-a"},
+            {
+                "id": "rec002",
+                "content": "other",
+                "changeset": "changeset-a",
+                "namespace": "other_namespace",
+            },
+        ]
+    )
+
+    result = client.get_records_by_changesets(["changeset-a"])
+
+    assert result.column("id").to_pylist() == ["rec001"]
+
+
+def test_get_records_by_changesets_nonexistent_changeset_returns_empty(
+    adapter_store_with_records: AdapterStoreFactory,
+) -> None:
+    """Changesets with no rows return an empty table."""
+    client = adapter_store_with_records(
+        [{"id": "rec001", "content": "first", "changeset": "changeset-a"}]
+    )
+
+    assert client.get_records_by_changesets(["nonexistent"]).num_rows == 0
+
+
+def test_get_records_by_changesets_empty_input_returns_empty(
+    adapter_store_with_records: AdapterStoreFactory,
+) -> None:
+    """An empty changeset id list returns an empty table without erroring."""
+    client = adapter_store_with_records(
+        [{"id": "rec001", "content": "first", "changeset": "changeset-a"}]
+    )
+
+    assert client.get_records_by_changesets([]).num_rows == 0
+
+
+def test_get_records_by_changesets_pins_snapshot(
+    adapter_store_with_records: AdapterStoreFactory,
+) -> None:
+    """Rows are read at the pinned snapshot, excluding later appends."""
+    client = adapter_store_with_records(
+        [{"id": "rec001", "content": "first", "changeset": "changeset-a"}]
+    )
+    pinned_snapshot_id = client.current_snapshot_id()
+
+    client.table.append(
+        adapter_records_to_table(
+            [{"id": "rec002", "content": "later", "changeset": "changeset-a"}]
+        )
+    )
+
+    pinned = client.get_records_by_changesets(["changeset-a"], pinned_snapshot_id)
+    current = client.get_records_by_changesets(["changeset-a"])
+
+    assert pinned.column("id").to_pylist() == ["rec001"]
+    current_ids = cast(list[str], current.column("id").to_pylist())
+    assert sorted(current_ids) == ["rec001", "rec002"]
 
 
 # =============================================================================


### PR DESCRIPTION
Closes #3444.

## What does this change?

Reading a changeset from the adapter stores filtered on the `changeset` column, but the tables are sorted by `id`, so the filter cannot prune data files: a 1-row changeset read scanned 19 of 23 FOLIO data files at about 1.9 GB peak and 45 seconds, and tipped the transformer Lambda into OOM once the item-enrichment join (PR #3438) was added on top.

The changeset branch of `AdapterStoreSource.stream_raw` now calls a new `PipelineStore.get_records_by_changesets`, which reads in two phases at one resolved snapshot:

1. A projected scan of only the `last_modified` column (with the changeset filter) finds the minimum `last_modified` across the changesets' rows. Reading one narrow column keeps this cheap even though the changeset filter still cannot prune.
2. The content read applies that minimum as a `last_modified >=` bound alongside the changeset filter. The bound is exact by construction: every target row is at or after the minimum of its own set, so it can never exclude a row. What it does is let file-level column stats skip every data file that predates the changesets, which is where all the wasted decompression went.

The bound can only remove files relative to the plain changeset scan, so the worst case is today's behaviour. That property means no size threshold or fallback path is needed: a huge changeset (an EBSCO full load commits the whole file as one changeset) carries a bound equal to the load time, which prunes to the files that load wrote, and those are exactly the files that must be read. A replayed old changeset carries an old bound and degrades gracefully toward the plain scan.

Soft-deleted rows keep flowing through with their preserved content, which downstream needs to overwrite documents. The full-reindex branch (PR #3445), `get_records_by_changeset` itself, loaders, events and state machines are untouched. The Axiell reconciler consumes the same `stream_raw`, so it benefits without changes.

### Measurements

> RSS stands for Resident Set Size. It is the portion of an app or program's memory that is currently stored in RAM.

All runs are read-only against the production adapter S3 Tables, one fresh process per measurement, reading the same changeset via the old path (plain changeset scan) and the new path (bounded read). Peak RSS is resident set size: the maximum physical memory the process held. Times are wall clock for the whole read.

Recent changesets, the normal operating case (the transformer runs minutes after its loader):

| Store | Changeset size | Files read (old / new) | Peak RSS (old / new) | Time (old / new) |
| --- | --- | --- | --- | --- |
| FOLIO (1.7M rows, 24 files) | 1 row | 19/24 / 1/24 | 2,274 MB / 277 MB | 39.4s / 2.1s |
| FOLIO | 5 rows | 18/24 / 1/24 | 2,810 MB / 1,442 MB | 40.4s / 5.6s |
| Axiell (229k rows, 3 files) | 10 rows | 1/3 / 1/3 | 562 MB / 570 MB | 1.9s / 1.9s |
| Axiell | 93 rows | 1/3 / 1/3 | 564 MB / 585 MB | 1.6s / 1.6s |
| Axiell | 188 rows | 1/3 / 1/3 | 563 MB / 569 MB | 1.4s / 1.6s |
| EBSCO (189k rows, 4 files) | 6,730 rows | 4/4 / 2/4 | 1,062 MB / 281 MB | 5.1s / 0.9s |

Aged changesets, the replay case (an old bound prunes little, so the new path degrades to the old one; these were measured on the new path and match the old path's profile):

| Store | Changeset size | Files read | Peak RSS | Time |
| --- | --- | --- | --- | --- |
| FOLIO | 10 rows (months old) | 18/24 | 1,944 MB | 45.2s |
| FOLIO | 107 rows (months old) | 18/24 | 2,054 MB | 40.2s |
| FOLIO | 1,000 rows (months old) | 18/24 | 1,962 MB | 42.8s |

Peak memory tracks the size of the data files holding the changeset's rows, not the row count. Rows still in their own commit files read in a few hundred MB even at thousands of rows (the EBSCO case), while rows already merged into a compacted file cost that file's whole content column: the FOLIO 5-row changeset matched a single 92k-row, 47 MB compacted file, which decompresses to ~1.4 GB. On the small three-file Axiell store the two paths are equivalent, since any read there touches its one large file; the win comes on large, many-file stores, which is where the problem was found.

End to end through the store methods, the read returned row sets identical to the old path (compared on id, last_modified, deleted and a content hash).

### Alternatives ruled out

- Threading the changed ids from the loader through the state machine event: the ids would cross three 256 KB payload limits (Step Functions state, EventBridge detail, nested reconciler execution), an EBSCO changeset can span the whole table, and the loaders no longer persist changed ids.
- An id-based read (`In("id", ids)` with the same bound) was implemented first (this branch's history, commits 969e337d21 and b907261789) and measured at 2/23 files and 332 MB. It needed a size threshold with a fallback path, because at whole-table scale a giant `In` expression costs CPU and memory while the bound does all the pruning anyway. The changeset+bound read matches it (1/23 files, 296 MB) with one code path and no threshold, so the id plumbing was removed.
- Smaller parquet row groups (a table write property) as the structural fix was considered and deliberately dropped as a write-side change.

## How to test

Inside `catalogue_graph/`:

```
uv run ruff check .
uv run ruff format --check .
uv run mypy .
uv run pytest
```

On this branch: ruff clean, mypy clean (558 files), 1360 tests pass. New tests cover: rows returned for the requested changesets only (scoped to namespace, empty for unknown changesets and empty input), parity of the bounded multi-changeset read with per-changeset reads across rows with mixed timestamps, deleted rows returned with preserved content, snapshot pinning, and the stream_raw changeset path end to end including deleted rows and empty changesets.

## How can we measure success?

Incremental window transforms read their changeset in a few seconds instead of a 45-second full-table scan, at a peak typically between a few hundred MB and ~1.4 GB (depending on whether the rows have been compacted into larger files) instead of a uniform ~1.9 GB, and transformer memory stays comfortably within the Lambda limit with the enrichment join from PR #3438 in place.

## Have we considered potential risks?

- The bound is `>=`, so files written by other commits after the changeset also survive it. For a transform running minutes after its loader that is negligible; replaying a months-old changeset scans everything written since, degrading toward the plain changeset read, which is exactly the pre-change behaviour (measured: ~1.9-2 GB and ~40-45s for aged changesets, matching the old path's 2.3-2.8 GB and ~40s on the same store).
- PR #3438 wraps this branch's tail in `_with_enrichment(table.to_pylist())`. The changeset branch is again a plain table read followed by `to_pylist`, so the resolution is the same one-line wrap as before this PR.
- Multiple changesets are now read as one union rather than per changeset. No consumer is order-sensitive (rows are keyed by id downstream), and changesets partition rows at a snapshot, so the union equals the concatenation. Peak memory for the union's Arrow table scales with the sum of the requested changesets rather than the largest one; the Python dict conversion is done one record batch at a time so it never doubles that peak, and a nonexistent changeset id short-circuits before the content scan instead of paying an un-prunable full read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



