### PR TITLE
Tweak graph integration test

### DIFF
--- a/catalogue_graph/integration/graph/fixtures/work_ids_without_ancestors.json
+++ b/catalogue_graph/integration/graph/fixtures/work_ids_without_ancestors.json
@@ -18,5 +18,5 @@
   "q32vd33u",
   "pscmd6m5",
   "stgstg28",
-  "gcrgjr2c"
+  "a22526q9"
 ]


### PR DESCRIPTION
## What does this change?

One of the works we use in our `work_ids_without_ancestors` graph integration test (which randomly chooses a small set of non-archive works and verifies that none of them have an ancestor in the graph) now has an ancestor. 

This change came from the source system and is valid, so I swapped the work for a different one to stop the test from failing. 
