### PR TITLE
Change graph stack outputs and update downstream consumers

### DIFF
--- a/builds/deploy_catalogue_pipeline.sh
+++ b/builds/deploy_catalogue_pipeline.sh
@@ -59,7 +59,8 @@ ENV_TAG="env.$PIPELINE_DATE" "$ROOT/builds/update_ecr_image_tag.sh" \
   uk.ac.wellcome/transformer_miro \
   uk.ac.wellcome/transformer_sierra \
   uk.ac.wellcome/transformer_tei \
-  uk.ac.wellcome/unified_pipeline_lambda
+  uk.ac.wellcome/unified_pipeline_lambda \
+  uk.ac.wellcome/unified_pipeline_task
   
 if [[ "$TASK" == "tag_images_and_deploy_services" ]]
 then

--- a/builds/terraform/github/gha_role_catalogue_graph.tf
+++ b/builds/terraform/github/gha_role_catalogue_graph.tf
@@ -67,10 +67,10 @@ data "aws_iam_policy_document" "gha_catalogue_graph_ci" {
       "secretsmanager:GetSecretValue",
       "secretsmanager:DescribeSecret",
     ]
-    resources = [
-      data.terraform_remote_state.catalogue_graph.outputs.neptune_cluster_endpoint_secret_arn,
-      data.aws_secretsmanager_secret.wc_platform_alerts_slack_webhook.arn,
-    ]
+    resources = concat(
+      values(data.terraform_remote_state.catalogue_graph.outputs.neptune_cluster_endpoint_secret_arns),
+      [data.aws_secretsmanager_secret.wc_platform_alerts_slack_webhook.arn],
+    )
   }
 
   statement {
@@ -89,9 +89,7 @@ data "aws_iam_policy_document" "gha_catalogue_graph_ci" {
       "neptune-db:List*"
     ]
 
-    resources = [
-      data.terraform_remote_state.catalogue_graph.outputs.neptune_cluster_data_access_arn
-    ]
+    resources = values(data.terraform_remote_state.catalogue_graph.outputs.neptune_cluster_data_access_arns)
   }
 
   statement {

--- a/catalogue_graph/infra/graph/neptune.tf
+++ b/catalogue_graph/infra/graph/neptune.tf
@@ -1,3 +1,13 @@
+locals {
+  neptune_clusters = [
+    module.catalogue_graph_neptune_cluster,
+    module.catalogue_graph_neptune_cluster_dev,
+    module.catalogue_graph_neptune_cluster_2026_07_03
+  ]
+
+  production_cluster = module.catalogue_graph_neptune_cluster
+}
+
 module "catalogue_graph_neptune_cluster" {
   source = "./modules/catalogue_graph"
 
@@ -54,9 +64,10 @@ module "catalogue_graph_neptune_cluster_2026_07_03" {
     aws.dns = aws.dns
   }
 }
+
 resource "aws_ssm_parameter" "production_graph_date" {
   name        = "/catalogue_graph/production_graph_date"
   type        = "String"
   description = "The graph_date of the current production Neptune cluster (or 'prod' for the legacy cluster), read by CI."
-  value       = module.catalogue_graph_neptune_cluster.graph_date != "" ? module.catalogue_graph_neptune_cluster.graph_date : "prod"
+  value       = local.production_cluster.graph_date != "" ? local.production_cluster.graph_date : "prod"
 }

--- a/catalogue_graph/infra/graph/outputs.tf
+++ b/catalogue_graph/infra/graph/outputs.tf
@@ -1,15 +1,17 @@
-output "neptune_cluster_arn" {
-  value = module.catalogue_graph_neptune_cluster.neptune_cluster_arn
+# Output maps keyed by graph_date.
+
+output "neptune_cluster_arns" {
+  value = { for cluster in local.neptune_clusters : cluster.graph_date => cluster.neptune_cluster_arn }
 }
 
-output "neptune_cluster_resource_id" {
-  value = module.catalogue_graph_neptune_cluster.neptune_cluster_resource_id
+output "neptune_cluster_resource_ids" {
+  value = { for cluster in local.neptune_clusters : cluster.graph_date => cluster.neptune_cluster_resource_id }
 }
 
-output "neptune_cluster_data_access_arn" {
-  value = module.catalogue_graph_neptune_cluster.neptune_cluster_data_access_arn
+output "neptune_cluster_endpoint_secret_arns" {
+  value = { for cluster in local.neptune_clusters : cluster.graph_date => cluster.neptune_cluster_endpoint_secret_arn }
 }
 
-output "neptune_cluster_endpoint_secret_arn" {
-  value = module.catalogue_graph_neptune_cluster.neptune_cluster_endpoint_secret_arn
+output "neptune_cluster_data_access_arns" {
+  value = { for cluster in local.neptune_clusters : cluster.graph_date => cluster.neptune_cluster_data_access_arn }
 }

--- a/catalogue_graph/infra/graph/outputs.tf
+++ b/catalogue_graph/infra/graph/outputs.tf
@@ -1,5 +1,5 @@
 # Output maps keyed by graph_date.
-
+# Note: the legacy production cluster uses an empty string ("") graph_date, so prod is keyed by "" in these maps.
 output "neptune_cluster_arns" {
   value = { for cluster in local.neptune_clusters : cluster.graph_date => cluster.neptune_cluster_arn }
 }

--- a/pipeline/terraform/modules/pipeline/graph/iam.tf
+++ b/pipeline/terraform/modules/pipeline/graph/iam.tf
@@ -7,7 +7,7 @@ locals {
 
 data "aws_iam_policy_document" "allow_catalogue_graph_secret_read" {
   statement {
-    actions   = ["secretsmanager:GetSecretValue"]
+    actions = ["secretsmanager:GetSecretValue"]
     resources = [
       "${local.secrets_manager_prefix}:catalogue-graph/*"
     ]
@@ -28,7 +28,7 @@ data "aws_iam_policy_document" "allow_slack_secret_read" {
 
 data "aws_iam_policy_document" "ingestor_allow_pipeline_storage_secret_read" {
   statement {
-    actions   = ["secretsmanager:GetSecretValue"]
+    actions = ["secretsmanager:GetSecretValue"]
     resources = [
       "${local.secrets_manager_prefix}:${var.es_cluster_host}*",
       "${local.secrets_manager_prefix}:${var.es_cluster_port}*",
@@ -43,7 +43,7 @@ data "aws_iam_policy_document" "ingestor_allow_pipeline_storage_secret_read" {
 
 data "aws_iam_policy_document" "allow_pipeline_storage_secret_read_denormalised_read_only" {
   statement {
-    actions   = ["secretsmanager:GetSecretValue"]
+    actions = ["secretsmanager:GetSecretValue"]
     resources = [
       "${local.secrets_manager_prefix}:${var.es_cluster_host}*",
       "${local.secrets_manager_prefix}:${var.es_cluster_port}*",

--- a/pipeline/terraform/modules/pipeline/graph/iam.tf
+++ b/pipeline/terraform/modules/pipeline/graph/iam.tf
@@ -7,7 +7,7 @@ locals {
 
 data "aws_iam_policy_document" "allow_catalogue_graph_secret_read" {
   statement {
-    actions = ["secretsmanager:GetSecretValue"]
+    actions   = ["secretsmanager:GetSecretValue"]
     resources = [
       "${local.secrets_manager_prefix}:catalogue-graph/*"
     ]
@@ -28,7 +28,7 @@ data "aws_iam_policy_document" "allow_slack_secret_read" {
 
 data "aws_iam_policy_document" "ingestor_allow_pipeline_storage_secret_read" {
   statement {
-    actions = ["secretsmanager:GetSecretValue"]
+    actions   = ["secretsmanager:GetSecretValue"]
     resources = [
       "${local.secrets_manager_prefix}:${var.es_cluster_host}*",
       "${local.secrets_manager_prefix}:${var.es_cluster_port}*",
@@ -43,7 +43,7 @@ data "aws_iam_policy_document" "ingestor_allow_pipeline_storage_secret_read" {
 
 data "aws_iam_policy_document" "allow_pipeline_storage_secret_read_denormalised_read_only" {
   statement {
-    actions = ["secretsmanager:GetSecretValue"]
+    actions   = ["secretsmanager:GetSecretValue"]
     resources = [
       "${local.secrets_manager_prefix}:${var.es_cluster_host}*",
       "${local.secrets_manager_prefix}:${var.es_cluster_port}*",
@@ -62,7 +62,7 @@ data "aws_iam_policy_document" "neptune_read" {
     ]
 
     resources = [
-      data.terraform_remote_state.catalogue_graph.outputs.neptune_cluster_data_access_arn
+      data.terraform_remote_state.catalogue_graph.outputs.neptune_cluster_data_access_arns[var.graph_date]
     ]
   }
 }
@@ -74,7 +74,7 @@ data "aws_iam_policy_document" "neptune_delete" {
     ]
 
     resources = [
-      data.terraform_remote_state.catalogue_graph.outputs.neptune_cluster_data_access_arn
+      data.terraform_remote_state.catalogue_graph.outputs.neptune_cluster_data_access_arns[var.graph_date]
     ]
   }
 }


### PR DESCRIPTION
## What does this change?

Change the outputs of the graph terraform stack to include outputs from all clusters rather than just the current production cluster. This change was originally included in the [new pipeline PR](https://github.com/wellcomecollection/catalogue-pipeline/pull/3465) and applied as part of the new terraform stack, but I moved it to a separate branch so that we can merge it independently and prevent terraform drift on the main branch. 

## How to test

* Run `terraform apply` on the graph stack and check outputs.
* Run `terraform apply` on the GitHub stack
* Verify that all consumers of the graph stack outputs access the new output names

## How can we measure success?

* The GitHub action running integration tests should be able to run the tests against all clusters, not just the current production cluster
* The IAM permissions defined in each pipeline stack should be scoped to the right Neptune cluster, depending on the stack's `graph_date`


## Have we considered potential risks?

This change is low risk. Running `terraform plan` on the 2025-10-02 stack yields no changes.