### PR TITLE
Fix graph integration tests

### DIFF
--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -7,6 +7,9 @@ inputs:
   slack_webhook_secret_id:
     description: "Secrets Manager secret id/name for the Slack failure alert webhook"
     required: true
+  graph_date:
+    description: "Neptune graph date (empty string for the legacy production cluster)"
+    required: true
 runs:
   using: "composite"
   steps:
@@ -29,6 +32,8 @@ runs:
         uv run pytest -m "integration"
       working-directory: catalogue_graph
       shell: bash
+      env:
+        GRAPH_DATE: ${{ inputs.graph_date }}
 
     - name: Get Slack webhook URL
       if: ${{ failure() }}

--- a/.github/workflows/catalogue-graph-ci.yml
+++ b/.github/workflows/catalogue-graph-ci.yml
@@ -75,11 +75,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: eu-west-1
+          role-to-assume: ${{ secrets.CATALOGUE_GRAPH_CI_ROLE_ARN }}
+      - name: Get production graph date
+        id: graph_date
+        run: |
+          VALUE=$(aws ssm get-parameter \
+            --name /catalogue_graph/production_graph_date \
+            --query Parameter.Value --output text)
+          echo "value=$VALUE" >> "$GITHUB_OUTPUT"
+        shell: bash
       - uses: ./.github/actions/run-integration-tests
         with:
           role_to_assume: ${{ secrets.CATALOGUE_GRAPH_CI_ROLE_ARN }}
           slack_webhook_secret_id: monitoring/critical_slack_webhook
-          graph_date: ""
+          graph_date: ${{ steps.graph_date.outputs.value }}
 
   deploy:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/.github/workflows/catalogue-graph-ci.yml
+++ b/.github/workflows/catalogue-graph-ci.yml
@@ -71,7 +71,7 @@ jobs:
           publish_latest: ${{ github.ref == 'refs/heads/main' }}
 
   integration:
-    if: (github.ref == 'refs/heads/main' && github.event_name == 'push') || github.event_name == 'workflow_dispatch'
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/catalogue-graph-ci.yml
+++ b/.github/workflows/catalogue-graph-ci.yml
@@ -79,6 +79,7 @@ jobs:
         with:
           role_to_assume: ${{ secrets.CATALOGUE_GRAPH_CI_ROLE_ARN }}
           slack_webhook_secret_id: monitoring/critical_slack_webhook
+          graph_date: ""
 
   deploy:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/.github/workflows/catalogue-graph-ci.yml
+++ b/.github/workflows/catalogue-graph-ci.yml
@@ -71,7 +71,7 @@ jobs:
           publish_latest: ${{ github.ref == 'refs/heads/main' }}
 
   integration:
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: (github.ref == 'refs/heads/main' && github.event_name == 'push') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/builds/terraform/github/gha_role_catalogue_graph.tf
+++ b/builds/terraform/github/gha_role_catalogue_graph.tf
@@ -68,7 +68,6 @@ data "aws_iam_policy_document" "gha_catalogue_graph_ci" {
       "secretsmanager:DescribeSecret",
     ]
     resources = [
-      data.terraform_remote_state.catalogue_graph.outputs.neptune_nlb_url_secret_arn,
       data.terraform_remote_state.catalogue_graph.outputs.neptune_cluster_endpoint_secret_arn,
       data.aws_secretsmanager_secret.wc_platform_alerts_slack_webhook.arn,
     ]
@@ -92,6 +91,15 @@ data "aws_iam_policy_document" "gha_catalogue_graph_ci" {
 
     resources = [
       data.terraform_remote_state.catalogue_graph.outputs.neptune_cluster_data_access_arn
+    ]
+  }
+
+  statement {
+    actions = [
+      "ssm:GetParameter",
+    ]
+    resources = [
+      "arn:aws:ssm:eu-west-1:760097843905:parameter/catalogue_graph/production_graph_date",
     ]
   }
 }

--- a/catalogue_graph/infra/graph/modules/catalogue_graph/outputs.tf
+++ b/catalogue_graph/infra/graph/modules/catalogue_graph/outputs.tf
@@ -13,3 +13,7 @@ output "neptune_cluster_data_access_arn" {
 output "neptune_cluster_endpoint_secret_arn" {
   value = aws_secretsmanager_secret.neptune_cluster_endpoint.arn
 }
+
+output "graph_date" {
+  value = var.graph_date
+}

--- a/catalogue_graph/infra/graph/neptune.tf
+++ b/catalogue_graph/infra/graph/neptune.tf
@@ -38,3 +38,10 @@ module "catalogue_graph_neptune_cluster_dev" {
     aws.dns = aws.dns
   }
 }
+
+resource "aws_ssm_parameter" "production_graph_date" {
+  name        = "/catalogue_graph/production_graph_date"
+  type        = "String"
+  description = "The graph_date of the current production Neptune cluster, read by CI."
+  value       = module.catalogue_graph_neptune_cluster.graph_date != "" ? module.catalogue_graph_neptune_cluster.graph_date : "prod"
+}

--- a/catalogue_graph/infra/graph/neptune.tf
+++ b/catalogue_graph/infra/graph/neptune.tf
@@ -43,4 +43,5 @@ resource "aws_ssm_parameter" "production_graph_date" {
   name        = "/catalogue_graph/production_graph_date"
   type        = "String"
   description = "The graph_date of the current production Neptune cluster (or 'prod' for the legacy cluster), read by CI."
+  value       = module.catalogue_graph_neptune_cluster.graph_date != "" ? module.catalogue_graph_neptune_cluster.graph_date : "prod"
 }

--- a/catalogue_graph/infra/graph/neptune.tf
+++ b/catalogue_graph/infra/graph/neptune.tf
@@ -42,6 +42,5 @@ module "catalogue_graph_neptune_cluster_dev" {
 resource "aws_ssm_parameter" "production_graph_date" {
   name        = "/catalogue_graph/production_graph_date"
   type        = "String"
-  description = "The graph_date of the current production Neptune cluster, read by CI."
-  value       = module.catalogue_graph_neptune_cluster.graph_date != "" ? module.catalogue_graph_neptune_cluster.graph_date : "prod"
+  description = "The graph_date of the current production Neptune cluster (or 'prod' for the legacy cluster), read by CI."
 }

--- a/catalogue_graph/integration/graph/test_graph_queries.py
+++ b/catalogue_graph/integration/graph/test_graph_queries.py
@@ -49,7 +49,9 @@ GRAPH_DATE = os.environ.get("GRAPH_DATE")
 @lru_cache(maxsize=1)
 def neptune_client() -> NeptuneClient:
     if GRAPH_DATE is None:
-        raise ValueError("GRAPH_DATE environment variable must be set to run integration tests")
+        raise ValueError(
+            "GRAPH_DATE environment variable must be set to run integration tests"
+        )
     return NeptuneClient(GRAPH_DATE)
 
 

--- a/catalogue_graph/integration/graph/test_graph_queries.py
+++ b/catalogue_graph/integration/graph/test_graph_queries.py
@@ -43,11 +43,13 @@ from ingestor.queries.work_queries import (
 pytestmark = pytest.mark.integration
 
 
-GRAPH_DATE = os.environ["GRAPH_DATE"]
+GRAPH_DATE = os.environ.get("GRAPH_DATE")
 
 
 @lru_cache(maxsize=1)
 def neptune_client() -> NeptuneClient:
+    if GRAPH_DATE is None:
+        raise ValueError("GRAPH_DATE environment variable must be set to run integration tests")
     return NeptuneClient(GRAPH_DATE)
 
 

--- a/catalogue_graph/integration/graph/test_graph_queries.py
+++ b/catalogue_graph/integration/graph/test_graph_queries.py
@@ -4,11 +4,12 @@ These tests use the live database, so they are marked as `integration` and
 deselected by default in pytest config.
 
 Usage:
-    AWS_PROFILE=platform-developer uv run pytest -m "integration"
+    GRAPH_DATE=2026-01-01 AWS_PROFILE=platform-developer uv run pytest -m "integration"
 """
 
 import csv
 import json
+import os
 import warnings
 from functools import cache, lru_cache
 from pathlib import Path
@@ -42,9 +43,12 @@ from ingestor.queries.work_queries import (
 pytestmark = pytest.mark.integration
 
 
+GRAPH_DATE = os.environ["GRAPH_DATE"]
+
+
 @lru_cache(maxsize=1)
 def neptune_client() -> NeptuneClient:
-    return NeptuneClient("prod")
+    return NeptuneClient(GRAPH_DATE)
 
 
 @cache

--- a/catalogue_graph/src/clients/neptune_client.py
+++ b/catalogue_graph/src/clients/neptune_client.py
@@ -63,8 +63,10 @@ class NeptuneClient:
     def namespace(self) -> str:
         # The current production cluster was created before we introduced graph dates, requiring the if/else statement.
         # We can simplify this once we switch to a dated cluster.
-        date_infix = f"-{self.graph_date}" if self.graph_date else ""
-        return f"catalogue-graph{date_infix}"
+        if self.graph_date == "prod" or not self.graph_date:
+            return "catalogue-graph"
+
+        return f"catalogue-graph-{self.graph_date}"
 
     def _get_client_url(self) -> str:
         return f"https://{self.neptune_endpoint}:{NEPTUNE_PORT}"

--- a/catalogue_graph/src/clients/neptune_client.py
+++ b/catalogue_graph/src/clients/neptune_client.py
@@ -61,9 +61,11 @@ class NeptuneClient:
 
     @property
     def namespace(self) -> str:
-        # The current production cluster was created before we introduced graph dates, requiring the if/else statement.
-        # We can simplify this once we switch to a dated cluster.
-        if self.graph_date == "prod" or not self.graph_date:
+        # The current production cluster was created before we introduced graph dates. Its graph date is blank to
+        # preserve its Neptune cluster ID. In places which do not support empty labels (SSM, CloudWatch metrics, S3),
+        # the cluster is labelled `prod`, so both `` and `prod` refer to the same legacy production cluster.
+        # This is confusing, but temporary. Once we switch to a new (dated) cluster, we will be able to remove this.
+        if self.graph_date in ("prod", ""):
             return "catalogue-graph"
 
         return f"catalogue-graph-{self.graph_date}"


### PR DESCRIPTION
## What does this change?

Follows https://github.com/wellcomecollection/catalogue-pipeline/pull/3458

* Update graph integration tests to expect a `GRAPH_DATE` environment variable. (Previously, tests always ran against the fixed prod cluster).
* Add an SSM parameter storing the graph date of the current production cluster, managed from the same Terraform stack as the Neptune clusters themselves.
* Read the new SSM parameter as part of the GitHub action and pass it to the integration tests as an environment variable.

## How to test

I tested the GitHub action on this branch, verifying that integration tests succeed. 

## How can we measure success?

* The GitHub action running integration tests against the Neptune cluster should stop failing.
*  When we provision a new production cluster in Terraform, the GitHub action should automatically run integration tests against the new cluster.

## Have we considered potential risks?

This change is low risk.
