### PR TITLE
Allow insert errors when bulk loading incremental concept edges

### DIFF
--- a/pipeline/terraform/modules/pipeline/graph/locals.tf
+++ b/pipeline/terraform/modules/pipeline/graph/locals.tf
@@ -168,7 +168,15 @@ locals {
     {
       "label" : "Catalogue Concept Edges",
       "transformer_type" : "catalogue_concepts",
-      "entity_type" : "edges"
+      "entity_type" : "edges",
+      # When bulk loading concept edges, we are expecting a small number of insert failures due to missing
+      # source concept nodes. Catalogue concepts are matched against the LoC/MeSH bulk load files in S3, which
+      # the monthly pipeline refreshes hours before it loads the corresponding nodes into Neptune, so an edge
+      # can reference a newly minted source concept which does not exist in the graph yet. Neptune drops such
+      # edges; the edge is created the next time the referencing work is updated after the monthly load completes.
+      # When running in incremental mode, we cannot predict how many of these missing source concepts will exist
+      # in any given batch, and so we allow any number of insert errors.
+      "insert_error_threshold" : 1
     },
     {
       "label" : "Catalogue Image Edges",


### PR DESCRIPTION
## What is included in this PR?

Adds an insert_error_threshold override for the catalogue_concepts edges input of the incremental graph pipeline, mirroring the existing override on catalogue_work_identifiers edges.

## Why?

The incremental pipeline failed on 2026-07-06 (window 11:45 to 12:00 UTC). The catalogue_concepts transformer matches concepts against the LoC/MeSH bulk load files in S3, which the monthly pipeline refreshes hours before it loads the corresponding nodes into Neptune. During that gap a concept ("Laboratory manuals") was matched to a newly minted LCSH heading (sh2026001150) that was not in Neptune yet, the edge load failed with FROM_OR_TO_VERTEX_ARE_MISSING, and with the default 1e-4 threshold a single bad edge fails a small window. This recurs on every monthly run.

Neptune drops edges with missing endpoints, so with this change the window completes and the dropped edge is recreated the next time the referencing work is updated after the monthly load completes. We prototyped a self-healing alternative that emits stub source concept nodes (#3454) but decided the added complexity and the extra cost of building the label checker in the nodes pass every window were not worth it.

Note the bulk loader publishes an insert_error_count metric on every load, so dropped edges remain visible in CloudWatch even though the pipeline no longer fails.

## How to apply

Terraform apply is manual: pipeline/terraform/2025-10-02.