### PR TITLE
Add a reconcile state to the adapter state machine (Phase B)

### DIFF
--- a/.github/workflows/catalogue-graph-deploy.yml
+++ b/.github/workflows/catalogue-graph-deploy.yml
@@ -80,6 +80,7 @@ jobs:
             folio-adapter-trigger,
             axiell-adapter-mark-published,
             folio-adapter-mark-published,
+            axiell-adapter-reconcile,
           ]
     steps:
       - uses: actions/checkout@v3

--- a/catalogue_graph/infra/adapters/main.tf
+++ b/catalogue_graph/infra/adapters/main.tf
@@ -16,17 +16,18 @@ module "ebsco" {
 }
 
 module "axiell" {
-  source              = "./modules/adapter"
-  namespace           = "axiell"
-  steps_namespace     = "oai_pmh"
-  s3_bucket_name      = "wellcomecollection-platform-axiell-adapter"
-  schedule_expression = "rate(15 minutes)"
-  repository_url      = data.aws_ecr_repository.unified_pipeline_lambda.repository_url
-  event_bus_name      = aws_cloudwatch_event_bus.event_bus.name
-  ecs_cluster_arn     = aws_ecs_cluster.adapters.arn
-  subnets             = local.private_subnets
-  security_group_ids  = [aws_security_group.adapter_egress.id]
-  task_repository_url = data.aws_ecr_repository.unified_pipeline_task.repository_url
+  source                = "./modules/adapter"
+  namespace             = "axiell"
+  steps_namespace       = "oai_pmh"
+  s3_bucket_name        = "wellcomecollection-platform-axiell-adapter"
+  schedule_expression   = "rate(15 minutes)"
+  repository_url        = data.aws_ecr_repository.unified_pipeline_lambda.repository_url
+  event_bus_name        = aws_cloudwatch_event_bus.event_bus.name
+  ecs_cluster_arn       = aws_ecs_cluster.adapters.arn
+  subnets               = local.private_subnets
+  security_group_ids    = [aws_security_group.adapter_egress.id]
+  task_repository_url   = data.aws_ecr_repository.unified_pipeline_task.repository_url
+  enable_reconciliation = true
 }
 
 module "folio" {

--- a/catalogue_graph/infra/adapters/modules/adapter/iam.tf
+++ b/catalogue_graph/infra/adapters/modules/adapter/iam.tf
@@ -140,6 +140,7 @@ resource "aws_iam_policy" "state_machine_lambda_policy" {
         Resource = concat(
           [module.trigger_lambda.lambda.arn],
           module.mark_published_lambda[*].lambda.arn,
+          module.reconcile_lambda[*].lambda.arn,
         )
       }
     ]

--- a/catalogue_graph/infra/adapters/modules/adapter/lambda_reconcile.tf
+++ b/catalogue_graph/infra/adapters/modules/adapter/lambda_reconcile.tf
@@ -1,0 +1,32 @@
+module "reconcile_lambda" {
+  count  = var.enable_reconciliation ? 1 : 0
+  source = "git@github.com:wellcomecollection/terraform-aws-lambda?ref=v1.2.0"
+
+  name         = "${var.namespace}-adapter-reconcile"
+  description  = "Lambda function to record guid-change deletion facts before the completed event fires"
+  package_type = "Image"
+  image_uri    = "${var.repository_url}:prod"
+  # CI deploys via `update-function-code --publish` and nothing consumes a
+  # versioned ARN, so Terraform publishing only caused a perpetual version diff.
+  publish = false
+
+  image_config = {
+    command = ["adapters.steps.${local.steps_namespace}.reconcile.lambda_handler"]
+  }
+
+  # The changeset read of the id-sorted adapter store cannot prune and can
+  # materialise most of the table (#3444); sized to match the pipeline
+  # transformer lambda, which performs the same read.
+  memory_size = 10240
+  timeout     = 600
+
+  ephemeral_storage = {
+    size = 1024
+  }
+}
+
+resource "aws_iam_role_policy" "reconcile_lambda_iceberg_write" {
+  count  = var.enable_reconciliation ? 1 : 0
+  role   = one(module.reconcile_lambda[*].lambda_role.name)
+  policy = data.aws_iam_policy_document.iceberg_write.json
+}

--- a/catalogue_graph/infra/adapters/modules/adapter/state_machine.tf
+++ b/catalogue_graph/infra/adapters/modules/adapter/state_machine.tf
@@ -1,8 +1,12 @@
 locals {
-  # When item enrichment is enabled, the loader routes through a "Run enrichment"
-  # state before publishing, so both the bib and item changesets exist by the time
-  # "folio.adapter.completed" fires. Otherwise the loader goes straight to publish.
-  loader_next = var.enable_item_enrichment ? "Should enrich?" : "Should publish event?"
+  # When reconciliation is enabled, the loader routes through a "Run reconcile"
+  # state so deletion facts are durably recorded before the completed event
+  # fires; when item enrichment is enabled, it routes through "Run enrichment"
+  # so both the bib and item changesets exist by then. Otherwise the loader
+  # goes straight to publish. No adapter currently enables both, but the
+  # chain composes: reconcile runs first, then enrichment.
+  loader_next    = var.enable_reconciliation ? "Should reconcile?" : local.reconcile_next
+  reconcile_next = var.enable_item_enrichment ? "Should enrich?" : "Should publish event?"
 
   # With published tracking, both the publish and the quiet no-publish paths end
   # in "Mark published", which stamps the covered windows so the trigger resumes
@@ -34,6 +38,56 @@ locals {
       }
     ]...)
   )
+
+  reconcile_states = merge([
+    for _ in range(var.enable_reconciliation ? 1 : 0) : {
+      "Should reconcile?" = {
+        Type = "Choice"
+        Choices = [
+          {
+            Condition = "{% $exists($states.input.changeset_ids[0]) %}"
+            Next      = "Run reconcile"
+          }
+        ]
+        Default = local.reconcile_next
+      }
+      "Run reconcile" = {
+        Type     = "Task"
+        Resource = "arn:aws:states:::lambda:invoke"
+        Arguments = {
+          FunctionName = one(module.reconcile_lambda[*].lambda.arn)
+          # The loader response carries no adapter identity, so inject it.
+          Payload = "{% $merge([$states.input, {'adapter_type': '${var.namespace}'}]) %}"
+        }
+        # The loader response continues downstream unchanged; the reconcile
+        # response (fact and mapping counts) stays visible in the execution
+        # history.
+        Output = "{% $states.input %}"
+        Next   = local.reconcile_next
+        Retry = [
+          {
+            ErrorEquals     = ["Lambda.ServiceException", "Lambda.AWSLambdaException", "Lambda.SdkClientException"]
+            IntervalSeconds = 2
+            MaxAttempts     = 3
+            BackoffRate     = 2.0
+          },
+          {
+            # Iceberg optimistic-concurrency commit conflicts; re-runs dedupe
+            # on deterministic fact ids, so retrying is safe.
+            ErrorEquals     = ["States.ALL"]
+            IntervalSeconds = 5
+            MaxAttempts     = 3
+            BackoffRate     = 2.0
+          }
+        ]
+        # No Catch: a failed reconcile must fail the execution before
+        # "Publish event" and "Mark published". A guid change never reappears
+        # in a later changeset, so publishing without its facts would lose
+        # the deletion; leaving the windows unstamped makes the next trigger
+        # re-cover them and retry.
+      }
+    }
+  ]...)
 
   enrichment_states = merge([
     for _ in range(var.enable_item_enrichment ? 1 : 0) : {
@@ -218,7 +272,7 @@ locals {
     QueryLanguage = "JSONata"
     Comment       = "Adapter pipeline (trigger, loader, publish event)"
     StartAt       = "Run trigger"
-    States        = merge(local.base_states, local.enrichment_states, local.mark_published_states)
+    States        = merge(local.base_states, local.reconcile_states, local.enrichment_states, local.mark_published_states)
   })
 }
 

--- a/catalogue_graph/infra/adapters/modules/adapter/variables.tf
+++ b/catalogue_graph/infra/adapters/modules/adapter/variables.tf
@@ -55,3 +55,9 @@ variable "enable_item_enrichment" {
   default     = false
   description = "Run a FOLIO item-enrichment state between Run loader and Publish event. FOLIO-only; leave false for other adapters."
 }
+
+variable "enable_reconciliation" {
+  type        = bool
+  default     = false
+  description = "Run a reconcile state between Run loader and Publish event, recording guid-change deletion facts before the completed event fires. Axiell-only; leave false for other adapters."
+}


### PR DESCRIPTION
## What does this change?

Phase B of wellcomecollection/platform#6446 (Phase A was #3478, merged 2026-07-21). Adds a reconcile state to the adapter state machine module, behind a new `enable_reconciliation` variable, enabled for Axiell only.

On busy windows (those with `changeset_ids`) the loader now routes through the `axiell-adapter-reconcile` lambda before the `axiell.adapter.completed` event publishes, so guid-change deletion facts are durably recorded before the completed event fires. Quiet windows skip straight to "Mark published".

The reconcile state deliberately has no `Catch`. A guid change never reappears in a later changeset, so a failure has to block publishing and window-stamping rather than be swallowed. The next trigger re-covers the unstamped windows, and retries are idempotent because detection dedupes on deterministic fact ids. It retries transient Lambda errors and Iceberg commit conflicts, then fails.

The lambda is sized 10240MB / 600s to match the pipeline transformer, which does the same unprunable changeset read of the id-sorted store (#3444). A CI deploy-matrix entry is needed because image lambdas pin the `:prod` digest at creation and never follow the tag.

## How to test

- `terraform fmt -check -recursive` and `terraform validate` pass.
- A read-only `terraform plan` against live state, diffed against a plan of clean `origin/main`, shows an exclusive footprint of 7 adds plus 2 in-place changes, all under `module.axiell`.

## How can we measure success?

- Busy Axiell windows show a "Run reconcile" task in the execution history, with fact and mapping counts in its output, before "Publish event".
- Quiet windows skip reconcile and still reach "Mark published".
- No new state machine alarms fire on the Axiell adapter.

## Have we considered potential risks?

- A failed reconcile fails the whole execution by design, so a broken lambda blocks Axiell publishing until fixed. That is intentional: losing a deletion is worse than a stalled window.
- The no-`Catch` behaviour rests on the invariant that a guid change never reappears in a later changeset. If that stops holding, the design needs revisiting.

## Deployment status

Already applied to production (2026-07-21, targeted apply; footprint verified as 7 adds plus 2 in-place changes, all in `module.axiell`). The lambda is live and overnight quiet-path executions are all green. Merge is gated only on soak. If #3460 (loader id mode) merges first, expect a small merge in `state_machine.tf`.
