### PR TITLE
Remove satisfied dev-image TODO from folio loader task

### DIFF
--- a/catalogue_graph/infra/adapters/modules/adapter/ecs_loader.tf
+++ b/catalogue_graph/infra/adapters/modules/adapter/ecs_loader.tf
@@ -2,8 +2,7 @@ module "loader_ecs_task" {
   source = "../../../../../pipeline/terraform/modules/ecs_task"
 
   task_name = "${var.namespace}-adapter-loader"
-  # TODO: Change to :prod before merging — currently :dev for testing
-  image = "${var.task_repository_url}:prod"
+  image     = "${var.task_repository_url}:prod"
 
   cpu    = 4096
   memory = 16384


### PR DESCRIPTION
## What's changing

Removes a leftover TODO comment in the folio adapter loader task definition. The comment said the image was pinned to :dev for pre-merge testing, but the image was switched back to :prod before #3438 merged, so the note no longer describes the config.

## Why

Comment residue from the item enrichment rollout. No functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)