### PR TITLE
Enable the 2026-07-03 pipeline works and images path

### DIFF
--- a/pipeline/terraform/2026-07-03/main.tf
+++ b/pipeline/terraform/2026-07-03/main.tf
@@ -21,8 +21,10 @@ module "pipeline" {
   # Base AMI for ECS instances
   ami_id = "resolve:ssm:arn:aws:ssm:eu-west-1:760097843905:parameter/imagebuilder/weco-al2023-ecs-optimised-x86_64/latest"
 
-  enable_graph_pipeline_schedule = false
-  enable_image_inferrer_schedule = false
+  enable_adapter_transformer_trigger = true
+  enable_id_minter_schedule          = true
+  enable_graph_pipeline_schedule     = true
+  enable_image_inferrer_schedule     = true
 
   pipeline_date = local.pipeline_date // namespaces services
   graph_date    = "2026-07-03"        // namespaces graph database

--- a/pipeline/terraform/modules/pipeline_new/state_machine_id_generator.tf
+++ b/pipeline/terraform/modules/pipeline_new/state_machine_id_generator.tf
@@ -57,7 +57,7 @@ resource "aws_scheduler_schedule" "minter_id_generator_schedule" {
     role_arn = aws_iam_role.run_minter_id_generator_role.arn
   }
 
-  state = "DISABLED" # DISABLE for now
+  state = var.enable_id_minter_schedule ? "ENABLED" : "DISABLED"
 }
 
 resource "aws_iam_role" "run_minter_id_generator_role" {

--- a/pipeline/terraform/modules/pipeline_new/state_machine_id_minter.tf
+++ b/pipeline/terraform/modules/pipeline_new/state_machine_id_minter.tf
@@ -77,7 +77,7 @@ resource "aws_scheduler_schedule" "id_minter_schedule" {
     JSON
   }
 
-  state = "DISABLED" # DISABLE for now
+  state = var.enable_id_minter_schedule ? "ENABLED" : "DISABLED"
 }
 
 resource "aws_iam_role" "run_id_minter_role" {

--- a/pipeline/terraform/modules/pipeline_new/state_machine_transformers.tf
+++ b/pipeline/terraform/modules/pipeline_new/state_machine_transformers.tf
@@ -184,7 +184,7 @@ module "adapter_transformer_trigger" {
   event_bus_name    = data.aws_cloudwatch_event_bus.adapter_event_bus.name
   state_machine_arn = module.transformer_state_machine.state_machine_arn
 
-  enabled = false # DISABLE for now
+  enabled = var.enable_adapter_transformer_trigger
 
   event_pattern = {
     source        = [each.value.adapter_source],

--- a/pipeline/terraform/modules/pipeline_new/variables.tf
+++ b/pipeline/terraform/modules/pipeline_new/variables.tf
@@ -72,6 +72,18 @@ variable "enable_image_inferrer_schedule" {
   description = "Whether the scheduled image-inferrer state machine is enabled. Set to false as a kill-switch to pause scheduled inference, e.g. during an incident or a large reindex."
 }
 
+variable "enable_adapter_transformer_trigger" {
+  type        = bool
+  default     = false
+  description = "Whether the EventBridge rule that starts the transformer on <adapter>.adapter.completed events is enabled."
+}
+
+variable "enable_id_minter_schedule" {
+  type        = bool
+  default     = false
+  description = "Whether the id-minter sweep schedule and its id-generator id-pool top-up schedule are enabled."
+}
+
 variable "image_inferrer_max_concurrency" {
   type        = number
   default     = 10


### PR DESCRIPTION
## What does this change?

Turns on continuous processing for the `2026-07-03` catalogue pipeline so it tracks live adapter changes end to end: the works path (source → identified → denormalised → indexed) and the images path. Until now this pipeline's per-hop schedules and its adapter-completed transformer trigger shipped disabled, so `works-indexed-2026-07-03` / `images-indexed-2026-07-03` were near-empty.

Enabling them lets staff preview real, current Axiell/EBSCO output in the live API and website through the existing per-request `?elasticCluster=axiell-collections-testing` toggle (platform#6421), with no cutover.

- Two previously-hardcoded `DISABLED` switches (the adapter-completed transformer trigger, and the id-minter sweep plus its id-generator id-pool top-up schedule) are now gated on new root variables, matching the existing `enable_graph_pipeline_schedule` / `enable_image_inferrer_schedule` pattern. All four are set `true` in the `2026-07-03` root.
- FOLIO stays off — its transformer type remains commented out.
- The matcher and merger need no switch; they are SQS/SNS-driven and cascade automatically.
- The `2025-10-02` production pipeline is untouched: the `pipeline_new` module is consumed only by the `2026-07-03` root.

## How to test

- `terraform validate` passes; a targeted plan of the `2026-07-03` root flips exactly the seven scheduler/event-rule resources from `DISABLED` to `ENABLED`. (The plan also refreshes seven elasticstack index resources' computed `settings_raw` — a pre-existing benign no-op with no managed index attribute changes.)
- End to end: a live adapter run should flow through to `works-indexed-2026-07-03` and be visible via `?elasticCluster=axiell-collections-testing`.

## How can we measure success?

Staff can preview live Axiell/EBSCO records in the API and website before any production cutover.

## Have we considered potential risks?

Rollback is reverting the four root flags. Production (`2025-10-02`) is unaffected as it does not consume this module.
