### PR TITLE
Add tflint to the Terraform workflow

### DIFF
--- a/.github/workflows/tflint.yml
+++ b/.github/workflows/tflint.yml
@@ -1,0 +1,60 @@
+name: "Terraform: tflint"
+
+on:
+  pull_request:
+    paths:
+      - "**/*.tf"
+      - "**/.terraform.lock.hcl"
+      - ".tflint.hcl"
+      - ".github/workflows/tflint.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "**/*.tf"
+      - "**/.terraform.lock.hcl"
+      - ".tflint.hcl"
+      - ".github/workflows/tflint.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  tflint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: terraform-linters/setup-tflint@v4
+        with:
+          tflint_version: v0.54.0
+
+      - name: Initialise tflint plugins
+        run: tflint --init
+
+      - name: Run tflint on all Terraform roots
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          config_file="$(pwd)/.tflint.hcl"
+
+          mapfile -t terraform_roots < <(
+            find . -type f -name '.terraform.lock.hcl' -exec dirname {} \; | sort -u
+          )
+
+          if [[ ${#terraform_roots[@]} -eq 0 ]]; then
+            echo "No Terraform roots found"
+            exit 1
+          fi
+
+          for root in "${terraform_roots[@]}"; do
+            if [[ "${root}" == "./reindexer/terraform" ]]; then
+              echo "Skipping ${root}; this root currently fails static evaluation in a shared module"
+              continue
+            fi
+
+            echo "Linting ${root}"
+            tflint --chdir="${root}" --config="${config_file}" --format=compact --minimum-failure-severity=error
+          done

--- a/.github/workflows/tflint.yml
+++ b/.github/workflows/tflint.yml
@@ -40,8 +40,14 @@ jobs:
 
           config_file="$(pwd)/.tflint.hcl"
 
+          # A Terraform root is identified by having a backend configuration.
+          # Child modules (under modules/, etc.) never declare a backend, so this
+          # discovers every root without depending on a committed .terraform.lock.hcl.
           mapfile -t terraform_roots < <(
-            find . -type f -name '.terraform.lock.hcl' -exec dirname {} \; | sort -u
+            grep -rlE '^\s*backend\s+"' --include='*.tf' . \
+              | xargs -r -n1 dirname \
+              | sed 's|^\./||' \
+              | sort -u
           )
 
           if [[ ${#terraform_roots[@]} -eq 0 ]]; then
@@ -50,7 +56,7 @@ jobs:
           fi
 
           for root in "${terraform_roots[@]}"; do
-            if [[ "${root}" == "./reindexer/terraform" ]]; then
+            if [[ "${root}" == "reindexer/terraform" ]]; then
               echo "Skipping ${root}; this root currently fails static evaluation in a shared module"
               continue
             fi

--- a/.github/workflows/tflint.yml
+++ b/.github/workflows/tflint.yml
@@ -28,39 +28,8 @@ jobs:
 
       - uses: terraform-linters/setup-tflint@v4
         with:
-          tflint_version: v0.54.0
-
-      - name: Initialise tflint plugins
-        run: tflint --init
+          tflint_version: v0.64
 
       - name: Run tflint on all Terraform roots
         shell: bash
-        run: |
-          set -euo pipefail
-
-          config_file="$(pwd)/.tflint.hcl"
-
-          # A Terraform root is identified by having a backend configuration.
-          # Child modules (under modules/, etc.) never declare a backend, so this
-          # discovers every root without depending on a committed .terraform.lock.hcl.
-          mapfile -t terraform_roots < <(
-            grep -rlE '^\s*backend\s+"' --include='*.tf' . \
-              | xargs -r -n1 dirname \
-              | sed 's|^\./||' \
-              | sort -u
-          )
-
-          if [[ ${#terraform_roots[@]} -eq 0 ]]; then
-            echo "No Terraform roots found"
-            exit 1
-          fi
-
-          for root in "${terraform_roots[@]}"; do
-            if [[ "${root}" == "reindexer/terraform" ]]; then
-              echo "Skipping ${root}; this root currently fails static evaluation in a shared module"
-              continue
-            fi
-
-            echo "Linting ${root}"
-            tflint --chdir="${root}" --config="${config_file}" --format=compact --minimum-failure-severity=error
-          done
+        run: builds/run_tflint.sh

--- a/.github/workflows/tflint.yml
+++ b/.github/workflows/tflint.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: terraform-linters/setup-tflint@v4
         with:
-          tflint_version: v0.64
+          tflint_version: v0.64.0
 
       - name: Run tflint on all Terraform roots
         shell: bash

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -12,3 +12,10 @@ plugin "aws" {
   version = "0.48.0"
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
+
+# Enforce the recommended Terraform naming convention (snake_case, the
+# rule default) for resources, variables, outputs, etc.
+rule "terraform_naming_convention" {
+  enabled = true
+  format  = "snake_case"
+}

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,0 +1,14 @@
+config {
+  call_module_type = "none"
+}
+
+plugin "terraform" {
+  enabled = true
+  preset  = "recommended"
+}
+
+plugin "aws" {
+  enabled = true
+  version = "0.48.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-aws"
+}

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -13,9 +13,9 @@ plugin "aws" {
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
 
-# Enforce the recommended Terraform naming convention (snake_case, the
-# rule default) for resources, variables, outputs, etc.
+# Advisory check for Terraform naming conventions. Under our current CI
+# threshold (--minimum-failure-severity=error), this rule's Notice-level
+# findings are reported in logs but do not fail the build.
 rule "terraform_naming_convention" {
   enabled = true
-  format  = "snake_case"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,21 @@ uv run ruff check --fix
 Scope `pytest`/`mypy` paths to the area you changed when the project is large
 (e.g. `catalogue_graph/`); a full run can be slow.
 
+### Before finalising a Terraform change
+
+Run from the repository root:
+
+```bash
+tflint --init
+find . -type f -name '.terraform.lock.hcl' -exec dirname {} \; | sort -u | while IFS= read -r root; do
+  if [[ "$root" == "./reindexer/terraform" ]]; then
+    continue
+  fi
+
+  tflint --chdir="$root" --config="$(pwd)/.tflint.hcl" --format=compact --minimum-failure-severity=error
+done
+```
+
 ## Scala conventions
 
 - SBT project at the repo root. Sub-projects are wired up in `build.sbt` via

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,13 +81,21 @@ Run from the repository root:
 
 ```bash
 tflint --init
-find . -type f -name '.terraform.lock.hcl' -exec dirname {} \; | sort -u | while IFS= read -r root; do
-  if [[ "$root" == "./reindexer/terraform" ]]; then
-    continue
-  fi
 
-  tflint --chdir="$root" --config="$(pwd)/.tflint.hcl" --format=compact --minimum-failure-severity=error
-done
+config_file="$(pwd)/.tflint.hcl"
+
+grep -rlE '^\s*backend\s+"' --include='*.tf' . \
+  | xargs -r -n1 dirname \
+  | sed 's|^\./||' \
+  | sort -u \
+  | while IFS= read -r root; do
+    if [[ "$root" == "reindexer/terraform" ]]; then
+      continue
+    fi
+
+    echo "Linting ${root}"
+    tflint --chdir="${root}" --config="${config_file}" --format=compact --minimum-failure-severity=error
+  done
 ```
 
 ## Scala conventions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,27 +75,20 @@ uv run ruff check --fix
 Scope `pytest`/`mypy` paths to the area you changed when the project is large
 (e.g. `catalogue_graph/`); a full run can be slow.
 
+## Terraform conventions
+
 ### Before finalising a Terraform change
 
 Run from the repository root:
 
 ```bash
-tflint --init
+builds/run_tflint.sh
+```
 
-config_file="$(pwd)/.tflint.hcl"
+Optionally pass one or more Terraform roots to target a subset:
 
-grep -rlE '^\s*backend\s+"' --include='*.tf' . \
-  | xargs -r -n1 dirname \
-  | sed 's|^\./||' \
-  | sort -u \
-  | while IFS= read -r root; do
-    if [[ "$root" == "reindexer/terraform" ]]; then
-      continue
-    fi
-
-    echo "Linting ${root}"
-    tflint --chdir="${root}" --config="${config_file}" --format=compact --minimum-failure-severity=error
-  done
+```bash
+builds/run_tflint.sh calm_adapter/terraform infrastructure/adapter_stack
 ```
 
 ## Scala conventions

--- a/builds/run_tflint.sh
+++ b/builds/run_tflint.sh
@@ -15,12 +15,20 @@ else
   # A Terraform root is identified by having a backend configuration.
   # Child modules (under modules/, etc.) never declare a backend, so this
   # discovers every root without depending on a committed .terraform.lock.hcl.
-  mapfile -t terraform_roots < <(
-    grep -rlE '^\s*backend\s+"' --exclude-dir='.terraform' --include='*.tf' . \
-      | xargs -r -n1 dirname \
-      | sed 's|^\./||' \
-      | sort -u
-  )
+  roots_file="$(mktemp)"
+
+  while IFS= read -r tf_file; do
+    dirname "${tf_file}"
+  done < <(
+    grep -rlE '^[[:space:]]*backend[[:space:]]+"' --exclude-dir='.terraform' --include='*.tf' . || true
+  ) | sed 's|^\./||' | sort -u > "${roots_file}"
+
+  terraform_roots=()
+  while IFS= read -r root; do
+    terraform_roots+=("${root}")
+  done < "${roots_file}"
+
+  rm -f "${roots_file}"
 fi
 
 if [[ ${#terraform_roots[@]} -eq 0 ]]; then

--- a/builds/run_tflint.sh
+++ b/builds/run_tflint.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "${repo_root}"
+
+tflint --init
+
+config_file="${repo_root}/.tflint.hcl"
+
+if [[ $# -gt 0 ]]; then
+  terraform_roots=("$@")
+else
+  # A Terraform root is identified by having a backend configuration.
+  # Child modules (under modules/, etc.) never declare a backend, so this
+  # discovers every root without depending on a committed .terraform.lock.hcl.
+  mapfile -t terraform_roots < <(
+    grep -rlE '^\s*backend\s+"' --exclude-dir='.terraform' --include='*.tf' . \
+      | xargs -r -n1 dirname \
+      | sed 's|^\./||' \
+      | sort -u
+  )
+fi
+
+if [[ ${#terraform_roots[@]} -eq 0 ]]; then
+  echo "No Terraform roots found"
+  exit 1
+fi
+
+linted_roots=0
+
+for root in "${terraform_roots[@]}"; do
+  root="${root#./}"
+
+  if [[ "${root}" == "reindexer/terraform" ]]; then
+    echo "Skipping ${root}; this root currently fails static evaluation in a shared module"
+    continue
+  fi
+
+  if [[ ! -d "${root}" ]]; then
+    echo "Terraform root does not exist: ${root}" >&2
+    exit 1
+  fi
+
+  echo "Linting ${root}"
+  tflint --chdir="${root}" --config="${config_file}" --format=compact --minimum-failure-severity=error
+  linted_roots=$((linted_roots + 1))
+done
+
+if [[ ${linted_roots} -eq 0 ]]; then
+  echo "No Terraform roots were linted"
+  exit 1
+fi


### PR DESCRIPTION
## What does this change?

Adds [tflint](https://github.com/terraform-linters/tflint) as a Terraform linting step for the repository.

Four files are added or modified:

### `builds/run_tflint.sh` — shared tflint helper (new)

Extracts the Terraform-root discovery and lint loop into a single script so CI and local developer instructions share one source of truth and can't drift independently again.

- Discovers all Terraform roots by looking for files that declare a `backend` block (root modules only, not child modules). Excludes `.terraform/` directories so locally-cached provider modules can't be picked up as false roots.
- Accepts optional positional arguments to target specific roots (e.g. `builds/run_tflint.sh calm_adapter/terraform`) for faster local runs.
- Runs `tflint --init` then lints each root with `--minimum-failure-severity=error` so warnings don't fail CI.
- Skips `reindexer/terraform` (with a comment) because a shared module it references fails static evaluation without provider initialisation.

### `.tflint.hcl` — repo-level tflint configuration

- Module evaluation disabled (`call_module_type = "none"`) so static analysis doesn't follow cross-module references that require provider credentials to resolve.
- `terraform` plugin enabled with the `recommended` preset.
- `aws` ruleset pinned to v0.48.0 for reproducible runs.
- `terraform_naming_convention` enabled with an explicit comment noting it is **advisory**: the rule emits Notice-severity findings, which are logged but do not fail CI under the current `--minimum-failure-severity=error` threshold. (Dated module labels like `sierra-adapter-20200604` are a repo-wide pattern; enforcement would need a cleanup pass first.) The redundant `format = "snake_case"` default is omitted.

### `.github/workflows/tflint.yml` — CI workflow

Triggers on:
- Pull requests that touch any `.tf` file, `.terraform.lock.hcl`, `.tflint.hcl`, or the workflow itself.
- Pushes to `main` on the same paths.
- Manual `workflow_dispatch`.

The workflow now delegates entirely to `builds/run_tflint.sh` — the inline discovery loop has been removed. tflint pinned to v0.64 (updated from v0.54.0).

### `AGENTS.md` — local instructions for agents and developers

- Terraform guidance promoted to its own `## Terraform conventions` section (previously nested under `## Python conventions`).
- Local command simplified to `builds/run_tflint.sh`, matching CI exactly.

## How to test

1. Open a PR that modifies a `.tf` file and observe the **Terraform: tflint** check running.
2. Introduce a deliberate error (e.g. reference an undefined variable) and confirm the check fails.
3. Introduce a tflint warning (not an error) and confirm the check still passes.
4. Locally, from the repo root:
   ```bash
   builds/run_tflint.sh
   ```
   Or target a single root:
   ```bash
   builds/run_tflint.sh calm_adapter/terraform
   ```

## How can we measure success?

- The `tflint` check appears in the GitHub Actions tab for PRs that touch Terraform files.
- The check passes on `main` after merge.
- Future Terraform PRs surface errors that would previously only be caught in `terraform plan`.

## Have we considered potential risks?

- **False positives causing blocked PRs.** Mitigated by `--minimum-failure-severity=error`; only genuine errors block the check, not style warnings.
- **New failures on existing code.** The workflow was validated against all current Terraform roots before this PR was opened; all pass (aside from `reindexer/terraform` which is skipped with a comment).
- **Plugin version drift.** The aws ruleset is pinned to v0.48.0 in `.tflint.hcl` and tflint itself is pinned to v0.64 in the workflow, giving reproducible results until intentionally upgraded.
- **Local module cache false-positives.** The discovery grep excludes `.terraform/` directories, so cached provider modules cannot be picked up as Terraform roots.
