### PR TITLE
Axiell transformer: minor tweaks

### DIFF
--- a/catalogue_graph/src/adapters/transformers/axiell/contributors.py
+++ b/catalogue_graph/src/adapters/transformers/axiell/contributors.py
@@ -1,8 +1,8 @@
 from pymarc.record import Record
 
-from adapters.transformers.ebsco.label_subdivisions import build_concept
 from adapters.transformers.marc.common import non_empty_subfields
-from models.pipeline.concept import Contributor
+from models.pipeline.concept import Concept, Contributor
+from models.pipeline.identifier import Identifiable
 
 
 def extract_contributor_names(record: Record) -> list[str]:
@@ -11,4 +11,13 @@ def extract_contributor_names(record: Record) -> list[str]:
 
 def extract_contributors(record: Record) -> list[Contributor]:
     names = extract_contributor_names(record)
-    return [Contributor(agent=build_concept(name, "Agent")) for name in names]
+    return [
+        Contributor(
+            agent=Concept(
+                id=Identifiable.identifier_from_text(name, "Agent"),
+                label=name,
+                type="Agent",
+            )
+        )
+        for name in names
+    ]

--- a/catalogue_graph/src/adapters/transformers/axiell/organisation_and_arrangement.py
+++ b/catalogue_graph/src/adapters/transformers/axiell/organisation_and_arrangement.py
@@ -13,7 +13,8 @@ from models.pipeline.work_data import WorkType
 # TODO: There is a single Axiell work with the level 'Work' (collect:200000001). What work type should we map it to?
 
 # All raw level values are lowercased for consistency.
-# In Axiell, all `(?:sub)+section` levels (subsection, subsubsection, etc.) are mapped to 'sub-section'
+# In Axiell, nested subsection levels which existed in CALM (subsection, subsubsection, etc.)
+# are collapsed to a single 'sub-section' level.
 LEVEL_TO_WORK_TYPE_MAPPING: dict[str, WorkType] = {
     "collection": "Collection",
     "section": "Section",

--- a/catalogue_graph/src/adapters/transformers/axiell/organisation_and_arrangement.py
+++ b/catalogue_graph/src/adapters/transformers/axiell/organisation_and_arrangement.py
@@ -4,17 +4,16 @@ Extract organisation and arrangement from field
 https://www.loc.gov/marc/bibliographic/bd351.html
 """
 
+from models.pipeline.work_data import WorkType
 from pymarc.record import Record
 
 from adapters.transformers.marc.common import non_empty_subfields
 from adapters.transformers.marc.identifier import extract_id
-from models.pipeline.work_data import WorkType
 
 # TODO: There is a single Axiell work with the level 'Work' (collect:200000001). What work type should we map it to?
 
 # All raw level values are lowercased for consistency.
-# CALM has additional levels which currently don't exist in Axiell:
-# subsubsection, subsubsubsection, subsubseries, subsubsubseries
+# In Axiell, all `(?:sub)+section` levels (subsection, subsubsection, etc.) are mapped to 'sub-section'
 LEVEL_TO_WORK_TYPE_MAPPING: dict[str, WorkType] = {
     "collection": "Collection",
     "section": "Section",
@@ -23,6 +22,9 @@ LEVEL_TO_WORK_TYPE_MAPPING: dict[str, WorkType] = {
     "sub-series": "Series",
     "item": "Standard",
     "item part": "Standard",  # Equivalent of CALM 'piece'
+    # TODO: These appeared after the latest migration and are temporary. Remove before release. 
+    "sub-fonds": "Section",
+    "fonds": "Collection",
 }
 
 

--- a/catalogue_graph/src/adapters/transformers/axiell/organisation_and_arrangement.py
+++ b/catalogue_graph/src/adapters/transformers/axiell/organisation_and_arrangement.py
@@ -4,11 +4,11 @@ Extract organisation and arrangement from field
 https://www.loc.gov/marc/bibliographic/bd351.html
 """
 
-from models.pipeline.work_data import WorkType
 from pymarc.record import Record
 
 from adapters.transformers.marc.common import non_empty_subfields
 from adapters.transformers.marc.identifier import extract_id
+from models.pipeline.work_data import WorkType
 
 # TODO: There is a single Axiell work with the level 'Work' (collect:200000001). What work type should we map it to?
 
@@ -22,7 +22,7 @@ LEVEL_TO_WORK_TYPE_MAPPING: dict[str, WorkType] = {
     "sub-series": "Series",
     "item": "Standard",
     "item part": "Standard",  # Equivalent of CALM 'piece'
-    # TODO: These appeared after the latest migration and are temporary. Remove before release. 
+    # TODO: These appeared after the latest migration and are temporary. Remove before release.
     "sub-fonds": "Section",
     "fonds": "Collection",
 }

--- a/catalogue_graph/src/adapters/transformers/utils/html.py
+++ b/catalogue_graph/src/adapters/transformers/utils/html.py
@@ -1,4 +1,3 @@
-import html
 from typing import Literal
 from urllib.parse import urlparse
 
@@ -70,7 +69,7 @@ def normalise_text(s: str, allowed_tags: AllowedTags = "basic") -> str:
             continue
         result.append(line)
 
-    return html.unescape("\n".join(result)).strip()
+    return "\n".join(result).strip()
 
 
 def is_url(maybe_url: str) -> bool:

--- a/catalogue_graph/tests/adapters/transformers/axiell/bdd/features/contributors.feature
+++ b/catalogue_graph/tests/adapters/transformers/axiell/bdd/features/contributors.feature
@@ -21,10 +21,10 @@ Feature: Contributors extraction from Axiell MARC records
     And the only contributor has the agent.label "Smith, John"
     And the only contributor has the agent.type "Agent"
 
-  Scenario: Trailing comma in name is stripped
-    Given the MARC record has a 720 field with subfield "a" value "Smith, John,"
+  Scenario: Trailing period in name is not stripped
+    Given the MARC record has a 720 field with subfield "a" value "Smith, John."
     When I transform the MARC record
-    Then the only contributor has the agent.label "Smith, John"
+    Then the only contributor has the agent.label "Smith, John."
 
   Scenario: Multiple contributors preserve order
     Given the MARC record has a 720 field with subfield "a" value "Smith, John"

--- a/catalogue_graph/tests/adapters/transformers/utils/test_html.py
+++ b/catalogue_graph/tests/adapters/transformers/utils/test_html.py
@@ -67,8 +67,8 @@ def test_normalise_retains_links_stripping_non_href_attributes() -> None:
 
 
 def test_normalise_escapes_symbols() -> None:
-    s = "Ampersand &amp; some other symbols like &gt;."
-    assert normalise_text(s) == s
+    s = "Ampersand & some other symbols like >."
+    assert normalise_text(s) == "Ampersand &amp; some other symbols like &gt;."
 
 
 def test_normalise_strips_hreflang_from_links() -> None:

--- a/catalogue_graph/tests/adapters/transformers/utils/test_html.py
+++ b/catalogue_graph/tests/adapters/transformers/utils/test_html.py
@@ -39,6 +39,13 @@ def test_normalise_removes_script_tags_and_inner_content() -> None:
     assert normalise_text(s) == "Nothing here... Nothing."
 
 
+def test_normalise_treats_html_encoded_script_tags_as_text() -> None:
+    # &lt;script&gt; is an HTML-encoded literal, not an executable tag.
+    # It should be preserved as-is rather than decoded into a script element.
+    s = "&lt;script&gt;alert(1)&lt;/script&gt;"
+    assert normalise_text(s) == s
+
+
 def test_normalise_does_not_error_on_missing_closing_tags() -> None:
     assert (
         normalise_text("Someone forgot <em>to close something..")

--- a/catalogue_graph/tests/adapters/transformers/utils/test_html.py
+++ b/catalogue_graph/tests/adapters/transformers/utils/test_html.py
@@ -59,8 +59,8 @@ def test_normalise_retains_links_stripping_non_href_attributes() -> None:
     )
 
 
-def test_normalise_does_not_escape_symbols() -> None:
-    s = "Ampersand & some other symbols like >."
+def test_normalise_escapes_symbols() -> None:
+    s = "Ampersand &amp; some other symbols like &gt;."
     assert normalise_text(s) == s
 
 


### PR DESCRIPTION
## What does this change?

https://github.com/wellcomecollection/platform/issues/6337

* Do not normalise contributor labels in the Axiell transformer, mirroring the CALM transformer (see `CalmContributors.scala`).
* Do not unescape HTML after sanitising it in the `normalise_text` function. Unescaping creates a XSS vulnerability, since the frontend renders HTML text using `dangerouslySetInnerHTML`.
* Add two more hierarchical levels to `LEVEL_TO_WORK_TYPE_MAPPING`. These are temporary (as indicated in a spreadsheet by collections info), but for now they are needed to allow us to transform works correctly.

## How to test

Transform a test document using the Axiell transformer.

Transform a work with a malicious description (e.g. `&lt;script&gt;alert(1)&lt;/script&gt;`). Previously, the escaped HTML would get unescaped, producing in the `<script>alert(1)</script>` element, resulting in an alert pop-up on the work page. With this change, the malicious description stays escaped. 

## How can we measure success?

* Contributor parity between Axiell and CALM
* Removal of XSS vulnerability

## Have we considered potential risks?

This change is low risk and does not affect production.

Removing the unescape call creates a divergence from the Scala pipeline. However, this is desirable, since:
* It removes an XSS attack vector
* The Scala pipeline called unescape to remove HTML symbol entities (e.g. replacing `&amp;` with `&`), which is not what we want anyway, since the frontend expects the fields to contain valid HTML and will escape the symbols before rendering the final text.
