### PR TITLE
Turn off reindexing on the 2025-10-02 pipeline

### DIFF
--- a/pipeline/terraform/2025-10-02/main.tf
+++ b/pipeline/terraform/2025-10-02/main.tf
@@ -2,7 +2,7 @@ module "pipeline" {
   source = "../modules/pipeline"
 
   reindexing_state = {
-    listen_to_reindexer      = true
+    listen_to_reindexer      = false
     scale_up_tasks           = false
     scale_up_elastic_cluster = false
     scale_up_matcher_db      = false


### PR DESCRIPTION
> [!Note]
> This has been applied.

## What does this change?

Turns off reindexing on the production (`2025-10-02`) pipeline by setting `listen_to_reindexer` to false. Both pipelines currently subscribe to the shared per-source reindex topics, so a reindex would otherwise reach production too. With production unsubscribed, a reindex reaches only the `2026-07-03` pipeline.

On the production stack this flag gates only the reindex-topic subscription and the adapter reindex trigger. Production keeps ingesting live changes: the `adapter.completed` trigger stays enabled and the normal source subscriptions are untouched.

This is part of the full reindex into the new pipeline (wellcomecollection/platform#6445). The `2026-07-03` scale-up that this branch originally carried will follow in a separate PR.

## How to test

`terraform fmt` and `terraform validate` pass for the `2025-10-02` root.

## How can we measure success?

After apply, a reindex reaches only the `2026-07-03` pipeline and production shows no reindex activity.

## Have we considered potential risks?

Reversible, and production's live ingest is unaffected. Apply before starting the full reindex.
