### PR TITLE
Deploy the mark-published lambdas from CI

### DIFF
--- a/.github/workflows/catalogue-graph-deploy.yml
+++ b/.github/workflows/catalogue-graph-deploy.yml
@@ -78,6 +78,8 @@ jobs:
             ebsco-adapter-trigger,
             axiell-adapter-trigger,
             folio-adapter-trigger,
+            axiell-adapter-mark-published,
+            folio-adapter-mark-published,
           ]
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## What does this change?

Adds axiell-adapter-mark-published and folio-adapter-mark-published to the unified pipeline lambdas deploy matrix. Image lambdas pin the digest that :prod resolves to at function creation and never follow the tag afterwards; the matrix is what re-points them on each deploy. Without entries the mark-published handlers stay frozen at creation-day code while the repo moves on, and mark-published sits on the critical path of every Axiell and FOLIO window (it stamps the published cursor, and runs as the final state of the adapter state machine).

Same fix as the reconcile lambda entry in #3479, which found the gap.

## Where these lambdas came from

The mark-published lambdas were introduced by #3449 (merged 2026-07-07), which added the published-window cursor: mark_published.py stamps harvested windows in the window store, and the trigger resumes from the last published window. #3449 added the functions and their state machine wiring to terraform, but not to the deploy matrix, and the adapters stack was not applied in the meantime, so the functions did not exist until a targeted apply of merged main on 2026-07-21 (see comments below). The gap was noticed while adding the reconcile lambda in #3479, which needed the same matrix treatment.

## Merge order

The deploy script fails against a function that does not exist, so the mark-published lambdas (currently pending in the adapters stack) are being created by a targeted terraform apply of merged main before this merges. Do not merge until that apply is confirmed on this PR.

## How to test

After the apply, `aws lambda get-function-configuration --function-name axiell-adapter-mark-published` (and the folio equivalent) succeed, so the new matrix entries deploy cleanly on the next merge to main.

## How can we measure success?

Future changes to mark_published.py reach the deployed functions on merge, visible as updated CodeSha256/image digest after each deploy run.

## Have we considered potential risks?

The entries only run update-function-code against existing functions with the same image the trigger lambdas already deploy. If the apply had not happened, the deploy job would fail loudly rather than deploy anything wrong.
