### PR TITLE
Scale up the 2026-07-03 pipeline for reindexing

### DIFF
--- a/pipeline/terraform/2026-07-03/main.tf
+++ b/pipeline/terraform/2026-07-03/main.tf
@@ -3,8 +3,8 @@ module "pipeline" {
 
   reindexing_state = {
     listen_to_reindexer = true
-    scale_up_tasks      = false
-    scale_up_matcher_db = false
+    scale_up_tasks      = true
+    scale_up_matcher_db = true
   }
 
   index_dates = {


### PR DESCRIPTION
## What does this change?

Turns on the reindex-mode capacity flags for the `2026-07-03` pipeline. During the current reindex the matcher was pinned to low concurrency and backlogged (tens of thousands of messages queued), so works were not reaching the denormalised and indexed stages. Scaling up gives the matcher, transformer, and ingestor the capacity to clear the backlog.

Affects the `2026-07-03` pipeline only; production (`2025-10-02`) is untouched.

Part of the full-reindex effort tracked in wellcomecollection/platform#6445 — this is the scale-up prerequisite step noted there.

## How to test

`terraform fmt` and `terraform validate` pass for the `2026-07-03` root.

## How can we measure success?

Matcher queue drains and works progress through the denormalise and index stages.

## Have we considered potential risks?

Apply when reindexing, and revert once it is done: the scale-down apply can only run once per day, so leaving the pipeline scaled up blocks bringing it back down until the next day.
