### PR TITLE
Tidy OAI-PMH report paths and generalise record writer naming

### DIFF
--- a/catalogue_graph/src/adapters/extractors/oai_pmh/README.md
+++ b/catalogue_graph/src/adapters/extractors/oai_pmh/README.md
@@ -29,7 +29,7 @@ All OAI-PMH adapters follow this pattern:
 
 ### Loader (`steps/loader.py`)
 
-- Receives the loader event and spins up a `WindowHarvestManager` with an OAI client plus a per-window `WindowRecordWriter` callback.
+- Receives the loader event and spins up a `WindowHarvestManager` with an OAI client plus a `RecordWriter` callback.
 - For each harvested record, serialises the XML payload into the **Iceberg record table** under the adapter namespace and associates it with the current `job_id`.
 - Updates the window status table with `pending/success/failed` states and attaches tags for `job_id`, `window_key`, and every Iceberg `changeset_id` produced.
 - Returns a `LoaderResponse` containing window results and `changeset_ids`.

--- a/catalogue_graph/src/adapters/extractors/oai_pmh/record_writer.py
+++ b/catalogue_graph/src/adapters/extractors/oai_pmh/record_writer.py
@@ -46,7 +46,7 @@ def build_adapter_store_row(
     }
 
 
-class WindowRecordWriter:
+class RecordWriter:
     """Callback for persisting harvested records to an adapter store.
 
     This callback is invoked by WindowHarvestManager for each batch of records
@@ -59,7 +59,7 @@ class WindowRecordWriter:
         namespace: str,
         table_client: AdapterStore,
         job_id: str,
-        window_range: str | None = None,
+        extra_tags: dict[str, str] | None = None,
     ) -> None:
         """Initialize the record writer.
 
@@ -67,14 +67,15 @@ class WindowRecordWriter:
             namespace: Namespace for records in the adapter store.
             table_client: AdapterStore instance for persisting records.
             job_id: Job identifier for tagging records.
-            window_range: Human-readable window range for tagging. ``None`` when
-                the caller is not harvesting a window (the loader's id mode), in
-                which case rows are tagged with the job id alone.
+            extra_tags: Additional tags merged onto every write, alongside
+                job_id. For example, window mode tags rows with the harvested
+                window range; the loader's id mode passes none, so rows are
+                tagged with the job id alone.
         """
         self.namespace = namespace
         self.table_client = table_client
         self.job_id = job_id
-        self.window_range = window_range
+        self.extra_tags = extra_tags
 
     def _build_rows(self, records: list[tuple[str, Record]]) -> list[dict[str, Any]]:
         """Serialize (identifier, Record) pairs into adapter store rows."""
@@ -88,8 +89,8 @@ class WindowRecordWriter:
     @property
     def _tags(self) -> dict[str, str]:
         tags = {"job_id": self.job_id}
-        if self.window_range is not None:
-            tags["window_range"] = self.window_range
+        if self.extra_tags:
+            tags.update(self.extra_tags)
         return tags
 
     def __call__(
@@ -121,8 +122,8 @@ class WindowRecordWriter:
         )
 
 
-class BufferedWindowRecordWriter(WindowRecordWriter):
-    """Record writer that buffers rows across windows and commits per flush.
+class BufferedRecordWriter(RecordWriter):
+    """Record writer that buffers rows across calls and commits per flush.
 
     In the default (unbuffered) mode every window costs one Iceberg commit for
     its records, which dominates wall-clock time on slow catalogs (e.g. S3
@@ -130,7 +131,7 @@ class BufferedWindowRecordWriter(WindowRecordWriter):
     accumulates rows across windows and commits a single
     ``AdapterStore.incremental_update`` per ``flush()`` call.
 
-    Semantics compared to ``WindowRecordWriter``:
+    Semantics compared to ``RecordWriter``:
 
     - ``__call__`` only buffers: it returns ``changeset_id=None`` and an empty
       ``upserted_record_ids`` list, so per-window summaries carry no changeset
@@ -151,7 +152,7 @@ class BufferedWindowRecordWriter(WindowRecordWriter):
         namespace: str,
         table_client: AdapterStore,
         job_id: str,
-        window_range: str | None = None,
+        extra_tags: dict[str, str] | None = None,
         flush_threshold: int | None = None,
     ) -> None:
         """Initialize the buffered writer.
@@ -165,7 +166,7 @@ class BufferedWindowRecordWriter(WindowRecordWriter):
             namespace=namespace,
             table_client=table_client,
             job_id=job_id,
-            window_range=window_range,
+            extra_tags=extra_tags,
         )
         # Keyed by record id so later windows overwrite earlier buffered rows.
         self._buffer: dict[str, dict[str, Any]] = {}

--- a/catalogue_graph/src/adapters/extractors/oai_pmh/record_writer.py
+++ b/catalogue_graph/src/adapters/extractors/oai_pmh/record_writer.py
@@ -88,9 +88,8 @@ class RecordWriter:
 
     @property
     def _tags(self) -> dict[str, str]:
-        tags = {"job_id": self.job_id}
-        if self.extra_tags:
-            tags.update(self.extra_tags)
+        tags = dict(self.extra_tags) if self.extra_tags else {}
+        tags["job_id"] = self.job_id
         return tags
 
     def __call__(

--- a/catalogue_graph/src/adapters/extractors/oai_pmh/reporting.py
+++ b/catalogue_graph/src/adapters/extractors/oai_pmh/reporting.py
@@ -6,6 +6,7 @@ dimensions, enabling reuse across Axiell, FOLIO, and other adapters.
 
 from __future__ import annotations
 
+from pathlib import PurePosixPath
 from typing import ClassVar
 from uuid import uuid4
 
@@ -61,10 +62,14 @@ class OAIPMHReport(OAIPMHReportBase):
     def s3_uri(self) -> str:
         start = self.window.start_time.strftime("%Y%m%dT%H%M%S")
         end = self.window.end_time.strftime("%Y%m%dT%H%M%S")
-        return (
-            f"s3://{self.report_s3_bucket}/{self.report_s3_prefix}"
-            f"/reports/{self.adapter_type}/{self.label}/{start}_{end}.json"
+        path = PurePosixPath(
+            self.report_s3_prefix,
+            "reports",
+            self.adapter_type,
+            self.label,
+            f"{start}_{end}.json",
         )
+        return f"s3://{self.report_s3_bucket}/{path}"
 
 
 class OAIPMHLoaderReport(OAIPMHReport):
@@ -168,11 +173,14 @@ class OAIPMHIdLoadReport(OAIPMHReportBase):
 
     @property
     def s3_uri(self) -> str:
-        return (
-            f"s3://{self.report_s3_bucket}/{self.report_s3_prefix}"
-            f"/reports/{self.adapter_type}/{self.label}"
-            f"/{self.job_id}_{self.report_id}.json"
+        path = PurePosixPath(
+            self.report_s3_prefix,
+            "reports",
+            self.adapter_type,
+            self.label,
+            f"{self.job_id}_{self.report_id}.json",
         )
+        return f"s3://{self.report_s3_bucket}/{path}"
 
     @classmethod
     def from_id_load(

--- a/catalogue_graph/src/adapters/steps/oai_pmh/loader.py
+++ b/catalogue_graph/src/adapters/steps/oai_pmh/loader.py
@@ -41,8 +41,8 @@ from adapters.extractors.oai_pmh.models.step_events import (
     validate_loader_event,
 )
 from adapters.extractors.oai_pmh.record_writer import (
-    BufferedWindowRecordWriter,
-    WindowRecordWriter,
+    BufferedRecordWriter,
+    RecordWriter,
 )
 from adapters.extractors.oai_pmh.registry import get_config
 from adapters.extractors.oai_pmh.reporting import OAIPMHIdLoadReport, OAIPMHLoaderReport
@@ -201,19 +201,15 @@ def build_harvester(
     store = runtime.require_window_store()
     window_generator = runtime.require_window_generator()
 
-    writer_cls = (
-        BufferedWindowRecordWriter if runtime.flush_every else WindowRecordWriter
-    )
+    writer_cls = BufferedRecordWriter if runtime.flush_every else RecordWriter
     record_writer = writer_cls(
         namespace=runtime.adapter_namespace,
         table_client=runtime.table_client,
         job_id=request.job_id,
-        window_range=request.window.to_iso_string(),
+        extra_tags={"window_range": request.window.to_iso_string()},
     )
     flush_callback = (
-        record_writer.flush
-        if isinstance(record_writer, BufferedWindowRecordWriter)
-        else None
+        record_writer.flush if isinstance(record_writer, BufferedRecordWriter) else None
     )
     return WindowHarvestManager(
         store=store,
@@ -264,7 +260,7 @@ def execute_loader(
     # added to the response here.
     extra_changeset_ids: list[str] = []
     extra_upserted_record_count = 0
-    if isinstance(harvester.record_callback, BufferedWindowRecordWriter):
+    if isinstance(harvester.record_callback, BufferedRecordWriter):
         extra_changeset_ids = harvester.record_callback.changeset_ids
         extra_upserted_record_count = harvester.record_callback.upserted_record_count
 
@@ -327,7 +323,7 @@ def execute_id_loader(
     # prefix rather than passing None through to a malformed request.
     metadata_prefix = request.metadata_prefix or runtime.oai_metadata_prefix
 
-    writer = BufferedWindowRecordWriter(
+    writer = BufferedRecordWriter(
         namespace=runtime.adapter_namespace,
         table_client=runtime.table_client,
         job_id=request.job_id,

--- a/catalogue_graph/tests/adapters/extractors/oai_pmh/test_loader.py
+++ b/catalogue_graph/tests/adapters/extractors/oai_pmh/test_loader.py
@@ -17,8 +17,8 @@ from adapters.extractors.oai_pmh.models.step_events import (
     OAIPMHLoaderResponse,
 )
 from adapters.extractors.oai_pmh.record_writer import (
-    BufferedWindowRecordWriter,
-    WindowRecordWriter,
+    BufferedRecordWriter,
+    RecordWriter,
 )
 from adapters.steps.oai_pmh import loader
 from adapters.steps.oai_pmh.loader import LoaderRuntime
@@ -283,22 +283,22 @@ class TestHandler:
 
 
 # ---------------------------------------------------------------------------
-# WindowRecordWriter tests (adapter-agnostic)
+# RecordWriter tests (adapter-agnostic)
 # ---------------------------------------------------------------------------
 WINDOW_RANGE = "2025-01-01T10:00:00+00:00-2025-01-01T10:15:00+00:00"
 
 
-class TestWindowRecordWriter:
+class TestRecordWriter:
     def test_persists_window(
         self,
         adapter_store_client: AdapterStore,
         adapter_namespace: str,
     ) -> None:
-        writer = WindowRecordWriter(
+        writer = RecordWriter(
             namespace=adapter_namespace,
             table_client=adapter_store_client,
             job_id="job-123",
-            window_range=WINDOW_RANGE,
+            extra_tags={"window_range": WINDOW_RANGE},
         )
         last_modified = datetime(2023, 1, 1, 12, 0, 0, tzinfo=UTC)
         result = writer(
@@ -326,11 +326,11 @@ class TestWindowRecordWriter:
         adapter_store_client: AdapterStore,
         adapter_namespace: str,
     ) -> None:
-        writer = WindowRecordWriter(
+        writer = RecordWriter(
             namespace=adapter_namespace,
             table_client=adapter_store_client,
             job_id="job-123",
-            window_range=WINDOW_RANGE,
+            extra_tags={"window_range": WINDOW_RANGE},
         )
         result = writer(records=[])
 
@@ -344,11 +344,11 @@ class TestWindowRecordWriter:
         adapter_store_client: AdapterStore,
         adapter_namespace: str,
     ) -> None:
-        writer = WindowRecordWriter(
+        writer = RecordWriter(
             namespace=adapter_namespace,
             table_client=adapter_store_client,
             job_id="job-123",
-            window_range=WINDOW_RANGE,
+            extra_tags={"window_range": WINDOW_RANGE},
         )
 
         last_modified = datetime(2023, 1, 1, 12, 0, 0, tzinfo=UTC)
@@ -379,11 +379,11 @@ class TestWindowRecordWriter:
         adapter_store_client: AdapterStore,
         adapter_namespace: str,
     ) -> None:
-        writer = WindowRecordWriter(
+        writer = RecordWriter(
             namespace=adapter_namespace,
             table_client=adapter_store_client,
             job_id="job-123",
-            window_range=WINDOW_RANGE,
+            extra_tags={"window_range": WINDOW_RANGE},
         )
 
         last_modified = datetime(2023, 1, 1, 12, 0, 0, tzinfo=UTC)
@@ -440,11 +440,11 @@ class TestWindowRecordWriter:
         adapter_store_client: AdapterStore,
         adapter_namespace: str,
     ) -> None:
-        writer = WindowRecordWriter(
+        writer = RecordWriter(
             namespace=adapter_namespace,
             table_client=adapter_store_client,
             job_id="job-123",
-            window_range=WINDOW_RANGE,
+            extra_tags={"window_range": WINDOW_RANGE},
         )
 
         last_modified = datetime(2023, 1, 1, 12, 0, 0, tzinfo=UTC)
@@ -533,12 +533,12 @@ class TestLoaderBackfillMode:
         req = _create_loader_event()
 
         legacy = loader.build_harvester(req, loader_runtime)
-        assert type(legacy.record_callback) is WindowRecordWriter
+        assert type(legacy.record_callback) is RecordWriter
         assert legacy.flush_callback is None
 
         loader_runtime.flush_every = 10
         buffered = loader.build_harvester(req, loader_runtime)
-        assert isinstance(buffered.record_callback, BufferedWindowRecordWriter)
+        assert isinstance(buffered.record_callback, BufferedRecordWriter)
         assert buffered.flush_callback == buffered.record_callback.flush
 
     def test_flush_changeset_ids_and_counts_reach_the_response(
@@ -558,7 +558,7 @@ class TestLoaderBackfillMode:
             self: WindowHarvestManager, **kwargs: object
         ) -> list[WindowSummary]:
             # Simulate a flush having committed a changeset during the harvest
-            assert isinstance(self.record_callback, BufferedWindowRecordWriter)
+            assert isinstance(self.record_callback, BufferedRecordWriter)
             self.record_callback.changeset_ids.append("cs-flush-1")
             self.record_callback.upserted_record_count += 1234
             return [summary]
@@ -682,17 +682,17 @@ class TestFromSummariesExtraChangesets:
 
 
 # ---------------------------------------------------------------------------
-# BufferedWindowRecordWriter tests (adapter-agnostic)
+# BufferedRecordWriter tests (adapter-agnostic)
 # ---------------------------------------------------------------------------
-class TestBufferedWindowRecordWriter:
+class TestBufferedRecordWriter:
     def _make_writer(
         self, adapter_store_client: AdapterStore, adapter_namespace: str
-    ) -> BufferedWindowRecordWriter:
-        return BufferedWindowRecordWriter(
+    ) -> BufferedRecordWriter:
+        return BufferedRecordWriter(
             namespace=adapter_namespace,
             table_client=adapter_store_client,
             job_id="job-123",
-            window_range=WINDOW_RANGE,
+            extra_tags={"window_range": WINDOW_RANGE},
         )
 
     def _record(self, content: str | None, when: datetime) -> SimpleNamespace:

--- a/catalogue_graph/tests/adapters/extractors/oai_pmh/test_record_writer.py
+++ b/catalogue_graph/tests/adapters/extractors/oai_pmh/test_record_writer.py
@@ -8,26 +8,26 @@ from lxml import etree
 from oai_pmh_client.models import Header, Record
 
 from adapters.extractors.oai_pmh.record_writer import (
-    BufferedWindowRecordWriter,
-    WindowRecordWriter,
+    BufferedRecordWriter,
+    RecordWriter,
     build_adapter_store_row,
 )
 from adapters.utils.adapter_store import AdapterStore
 from adapters.utils.schemata import ADAPTER_STORE_ARROW_SCHEMA
 
 
-class TestWindowRecordWriterMocked:
+class TestRecordWriterMocked:
     def test_writes_records_to_store(self) -> None:
         mock_store = Mock(spec=AdapterStore)
         mock_store.incremental_update.return_value = Mock(
             changeset_id="123", upserted_record_ids=["rec1"]
         )
 
-        writer = WindowRecordWriter(
+        writer = RecordWriter(
             namespace="test_namespace",
             table_client=mock_store,
             job_id="test_job",
-            window_range="2023-01-01-2023-01-02",
+            extra_tags={"window_range": "2023-01-01-2023-01-02"},
         )
 
         record_header = Header(
@@ -72,11 +72,11 @@ class TestWindowRecordWriterMocked:
     def test_handles_empty_records(self) -> None:
         mock_store = Mock(spec=AdapterStore)
 
-        writer = WindowRecordWriter(
+        writer = RecordWriter(
             namespace="test_namespace",
             table_client=mock_store,
             job_id="test_job",
-            window_range="2023-01-01-2023-01-02",
+            extra_tags={"window_range": "2023-01-01-2023-01-02"},
         )
 
         result = writer([])
@@ -96,11 +96,11 @@ class TestWindowRecordWriterMocked:
             changeset_id="456", upserted_record_ids=["rec1"]
         )
 
-        writer = WindowRecordWriter(
+        writer = RecordWriter(
             namespace="test_namespace",
             table_client=mock_store,
             job_id="test_job",
-            window_range="2023-01-01-2023-01-02",
+            extra_tags={"window_range": "2023-01-01-2023-01-02"},
         )
 
         record_header = Header(
@@ -162,10 +162,8 @@ class TestBuildAdapterStoreRow:
 
 
 class TestBufferedWriterFlushThreshold:
-    def _writer(
-        self, mock_store: Mock, threshold: int | None
-    ) -> BufferedWindowRecordWriter:
-        return BufferedWindowRecordWriter(
+    def _writer(self, mock_store: Mock, threshold: int | None) -> BufferedRecordWriter:
+        return BufferedRecordWriter(
             namespace="ns",
             table_client=mock_store,
             job_id="job",

--- a/catalogue_graph/tests/adapters/utils/test_window_harvester.py
+++ b/catalogue_graph/tests/adapters/utils/test_window_harvester.py
@@ -19,7 +19,7 @@ from pyiceberg.exceptions import NamespaceAlreadyExistsError
 from pyiceberg.table import Table as IcebergTable
 
 import adapters.utils.window_harvester as harvester_mod
-from adapters.extractors.oai_pmh.record_writer import BufferedWindowRecordWriter
+from adapters.extractors.oai_pmh.record_writer import BufferedRecordWriter
 from adapters.utils.adapter_store import AdapterStore
 from adapters.utils.pipeline_store import PipelineStoreUpdate
 from adapters.utils.window_generator import WindowGenerator
@@ -892,13 +892,13 @@ def _build_buffered_harvester(
     temporary_table: IcebergTable,
     *,
     record_callback: WindowCallback | None = None,
-) -> tuple[WindowHarvestManager, BufferedWindowRecordWriter, AdapterStore, FlushSpies]:
+) -> tuple[WindowHarvestManager, BufferedRecordWriter, AdapterStore, FlushSpies]:
     adapter_store = AdapterStore(temporary_table, namespace="harvest")
-    writer = BufferedWindowRecordWriter(
+    writer = BufferedRecordWriter(
         namespace="harvest",
         table_client=adapter_store,
         job_id="job-1",
-        window_range="range",
+        extra_tags={"window_range": "range"},
     )
     harvester = _build_harvester(
         tmp_path,
@@ -971,11 +971,11 @@ def test_flush_every_persists_failed_windows(
     """Failed windows in deferred mode must still have their summaries
     persisted at the flush boundary."""
     adapter_store = AdapterStore(temporary_table, namespace="harvest")
-    writer = BufferedWindowRecordWriter(
+    writer = BufferedRecordWriter(
         namespace="harvest",
         table_client=adapter_store,
         job_id="job-1",
-        window_range="range",
+        extra_tags={"window_range": "range"},
     )
 
     calls = {"count": 0}
@@ -1105,11 +1105,11 @@ def test_flush_every_crash_between_records_and_statuses_recovers_on_rerun(
     successful, so a rerun re-harvests them and the record upserts converge
     (no duplicate rows)."""
     adapter_store = AdapterStore(temporary_table, namespace="harvest")
-    writer = BufferedWindowRecordWriter(
+    writer = BufferedRecordWriter(
         namespace="harvest",
         table_client=adapter_store,
         job_id="job-1",
-        window_range="range",
+        extra_tags={"window_range": "range"},
     )
     harvester = _build_harvester(
         tmp_path,


### PR DESCRIPTION
Follow-up to #3460, resolving two review comments from Stepan Brychta that were left open at merge. Both are mechanical and behaviour-preserving.

## What does this change?

- The OAI-PMH reports now build their S3 paths the same way the transformer reporting does, so path composition is consistent across the codebase. The paths produced are identical.
- The record writer's name and constructor implied it was window-specific, but it also serves the loader's id mode. Renamed and generalised so the name reflects both uses.

## How to test

From `catalogue_graph/`: `uv run pytest tests/adapters/ -q`, plus `ruff check`, `ruff format --check`, and `mypy .` — all clean.

## How can we measure success?

No measurable criteria. Internal cleanup with no behaviour change.

## Have we considered potential risks?

None. Report paths are byte-identical and the rename is a pure refactor.
