### PR TITLE
Build the reconcile runtime after the adapter store load

### DIFF
--- a/catalogue_graph/scripts/rebuild_adapter.py
+++ b/catalogue_graph/scripts/rebuild_adapter.py
@@ -453,11 +453,6 @@ def rebuild_adapter(
             )
 
     adapter_store = config.build_adapter_store(use_rest_api_table=use_rest_api_table)
-    reconcile_runtime: ReconcileRuntime | None = None
-    if adapter_type == "axiell":
-        reconcile_runtime = build_reconcile_runtime(
-            adapter_type, use_rest_api_table=use_rest_api_table
-        )
 
     # Phase 3: Wipe and reload all stores from snapshots.
     _wipe_store(adapter_store, store_name="adapter store")
@@ -468,7 +463,13 @@ def rebuild_adapter(
         _wipe_store(folio_items.store, store_name="items store")
         _populate_store_from_snapshot(folio_items.store, folio_items.snapshot_path)
 
-    if reconcile_runtime is not None:
+    if adapter_type == "axiell":
+        # Build the reconcile runtime after the load: a pyiceberg handle is
+        # pinned to the snapshot it opened at, so one built earlier would read
+        # nothing and reconcile would write an empty baseline.
+        reconcile_runtime = build_reconcile_runtime(
+            adapter_type, use_rest_api_table=use_rest_api_table
+        )
         _wipe_store(reconcile_runtime.reconciler_store, store_name="reconciler store")
         _run_reconcile(reconcile_runtime, adapter_type, job_id, changeset_ids)
 

--- a/catalogue_graph/tests/adapters/utils/test_rebuild_adapter.py
+++ b/catalogue_graph/tests/adapters/utils/test_rebuild_adapter.py
@@ -297,3 +297,83 @@ def test_rebuild_adapter_orchestration_axiell(
 
     assert len(reconciled) == 1
     assert published == [[changeset_id] for changeset_id in reconciled[0]]
+
+
+def test_reconcile_runtime_sees_the_loaded_records(
+    temporary_table: IcebergTable,
+    temporary_window_status_table: IcebergTable,
+    reconciler_temporary_table: IcebergTable,
+    deletion_facts_temporary_table: IcebergTable,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reconcile must see the loaded rows, so its runtime is built after the load.
+
+    A pyiceberg handle is pinned to the snapshot it opened at, so a runtime built
+    before the load reads nothing. Give build_reconcile_runtime a handle opened
+    at call time, as production does, and assert reconcile sees every record.
+    """
+    adapter_store = AdapterStore(temporary_table, "test_namespace")
+    window_store = WindowStore(temporary_window_status_table)
+
+    snapshot_path = tmp_path / "snapshot.parquet"
+    pq.write_table(
+        adapter_records_to_table(
+            [{"id": f"rec{i}", "content": f"content {i}"} for i in range(3)]
+        ),
+        snapshot_path,
+    )
+
+    def build_runtime_with_fresh_handle(
+        adapter_type: str, *, use_rest_api_table: bool
+    ) -> ReconcileRuntime:
+        # Reopen from the catalog like production's build_adapter_store, so the
+        # handle captures the table state at the moment the runtime is built.
+        fresh = temporary_table.catalog.load_table(temporary_table.name())
+        return ReconcileRuntime(
+            adapter_store=AdapterStore(fresh, "test_namespace"),
+            reconciler_store=ReconcilerStore(
+                reconciler_temporary_table, "test_namespace"
+            ),
+            facts_store=DeletionFactsStore(
+                deletion_facts_temporary_table, "test_namespace"
+            ),
+            adapter_name="axiell",
+            namespace="test_namespace",
+        )
+
+    config_stub = SimpleNamespace(
+        build_adapter_store=lambda **kwargs: adapter_store,
+        build_window_store=lambda **kwargs: window_store,
+    )
+    monkeypatch.setattr(rebuild_adapter, "get_config", lambda adapter_type: config_stub)
+    monkeypatch.setattr(
+        rebuild_adapter, "build_reconcile_runtime", build_runtime_with_fresh_handle
+    )
+    monkeypatch.setattr("builtins.input", lambda *args: "CONFIRM")
+
+    rows_seen_by_reconcile: list[int] = []
+    original_run_reconcile = rebuild_adapter._run_reconcile
+
+    def recording_run_reconcile(
+        runtime: ReconcileRuntime,
+        adapter_type: str,
+        job_id: str,
+        changeset_ids: list[str],
+    ) -> None:
+        rows_seen_by_reconcile.append(
+            runtime.adapter_store.get_records_by_changesets(changeset_ids).num_rows
+        )
+        original_run_reconcile(runtime, adapter_type, job_id, changeset_ids)
+
+    monkeypatch.setattr(rebuild_adapter, "_run_reconcile", recording_run_reconcile)
+
+    rebuild_adapter.rebuild_adapter(
+        "axiell",
+        use_rest_api_table=True,
+        snapshot_path=str(snapshot_path),
+        skip_publish_event=True,
+    )
+
+    # Every loaded record is visible to reconcile; 0 would mean a stale handle.
+    assert rows_seen_by_reconcile == [3]


### PR DESCRIPTION
## What does this change?

The adapter store rebuild script built its Axiell reconcile runtime before wiping and reloading the adapter store. A pyiceberg table handle is pinned to the snapshot it opened at and does not refresh on scan, so the reconcile step read zero records and wrote an empty reconciler baseline. After a rebuild the Axiell reconciler store was left empty, so the first incremental harvests afterward could not detect superseded GUIDs and would silently miss deletions.

This moves the reconcile-runtime construction to after the load, so it opens a handle that sees the freshly loaded records.

Relates to platform#6451 (adapter store rebuild), which this script belongs to.

## How to test

`uv run --group dev pytest tests/adapters/utils/test_rebuild_adapter.py` from `catalogue_graph/`.

The added regression test gives the reconcile runtime a handle opened at call time, as production does, and asserts reconcile sees every loaded record. It fails on the old ordering (0 rows seen) and passes on the fix.

Found originally by a full local dry-run rebuild of the Axiell adapter (~221k records): the reconciler store came out with 0 rows, and holds 220,722 mappings after the fix. The ~600 difference is records with no computable GUID, which reconcile legitimately skips.

## How can we measure success?

After the next Axiell adapter rebuild, the reconciler store is populated (rows roughly matching the record count, not zero), and the following incremental harvests correctly detect superseded GUIDs.

## Have we considered potential risks?

Low risk. The change is a reordering within a rebuild script that is run by hand, plus a test. The old behaviour was the failure mode, so the fix can only improve reconciler coverage.
