### PR TITLE
Add a PR template reminding authors to refresh catalogue-api fixtures

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## What does this change?
+
+<!-- What is the problem / why is the change needed, how does it solve it, and any points of discussion. -->
+
+### Checklist
+
+- [ ] Does this change the display model the catalogue API returns? If so, regenerate the test documents under `catalogue_graph/document_generators/test_documents`. catalogue-api pulls them in with `copy_test_documents.py`, and its OpenAPI contract tests validate the published spec against them, so stale fixtures let the spec drift.
+
+## How to test
+
+<!-- How can a reviewer verify the change? -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 ### Checklist
 
-- [ ] Does this change the display model the catalogue API returns? If so, regenerate the test documents under `catalogue_graph/document_generators/test_documents`. catalogue-api pulls them in with `copy_test_documents.py`, and its OpenAPI contract tests validate the published spec against them, so stale fixtures let the spec drift.
+- [ ] Does this change the display model the catalogue API returns? If so, regenerate the test documents under `catalogue_graph/document_generators/test_documents`. The `wellcomecollection/catalogue-api` repo copies them in with `copy_test_documents.py`, and its OpenAPI contract tests validate the published spec against them, so stale fixtures let the spec drift.
 
 ## How to test
 


### PR DESCRIPTION
## What does this change?

Adds a PR template to this repo. It has a single checklist item: if a change alters the display model the catalogue API returns, regenerate the test documents under `catalogue_graph/document_generators/test_documents`.

Those documents are the ground truth for catalogue-api's OpenAPI spec. catalogue-api copies them in with `copy_test_documents.py`, and a new contract test (`OpenApiSpecResponseTest`) validates the published spec's response schemas against them. Because that copy is manual, a display-model change here only reaches the spec once someone refreshes the fixtures. This reminder is the prompt to do so.

Suggested by a reviewer on wellcomecollection/catalogue-api#937, which added the spec and the contract test.

This repo had no PR template, so this adds a minimal one. Trim or expand it to taste.

## How to test

Open a new PR in this repo and confirm the template pre-fills the description.
