### PR TITLE
Strip the leading dot from Axiell Sierra system numbers

### DIFF
--- a/catalogue_graph/src/adapters/transformers/marc/other_identifiers.py
+++ b/catalogue_graph/src/adapters/transformers/marc/other_identifiers.py
@@ -76,6 +76,13 @@ def format_field(field: Field) -> SourceIdentifier | None:
     if identifier_type == "wellcome-accession-number":
         id_value = id_value.removeprefix("Acc").strip()
 
+    # Axiell Collections holds Sierra bib numbers in the ".b1234567x" notation (an
+    # artifact of the data migration), but the Sierra adapter and the rest of the
+    # pipeline use the canonical "b1234567x". Without stripping the leading dot the
+    # matcher never links an Axiell work to its Sierra record, so they fail to merge.
+    if identifier_type == "sierra-system-number":
+        id_value = id_value.lstrip(".")
+
     if not id_value:
         return None
 

--- a/catalogue_graph/tests/adapters/transformers/axiell/bdd/features/other_identifiers.feature
+++ b/catalogue_graph/tests/adapters/transformers/axiell/bdd/features/other_identifiers.feature
@@ -13,6 +13,7 @@ Feature: Other Identifiers extraction from MARC records
     Examples:
       | alternative_number                 | scheme                    | other_identifier |
       | (Bibliographic Number)b11839053    | sierra-system-number      | b11839053        |
+      | (Bibliographic Number).b11839053   | sierra-system-number      | b11839053        |
       | (Sierra Number)i12056868           | sierra-identifier         | i12056868        |
       | (Mimsy reference)WELL-55           | mimsy-reference           | WELL-55          |
       | (WI number)L0023438                | miro-image-number         | L0023438         |


### PR DESCRIPTION
## What does this change?

Axiell Collections stores Sierra bib numbers in `.b1234567x` notation (an artifact of the migration into Axiell), and the Axiell transformer was passing that dotted value straight through as the work's sierra-system-number. The Sierra adapter emits the canonical `b1234567x`, and the matcher compares identifier values exactly, so an Axiell archive work never linked to its Sierra catalogue record and the two indexed as separate works instead of merging.

This strips the leading dot from Sierra system numbers, mirroring the existing predecessor-identifier handling, so both sides agree on the identifier value.

Part of wellcomecollection/platform#6445.

## How to test

The added BDD example asserts that `(Bibliographic Number).b11839053` yields sierra-system-number `b11839053`. The full adapters suite (973 tests) passes, with ruff and mypy clean.

## How can we measure success?

Once Axiell replaces CALM as the archives source, archive works whose MARC 035 carries the dotted form merge with their Sierra records rather than indexing as duplicates. Found via a small GC179 Sierra/Axiell merge test reindexed into the 2026-07-03 pipeline; a fresh GetRecord confirmed the live Axiell OAI source still emits the dotted form.

## Have we considered potential risks?

Low risk: the normalisation only touches sierra-system-number values and only removes a leading dot the pipeline never expects. Sierra-sourced numbers have no leading dot, so they are unaffected.
