### PR TITLE
Handle missing GUIDs in reconciler + publish transformer run metrics

### DIFF
--- a/catalogue_graph/src/adapters/steps/transformer.py
+++ b/catalogue_graph/src/adapters/steps/transformer.py
@@ -29,6 +29,7 @@ from adapters.transformers.manifests import (
     TransformerManifest,
     TransformerManifestWriter,
 )
+from adapters.transformers.reporting import TransformerReport
 from adapters.transformers.source_work_transformer import (
     SourceWorkTransformer,
 )
@@ -198,6 +199,25 @@ def handler(
         successful_ids=transformer.successful_ids,
         errors=transformer.errors,
     )
+
+    success_count = result.successes.count
+    failure_count = result.failures.count if result.failures else 0
+
+    logger.info(
+        "Transformation complete",
+        job_id=event.job_id,
+        transformer_type=event.transformer_type,
+        success_count=success_count,
+        failure_count=failure_count,
+    )
+
+    TransformerReport(
+        pipeline_date=config.PIPELINE_DATE,
+        transformer_type=event.transformer_type,
+        success_count=success_count,
+        failure_count=failure_count,
+    ).publish()
+
     return result
 
 

--- a/catalogue_graph/src/adapters/transformers/axiell_reconciler.py
+++ b/catalogue_graph/src/adapters/transformers/axiell_reconciler.py
@@ -49,9 +49,12 @@ class AxiellReconciler(SourceWorkTransformer):
             builder = AxiellWorkBuilder(marc_record, adapter_row["last_modified"])
             return builder.source_identifier.value
         except Exception as e:
-            logger.error(
-                "Error extracting record GUID", row_id=adapter_row["id"], error=str(e)
-            )
+            if adapter_row["id"] not in self.error_ids:  # only log on first encounter
+                logger.error(
+                    "Error extracting record GUID",
+                    row_id=adapter_row["id"],
+                    error=str(e),
+                )
             self._add_error(e, "transform", adapter_row["id"])
             return None
 

--- a/catalogue_graph/src/adapters/transformers/axiell_reconciler.py
+++ b/catalogue_graph/src/adapters/transformers/axiell_reconciler.py
@@ -45,8 +45,15 @@ class AxiellReconciler(SourceWorkTransformer):
         if not marc_record:
             return None
 
-        builder = AxiellWorkBuilder(marc_record, adapter_row["last_modified"])
-        return builder.source_identifier.value
+        try:
+            builder = AxiellWorkBuilder(marc_record, adapter_row["last_modified"])
+            return builder.source_identifier.value
+        except Exception as e:
+            logger.error(
+                "Error extracting record GUID", row_id=adapter_row["id"], error=str(e)
+            )
+            self._add_error(e, "transform", adapter_row["id"])
+            return None
 
     def _rows_to_reconciler_arrow_table(
         self, rows: Iterable[dict[str, Any]]

--- a/catalogue_graph/src/adapters/transformers/reporting.py
+++ b/catalogue_graph/src/adapters/transformers/reporting.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import ClassVar, Literal
+
+from utils.reporting import PipelineMetric, PipelineReport
+
+
+class TransformerReport(PipelineReport):
+    label: ClassVar[str] = "adapter_transformer"
+
+    pipeline_date: str
+    transformer_type: str
+    success_count: int
+    failure_count: int
+    # S3 publishing is disabled because the manifest writer already writes
+    # successes and failures to S3, from which these counts can be inferred.
+    publish_to_s3: Literal[False] = False
+
+    @property
+    def publish_to_cloudwatch(self) -> bool:
+        return self.pipeline_date != "dev"
+
+    @property
+    def metric_namespace(self) -> str:
+        return "catalogue_graph_pipeline"
+
+    @property
+    def metric_dimensions(self) -> dict:
+        return {
+            "pipeline_date": self.pipeline_date,
+            "transformer_type": self.transformer_type,
+        }
+
+    @property
+    def metrics(self) -> list[PipelineMetric]:
+        return [
+            PipelineMetric(name="success_count", value=self.success_count),
+            PipelineMetric(name="failure_count", value=self.failure_count),
+        ]

--- a/catalogue_graph/tests/adapters/transformers/axiell/test_reconciler_transformer.py
+++ b/catalogue_graph/tests/adapters/transformers/axiell/test_reconciler_transformer.py
@@ -16,6 +16,13 @@ from adapters.utils.schemata import (
 )
 from tests.mocks import MockElasticsearchClient, MockSmartOpen
 
+CONTENT_WITHOUT_001 = (
+    "<record><leader>00000nam a2200000   4500</leader>"
+    "<datafield tag='245' ind1='0' ind2='0'>"
+    "<subfield code='a'>Title without GUID</subfield>"
+    "</datafield></record>"
+)
+
 
 def _marcxml(guid: str) -> str:
     return (
@@ -477,9 +484,18 @@ def test_reconciler_skips_missing_or_invalid_content(
                     "last_modified": datetime.now(UTC),
                     "deleted": False,
                 },
+                {
+                    "namespace": "axiell",
+                    "id": "collect-missing-001",
+                    "content": CONTENT_WITHOUT_001,
+                    "changeset": None,
+                    "last_modified": datetime.now(UTC),
+                    "deleted": False,
+                },
             ]
         )
     )
+
     assert adapter_changeset is not None
 
     result = _run_reconciler(
@@ -493,7 +509,7 @@ def test_reconciler_skips_missing_or_invalid_content(
 
     assert result.successes.count == 0
     assert result.failures is not None
-    assert result.failures.count == 2
+    assert result.failures.count == 3
     assert MockElasticsearchClient.inputs == []
 
 
@@ -527,40 +543,18 @@ def _make_reconciler(
     )
 
 
-def test_get_record_guid_returns_none_when_content_missing(
-    temporary_table: IcebergTable,
-    reconciler_temporary_table: IcebergTable,
-) -> None:
-    """A row with no MARC content returns None and records an error without raising."""
-    reconciler = _make_reconciler(temporary_table, reconciler_temporary_table)
-    row = {
-        "id": "collect-no-content",
-        "content": None,
-        "last_modified": datetime.now(UTC),
-    }
-
-    result = reconciler._get_record_guid(row)
-
-    assert result is None
-    assert len(reconciler.errors) == 1
-    assert reconciler.errors[0].row_id == "collect-no-content"
-
-
 def test_get_record_guid_returns_none_and_logs_error_when_guid_missing(
     temporary_table: IcebergTable,
     reconciler_temporary_table: IcebergTable,
 ) -> None:
-    """A valid MARC record without a 001 field cannot yield a GUID; the run continues and the record is logged as an error."""
+    """
+    A valid MARC record without a 001 field cannot yield a GUID. The run continues and the record is logged as an error.
+    """
     reconciler = _make_reconciler(temporary_table, reconciler_temporary_table)
-    content_without_001 = (
-        "<record><leader>00000nam a2200000   4500</leader>"
-        "<datafield tag='245' ind1='0' ind2='0'>"
-        "<subfield code='a'>Title without GUID</subfield>"
-        "</datafield></record>"
-    )
+
     row = {
         "id": "collect-no-guid",
-        "content": content_without_001,
+        "content": CONTENT_WITHOUT_001,
         "last_modified": datetime.now(UTC),
     }
 

--- a/catalogue_graph/tests/adapters/transformers/axiell/test_reconciler_transformer.py
+++ b/catalogue_graph/tests/adapters/transformers/axiell/test_reconciler_transformer.py
@@ -6,6 +6,7 @@ import pytest
 from pyiceberg.table import Table as IcebergTable
 
 from adapters.steps.transformer import TransformerEvent, handler
+from adapters.transformers.axiell_reconciler import AxiellReconciler
 from adapters.transformers.manifests import TransformerManifest
 from adapters.utils.adapter_store import AdapterStore
 from adapters.utils.reconciler_store import ReconcilerStore
@@ -511,3 +512,79 @@ def test_reconciler_requires_changeset_id(
             reconciler_temporary_table,
             [],
         )
+
+
+def _make_reconciler(
+    temporary_table: IcebergTable,
+    reconciler_temporary_table: IcebergTable,
+) -> AxiellReconciler:
+    return AxiellReconciler(
+        adapter_store=AdapterStore(temporary_table, namespace="axiell"),
+        changeset_ids=[],
+        reconciler_store=ReconcilerStore(
+            reconciler_temporary_table, namespace="axiell"
+        ),
+    )
+
+
+def test_get_record_guid_returns_none_when_content_missing(
+    temporary_table: IcebergTable,
+    reconciler_temporary_table: IcebergTable,
+) -> None:
+    """A row with no MARC content returns None and records an error without raising."""
+    reconciler = _make_reconciler(temporary_table, reconciler_temporary_table)
+    row = {
+        "id": "collect-no-content",
+        "content": None,
+        "last_modified": datetime.now(UTC),
+    }
+
+    result = reconciler._get_record_guid(row)
+
+    assert result is None
+    assert len(reconciler.errors) == 1
+    assert reconciler.errors[0].row_id == "collect-no-content"
+
+
+def test_get_record_guid_returns_none_and_logs_error_when_guid_missing(
+    temporary_table: IcebergTable,
+    reconciler_temporary_table: IcebergTable,
+) -> None:
+    """A valid MARC record without a 001 field cannot yield a GUID; the run continues and the record is logged as an error."""
+    reconciler = _make_reconciler(temporary_table, reconciler_temporary_table)
+    content_without_001 = (
+        "<record><leader>00000nam a2200000   4500</leader>"
+        "<datafield tag='245' ind1='0' ind2='0'>"
+        "<subfield code='a'>Title without GUID</subfield>"
+        "</datafield></record>"
+    )
+    row = {
+        "id": "collect-no-guid",
+        "content": content_without_001,
+        "last_modified": datetime.now(UTC),
+    }
+
+    result = reconciler._get_record_guid(row)
+
+    assert result is None
+    assert len(reconciler.errors) == 1
+    assert reconciler.errors[0].row_id == "collect-no-guid"
+    assert reconciler.errors[0].stage == "transform"
+
+
+def test_get_record_guid_returns_guid_for_valid_record(
+    temporary_table: IcebergTable,
+    reconciler_temporary_table: IcebergTable,
+) -> None:
+    """A MARC record with a 001 field returns the GUID value and records no errors."""
+    reconciler = _make_reconciler(temporary_table, reconciler_temporary_table)
+    row = {
+        "id": "collect-valid",
+        "content": _marcxml("expected-guid"),
+        "last_modified": datetime.now(UTC),
+    }
+
+    result = reconciler._get_record_guid(row)
+
+    assert result == "expected-guid"
+    assert reconciler.errors == []

--- a/catalogue_graph/tests/adapters/transformers/test_reporting.py
+++ b/catalogue_graph/tests/adapters/transformers/test_reporting.py
@@ -1,0 +1,103 @@
+import pytest
+from pyiceberg.table import Table as IcebergTable
+
+import adapters.extractors.oai_pmh.folio.config as adapter_config
+from adapters.extractors.oai_pmh.folio.runtime import FOLIO_CONFIG
+from adapters.steps.transformer import TransformerEvent, handler
+from tests.adapters.extractors.ebsco.helpers import prepare_changeset
+from tests.adapters.transformers.folio.helpers import make_items_store
+from tests.mocks import MockCloudwatchClient
+
+FOLIO_NAMESPACE = FOLIO_CONFIG.config.adapter_namespace
+
+_MINIMAL_RECORD = (
+    "<record>"
+    "<leader>00000nam a2200000   4500</leader>"
+    "<controlfield tag='005'>20261225123045.0</controlfield>"
+    "<controlfield tag='001'>{id}</controlfield>"
+    "<datafield tag='245' ind1='0' ind2='0'>"
+    "<subfield code='a'>Title {id}</subfield>"
+    "</datafield>"
+    "</record>"
+)
+
+
+def _run_transform(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    changeset_ids: list[str],
+    pipeline_date: str = "2026-01-01",
+) -> None:
+    monkeypatch.setattr(adapter_config, "PIPELINE_DATE", pipeline_date)
+    monkeypatch.setattr(adapter_config, "INDEX_DATE", None)
+
+    items_store = make_items_store({})
+    monkeypatch.setattr(
+        "adapters.steps.transformer.build_items_store",
+        lambda **kwargs: items_store,
+    )
+
+    event = TransformerEvent(
+        transformer_type="folio",
+        job_id="20260101T1200",
+        changeset_ids=changeset_ids,
+    )
+    handler(event=event, es_mode="local", use_rest_api_table=False)
+
+
+def test_transformer_run_publishes_counts_to_cloudwatch(
+    temporary_table: IcebergTable, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    changeset_id = prepare_changeset(
+        temporary_table,
+        monkeypatch,
+        {
+            "fo00001": _MINIMAL_RECORD.format(id="fo00001"),
+            "fo00002": _MINIMAL_RECORD.format(id="fo00002"),
+            "fo00003": "invalid data",
+        },
+        namespace=FOLIO_NAMESPACE,
+        transformer_type="folio",
+    )
+
+    _run_transform(monkeypatch, changeset_ids=[changeset_id])
+
+    reported = {m["metric_name"]: m for m in MockCloudwatchClient.metrics_reported}
+    assert reported["success_count"]["value"] == 2
+    assert reported["failure_count"]["value"] == 1
+
+
+def test_transformer_run_cloudwatch_dimensions(
+    temporary_table: IcebergTable, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    changeset_id = prepare_changeset(
+        temporary_table,
+        monkeypatch,
+        {"fo00001": _MINIMAL_RECORD.format(id="fo00001")},
+        namespace=FOLIO_NAMESPACE,
+        transformer_type="folio",
+    )
+
+    _run_transform(
+        monkeypatch, changeset_ids=[changeset_id], pipeline_date="2026-03-15"
+    )
+
+    for metric in MockCloudwatchClient.metrics_reported:
+        assert metric["dimensions"]["pipeline_date"] == "2026-03-15"
+        assert metric["dimensions"]["transformer_type"] == "folio"
+
+
+def test_transformer_run_skips_cloudwatch_for_dev_pipeline_date(
+    temporary_table: IcebergTable, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    changeset_id = prepare_changeset(
+        temporary_table,
+        monkeypatch,
+        {"fo00001": _MINIMAL_RECORD.format(id="fo00001")},
+        namespace=FOLIO_NAMESPACE,
+        transformer_type="folio",
+    )
+
+    _run_transform(monkeypatch, changeset_ids=[changeset_id], pipeline_date="dev")
+
+    assert MockCloudwatchClient.metrics_reported == []

--- a/pipeline/terraform/modules/pipeline/state_machine_transformers.tf
+++ b/pipeline/terraform/modules/pipeline/state_machine_transformers.tf
@@ -181,6 +181,46 @@ module "transformer_state_machine_alarms" {
   }
 }
 
+resource "aws_iam_role_policy" "transformer_lambda_cloudwatch_write" {
+  role   = module.transformer_lambda.lambda_role.name
+  policy = data.aws_iam_policy_document.transformer_lambda_cloudwatch_write.json
+}
+
+data "aws_iam_policy_document" "transformer_lambda_cloudwatch_write" {
+  statement {
+    actions   = ["cloudwatch:PutMetricData"]
+    resources = ["*"]
+  }
+}
+
+locals {
+  # All transformer types that can report failure_count metrics, including
+  # axiell_reconciler which is invoked from within the state machine.
+  all_transformer_types = toset(concat(keys(local.transformer_types), ["axiell_reconciler"]))
+}
+
+resource "aws_cloudwatch_metric_alarm" "transformer_failures" {
+  for_each = local.all_transformer_types
+
+  alarm_name          = "${each.key}-transformer-failures-${var.pipeline_date}"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "failure_count"
+  namespace           = "catalogue_graph_pipeline"
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 0
+  alarm_description   = "${each.key} adapter transformer Lambda reported transformation failures"
+
+  dimensions = {
+    pipeline_date    = var.pipeline_date
+    pipeline_step    = "adapter_transformer"
+    transformer_type = each.key
+  }
+
+  alarm_actions = [local.monitoring_infra["chatbot_topic_arn"]]
+}
+
 # Trigger State Machine on adapter completed events
 module "adapter_transformer_trigger" {
   for_each = local.transformer_types


### PR DESCRIPTION
## What does this change?

https://github.com/wellcomecollection/platform/issues/6437

* Handle missing GUIDs in reconciler: Previously, a single adapter record with a missing GUID would cause the Axiell reconciler service to fail. This change places GUID lookup into a try/except block, recording all failures in `self.errors` so that they can be included in the run manifest.
* Publish CloudWatch metrics as part of each transformer run: Unlike other services in the pipeline, the transformer does not currently publish run metrics. Combined with the per-row error isolation, this means that even if all rows failed to process, the state machine would succeed and we would not be alerted. This PR ensures that success/failure count metrics are published at the end of each run and wired to an alarm (mirroring the ID minter service).

## How to test

Both changes are covered by unit tests.

## How can we measure success?

* The reconciler should proceed even when some records it processes do not have a valid GUID, ensuring that one bad record does not block valid records from being processed.
* All transformers should publish run metrics at the end of each run, wired to a CloudWatch alarm. If a run fails to process one or more records, we will be alerted on Slack.

## Have we considered potential risks?

If one of the source systems frequently returns invalid records (e.g. missing required fields), a large percentage of runs would have at least one failed record, resulting in too many Slack notifications. Should this happen, we would have to revisit the alarm added in this PR (increasing the alarm threshold or replacing it with a Grafana dashboard).
