### PR TITLE
Duplicate pipeline connection secrets to the catalogue account

### DIFF
--- a/pipeline/terraform/modules/pipeline_new/elastic_indices/main.tf
+++ b/pipeline/terraform/modules/pipeline_new/elastic_indices/main.tf
@@ -199,12 +199,9 @@ resource "elasticstack_elasticsearch_ingest_pipeline" "set_indexed_at" {
   ]
 }
 
-# Cluster connection secrets 
-module "pipeline_storage_connection_secrets" {
-  source        = "github.com/wellcomecollection/terraform-aws-secrets?ref=v1.5.0"
-  deletion_mode = "IMMEDIATE"
-
-  key_value_map = {
+# Cluster connection secrets
+locals {
+  connection_secrets_kv_map = {
     "elasticsearch/pipeline_storage_${var.pipeline_date}/public_host"           = var.es_cluster.public_host
     "elasticsearch/pipeline_storage_${var.pipeline_date}/private_host"          = var.es_cluster.private_host
     "elasticsearch/pipeline_storage_${var.pipeline_date}/port"                  = var.es_cluster.port
@@ -214,4 +211,24 @@ module "pipeline_storage_connection_secrets" {
     "elasticsearch/pipeline_storage_${var.pipeline_date}/read_only/es_username" = var.es_cluster.read_only_username
     "elasticsearch/pipeline_storage_${var.pipeline_date}/read_only/es_password" = var.es_cluster.read_only_password
   }
+}
+
+module "pipeline_storage_connection_secrets" {
+  source        = "github.com/wellcomecollection/terraform-aws-secrets?ref=v1.5.0"
+  deletion_mode = "IMMEDIATE"
+
+  key_value_map = local.connection_secrets_kv_map
+}
+
+# Readers in the catalogue account (e.g. the catalogue API's multiCluster
+# entries) resolve these secrets there, so duplicate them like the old
+# pipeline module's pipeline_storage_secrets_catalogue.
+module "pipeline_storage_connection_secrets_catalogue" {
+  source        = "github.com/wellcomecollection/terraform-aws-secrets?ref=v1.5.0"
+  deletion_mode = "IMMEDIATE"
+  providers = {
+    aws = aws.catalogue
+  }
+
+  key_value_map = local.connection_secrets_kv_map
 }


### PR DESCRIPTION
## What does this change?

In `pipeline/terraform/modules/pipeline_new/elastic_indices/main.tf` the cluster connection secrets key/value map is hoisted into a local (`connection_secrets_kv_map`), and a second `terraform-aws-secrets` module instance (`pipeline_storage_connection_secrets_catalogue`) writes the same map into the catalogue account via the `aws.catalogue` provider.

The old pipeline module (`modules/pipeline/elastic/main.tf`) wrote its connection secrets to both the platform and the catalogue accounts (via its `pipeline_storage_secrets_catalogue` module), but `pipeline_new` only wrote them with the default (platform) provider. The catalogue API runs in and reads Secrets Manager from the catalogue account, so its new `axiell-collections-testing` multiCluster entry (wellcomecollection/catalogue-api#936), which reads `elasticsearch/pipeline_storage_2026-07-03/{private_host,port,protocol}`, fails to build at startup and requests selecting that cluster 404.

The `aws.catalogue` alias is already declared in the module's `provider.tf` and passed by the 2026-07-03 stack (`pipeline/terraform/2026-07-03/elastic.tf`), so no wiring changes are needed. There is no behaviour change for the platform-account secrets, which the existing `pipeline_storage_connection_secrets` module still writes. `terraform fmt` applied.

Part of wellcomecollection/platform#6421.

## How to test

Verified today (2026-07-21) before the change:

- The platform account has the full `pipeline_storage_2026-07-03` connection secret set.
- The catalogue account has only the `api_key` secrets for that pipeline date (the connection secrets are missing).
- A locally run catalogue API confirms the `axiell-collections-testing` cluster is dropped at startup because those secrets do not resolve in the catalogue account.

To confirm the fix, run a `terraform plan`/`apply` for the 2026-07-03 stack and check that the catalogue account gains the same `pipeline_storage_2026-07-03` connection secrets that already exist in the platform account. As a reference point, `pipeline_storage_2025-10-02` exists in both accounts, which is the state we are matching here. After apply, the catalogue API should build the `axiell-collections-testing` cluster and requests selecting it should stop 404ing.

## How can we measure success?

The catalogue API's `axiell-collections-testing` multiCluster entry builds successfully and requests selecting that cluster return results instead of 404. The catalogue account holds the full `pipeline_storage_2026-07-03` connection secret set, matching the platform account and matching how the old pipelines behave.

## Have we considered potential risks?

The change only adds a second secrets module writing into the catalogue account; the platform-account secrets are unchanged, so existing readers there are unaffected. The `aws.catalogue` provider is already declared and passed by the calling stack, so there is no new provider plumbing. This mirrors the behaviour of the old pipeline module, so it restores parity rather than introducing a new pattern. The `deletion_mode = "IMMEDIATE"` setting matches the platform-side module.
