### PR TITLE
Add Axiell support to matcher/merger

### DIFF
--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/generators/AxiellWorkGenerators.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/generators/AxiellWorkGenerators.scala
@@ -4,8 +4,9 @@ import weco.catalogue.internal_model.work.{Work, WorkState}
 
 trait AxiellWorkGenerators extends WorkGenerators with ItemsGenerators {
 
+  private def createAxiellItem = createCalmItem
+
   def axiellIdentifiedWork(): Work.Visible[WorkState.Identified] =
     identifiedWork(sourceIdentifier = createAxiellSourceIdentifier)
-      .items(List(createCalmItem))
-
+      .items(List(createAxiellItem))
 }

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/generators/AxiellWorkGenerators.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/generators/AxiellWorkGenerators.scala
@@ -1,0 +1,11 @@
+package weco.catalogue.internal_model.work.generators
+
+import weco.catalogue.internal_model.work.{Work, WorkState}
+
+trait AxiellWorkGenerators extends WorkGenerators with ItemsGenerators {
+
+  def axiellIdentifiedWork(): Work.Visible[WorkState.Identified] =
+    identifiedWork(sourceIdentifier = createAxiellSourceIdentifier)
+      .items(List(createCalmItem))
+
+}

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/generators/SourceWorkGenerators.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/generators/SourceWorkGenerators.scala
@@ -5,4 +5,5 @@ trait SourceWorkGenerators
     with MiroWorkGenerators
     with MetsWorkGenerators
     with CalmWorkGenerators
+    with AxiellWorkGenerators
     with TeiWorkGenerators

--- a/pipeline/matcher_merger/matcher/src/test/scala/weco/pipeline/matcher/generators/MergeCandidateGenerators.scala
+++ b/pipeline/matcher_merger/matcher/src/test/scala/weco/pipeline/matcher/generators/MergeCandidateGenerators.scala
@@ -38,6 +38,15 @@ trait MergeCandidateGenerators {
       reason = "Calm/Sierra harvest"
     )
 
+  def createAxiellMergeCandidateFor(
+    w: Work[WorkState.Identified]
+  ): MergeCandidate[IdState.Identified] =
+    createMergeCandidate(
+      w,
+      IdentifierType.AxiellGuid,
+      reason = "CALM/Sierra harvest work"
+    )
+
   def createCalmMiroMergeCandidateFor(
     w: Work[WorkState.Identified]
   ): MergeCandidate[IdState.Identified] =

--- a/pipeline/matcher_merger/merger/src/main/scala/weco/pipeline/merger/rules/ItemsRule.scala
+++ b/pipeline/matcher_merger/merger/src/main/scala/weco/pipeline/merger/rules/ItemsRule.scala
@@ -139,7 +139,7 @@ object ItemsRule extends FieldMergeRule with MergerLogging {
     * we'll also pick up any items linked to the Sierra work from METS or Miro.
     */
   private val mergeIntoCalmTarget = new PartialRule {
-    val isDefinedForTarget: WorkPredicate = singlePhysicalItemCalmWork
+    val isDefinedForTarget: WorkPredicate = singlePhysicalItemCalmWork or singlePhysicalItemAxiellWork
     val isDefinedForSource: WorkPredicate =
       singleDigitalItemMetsWork or
         singleDigitalItemMiroWork or

--- a/pipeline/matcher_merger/merger/src/main/scala/weco/pipeline/merger/rules/ItemsRule.scala
+++ b/pipeline/matcher_merger/merger/src/main/scala/weco/pipeline/merger/rules/ItemsRule.scala
@@ -139,7 +139,8 @@ object ItemsRule extends FieldMergeRule with MergerLogging {
     * we'll also pick up any items linked to the Sierra work from METS or Miro.
     */
   private val mergeIntoCalmTarget = new PartialRule {
-    val isDefinedForTarget: WorkPredicate = singlePhysicalItemCalmWork or singlePhysicalItemAxiellWork
+    val isDefinedForTarget: WorkPredicate =
+      singlePhysicalItemCalmWork or singlePhysicalItemAxiellWork
     val isDefinedForSource: WorkPredicate =
       singleDigitalItemMetsWork or
         singleDigitalItemMiroWork or

--- a/pipeline/matcher_merger/merger/src/main/scala/weco/pipeline/merger/rules/ItemsRule.scala
+++ b/pipeline/matcher_merger/merger/src/main/scala/weco/pipeline/merger/rules/ItemsRule.scala
@@ -127,16 +127,19 @@ object ItemsRule extends FieldMergeRule with MergerLogging {
       Nil
     }
 
-  /** When records are harvested from Calm, both a bib and an item record are
-    * created in Sierra. The Sierra item will have more interesting information
-    * about access status, hold count, etc. The Calm items are just stubs.
+  /** When records are harvested from Calm/Axiell, both a bib and an item record
+    * are created in Sierra. The Sierra item will have more interesting
+    * information about access status, hold count, etc. The Calm/Axiell items
+    * are just stubs.
     *
-    * See CalmItems.scala -- the Calm item is only:
+    * See CalmItems.scala (axiell_work_builder.py) -- the Calm/Axiell item is
+    * only:
     *
     * Item { locations: [ Location { locationType = ClosedStores } ] }
     *
-    * For this reason, we keep all the items *except* the Calm item. This means
-    * we'll also pick up any items linked to the Sierra work from METS or Miro.
+    * For this reason, we keep all the items *except* the Calm/Axiell item. This
+    * means we'll also pick up any items linked to the Sierra work from METS or
+    * Miro.
     */
   private val mergeIntoCalmTarget = new PartialRule {
     val isDefinedForTarget: WorkPredicate =

--- a/pipeline/matcher_merger/merger/src/main/scala/weco/pipeline/merger/rules/ItemsRule.scala
+++ b/pipeline/matcher_merger/merger/src/main/scala/weco/pipeline/merger/rules/ItemsRule.scala
@@ -132,10 +132,10 @@ object ItemsRule extends FieldMergeRule with MergerLogging {
     * information about access status, hold count, etc. The Calm/Axiell items
     * are just stubs.
     *
-    * See CalmItems.scala (axiell_work_builder.py) -- the Calm/Axiell item is
-    * only:
-    *
-    * Item { locations: [ Location { locationType = ClosedStores } ] }
+     * See CalmItems.scala and axiell_work_builder.py -- the Calm/Axiell item is essentially a single
+     * item with a ClosedStores PhysicalLocation (and optional accessConditions), e.g.
+     *
+     * Item { locations: [ PhysicalLocation { locationType = ClosedStores, accessConditions = [...] } ] }
     *
     * For this reason, we keep all the items *except* the Calm/Axiell item. This
     * means we'll also pick up any items linked to the Sierra work from METS or

--- a/pipeline/matcher_merger/merger/src/main/scala/weco/pipeline/merger/rules/ItemsRule.scala
+++ b/pipeline/matcher_merger/merger/src/main/scala/weco/pipeline/merger/rules/ItemsRule.scala
@@ -132,10 +132,12 @@ object ItemsRule extends FieldMergeRule with MergerLogging {
     * information about access status, hold count, etc. The Calm/Axiell items
     * are just stubs.
     *
-    * See CalmItems.scala (axiell_work_builder.py) -- the Calm/Axiell item is
-    * only:
+    * See CalmItems.scala and axiell_work_builder.py -- the Calm/Axiell item is
+    * essentially a single item with a ClosedStores PhysicalLocation (and
+    * optional accessConditions), e.g.
     *
-    * Item { locations: [ Location { locationType = ClosedStores } ] }
+    * Item { locations: [ PhysicalLocation { locationType = ClosedStores,
+    * accessConditions = [...] } ] }
     *
     * For this reason, we keep all the items *except* the Calm/Axiell item. This
     * means we'll also pick up any items linked to the Sierra work from METS or

--- a/pipeline/matcher_merger/merger/src/main/scala/weco/pipeline/merger/rules/ItemsRule.scala
+++ b/pipeline/matcher_merger/merger/src/main/scala/weco/pipeline/merger/rules/ItemsRule.scala
@@ -132,10 +132,12 @@ object ItemsRule extends FieldMergeRule with MergerLogging {
     * information about access status, hold count, etc. The Calm/Axiell items
     * are just stubs.
     *
-     * See CalmItems.scala and axiell_work_builder.py -- the Calm/Axiell item is essentially a single
-     * item with a ClosedStores PhysicalLocation (and optional accessConditions), e.g.
-     *
-     * Item { locations: [ PhysicalLocation { locationType = ClosedStores, accessConditions = [...] } ] }
+    * See CalmItems.scala and axiell_work_builder.py -- the Calm/Axiell item is
+    * essentially a single item with a ClosedStores PhysicalLocation (and
+    * optional accessConditions), e.g.
+    *
+    * Item { locations: [ PhysicalLocation { locationType = ClosedStores,
+    * accessConditions = [...] } ] }
     *
     * For this reason, we keep all the items *except* the Calm/Axiell item. This
     * means we'll also pick up any items linked to the Sierra work from METS or

--- a/pipeline/matcher_merger/merger/src/main/scala/weco/pipeline/merger/rules/ItemsRule.scala
+++ b/pipeline/matcher_merger/merger/src/main/scala/weco/pipeline/merger/rules/ItemsRule.scala
@@ -28,7 +28,7 @@ object ItemsRule extends FieldMergeRule with MergerLogging {
   ): FieldMergeResult[FieldData] = {
     val items =
       mergeIntoTeiTarget(target, sources)
-        .orElse(mergeIntoCalmTarget(target, sources))
+        .orElse(mergeIntoCalmOrAxiellTarget(target, sources))
         .orElse(mergeMetsIntoSierraTarget(target, sources))
         .orElse(
           mergeSingleMiroIntoSingleOrZeroItemSierraTarget(target, sources)
@@ -39,7 +39,7 @@ object ItemsRule extends FieldMergeRule with MergerLogging {
     val mergedSources = (
       List(
         mergeIntoTeiTarget,
-        mergeIntoCalmTarget,
+        mergeIntoCalmOrAxiellTarget,
         mergeMetsIntoSierraTarget,
         mergeSingleMiroIntoSingleOrZeroItemSierraTarget
       ).flatMap {
@@ -141,7 +141,7 @@ object ItemsRule extends FieldMergeRule with MergerLogging {
     * means we'll also pick up any items linked to the Sierra work from METS or
     * Miro.
     */
-  private val mergeIntoCalmTarget = new PartialRule {
+  private val mergeIntoCalmOrAxiellTarget = new PartialRule {
     val isDefinedForTarget: WorkPredicate =
       singlePhysicalItemCalmWork or singlePhysicalItemAxiellWork
     val isDefinedForSource: WorkPredicate =

--- a/pipeline/matcher_merger/merger/src/main/scala/weco/pipeline/merger/rules/OtherIdentifiersRule.scala
+++ b/pipeline/matcher_merger/merger/src/main/scala/weco/pipeline/merger/rules/OtherIdentifiersRule.scala
@@ -111,7 +111,8 @@ object OtherIdentifiersRule extends FieldMergeRule with MergerLogging {
   }
 
   private val mergeIntoCalmTarget = new OtherIdentifiersMergeRule {
-    val isDefinedForTarget: WorkPredicate = singlePhysicalItemCalmWork or singlePhysicalItemAxiellWork
+    val isDefinedForTarget: WorkPredicate =
+      singlePhysicalItemCalmWork or singlePhysicalItemAxiellWork
     val isDefinedForSource: WorkPredicate =
       singleDigitalItemMetsWork or sierraWork or singleDigitalItemMiroWork
   }

--- a/pipeline/matcher_merger/merger/src/main/scala/weco/pipeline/merger/rules/OtherIdentifiersRule.scala
+++ b/pipeline/matcher_merger/merger/src/main/scala/weco/pipeline/merger/rules/OtherIdentifiersRule.scala
@@ -107,11 +107,11 @@ object OtherIdentifiersRule extends FieldMergeRule with MergerLogging {
   private val mergeIntoTeiTarget = new OtherIdentifiersMergeRule {
     val isDefinedForTarget: WorkPredicate = teiWork
     val isDefinedForSource: WorkPredicate =
-      sierraWork or singleDigitalItemMiroWork or singlePhysicalItemCalmWork
+      sierraWork or singleDigitalItemMiroWork or singlePhysicalItemCalmWork or singlePhysicalItemAxiellWork
   }
 
   private val mergeIntoCalmTarget = new OtherIdentifiersMergeRule {
-    val isDefinedForTarget: WorkPredicate = singlePhysicalItemCalmWork
+    val isDefinedForTarget: WorkPredicate = singlePhysicalItemCalmWork or singlePhysicalItemAxiellWork
     val isDefinedForSource: WorkPredicate =
       singleDigitalItemMetsWork or sierraWork or singleDigitalItemMiroWork
   }

--- a/pipeline/matcher_merger/merger/src/main/scala/weco/pipeline/merger/rules/OtherIdentifiersRule.scala
+++ b/pipeline/matcher_merger/merger/src/main/scala/weco/pipeline/merger/rules/OtherIdentifiersRule.scala
@@ -44,7 +44,7 @@ object OtherIdentifiersRule extends FieldMergeRule with MergerLogging {
     val ids = (
       mergeDigitalIntoPhysicalSierraTarget(target, sources) |+|
         mergeIntoTeiTarget(target, sources)
-          .orElse(mergeIntoCalmTarget(target, sources))
+          .orElse(mergeIntoCalmOrAxiellTarget(target, sources))
           .orElse(
             mergeSingleMiroIntoSingleOrZeroItemSierraTarget(target, sources)
           )
@@ -57,7 +57,7 @@ object OtherIdentifiersRule extends FieldMergeRule with MergerLogging {
       List(
         mergeIntoEbscoTarget,
         mergeIntoTeiTarget,
-        mergeIntoCalmTarget,
+        mergeIntoCalmOrAxiellTarget,
         mergeSingleMiroIntoSingleOrZeroItemSierraTarget,
         mergeMiroIntoDigmiroTarget
       ).flatMap {
@@ -110,7 +110,7 @@ object OtherIdentifiersRule extends FieldMergeRule with MergerLogging {
       sierraWork or singleDigitalItemMiroWork or singlePhysicalItemCalmWork or singlePhysicalItemAxiellWork
   }
 
-  private val mergeIntoCalmTarget = new OtherIdentifiersMergeRule {
+  private val mergeIntoCalmOrAxiellTarget = new OtherIdentifiersMergeRule {
     val isDefinedForTarget: WorkPredicate =
       singlePhysicalItemCalmWork or singlePhysicalItemAxiellWork
     val isDefinedForSource: WorkPredicate =

--- a/pipeline/matcher_merger/merger/src/main/scala/weco/pipeline/merger/rules/OtherIdentifiersRule.scala
+++ b/pipeline/matcher_merger/merger/src/main/scala/weco/pipeline/merger/rules/OtherIdentifiersRule.scala
@@ -12,7 +12,7 @@ import weco.pipeline.merger.models.FieldMergeResult
 
 /** Identifiers are merged as follows:
   *
-  *   - All source identifiers are merged into Calm works
+  *   - All source identifiers are merged into Calm/Axiell works
   *   - Miro identifiers are merged into single or zero item Sierra works
   *   - Sierra works with linked digitised Sierra works have the first of these
   *     linked IDs merged into them
@@ -27,7 +27,7 @@ object OtherIdentifiersRule extends FieldMergeRule with MergerLogging {
   // from a source work's otherIdentifiers into a target work.
   //
   // - wellcome-digcode is present to persist digcode identifiers from
-  //   Encore records onto Calm target works if they are merged, because
+  //   Encore records onto Calm/Axiell target works if they are merged, because
   //   digcode identifiers are used as a tagging/classification system.
   private val otherIdentifiersTypeAllowList =
     Set(

--- a/pipeline/matcher_merger/merger/src/main/scala/weco/pipeline/merger/rules/TargetPrecedence.scala
+++ b/pipeline/matcher_merger/merger/src/main/scala/weco/pipeline/merger/rules/TargetPrecedence.scala
@@ -10,7 +10,7 @@ object TargetPrecedence {
   private val targetPrecedence = Seq(
     ebscoWork,
     teiWork,
-    singlePhysicalItemCalmWork,
+    singlePhysicalItemCalmWork or singlePhysicalItemAxiellWork,
     sierraDigitisedAv,
     physicalSierra,
     sierraWork

--- a/pipeline/matcher_merger/merger/src/main/scala/weco/pipeline/merger/rules/ThumbnailRule.scala
+++ b/pipeline/matcher_merger/merger/src/main/scala/weco/pipeline/merger/rules/ThumbnailRule.scala
@@ -55,7 +55,7 @@ object ThumbnailRule extends FieldMergeRule with MergerLogging {
   private val getMetsThumbnail =
     new PartialRule {
       val isDefinedForTarget: WorkPredicate =
-        sierraWork or singlePhysicalItemCalmWork or teiWork
+        sierraWork or singlePhysicalItemCalmWork or singlePhysicalItemAxiellWork or teiWork
       val isDefinedForSource: WorkPredicate = singleDigitalItemMetsWork
 
       def rule(
@@ -70,7 +70,7 @@ object ThumbnailRule extends FieldMergeRule with MergerLogging {
   private val getMinMiroThumbnail =
     new PartialRule {
       val isDefinedForTarget: WorkPredicate =
-        singleItemSierra or zeroItemSierra or singlePhysicalItemCalmWork or teiWork
+        singleItemSierra or zeroItemSierra or singlePhysicalItemCalmWork or singlePhysicalItemAxiellWork or teiWork
       val isDefinedForSource: WorkPredicate = singleDigitalItemMiroWork
 
       def rule(

--- a/pipeline/matcher_merger/merger/src/main/scala/weco/pipeline/merger/rules/WorkPredicates.scala
+++ b/pipeline/matcher_merger/merger/src/main/scala/weco/pipeline/merger/rules/WorkPredicates.scala
@@ -26,6 +26,9 @@ object WorkPredicates {
   private val calmIdentified: WorkPredicate = identifierTypeId(
     IdentifierType.CalmRecordIdentifier
   )
+  private val axiellIdentified: WorkPredicate = identifierTypeId(
+    IdentifierType.AxiellGuid
+  )
   private val teiIdentified: WorkPredicate = identifierTypeId(
     IdentifierType.Tei
   )
@@ -61,6 +64,13 @@ object WorkPredicates {
     */
   val singlePhysicalItemCalmWork: WorkPredicate = satisfiesAll(
     calmIdentified,
+    singleItem,
+    singleLocation,
+    allPhysicalLocations
+  )
+
+  val singlePhysicalItemAxiellWork: WorkPredicate = satisfiesAll(
+    axiellIdentified,
     singleItem,
     singleLocation,
     allPhysicalLocations

--- a/pipeline/matcher_merger/merger/src/test/scala/weco/pipeline/merger/MergerIntegrationTest.scala
+++ b/pipeline/matcher_merger/merger/src/test/scala/weco/pipeline/merger/MergerIntegrationTest.scala
@@ -380,6 +380,87 @@ class MergerIntegrationTest
     }
   }
 
+  Scenario("An Axiell work and a Sierra work are matched") {
+    withContext {
+      implicit context =>
+        Given("a Sierra work and an Axiell work")
+        val axiell = axiellIdentifiedWork()
+        val sierra = sierraPhysicalIdentifiedWork()
+          .mergeCandidates(List(createAxiellMergeCandidateFor(axiell)))
+
+        When("the works are processed by the matcher/merger")
+        processWorks(sierra, axiell)
+
+        Then("the Sierra work is redirected to the Axiell work")
+        context.getMerged(sierra) should beRedirectedTo(axiell)
+
+        And("the Axiell work contains the Sierra item ID")
+        val axiellItem = context.getMerged(axiell).data.items.head
+        axiellItem.id shouldBe sierra.data.items.head.id
+    }
+  }
+
+  Scenario("An Axiell work, a Sierra work, and a Miro work are matched") {
+    withContext {
+      implicit context =>
+        Given("An Axiell work, a Sierra work and a Miro work")
+        val axiell = axiellIdentifiedWork()
+        val miro = miroIdentifiedWork()
+        val sierra = sierraPhysicalIdentifiedWork()
+          .mergeCandidates(
+            List(
+              createMiroSierraMergeCandidateFor(miro),
+              createAxiellMergeCandidateFor(axiell)
+            )
+          )
+
+        When("the works are processed by the matcher/merger")
+        processWorks(sierra, axiell, miro)
+
+        Then("the Sierra work is redirected to the Axiell work")
+        context.getMerged(sierra) should beRedirectedTo(axiell)
+
+        And("the Miro work is redirected to the Axiell work")
+        context.getMerged(miro) should beRedirectedTo(axiell)
+
+        And("the Axiell work contains the Miro location")
+        context.getMerged(axiell).data.items.flatMap(_.locations) should
+          contain(miro.data.items.head.locations.head)
+        And("the Axiell work contains the Miro image")
+        context.getMerged(axiell).data.imageData should contain(miro.singleImage)
+    }
+  }
+
+  Scenario("An Axiell work, a Sierra picture work, and a METS work are matched") {
+    withContext {
+      implicit context =>
+        Given("An Axiell work, a Sierra picture work and a METS work")
+        val axiell = axiellIdentifiedWork()
+        val sierraPicture = sierraIdentifiedWork()
+          .items(List(createIdentifiedPhysicalItem))
+          .format(Format.Pictures)
+          .mergeCandidates(List(createAxiellMergeCandidateFor(axiell)))
+        val mets = metsIdentifiedWork()
+          .mergeCandidates(List(createMetsMergeCandidateFor(sierraPicture)))
+
+        When("the works are processed by the matcher/merger")
+        processWorks(sierraPicture, axiell, mets)
+
+        Then("the Sierra work is redirected to the Axiell work")
+        context.getMerged(sierraPicture) should beRedirectedTo(axiell)
+
+        And("the METS work is redirected to the Axiell work")
+        context.getMerged(mets) should beRedirectedTo(axiell)
+
+        And("the Axiell work contains the METS location")
+        context.getMerged(axiell).data.items.flatMap(_.locations) should
+          contain(mets.data.items.head.locations.head)
+
+        And("the Axiell work contains no images")
+        context.getMerged(axiell).data.imageData shouldBe empty
+    }
+  }
+
   Scenario("A digitised video with Sierra physical records and e-bibs") {
     withContext {
       implicit context =>
@@ -706,6 +787,92 @@ class MergerIntegrationTest
         teiItems should contain allElementsOf sierraWork.data.items
         teiItems should contain allElementsOf metsWork.data.items
         teiItems should contain noElementsOf calmWork.data.items
+
+        And("it gets the METS thumbnail")
+        context
+          .getMerged(teiWork)
+          .data
+          .thumbnail shouldBe metsWork.data.thumbnail
+    }
+  }
+
+  Scenario("A TEI work, an Axiell work, a Sierra work and a METS work") {
+    withContext {
+      implicit context =>
+        Given("four works")
+        val axiellWork =
+          axiellIdentifiedWork()
+            .otherIdentifiers(
+              List(
+                createSourceIdentifierWith(
+                  identifierType = IdentifierType.CalmRefNo
+                ),
+                createSourceIdentifierWith(
+                  identifierType = IdentifierType.CalmAltRefNo
+                )
+              )
+            )
+
+        val sierraWork =
+          sierraIdentifiedWork()
+            .otherIdentifiers(
+              List(
+                createSourceIdentifierWith(
+                  identifierType = IdentifierType.SierraIdentifier
+                ),
+                createSourceIdentifierWith(
+                  identifierType = IdentifierType.WellcomeDigcode
+                )
+              )
+            )
+            .items(List(createIdentifiedPhysicalItem))
+            .mergeCandidates(List(createAxiellMergeCandidateFor(axiellWork)))
+
+        val teiWork = teiIdentifiedWork()
+          .mergeCandidates(List(createTeiBnumberMergeCandidateFor(sierraWork)))
+
+        val metsWork =
+          metsIdentifiedWork()
+            .thumbnail(createDigitalLocation)
+            .items(List(createDigitalItem))
+            .mergeCandidates(List(createMetsMergeCandidateFor(sierraWork)))
+            .invisible(invisibilityReasons =
+              List(InvisibilityReason.MetsWorksAreNotVisible)
+            )
+
+        When("the works are processed by the matcher/merger")
+        processWorks(teiWork, sierraWork, metsWork, axiellWork)
+
+        Then("Everything should be redirected to the TEI work")
+        context.getMerged(sierraWork) should beRedirectedTo(teiWork)
+        context.getMerged(metsWork) should beRedirectedTo(teiWork)
+        context.getMerged(axiellWork) should beRedirectedTo(teiWork)
+
+        And("the TEI work gets all the Axiell and Sierra identifiers")
+        val teiMergedIdentifiers =
+          context
+            .getMerged(teiWork)
+            .data
+            .otherIdentifiers
+
+        teiMergedIdentifiers should contain allElementsOf axiellWork.data.otherIdentifiers :+ axiellWork.state.sourceIdentifier
+        teiMergedIdentifiers should contain allElementsOf sierraWork.data.otherIdentifiers :+ sierraWork.state.sourceIdentifier
+
+        And("it has no METS identifier")
+        teiMergedIdentifiers.filter(
+          _.identifierType == IdentifierType.METS
+        ) shouldBe empty
+
+        And("it only has two items (one physical, one digital)")
+        val teiItems =
+          context
+            .getMerged(teiWork)
+            .data
+            .items
+
+        teiItems should contain allElementsOf sierraWork.data.items
+        teiItems should contain allElementsOf metsWork.data.items
+        teiItems should contain noElementsOf axiellWork.data.items
 
         And("it gets the METS thumbnail")
         context

--- a/pipeline/matcher_merger/merger/src/test/scala/weco/pipeline/merger/rules/ItemsRuleTest.scala
+++ b/pipeline/matcher_merger/merger/src/test/scala/weco/pipeline/merger/rules/ItemsRuleTest.scala
@@ -42,6 +42,7 @@ class ItemsRuleTest
   val miroWork: Work.Visible[WorkState.Identified] = miroIdentifiedWork()
 
   val calmWork: Work.Visible[WorkState.Identified] = calmIdentifiedWork()
+  val axiellWork: Work.Visible[WorkState.Identified] = axiellIdentifiedWork()
 
   it(
     "leaves items unchanged and returns a digitised version of a Sierra work as a merged source"
@@ -384,6 +385,47 @@ class ItemsRuleTest
 
   it("replace Calm items with Sierra and METS items") {
     inside(ItemsRule.merge(calmWork, List(physicalPictureSierra, metsWork))) {
+      case FieldMergeResult(items, mergedSources) =>
+        items should have size 2
+
+        items shouldBe physicalPictureSierra.data.items ++ metsWork.data.items
+    }
+  }
+
+  // Axiell (drop-in replacement for Calm)
+  it("Adds Sierra item IDs to Axiell item") {
+    inside(ItemsRule.merge(axiellWork, List(physicalPictureSierra))) {
+      case FieldMergeResult(items, mergedSources) =>
+        items should have size 1
+        items.head.id should be(physicalPictureSierra.data.items.head.id)
+
+        mergedSources should be(Seq(physicalPictureSierra))
+    }
+  }
+
+  it("copies the locations from Sierra to Axiell") {
+    val ac = AccessCondition(
+      method = AccessMethod.OnlineRequest,
+      status = AccessStatus.Open
+    )
+
+    val location = createPhysicalLocationWith(accessConditions = List(ac))
+
+    val item = createIdentifiedItemWith(locations = List(location))
+
+    val sierraWork = sierraIdentifiedWork().items(List(item))
+
+    inside(ItemsRule.merge(axiellWork, List(sierraWork))) {
+      case FieldMergeResult(items, mergedSources) =>
+        items should have size 1
+        items.head.locations shouldBe Seq(location)
+
+        mergedSources shouldBe Seq(sierraWork)
+    }
+  }
+
+  it("replaces Axiell items with Sierra and METS items") {
+    inside(ItemsRule.merge(axiellWork, List(physicalPictureSierra, metsWork))) {
       case FieldMergeResult(items, mergedSources) =>
         items should have size 2
 

--- a/pipeline/matcher_merger/merger/src/test/scala/weco/pipeline/merger/rules/OtherIdentifiersRuleTest.scala
+++ b/pipeline/matcher_merger/merger/src/test/scala/weco/pipeline/merger/rules/OtherIdentifiersRuleTest.scala
@@ -64,6 +64,14 @@ class OtherIdentifiersRuleTest
       )
     )
 
+  val axiellWork: Work.Visible[WorkState.Identified] =
+    axiellIdentifiedWork().otherIdentifiers(
+      List(
+        createSourceIdentifierWith(identifierType = IdentifierType.CalmRefNo),
+        createSourceIdentifierWith(identifierType = IdentifierType.CalmAltRefNo)
+      )
+    )
+
   val mergeCandidate: Work.Visible[WorkState.Identified] =
     sierraIdentifiedWork()
 
@@ -128,6 +136,55 @@ class OtherIdentifiersRuleTest
             .get
 
         mergedSources should contain theSameElementsAs (physicalSierraWork :: miroWork :: metsWorks)
+    }
+  }
+
+  it("merges METS, Miro, and Sierra source IDs into Axiell target") {
+    inside(
+      OtherIdentifiersRule
+        .merge(
+          axiellWork,
+          physicalSierraWork :: nothingWork :: miroWork :: metsWorks
+        )
+    ) {
+      case FieldMergeResult(otherIdentifiers, mergedSources) =>
+        otherIdentifiers should contain theSameElementsAs
+          List(
+            physicalSierraWork.sourceIdentifier,
+            miroWork.sourceIdentifier
+          ) ++
+          metsWorks.map(_.sourceIdentifier) ++ axiellWork.data.otherIdentifiers :+
+          physicalSierraWork.data.otherIdentifiers
+            .find(_.identifierType.id == IdentifierType.SierraIdentifier.id)
+            .get
+
+        mergedSources should contain theSameElementsAs (physicalSierraWork :: miroWork :: metsWorks)
+    }
+  }
+
+  it("merges METS, Miro, Axiell and Sierra source IDs into Tei target") {
+    inside(
+      OtherIdentifiersRule
+        .merge(
+          teiWork,
+          axiellWork :: physicalSierraWork :: nothingWork :: miroWork :: metsWorks
+        )
+    ) {
+      case FieldMergeResult(otherIdentifiers, mergedSources) =>
+        otherIdentifiers should contain theSameElementsAs
+          List(
+            physicalSierraWork.sourceIdentifier,
+            miroWork.sourceIdentifier
+          ) ++ axiellWork.data.otherIdentifiers :+ axiellWork.sourceIdentifier :+
+          physicalSierraWork.data.otherIdentifiers
+            .find(_.identifierType.id == IdentifierType.SierraIdentifier.id)
+            .get
+
+        mergedSources should contain theSameElementsAs List(
+          physicalSierraWork,
+          miroWork,
+          axiellWork
+        )
     }
   }
   describe("Miro into Sierra") {
@@ -249,6 +306,18 @@ class OtherIdentifiersRuleTest
       case FieldMergeResult(otherIdentifiers, _) =>
         otherIdentifiers should contain only (
           (calmWork.data.otherIdentifiers ++ sierraWithDigcode.data.otherIdentifiers
+            .find(_.identifierType.id == "wellcome-digcode")
+            .toList :+
+            sierraWithDigcode.sourceIdentifier): _*
+        )
+    }
+  }
+
+  it("merges only digcode identifiers from sources' otherIdentifiers into Axiell target") {
+    inside(OtherIdentifiersRule.merge(axiellWork, Seq(sierraWithDigcode))) {
+      case FieldMergeResult(otherIdentifiers, _) =>
+        otherIdentifiers should contain only (
+          (axiellWork.data.otherIdentifiers ++ sierraWithDigcode.data.otherIdentifiers
             .find(_.identifierType.id == "wellcome-digcode")
             .toList :+
             sierraWithDigcode.sourceIdentifier): _*

--- a/pipeline/matcher_merger/merger/src/test/scala/weco/pipeline/merger/rules/TargetPrecedenceTest.scala
+++ b/pipeline/matcher_merger/merger/src/test/scala/weco/pipeline/merger/rules/TargetPrecedenceTest.scala
@@ -14,6 +14,7 @@ class TargetPrecedenceTest
 
   val tei = teiIdentifiedWork()
   val calm = calmIdentifiedWork()
+  val axiell = axiellIdentifiedWork()
   val videoSierra = sierraDigitalIdentifiedWork().format(Format.Videos)
   val multiItemPhysicalSierra = sierraIdentifiedWork().items(
     List(createIdentifiedPhysicalItem, createIdentifiedPhysicalItem)
@@ -42,6 +43,13 @@ class TargetPrecedenceTest
           Seq(videoSierra, multiItemPhysicalSierra, digitalSierra, calm, miro)
         )
         .value shouldBe calm
+    }
+    it("second, chooses an Axiell work at the same precedence as Calm") {
+      TargetPrecedence
+        .getTarget(
+          Seq(videoSierra, multiItemPhysicalSierra, digitalSierra, axiell, miro)
+        )
+        .value shouldBe axiell
     }
     it("third, chooses a Sierra e-video") {
       TargetPrecedence

--- a/pipeline/matcher_merger/merger/src/test/scala/weco/pipeline/merger/rules/ThumbnailRuleTest.scala
+++ b/pipeline/matcher_merger/merger/src/test/scala/weco/pipeline/merger/rules/ThumbnailRuleTest.scala
@@ -26,6 +26,7 @@ class ThumbnailRuleTest
   private val digitalSierraWork = sierraDigitalIdentifiedWork()
 
   private val calmWork = calmIdentifiedWork()
+  private val axiellWork = axiellIdentifiedWork()
   private val teiWork = teiIdentifiedWork()
 
   private val metsWork = metsIdentifiedWork()
@@ -139,6 +140,14 @@ class ThumbnailRuleTest
 
   it("chooses the METS thumbnail for a Calm target") {
     inside(ThumbnailRule.merge(calmWork, miroWorks :+ metsWork)) {
+      case FieldMergeResult(thumbnail, _) =>
+        thumbnail shouldBe defined
+        thumbnail shouldBe metsWork.data.thumbnail
+    }
+  }
+
+  it("chooses the METS thumbnail for an Axiell target") {
+    inside(ThumbnailRule.merge(axiellWork, miroWorks :+ metsWork)) {
       case FieldMergeResult(thumbnail, _) =>
         thumbnail shouldBe defined
         thumbnail shouldBe metsWork.data.thumbnail

--- a/pipeline/matcher_merger/merger/src/test/scala/weco/pipeline/merger/rules/WorkPredicatesTest.scala
+++ b/pipeline/matcher_merger/merger/src/test/scala/weco/pipeline/merger/rules/WorkPredicatesTest.scala
@@ -149,4 +149,12 @@ class WorkPredicatesTest
       ).items(List(createCalmItem))
     ) shouldBe false
   }
+
+  it("does not select an Axiell work as singlePhysicalItemCalmWork") {
+    WorkPredicates.singlePhysicalItemCalmWork(
+      identifiedWork(
+        sourceIdentifier = createAxiellSourceIdentifier
+      ).items(List(createCalmItem))
+    ) shouldBe false
+  }
 }

--- a/pipeline/matcher_merger/merger/src/test/scala/weco/pipeline/merger/rules/WorkPredicatesTest.scala
+++ b/pipeline/matcher_merger/merger/src/test/scala/weco/pipeline/merger/rules/WorkPredicatesTest.scala
@@ -3,13 +3,13 @@ package weco.pipeline.merger.rules
 import org.scalatest.Inspectors
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import weco.catalogue.internal_model.work.generators.MiroWorkGenerators
 import weco.catalogue.internal_model.work.WorkState.Identified
 import weco.catalogue.internal_model.locations.{
   DigitalLocation,
   PhysicalLocation
 }
 import weco.catalogue.internal_model.work.generators.{
+  AxiellWorkGenerators,
   MetsWorkGenerators,
   MiroWorkGenerators
 }
@@ -19,6 +19,7 @@ class WorkPredicatesTest
     extends AnyFunSpec
     with MetsWorkGenerators
     with MiroWorkGenerators
+    with AxiellWorkGenerators
     with Matchers
     with Inspectors {
   val works: Seq[Work[Identified]] = List(
@@ -134,5 +135,18 @@ class WorkPredicatesTest
         )
         work.data.otherIdentifiers.map(_.value) should contain("digaids")
     }
+  }
+
+  it("selects singlePhysicalItemAxiellWork works") {
+    val axiell = axiellIdentifiedWork()
+    WorkPredicates.singlePhysicalItemAxiellWork(axiell) shouldBe true
+  }
+
+  it("does not select a CALM work as singlePhysicalItemAxiellWork") {
+    WorkPredicates.singlePhysicalItemAxiellWork(
+      identifiedWork(
+        sourceIdentifier = createCalmSourceIdentifier
+      ).items(List(createCalmItem))
+    ) shouldBe false
   }
 }


### PR DESCRIPTION
## What does this change?

https://github.com/wellcomecollection/platform/issues/6394

Treat Axiell as a drop-in replacement for CALM in the merger.

## How to test

This change is covered by unit tests, and I also tested it on the live parallel pipeline (2026-07-03), merging an Axiell work with a Sierra work (`y2nsv3vw` and `j6r936aa`).

## How can we measure success?

The merger should treat Axiell and CALM identically. If it receives an Axiell work with the same canonical ID as some CALM work, its output should be the same as if it received the CALM work.

## Have we considered potential risks?

This change is low risk. The new merger logic will affect the production pipeline too (2025-10-02), but since production indexes do not contain any Axiell works, there should be no differences in the merger's output. The existing production pipeline will only use the CALM predicates, and the new pipeline will only use the Axiell predicates.
