### PR TITLE
Restore the org default PR template alongside the API fixtures checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@
 
 ## How to test
 
-<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
+<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z." -->
 
 ## How can we measure success?
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ## What does this change?
 
-<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. -->
+<!-- A PR should have enough detail to be understandable far in the future. e.g. what is the problem / why is the change needed, how does it solve it, and any questions or points of discussion. -->
 
 ### Checklist
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ## What does this change?
 
-<!-- What is the problem / why is the change needed, how does it solve it, and any points of discussion. -->
+<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. -->
 
 ### Checklist
 
@@ -8,4 +8,12 @@
 
 ## How to test
 
-<!-- How can a reviewer verify the change? -->
+<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
+
+## How can we measure success?
+
+<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
+
+## Have we considered potential risks?
+
+<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? -->


### PR DESCRIPTION
## What does this change?

#3472 added a repo-level PR template so authors get a reminder to refresh the catalogue-api test fixtures. That template replaced the org-wide default from `wellcomecollection/.github`, so we lost its "How can we measure success?" and "Have we considered potential risks?" sections along with the original comment wording.

This restores the org default template verbatim and keeps the fixtures checklist from #3472 as a "### Checklist" subsection under "What does this change?". The result is the full four-section org template plus the checklist.

## How to test

Merge this, then open a new PR in this repo. The description should be pre-filled with all four org sections (What does this change?, How to test, How can we measure success?, Have we considered potential risks?) and the fixtures checklist under the first section.

## How can we measure success?

Nothing to measure. The template renders correctly on the next PR opened here.

## Have we considered potential risks?

None worth flagging. It only touches the PR template markdown.
