### PR TITLE
Stop the elasticstack provider churning every plan

### DIFF
--- a/pipeline/terraform/modules/es_index/main.tf
+++ b/pipeline/terraform/modules/es_index/main.tf
@@ -26,4 +26,12 @@ resource "elasticstack_elasticsearch_index" "the_index" {
   default_pipeline     = var.default_pipeline
 
   deletion_protection = !var.allow_delete
+
+  # settings_raw is computed and never set here, but the provider marks it unknown
+  # on every plan. That diff propagates: it makes module.elastic look like it has
+  # pending changes, which defers the data sources in any module that depends_on a
+  # value derived from it, so their consumers churn too.
+  lifecycle {
+    ignore_changes = [settings_raw]
+  }
 }

--- a/pipeline/terraform/modules/es_index/main.tf
+++ b/pipeline/terraform/modules/es_index/main.tf
@@ -27,10 +27,7 @@ resource "elasticstack_elasticsearch_index" "the_index" {
 
   deletion_protection = !var.allow_delete
 
-  # settings_raw is computed and never set here, but the provider marks it unknown
-  # on every plan. That diff propagates: it makes module.elastic look like it has
-  # pending changes, which defers the data sources in any module that depends_on a
-  # value derived from it, so their consumers churn too.
+  # Computed, never set here, but the provider marks it unknown on every plan.
   lifecycle {
     ignore_changes = [settings_raw]
   }


### PR DESCRIPTION
## What does this change?

`terraform plan` on the 2026-07-03 pipeline reports 19 changes every time, none of them real, which is enough noise to hide genuine drift.

`settings_raw` is computed and never set by the `es_index` module, but elasticstack 0.16.1 marks it unknown on every plan. That is 7 of the changes, one per index. The other 12 cascade: `module.elastic` looks like it has pending changes, so Terraform defers the data sources in `module.task_definition` (which `depends_on` a value derived from it) to apply time, and the transformer roles reading them churn too.

Ignoring `settings_raw` breaks the chain and all 19 go away.

### Why now

Nothing in our config changed. The 2026-07-03 stack pins elasticstack `0.16.1` (`terraform.tf:27`); 2025-10-02 declares no constraint and is still on `0.7.0`, which does not do this. Same `es_index` module, same call, different provider.

That also means 2025-10-02 will start churning the moment its provider is upgraded, and it has the same `trigger_values` chain, so it would pick up the same cascade. This fixes both.

## How to test

`cd pipeline/terraform/2026-07-03 && ./run_terraform.sh plan`

Before: `Plan: 0 to add, 19 to change, 0 to destroy.` After: `No changes.` Verified against the real stack.

## Have we considered potential risks?

Terraform never managed `settings_raw`, so nothing that was under control stops being so. `mappings` and the `analysis_*` attributes stay managed. No index is modified: this changes what Terraform compares, not what it sends.
