### PR TITLE
Accept same-version updates that re-link merge candidates in the matcher

### DIFF
--- a/pipeline/matcher_merger/matcher/src/main/scala/weco/pipeline/matcher/matcher/StoredWorksMatcher.scala
+++ b/pipeline/matcher_merger/matcher/src/main/scala/weco/pipeline/matcher/matcher/StoredWorksMatcher.scala
@@ -100,7 +100,7 @@ object StoredWorksMatcher {
 
     new StoredWorksMatcher(
       retriever,
-      WorkMatcher(dynamoConfig, dynamoLockDaoConfig)
+      WorkMatcher(retriever, dynamoConfig, dynamoLockDaoConfig)
     )
   }
 

--- a/pipeline/matcher_merger/matcher/src/main/scala/weco/pipeline/matcher/matcher/WorkMatcher.scala
+++ b/pipeline/matcher_merger/matcher/src/main/scala/weco/pipeline/matcher/matcher/WorkMatcher.scala
@@ -15,6 +15,7 @@ import weco.pipeline.matcher.models.{
 import weco.pipeline.matcher.services.LockingBuilder
 import weco.pipeline.matcher.storage.{WorkGraphStore, WorkNodeDao}
 import weco.pipeline.matcher.workgraph.WorkGraphUpdater
+import weco.pipeline_storage.Retriever
 import weco.storage.dynamo.DynamoConfig
 import weco.storage.locking.dynamo.DynamoLockDaoConfig
 import weco.storage.locking.{
@@ -34,7 +35,8 @@ trait WorkStubMatcher {
 
 class WorkMatcher(
   workGraphStore: WorkGraphStore,
-  lockingService: LockingService[MatcherResult, Future, LockDao[String, UUID]]
+  lockingService: LockingService[MatcherResult, Future, LockDao[String, UUID]],
+  retriever: Retriever[WorkStub]
 )(implicit ec: ExecutionContext)
     extends WorkStubMatcher
     with Logging {
@@ -46,6 +48,18 @@ class WorkMatcher(
 
     withLocks(work, initialLockIds) {
       for {
+        // The work we were given was fetched before we acquired any locks,
+        // so another process may have matched a newer copy of it in the
+        // meantime -- e.g. a re-transform that corrected its merge candidates
+        // at the same version.  If we carried on with a stale copy, we'd
+        // accept it as a last-write-wins update and quietly revert the
+        // corrected graph.
+        //
+        // Check the stored work is still the one we're processing -- if it's
+        // stale, we should bail out and wait for the SQS logic to retry us
+        // with a fresh copy rather than recover.
+        _ <- checkWorkIsCurrent(work)
+
         beforeNodes <- workGraphStore.findAffectedWorks(work.ids)
         afterNodes = WorkGraphUpdater.update(work, beforeNodes)
 
@@ -76,6 +90,24 @@ class WorkMatcher(
       } yield matcherResult
     }
   }
+
+  private def checkWorkIsCurrent(work: WorkStub): Future[Unit] =
+    retriever(Seq(work.id.toString))
+      .flatMap {
+        result =>
+          result.found.get(work.id.toString) match {
+            case Some(latestWork) if latestWork != work =>
+              val t = new RuntimeException(
+                s"Error processing ${work.id}: stored work changed during matching"
+              )
+              Future.failed(t)
+
+            // If the work can't be retrieved (e.g. when the matcher is
+            // driven directly with a work that isn't in the store), carry
+            // on with the copy we were given.
+            case _ => Future.successful(())
+          }
+      }
 
   private def writeUpdate(
     work: WorkStub,
@@ -169,6 +201,7 @@ class WorkMatcher(
 object WorkMatcher extends Logging {
 
   def apply(
+    retriever: Retriever[WorkStub],
     dynamoConfig: DynamoConfig,
     dynamoLockDaoConfig: DynamoLockDaoConfig
   )(
@@ -188,7 +221,7 @@ object WorkMatcher extends Logging {
           dynamoLockDaoConfig
         )
 
-    new WorkMatcher(workGraphStore, lockingService)
+    new WorkMatcher(workGraphStore, lockingService, retriever)
   }
 
 }

--- a/pipeline/matcher_merger/matcher/src/main/scala/weco/pipeline/matcher/models/VersionConflictException.scala
+++ b/pipeline/matcher_merger/matcher/src/main/scala/weco/pipeline/matcher/models/VersionConflictException.scala
@@ -2,11 +2,3 @@ package weco.pipeline.matcher.models
 
 final case class VersionExpectedConflictException(message: String)
     extends Exception(message)
-
-case class VersionUnexpectedConflictException(e: Throwable)
-    extends Exception(e.getMessage)
-
-case object VersionUnexpectedConflictException {
-  def apply(message: String): VersionUnexpectedConflictException =
-    VersionUnexpectedConflictException(new IllegalStateException(message))
-}

--- a/pipeline/matcher_merger/matcher/src/main/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdater.scala
+++ b/pipeline/matcher_merger/matcher/src/main/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdater.scala
@@ -54,15 +54,24 @@ object WorkGraphUpdater extends Logging {
         throw VersionExpectedConflictException(versionConflictMessage)
 
       case Some(
-            SourceWorkData(_, existingVersion, _, existingMergeCandidateIds)
+            SourceWorkData(
+              _,
+              existingVersion,
+              existingSuppressed,
+              existingMergeCandidateIds
+            )
           )
-          if existingVersion == work.version && work.mergeCandidateIds != existingMergeCandidateIds.toSet =>
+          if existingVersion == work.version &&
+            (work.mergeCandidateIds != existingMergeCandidateIds.toSet ||
+              work.suppressed != existingSuppressed) =>
         // This can happen when a transformer change corrects a work's merge
-        // candidates without the source record itself changing: the work is
-        // re-processed at the same version but with different candidates.
+        // candidates or suppression without the source record itself changing:
+        // the work is re-processed at the same version with different content.
         // We accept the update (last write wins) so the graph can re-form.
         warn(
-          s"work:${work.id} v${work.version} resubmitted with different mergeCandidates (${existingMergeCandidateIds.toSet} -> ${work.mergeCandidateIds}); accepting update"
+          s"work:${work.id} v${work.version} resubmitted with different content " +
+            s"(mergeCandidates: ${existingMergeCandidateIds.toSet} -> ${work.mergeCandidateIds}, " +
+            s"suppressed: $existingSuppressed -> ${work.suppressed}); accepting update"
         )
 
       case _ => ()

--- a/pipeline/matcher_merger/matcher/src/main/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdater.scala
+++ b/pipeline/matcher_merger/matcher/src/main/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdater.scala
@@ -8,7 +8,6 @@ import weco.pipeline.matcher.models.{
   SourceWorkData,
   SubgraphId,
   VersionExpectedConflictException,
-  VersionUnexpectedConflictException,
   WorkNode,
   WorkStub
 }
@@ -58,10 +57,13 @@ object WorkGraphUpdater extends Logging {
             SourceWorkData(_, existingVersion, _, existingMergeCandidateIds)
           )
           if existingVersion == work.version && work.mergeCandidateIds != existingMergeCandidateIds.toSet =>
-        val versionConflictMessage =
-          s"update failed, work:${work.id} v${work.version} already exists with different content! update-ids:${work.mergeCandidateIds} != existing-ids:${existingMergeCandidateIds.toSet}"
-        debug(versionConflictMessage)
-        throw VersionUnexpectedConflictException(versionConflictMessage)
+        // This can happen when a transformer change corrects a work's merge
+        // candidates without the source record itself changing: the work is
+        // re-processed at the same version but with different candidates.
+        // We accept the update (last write wins) so the graph can re-form.
+        warn(
+          s"work:${work.id} v${work.version} resubmitted with different mergeCandidates (${existingMergeCandidateIds.toSet} -> ${work.mergeCandidateIds}); accepting update"
+        )
 
       case _ => ()
     }

--- a/pipeline/matcher_merger/matcher/src/test/scala/weco/pipeline/matcher/MatcherFeatureTest.scala
+++ b/pipeline/matcher_merger/matcher/src/test/scala/weco/pipeline/matcher/MatcherFeatureTest.scala
@@ -50,7 +50,6 @@ class MatcherFeatureTest
   private val g00dcafe = SQSTestLambdaMessage(message = "g00dcafe")
   private val g00dd00d = SQSTestLambdaMessage(message = "g00dd00d")
 
-
   private val LambdaBuilder: WorksMatcher => Downstream => StubLambda =
     StubLambda.curried
 

--- a/pipeline/matcher_merger/matcher/src/test/scala/weco/pipeline/matcher/fixtures/MatcherFixtures.scala
+++ b/pipeline/matcher_merger/matcher/src/test/scala/weco/pipeline/matcher/fixtures/MatcherFixtures.scala
@@ -47,7 +47,7 @@ trait MatcherFixtures
   )(testWith: TestWith[MatcherWorkerService[String], R]): R =
     withWorkGraphStore(graphTable) {
       workGraphStore =>
-        withWorkMatcher(workGraphStore) {
+        withWorkMatcher(workGraphStore, retriever) {
           workMatcher =>
             withActorSystem {
               implicit actorSystem =>
@@ -82,7 +82,8 @@ trait MatcherFixtures
     }
 
   def withWorkMatcher[R](
-    workGraphStore: WorkGraphStore
+    workGraphStore: WorkGraphStore,
+    retriever: Retriever[WorkStub] = new MemoryRetriever[WorkStub]()
   )(testWith: TestWith[WorkMatcher, R]): R = {
     implicit val lockDao: MemoryLockDao[String, UUID] =
       new MemoryLockDao[String, UUID]
@@ -91,7 +92,8 @@ trait MatcherFixtures
 
     val workMatcher = new WorkMatcher(
       workGraphStore = workGraphStore,
-      lockingService = lockingService
+      lockingService = lockingService,
+      retriever = retriever
     )
 
     testWith(workMatcher)
@@ -125,8 +127,9 @@ trait MatcherFixtures
     sendNotificationToSQS(queue, body = work.id.toString)
   }
 
-  case class MatcherStub(shorthandResults: Seq[Set[Set[String]]] = Seq(Set.empty[Set[String]]))
-      extends WorksMatcher {
+  case class MatcherStub(
+    shorthandResults: Seq[Set[Set[String]]] = Seq(Set.empty[Set[String]])
+  ) extends WorksMatcher {
 
     var internalShorthandResults: Seq[Set[Set[String]]] = shorthandResults
 

--- a/pipeline/matcher_merger/matcher/src/test/scala/weco/pipeline/matcher/matcher/WorkMatcherConcurrencyTest.scala
+++ b/pipeline/matcher_merger/matcher/src/test/scala/weco/pipeline/matcher/matcher/WorkMatcherConcurrencyTest.scala
@@ -5,7 +5,8 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.pipeline.matcher.fixtures.MatcherFixtures
 import weco.pipeline.matcher.generators.WorkStubGenerators
-import weco.pipeline.matcher.models.MatcherResult
+import weco.pipeline.matcher.models.{MatcherResult, WorkStub}
+import weco.pipeline_storage.memory.MemoryRetriever
 import weco.storage.locking.memory.{MemoryLockDao, MemoryLockingService}
 
 import java.util.UUID
@@ -31,7 +32,11 @@ class WorkMatcherConcurrencyTest
       graphTable =>
         withWorkGraphStore(graphTable) {
           workGraphStore =>
-            val workMatcher = new WorkMatcher(workGraphStore, lockingService)
+            val workMatcher = new WorkMatcher(
+              workGraphStore,
+              lockingService,
+              retriever = new MemoryRetriever[WorkStub]()
+            )
 
             val workA = createWorkWith(
               id = idA,

--- a/pipeline/matcher_merger/matcher/src/test/scala/weco/pipeline/matcher/matcher/WorkMatcherTest.scala
+++ b/pipeline/matcher_merger/matcher/src/test/scala/weco/pipeline/matcher/matcher/WorkMatcherTest.scala
@@ -11,11 +11,13 @@ import weco.pipeline.matcher.fixtures.MatcherFixtures
 import weco.pipeline.matcher.generators.WorkNodeGenerators
 import weco.pipeline.matcher.models._
 import weco.pipeline.matcher.storage.{WorkGraphStore, WorkNodeDao}
+import weco.pipeline_storage.memory.MemoryRetriever
 import weco.storage.fixtures.DynamoFixtures.Table
 import weco.storage.locking.LockFailure
 import weco.storage.locking.memory.{MemoryLockDao, MemoryLockingService}
 
 import java.util.UUID
+import scala.collection.mutable
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
@@ -206,7 +208,11 @@ class WorkMatcherTest
           workGraphStore =>
             val work = createWorkStub
 
-            val workMatcher = new WorkMatcher(workGraphStore, lockingService)
+            val workMatcher = new WorkMatcher(
+              workGraphStore,
+              lockingService,
+              retriever = new MemoryRetriever[WorkStub]()
+            )
 
             val result = workMatcher.matchWork(work)
 
@@ -254,7 +260,11 @@ class WorkMatcherTest
                   new MemoryLockingService[MatcherResult, Future]()
 
                 val workMatcher =
-                  new WorkMatcher(workGraphStore, lockingService)
+                  new WorkMatcher(
+                    workGraphStore,
+                    lockingService,
+                    retriever = new MemoryRetriever[WorkStub]()
+                  )
 
                 val result = workMatcher.matchWork(work)
 
@@ -338,6 +348,43 @@ class WorkMatcherTest
                 whenReady(futures) {
                   _ =>
                     putCount shouldBe 1
+                }
+            }
+        }
+    }
+  }
+
+  // The work we're asked to match is fetched from the store before any locks
+  // are taken, so by the time we hold the locks a newer copy may have been
+  // stored and matched -- e.g. a re-transform that corrected the work's merge
+  // candidates at the same version.  If we carried on with the stale copy,
+  // we'd quietly revert the corrected graph.
+  it("bails out if the stored work changed before it acquired the locks") {
+    withWorkGraphTable {
+      graphTable =>
+        withWorkGraphStore(graphTable) {
+          workGraphStore =>
+            val staleWork = createWorkWith(
+              id = idA,
+              version = 1,
+              mergeCandidateIds = Set(idB)
+            )
+            val latestWork = createWorkWith(
+              id = idA,
+              version = 1,
+              mergeCandidateIds = Set(idC)
+            )
+
+            val retriever = new MemoryRetriever[WorkStub](
+              index = mutable.Map(idA.toString -> latestWork)
+            )
+
+            withWorkMatcher(workGraphStore, retriever) {
+              workMatcher =>
+                whenReady(workMatcher.matchWork(staleWork).failed) {
+                  _.getMessage should include(
+                    "stored work changed during matching"
+                  )
                 }
             }
         }
@@ -446,7 +493,9 @@ class WorkMatcherTest
 
             val workMatcher = new WorkMatcher(
               workGraphStore = workGraphStore,
-              lockingService = new MemoryLockingService[MatcherResult, Future]()
+              lockingService =
+                new MemoryLockingService[MatcherResult, Future](),
+              retriever = new MemoryRetriever[WorkStub]()
             )
 
             // We have three works:

--- a/pipeline/matcher_merger/matcher/src/test/scala/weco/pipeline/matcher/services/MatcherWorkerServiceTest.scala
+++ b/pipeline/matcher_merger/matcher/src/test/scala/weco/pipeline/matcher/services/MatcherWorkerServiceTest.scala
@@ -19,7 +19,6 @@ import weco.pipeline.matcher.models.{
 import weco.pipeline.matcher.models.MatcherResult._
 import weco.pipeline_storage.memory.MemoryRetriever
 
-import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class MatcherWorkerServiceTest
@@ -368,7 +367,7 @@ class MatcherWorkerServiceTest
     }
   }
 
-  it("does not match an existing version with different information") {
+  it("matches an existing version with different information") {
     val workAv2 = createWorkWith(
       id = idA,
       version = 2
@@ -381,19 +380,36 @@ class MatcherWorkerServiceTest
         )
       )
 
+    val workBv1 = createWorkWith(
+      id = idB,
+      version = 1
+    )
+
+    val expectedWorkBv1 =
+      Set(
+        MatchedIdentifiers(
+          identifiers = Set(WorkIdentifier(idB, version = 1))
+        )
+      )
+
     implicit val retriever: MemoryRetriever[WorkStub] =
       new MemoryRetriever[WorkStub]()
     implicit val messageSender: MemoryMessageSender = new MemoryMessageSender()
 
-    withLocalSqsQueuePair(visibilityTimeout = 1 second) {
+    withLocalSqsQueuePair() {
       case QueuePair(queue, dlq) =>
         implicit val q: SQS.Queue = queue
 
         withMatcherService(retriever, queue, messageSender) {
           _ =>
             processAndAssertMatchedWorkIs(workAv2, expectedWorkAv2)
+            processAndAssertMatchedWorkIs(workBv1, expectedWorkBv1)
 
-            // Work V1 is sent but not matched
+            // Work A is re-sent at the same version, but with a merge
+            // candidate pointing at B -- e.g. a transformer change corrected
+            // its merge candidates without the source record changing.
+            //
+            // The matcher accepts the update and links the two works.
             val differentWorkAv2 =
               createWorkWith(
                 id = idA,
@@ -401,10 +417,21 @@ class MatcherWorkerServiceTest
                 mergeCandidateIds = Set(idB)
               )
 
-            sendWork(differentWorkAv2, retriever, queue)
+            processAndAssertMatchedWorkIs(
+              differentWorkAv2,
+              expectedWorks = Set(
+                MatchedIdentifiers(
+                  identifiers = Set(
+                    WorkIdentifier(idA, version = 2),
+                    WorkIdentifier(idB, version = 1)
+                  )
+                )
+              )
+            )
+
             eventually {
               assertQueueEmpty(queue)
-              assertQueueHasSize(dlq, size = 1)
+              assertQueueEmpty(dlq)
             }
         }
     }

--- a/pipeline/matcher_merger/matcher/src/test/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdaterTest.scala
+++ b/pipeline/matcher_merger/matcher/src/test/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdaterTest.scala
@@ -344,6 +344,36 @@ class WorkGraphUpdaterTest
         workB.copy(componentIds = List(idB))
       )
     }
+
+    it(
+      "processes an update for the same version if the suppression changes"
+    ) {
+      val (workA, workB) = createTwoWorks("A->B")
+
+      val existingVersion = workA.sourceWork.get.version
+
+      val result = WorkGraphUpdater
+        .update(
+          work = createWorkWith(
+            idA,
+            version = existingVersion,
+            mergeCandidateIds = Set(idB),
+            workType = "Deleted"
+          ),
+          affectedNodes = Set(workA, workB)
+        )
+
+      result shouldBe Set(
+        workA
+          .copy(componentIds = List(idA))
+          .updateSourceWork(
+            version = existingVersion,
+            mergeCandidateIds = Set(idB),
+            suppressed = true
+          ),
+        workB.copy(componentIds = List(idB))
+      )
+    }
   }
 
   describe("Removing links") {

--- a/pipeline/matcher_merger/matcher/src/test/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdaterTest.scala
+++ b/pipeline/matcher_merger/matcher/src/test/scala/weco/pipeline/matcher/workgraph/WorkGraphUpdaterTest.scala
@@ -7,7 +7,6 @@ import weco.pipeline.matcher.models.{
   SourceWorkData,
   SubgraphId,
   VersionExpectedConflictException,
-  VersionUnexpectedConflictException,
   WorkNode
 }
 
@@ -283,24 +282,67 @@ class WorkGraphUpdaterTest
     }
 
     it(
-      "doesn't process an update for the same version if the work is different from the one stored"
+      "processes an update for the same version if a merge candidate is added"
+    ) {
+      val (workA, workB) = createTwoWorks("A->B")
+      val workC = createOneWork("C")
+
+      val existingVersion = workA.sourceWork.get.version
+
+      val result = WorkGraphUpdater
+        .update(
+          work = createWorkWith(
+            idA,
+            version = existingVersion,
+            mergeCandidateIds = Set(idB, idC)
+          ),
+          affectedNodes = Set(workA, workB, workC)
+        )
+
+      result shouldBe Set(
+        workA
+          .copy(
+            subgraphId = SubgraphId(idA, idB, idC),
+            componentIds = List(idA, idB, idC)
+          )
+          .updateSourceWork(
+            version = existingVersion,
+            mergeCandidateIds = Set(idB, idC)
+          ),
+        workB.copy(
+          subgraphId = SubgraphId(idA, idB, idC),
+          componentIds = List(idA, idB, idC)
+        ),
+        workC.copy(
+          subgraphId = SubgraphId(idA, idB, idC),
+          componentIds = List(idA, idB, idC)
+        )
+      )
+    }
+
+    it(
+      "processes an update for the same version if a merge candidate is removed"
     ) {
       val (workA, workB) = createTwoWorks("A->B")
 
       val existingVersion = workA.sourceWork.get.version
 
-      val thrown = intercept[VersionUnexpectedConflictException] {
-        WorkGraphUpdater
-          .update(
-            work = createWorkWith(
-              idA,
-              version = existingVersion,
-              mergeCandidateIds = Set(idC)
-            ),
-            affectedNodes = Set(workA, workB)
-          )
-      }
-      thrown.getMessage shouldBe s"update failed, work:$idA v$existingVersion already exists with different content! update-ids:Set($idC) != existing-ids:Set($idB)"
+      val result = WorkGraphUpdater
+        .update(
+          work = createWorkWith(
+            idA,
+            version = existingVersion,
+            mergeCandidateIds = Set.empty
+          ),
+          affectedNodes = Set(workA, workB)
+        )
+
+      result shouldBe Set(
+        workA
+          .copy(componentIds = List(idA))
+          .updateSourceWork(version = existingVersion),
+        workB.copy(componentIds = List(idB))
+      )
     }
   }
 


### PR DESCRIPTION
## What does this change?

When a transformer change corrects a work's merge candidates, the work is re-processed at the **same version** (the source record itself hasn't changed). The matcher treated a same-version update with different merge candidates as a conflict and refused it: depending on the deployment the message was either dropped after an error log or retried until it reached the DLQ. Either way the corrected links never re-matched or re-merged until the source record next happened to be edited.

The matcher now accepts same-version updates. Last write wins, and components re-form or split through the normal update path. It still rejects strictly-older updates, and logs a warning whenever same-version content differs so the anomaly stays observable.

To make last-write-wins safe under concurrency, the matcher re-checks the stored work inside the lock and bails out if a fresher copy was matched while it waited, letting SQS retry with the current copy rather than reverting the corrected graph.

Behaviour applies to all pipelines on next deploy, and re-transform corrections become self-healing. One observability change to note: equal-version content divergence used to show up as matcher DLQ messages; it now shows up as a warning log ("resubmitted with different content"), so anything watching the matcher DLQ for this case should watch that log line instead.

Supports the full reindex work (wellcomecollection/platform#6445).

## How to test

The full matcher suite (docker-backed fixtures: localstack SQS, DynamoDB local, ES) passes locally, 71/71, including new tests for same-version re-link, split, idempotent redelivery, and the stale-copy bail-out. CI runs the same suite.

## How can we measure success?

Re-transformed works whose merge candidates changed re-match and re-merge without a source-record edit, and no `different content` conflicts are dropped.

## Have we considered potential risks?

Last-write-wins could revert a concurrent update; the in-lock re-check guards against that by bailing out for SQS to retry. The warning log keeps genuinely-diverging same-version content visible.

