### PR TITLE
Emit stub source concept nodes from the incremental concepts transformer

### DIFF
--- a/catalogue_graph/src/graph/converters/cypher/bulk_load_converter.py
+++ b/catalogue_graph/src/graph/converters/cypher/bulk_load_converter.py
@@ -33,7 +33,7 @@ class CypherBulkLoadConverter(CypherBaseConverter):
         return f"{field_name}:{field_type}"
 
     def _node_to_bulk_cypher(self, model: BaseNode) -> dict:
-        bulk_node = {":ID": model.id, ":LABEL": type(model).__name__}
+        bulk_node = {":ID": model.id, ":LABEL": type(model).bulk_load_label()}
 
         for field_name, raw_value in model.dict().items():
             column_header = self._get_bulk_loader_column_header(model, field_name)

--- a/catalogue_graph/src/graph/transformers/catalogue/concepts_transformer.py
+++ b/catalogue_graph/src/graph/transformers/catalogue/concepts_transformer.py
@@ -9,11 +9,27 @@ from graph.sources.catalogue.concepts_source import (
 from graph.transformers.graph_transformer import GraphBaseTransformer
 from models.events import BasePipelineEvent
 from models.graph_edge import ConceptHasSourceConcept, ConceptHasSourceConceptAttributes
-from models.graph_node import Concept
+from models.graph_node import (
+    Concept,
+    SourceConceptStub,
+    SourceLocationStub,
+    SourceNameStub,
+)
 from utils.ontology import get_transformers_from_ontology
+from utils.types import TransformerType
 
-from .id_label_checker import IdLabelChecker
+from .id_label_checker import IdLabelChecker, concept_source_from_id
 from .raw_concept import RawCatalogueConcept
+
+# The node label each source ontology transformer bulk loads its nodes under, so that stubs
+# minted here carry the same label as the full node which later enriches them in place.
+STUB_CLASSES_BY_TRANSFORMER: dict[TransformerType, type[SourceConceptStub]] = {
+    "loc_concepts": SourceConceptStub,
+    "loc_names": SourceNameStub,
+    "loc_locations": SourceLocationStub,
+    "mesh_concepts": SourceConceptStub,
+    "mesh_locations": SourceLocationStub,
+}
 
 
 class CatalogueConceptsTransformer(GraphBaseTransformer):
@@ -26,7 +42,18 @@ class CatalogueConceptsTransformer(GraphBaseTransformer):
 
         self.id_label_checker: IdLabelChecker | None = None
         self.id_lookup: set = set()
+        self.emitted_source_concept_ids: set[str] = set()
         self.event = event
+
+    def _get_id_label_checker(self) -> IdLabelChecker:
+        if self.id_label_checker is None:
+            transformers = []
+            for ontology in ("mesh", "loc"):
+                transformers += get_transformers_from_ontology(ontology)
+
+            self.id_label_checker = IdLabelChecker(transformers, self.event)
+
+        return self.id_label_checker
 
     def transform_node(self, extracted: ExtractedWorkConcept) -> Concept | None:
         raw_concept = RawCatalogueConcept(extracted.concept, self.id_label_checker)
@@ -42,44 +69,56 @@ class CatalogueConceptsTransformer(GraphBaseTransformer):
             source=raw_concept.source,
         )
 
+    def extract_supplementary_nodes(
+        self, raw_data: ExtractedWorkConcept
+    ) -> Generator[SourceConceptStub]:
+        """
+        Emit a stub node for every matched source concept, guaranteeing that the targets of this
+        window's `HAS_SOURCE_CONCEPT` edges exist in the graph even if the corresponding source
+        ontology node has not been bulk loaded yet. Stubs are upserted, so the full monthly load
+        enriches them in place (and re-emitting one over a full node is a no-op).
+        """
+        id_label_checker = self._get_id_label_checker()
+        raw_concept = RawCatalogueConcept(raw_data.concept, id_label_checker)
+
+        for match in raw_concept.matched_source_concepts():
+            if match.source_id in self.emitted_source_concept_ids:
+                continue
+
+            self.emitted_source_concept_ids.add(match.source_id)
+
+            source = concept_source_from_id(match.source_id)
+            transformer = id_label_checker.get_transformer(match.source_id)
+            stub_class = SourceConceptStub
+            if transformer is not None:
+                stub_class = STUB_CLASSES_BY_TRANSFORMER.get(
+                    transformer, SourceConceptStub
+                )
+
+            yield stub_class(
+                id=match.source_id,
+                label=id_label_checker.get_label(match.source_id, source),
+                source=source,
+            )
+
     def extract_edges(
         self, raw_data: ExtractedWorkConcept
     ) -> Generator[ConceptHasSourceConcept]:
-        if self.id_label_checker is None:
-            transformers = []
-            for ontology in ("mesh", "loc"):
-                transformers += get_transformers_from_ontology(ontology)
-
-            self.id_label_checker = IdLabelChecker(transformers, self.event)
-
-        raw_concept = RawCatalogueConcept(raw_data.concept, self.id_label_checker)
+        raw_concept = RawCatalogueConcept(
+            raw_data.concept, self._get_id_label_checker()
+        )
 
         if raw_concept.wellcome_id in self.id_lookup:
             return
 
         self.id_lookup.add(raw_concept.wellcome_id)
 
-        # Generate edge via label
-        if (
-            raw_concept.source == "label-derived"
-            and (source_id := raw_concept.label_matched_source_concept_id) is not None
-        ):
+        for match in raw_concept.matched_source_concepts():
             attributes = ConceptHasSourceConceptAttributes(
-                qualifier=None, matched_by="label"
+                qualifier=match.qualifier, matched_by=match.matched_by
             )
             yield ConceptHasSourceConcept(
                 from_id=raw_concept.wellcome_id,
-                to_id=source_id,
-                attributes=attributes,
-            )
-
-        # Generate edge via ID
-        if raw_concept.has_valid_source_concept:
-            attributes = ConceptHasSourceConceptAttributes(
-                qualifier=raw_concept.mesh_qualifier, matched_by="identifier"
-            )
-            yield ConceptHasSourceConcept(
-                from_id=raw_concept.wellcome_id,
-                to_id=str(raw_concept.source_concept_id),
+                to_id=match.source_id,
                 attributes=attributes,
             )

--- a/catalogue_graph/src/graph/transformers/catalogue/id_label_checker.py
+++ b/catalogue_graph/src/graph/transformers/catalogue/id_label_checker.py
@@ -18,7 +18,7 @@ with open(f"{os.path.dirname(__file__)}/data/concept_label_deny_list.txt") as f:
     CONCEPT_DENY_LIST = [line.strip().lower() for line in f]
 
 
-def _concept_source_from_id(source_id: str) -> ConceptSource:
+def concept_source_from_id(source_id: str) -> ConceptSource:
     if source_id[0] == "n":
         return "lc-names"
     if source_id[0] == "s":
@@ -49,6 +49,9 @@ class IdLabelChecker:
         self.alternative_labels_to_ids: dict[ConceptSource, dict[str, list[str]]] = (
             defaultdict(lambda: defaultdict(list))
         )
+        # Records which transformer's bulk load file each source id came from,
+        # so that stub nodes can be minted with the matching node label.
+        self.ids_to_transformers: dict[str, TransformerType] = {}
 
         for transformer in transformers:
             event = BulkLoaderEvent(
@@ -59,14 +62,17 @@ class IdLabelChecker:
             )
             for row in get_csv_from_s3(event.get_s3_uri()):
                 source_id = row[":ID"]
-                label = row["label:String"].lower()
+                # Labels are stored with their original casing (they are reused verbatim when
+                # minting stub nodes); lookups lowercase them at comparison time.
+                label = row["label:String"]
                 alternative_labels = [
                     label.lower()
                     for label in row["alternative_labels:String"].split("||")
                     if label != ""
                 ]
 
-                concept_source = _concept_source_from_id(source_id)
+                concept_source = concept_source_from_id(source_id)
+                self.ids_to_transformers[source_id] = transformer
                 self._add_label_mapping(label, source_id, concept_source)
                 self._add_alternative_label_mappings(
                     alternative_labels, source_id, concept_source
@@ -76,7 +82,7 @@ class IdLabelChecker:
         self, label: str, source_id: str, concept_source: ConceptSource
     ) -> None:
         self.ids_to_labels[concept_source][source_id] = label
-        self.labels_to_ids[concept_source][label].append(source_id)
+        self.labels_to_ids[concept_source][label.lower()].append(source_id)
 
     def _add_alternative_label_mappings(
         self, labels: list[str], source_id: str, concept_source: ConceptSource
@@ -129,6 +135,10 @@ class IdLabelChecker:
     def get_label(self, source_id: str, source: ConceptSource) -> str | None:
         """Given a source id from a specific source (e.g. nlm-mesh, lc-subjects), return its label."""
         return self.ids_to_labels[source].get(source_id, None)
+
+    def get_transformer(self, source_id: str) -> TransformerType | None:
+        """Given a source id, return the transformer type whose bulk load file it came from."""
+        return self.ids_to_transformers.get(source_id, None)
 
     def get_alternative_labels(
         self, source_id: str, source: ConceptSource

--- a/catalogue_graph/src/graph/transformers/catalogue/raw_concept.py
+++ b/catalogue_graph/src/graph/transformers/catalogue/raw_concept.py
@@ -1,5 +1,5 @@
 import re
-from typing import cast
+from typing import Literal, NamedTuple, cast
 
 from models.pipeline.concept import (
     IdentifiedConcept,
@@ -10,6 +10,12 @@ from models.pipeline.identifier import (
 from utils.types import ConceptSource
 
 from .id_label_checker import IdLabelChecker
+
+
+class SourceConceptMatch(NamedTuple):
+    source_id: str
+    matched_by: Literal["label", "identifier"]
+    qualifier: str | None
 
 
 class RawCatalogueConcept:
@@ -77,9 +83,9 @@ class RawCatalogueConcept:
                 self.source_concept_id, self.source
             )
 
-            all_source_labels = source_alternative_labels
+            all_source_labels = [label.lower() for label in source_alternative_labels]
             if source_label is not None:
-                all_source_labels.append(source_label)
+                all_source_labels.append(source_label.lower())
 
             normalised_label = self.label.lower()
 
@@ -93,3 +99,27 @@ class RawCatalogueConcept:
             )
 
         return False
+
+    def matched_source_concepts(self) -> list[SourceConceptMatch]:
+        """
+        Return all matched source concepts. Both `HAS_SOURCE_CONCEPT` edges and the stub nodes
+        guaranteeing their targets exist are derived from this single code path.
+        """
+        matches = []
+
+        # Match via label
+        if (
+            self.source == "label-derived"
+            and (source_id := self.label_matched_source_concept_id) is not None
+        ):
+            matches.append(SourceConceptMatch(source_id, "label", None))
+
+        # Match via ID
+        if self.has_valid_source_concept:
+            matches.append(
+                SourceConceptMatch(
+                    str(self.source_concept_id), "identifier", self.mesh_qualifier
+                )
+            )
+
+        return matches

--- a/catalogue_graph/src/graph/transformers/graph_transformer.py
+++ b/catalogue_graph/src/graph/transformers/graph_transformer.py
@@ -31,6 +31,13 @@ class GraphBaseTransformer(BaseTransformer):
             "Each transformer must implement an `extract_edges` method."
         )
 
+    def extract_supplementary_nodes(self, raw_node: Any) -> Generator[BaseNode]:
+        """
+        Accepts a raw node and returns a generator of additional nodes to stream alongside transformed
+        nodes (e.g. stub nodes guaranteeing that targets of later edge loads exist). No-op by default.
+        """
+        yield from ()
+
     def _stream_nodes(self, number: int | None = None) -> Generator[BaseNode]:
         """
         Extracts nodes from the specified source and transforms them. The `source` must define a `stream_raw` method.
@@ -49,6 +56,15 @@ class GraphBaseTransformer(BaseTransformer):
                     logger.info("Streaming nodes progress", count=counter)
             if counter == number:
                 return
+
+            for supplementary_node in self.extract_supplementary_nodes(raw_node):
+                yield supplementary_node
+                counter += 1
+
+                if counter % 10000 == 0:
+                    logger.info("Streaming nodes progress", count=counter)
+                if counter == number:
+                    return
 
         logger.info("Streamed all nodes", count=counter)
 

--- a/catalogue_graph/src/models/graph_node.py
+++ b/catalogue_graph/src/models/graph_node.py
@@ -14,6 +14,11 @@ class BaseNode(BaseModel):
     id: str
     label: str | None = None
 
+    @classmethod
+    def bulk_load_label(cls) -> str:
+        """The Neptune node label (`:LABEL`) under which instances are bulk loaded."""
+        return cls.__name__
+
 
 # Represents a LoC, MeSH, or Wikidata concept.
 # The `id` field stores a unique identifier provided by the source vocabulary/ontology
@@ -40,6 +45,30 @@ class SourceName(SourceConcept):
     date_of_birth: FormattedDateString | None = None
     date_of_death: FormattedDateString | None = None
     place_of_birth: str | None = None
+
+
+# A minimal stand-in for a source concept which is referenced by a catalogue concept but might not have been
+# bulk loaded into the graph yet (source ontology loads run monthly; catalogue loads run incrementally).
+# The full monthly load enriches the stub in place. The field set must stay identical to `Concept` so that
+# both can share a single bulk load CSV (whose header is derived from one model).
+class SourceConceptStub(BaseNode):
+    source: ConceptSource
+
+    @classmethod
+    def bulk_load_label(cls) -> str:
+        return "SourceConcept"
+
+
+class SourceLocationStub(SourceConceptStub):
+    @classmethod
+    def bulk_load_label(cls) -> str:
+        return "SourceLocation"
+
+
+class SourceNameStub(SourceConceptStub):
+    @classmethod
+    def bulk_load_label(cls) -> str:
+        return "SourceName"
 
 
 # The `id` field stores a canonical Wellcome identifier

--- a/catalogue_graph/tests/graph/transformers/catalogue/test_catalogue_concepts_transformer.py
+++ b/catalogue_graph/tests/graph/transformers/catalogue/test_catalogue_concepts_transformer.py
@@ -1,3 +1,6 @@
+import csv
+import io
+
 from graph.transformers.catalogue.concepts_transformer import (
     CatalogueConceptsTransformer,
 )
@@ -6,7 +9,7 @@ from models.graph_edge import (
     ConceptHasSourceConcept,
     ConceptHasSourceConceptAttributes,
 )
-from models.graph_node import Concept
+from models.graph_node import Concept, SourceConceptStub
 from tests.mocks import get_mock_es_client
 from tests.test_utils import (
     add_mock_merged_documents,
@@ -28,11 +31,79 @@ def test_catalogue_concepts_transformer_nodes() -> None:
 
     nodes = list(get_transformer()._stream_nodes())
 
-    assert len(nodes) == 12
+    concepts = [item for item in nodes if isinstance(item, Concept)]
+    stubs = [item for item in nodes if isinstance(item, SourceConceptStub)]
+
+    assert len(concepts) == 12
     assert any(
         item == Concept(id="s6s24vd7", label="Human anatomy", source="lc-subjects")
-        for item in nodes
+        for item in concepts
     )
+
+    # A stub node is emitted for every matched source concept, with the original-case
+    # label from the source ontology's bulk load file
+    assert any(
+        item
+        == SourceConceptStub(id="sh85045046", label="Etchings", source="lc-subjects")
+        for item in stubs
+    )
+
+
+def test_catalogue_concepts_transformer_stub_nodes() -> None:
+    pipeline_date = "2027-12-24"
+    add_mock_transformer_outputs_for_ontologies(["loc", "mesh"], pipeline_date)
+    add_mock_merged_documents(pipeline_date, work_status="Visible")
+
+    stubs = [
+        item
+        for item in get_transformer(pipeline_date)._stream_nodes()
+        if isinstance(item, SourceConceptStub)
+    ]
+
+    # Re-register the mocked ontology files consumed by the nodes run above
+    add_mock_transformer_outputs_for_ontologies(["loc", "mesh"], pipeline_date)
+    edges = list(get_transformer(pipeline_date)._stream_edges())
+
+    # Every edge target has a corresponding stub node, so edge bulk loads cannot
+    # reference a vertex which does not exist
+    assert {stub.id for stub in stubs} == {edge.to_id for edge in edges}
+
+    # One stub per distinct source id, even when multiple concepts match it
+    # (both s6s24vd8 and s6s24vd9 match D000715)
+    assert sum(1 for stub in stubs if stub.id == "D000715") == 1
+    assert any(
+        item == SourceConceptStub(id="D000715", label="Anatomy", source="nlm-mesh")
+        for item in stubs
+    )
+
+    # Stubs carry the same node label as the full node which later enriches them
+    for stub in stubs:
+        if stub.source == "nlm-mesh" or stub.id.startswith("s"):
+            assert type(stub).bulk_load_label() in ("SourceConcept", "SourceLocation")
+        if stub.id.startswith("n"):
+            assert type(stub).bulk_load_label() in ("SourceName", "SourceLocation")
+
+
+def test_catalogue_concepts_transformer_bulk_load_csv() -> None:
+    add_mock_transformer_outputs_for_ontologies(["loc", "mesh"])
+    add_mock_merged_documents(work_status="Visible")
+
+    file = io.StringIO()
+    get_transformer()._stream_to_bulk_load_file(file, "nodes")
+    rows = list(csv.DictReader(io.StringIO(file.getvalue())))
+
+    # Concept and stub rows share a single header but carry different node labels
+    assert set(rows[0].keys()) == {
+        ":ID",
+        ":LABEL",
+        "id:String",
+        "label:String",
+        "source:String",
+    }
+    labels = {row[":LABEL"] for row in rows}
+    assert "Concept" in labels
+    assert "SourceConcept" in labels
+    assert all(row[":ID"] for row in rows)
 
 
 def test_catalogue_concepts_transformer_edges() -> None:

--- a/catalogue_graph/tests/graph/transformers/catalogue/test_id_label_checker.py
+++ b/catalogue_graph/tests/graph/transformers/catalogue/test_id_label_checker.py
@@ -75,3 +75,21 @@ def test_id_label_checker_source_priority() -> None:
 
     # Prioritise matching on MeSH rather than LoC
     assert id_label_checker.get_id("anatomy", "Concept") == "D000715"
+
+
+def test_id_label_checker_original_case_labels() -> None:
+    id_label_checker = _setup_id_label_checker()
+
+    # Labels keep their original casing (they are reused verbatim by stub nodes),
+    # while matching stays case-insensitive
+    assert id_label_checker.get_label("sh00000002", "lc-subjects") == "Tacos"
+    assert id_label_checker.get_label("D000715", "nlm-mesh") == "Anatomy"
+
+
+def test_id_label_checker_transformer_per_id() -> None:
+    id_label_checker = _setup_id_label_checker()
+
+    assert id_label_checker.get_transformer("sh00000002") == "loc_concepts"
+    assert id_label_checker.get_transformer("n00000001") == "loc_names"
+    assert id_label_checker.get_transformer("D000715") == "mesh_concepts"
+    assert id_label_checker.get_transformer("does-not-exist") is None


### PR DESCRIPTION
> Do not merge yet. Merging auto-deploys to prod. This PR is up so the team can judge whether the approach is worth the complexity before we commit to it.

## What does this change?

The incremental graph pipeline failed on 2026-07-06 (execution `0904923d-c17a-4a14-894e-be12337f0d1b` of `graph-pipeline-incremental-2025-10-02`). The `catalogue_concepts` transformer label-matches concepts against the LoC/MeSH bulk load CSVs in S3. The monthly pipeline refreshes those CSVs hours before it bulk loads the corresponding nodes into Neptune, and the full run takes about 22h. During that gap an incremental window matched the concept "Laboratory manuals" to a newly minted LCSH heading (`sh2026001150`) that wasn't in Neptune yet. The edge load failed with `FROM_OR_TO_VERTEX_ARE_MISSING`, and one bad edge is enough to exceed the `1e-4` insert error threshold on a small window. This recurs on every monthly run. Relaxing the threshold instead would silently drop the edge forever, because nothing re-loads catalogue edges in full.

The fix: the transformer now also emits a minimal stub node (id, label, source) for every matched source concept into the same window's nodes CSV. The nodes CSV loads before the edges CSV, so edge targets always exist. The monthly full load enriches stubs in place: loads run with `updateSingleCardinalityProperties=TRUE` and empty CSV cells never clear properties.

Stubs carry the same node label (`SourceConcept` / `SourceName` / `SourceLocation`) as the full node that later enriches them, tracked per id in `IdLabelChecker`. `IdLabelChecker` now keeps labels in their original casing (lookups still lowercase at comparison time). Without that, a stub upserted over an already-enriched node would rewrite "United States" as "united states".

Both edges and stubs now derive from a new shared `RawCatalogueConcept.matched_source_concepts()`, so the two sets can't drift. The stub models share `Concept`'s exact field set so `Concept` and stub rows can live in one bulk load CSV (the header is derived from the first row).

Some honest trade-offs worth weighing:

- The nodes pass now builds `IdLabelChecker` too (it previously only ran in the edges pass). That means downloading the multi-GB LoC/MeSH CSVs every 15 minutes in the nodes extractor task as well. It's the same 16GB task envelope the edges pass already uses.
- There's a residual rarer race. The nodes and edges passes build their checkers from S3 independently, so a monthly CSV rewrite landing between the two reads could still produce an edge without a stub.
- Stub-only nodes serve sparse concept docs (no description or alternative labels) until the next monthly enrichment.

## How to test

Run the `catalogue_graph` suite from `catalogue_graph/`:

```
uv run --group dev pytest
uv run --group dev ruff check .
uv run --group dev ruff format --check .
uv run --group dev mypy .
```

The full suite passes (1428 tests) and ruff is clean. mypy reports pre-existing errors in `src/utils/marc.py` only, unrelated to this change.

New tests cover: a stub emitted per matched source id with an original-case label; the stub set equals the edge target set; dedup when two concepts match the same id; mixed `Concept` / `SourceConcept` rows in one CSV under a single header; original-case `get_label`; and per-id transformer tracking in the transformer.

## How can we measure success?

The incremental graph pipeline stops failing with `FROM_OR_TO_VERTEX_ARE_MISSING` around monthly source ontology refreshes. No new `HAS_SOURCE_CONCEPT` edge load errors from missing target vertices, and the previously dropped concept-to-heading edges (e.g. "Laboratory manuals" to `sh2026001150`) land in the window they were matched in rather than being lost.

## Have we considered potential risks?

- Merging auto-deploys to prod, so this stays unmerged until the team is happy with the approach.
- The nodes extractor task now downloads the same multi-GB CSVs every 15 minutes. It reuses the 16GB envelope the edges pass already runs in, but it's extra work and cost on the nodes pass.
- The narrow race between the two independent S3 reads remains. A monthly CSV rewrite landing between the nodes read and the edges read could still produce an edge without a stub. Rarer than the original window-vs-Neptune gap, but not zero.
- Stub-only nodes are sparse until the next monthly enrichment, so anything reading those concepts sees id, label and source but no description or alternative labels in the meantime.
- The label-casing change touches `IdLabelChecker` used across the catalogue graph transformers, not just stubs. Lookups still lowercase at comparison time, and the mixed-case tests guard against regressions there.
