### PR TITLE
Bump GitHub Actions to Node 24 versions

### DIFF
--- a/.github/actions/build-lambda-zip/action.yml
+++ b/.github/actions/build-lambda-zip/action.yml
@@ -49,7 +49,7 @@ runs:
 
     - name: Configure AWS credentials
       if: ${{ inputs.upload_to_s3 == 'true' }}
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         aws-region: eu-west-1
         role-to-assume: ${{ inputs.role_to_assume }}

--- a/.github/actions/deploy-dated-pipeline-lambda/action.yml
+++ b/.github/actions/deploy-dated-pipeline-lambda/action.yml
@@ -38,7 +38,7 @@ runs:
           "${{ inputs.lambda_suffix }}"
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         aws-region: ${{ inputs.aws_region }}
         role-to-assume: ${{ inputs.role_to_assume }}

--- a/.github/actions/deploy-lambda-image/action.yml
+++ b/.github/actions/deploy-lambda-image/action.yml
@@ -24,7 +24,7 @@ runs:
   using: "composite"
   steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         aws-region: ${{ inputs.aws_region }}
         role-to-assume: ${{ inputs.role_to_assume }}

--- a/.github/actions/deploy-lambda-zip/action.yml
+++ b/.github/actions/deploy-lambda-zip/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         aws-region: eu-west-1
         role-to-assume: ${{ inputs.role_to_assume }}

--- a/.github/actions/retag-docker-image/action.yml
+++ b/.github/actions/retag-docker-image/action.yml
@@ -20,7 +20,7 @@ runs:
   using: "composite"
   steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         aws-region: eu-west-1
         role-to-assume: ${{ inputs.role_to_assume }}

--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -14,7 +14,7 @@ runs:
   using: "composite"
   steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         aws-region: eu-west-1
         role-to-assume: ${{ inputs.role_to_assume }}

--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -18,7 +18,7 @@ runs:
       with:
         aws-region: eu-west-1
         role-to-assume: ${{ inputs.role_to_assume }}
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version-file: catalogue_graph/.python-version
     - name: setup dependencies
@@ -37,7 +37,7 @@ runs:
 
     - name: Get Slack webhook URL
       if: ${{ failure() }}
-      uses: aws-actions/aws-secretsmanager-get-secrets@v2
+      uses: aws-actions/aws-secretsmanager-get-secrets@v3
       with:
         secret-ids: |
           SLACK_WEBHOOK_URL,${{ inputs.slack_webhook_secret_id }}

--- a/.github/workflows/catalogue-graph-ci.yml
+++ b/.github/workflows/catalogue-graph-ci.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v7
       - name: Regenerate test documents
         working-directory: catalogue_graph
         run: |

--- a/.github/workflows/catalogue-graph-ci.yml
+++ b/.github/workflows/catalogue-graph-ci.yml
@@ -21,7 +21,7 @@ jobs:
   python-checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - uses: wellcomecollection/.github/.github/actions/python_check@main
         with:
           folder: catalogue_graph
@@ -29,7 +29,7 @@ jobs:
   check-test-documents:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v6
       - name: Regenerate test documents
         working-directory: catalogue_graph
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ python-checks ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - uses: wellcomecollection/.github/.github/actions/docker-build-and-push@main
         with:
           registry: 760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ python-checks ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - uses: wellcomecollection/.github/.github/actions/docker-build-and-push@main
         with:
           registry: 760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome
@@ -74,9 +74,9 @@ jobs:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: eu-west-1
           role-to-assume: ${{ secrets.CATALOGUE_GRAPH_CI_ROLE_ARN }}

--- a/.github/workflows/catalogue-graph-deploy.yml
+++ b/.github/workflows/catalogue-graph-deploy.yml
@@ -28,7 +28,7 @@ jobs:
     outputs:
       pipeline_dates: ${{ steps.discover.outputs.pipeline_dates }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Discover pipeline dates to deploy to
         id: discover
         uses: ./.github/actions/discover-pipeline-dates
@@ -41,7 +41,7 @@ jobs:
       matrix:
         image_name: [ unified_pipeline_task, unified_pipeline_lambda ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/retag-docker-image
         with:
           registry: 760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome
@@ -58,7 +58,7 @@ jobs:
         pipeline_date: ${{ fromJSON(needs.discover-pipeline-dates.outputs.pipeline_dates) }}
         image_name: [ unified_pipeline_task, unified_pipeline_lambda ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/retag-docker-image
         with:
           registry: 760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome
@@ -80,7 +80,7 @@ jobs:
             folio-adapter-trigger,
           ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/deploy-lambda-image
         with:
           lambda_name: ${{ matrix.lambda_name }}
@@ -116,7 +116,7 @@ jobs:
 
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Deploy dated pipeline lambda
         uses: ./.github/actions/deploy-dated-pipeline-lambda
         with:

--- a/.github/workflows/inferrer-python-ci.yml
+++ b/.github/workflows/inferrer-python-ci.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         project: [ aspect_ratio_inferrer, feature_inferrer, palette_inferrer ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - uses: wellcomecollection/.github/.github/actions/python_check@main
         with:
           folder: pipeline/inferrer/${{matrix.project}}
@@ -40,7 +40,7 @@ jobs:
       matrix:
         project: [ aspect_ratio_inferrer, feature_inferrer, palette_inferrer ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - uses: wellcomecollection/.github/.github/actions/docker-build-and-push@main
         with:
           registry: 760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome


### PR DESCRIPTION
## What does this change?

Bumps the GitHub Actions we pin so they run on Node 24 instead of the deprecated Node 20 runtime.

- `actions/checkout@v3` to `@v7` (12 uses)
- `aws-actions/configure-aws-credentials@v4` to `@v6` (7 uses)

Across 9 files under `.github` (workflows and composite actions). `aws-actions/amazon-ecr-login@v2` is already current, so it's left alone.

Every job was emitting a deprecation warning like "Node.js 20 is deprecated ... forced to run on Node.js 24". These bumps clear that.

The workflows only do plain checkouts and OIDC role assumption, so the breaking changes in the intervening major versions don't apply here.

## How to test

- Check the diff is only version-string changes on the two actions.
- CI on this PR runs `catalogue-graph-ci` (its workflow file changed), which exercises the bumped actions. A green run with no Node 20 deprecation warnings is the check.

## How can we measure success?

No more Node 20 deprecation warnings in the Actions logs.

## Have we considered potential risks?

Low risk. It's a mechanical version bump. The changed files were YAML-parsed locally, and the workflows use these actions only for checkout and role assumption, which the newer majors still support unchanged.
