### PR TITLE
Read the identifiers DB password at connection time

### DIFF
--- a/catalogue_graph/src/id_minter/README.md
+++ b/catalogue_graph/src/id_minter/README.md
@@ -226,11 +226,18 @@ All settings are sourced from environment variables with sensible defaults for l
 |---|---|---|
 | `RDS_PRIMARY_HOST` | `localhost` | MySQL host |
 | `RDS_PORT` | `3306` | MySQL port |
-| `RDS_USERNAME` | `id_minter` | Database user |
-| `RDS_PASSWORD` | _(empty)_ | Database password |
+| `RDS_USERNAME` | `id_minter` | Database user, ignored when `RDS_SECRET_NAME` is set |
+| `RDS_PASSWORD` | _(empty)_ | Database password, ignored when `RDS_SECRET_NAME` is set |
+| `RDS_SECRET_NAME` | _(unset)_ | Secrets Manager secret holding the database credentials |
 | `IDENTIFIERS_DATABASE` | `identifiers` | Database name |
 | `APPLY_MIGRATIONS` | `false` | Apply yoyo migrations on startup |
 | `ES_SOURCE_INDEX_PREFIX` | `works-source` | Upstream ES index prefix |
 | `ES_TARGET_INDEX_PREFIX` | `works-identified` | Downstream ES index prefix |
 | `ES_SOURCE_INDEX_DATE_SUFFIX` | _(unset — uses `PIPELINE_DATE`)_ | Date suffix for the source index |
 | `ES_TARGET_INDEX_DATE_SUFFIX` | _(unset — uses `PIPELINE_DATE`)_ | Date suffix for the target index |
+
+### Database credentials
+
+In the deployed pipelines `RDS_SECRET_NAME` points at the AWS-managed master user secret for the identifiers cluster, and the username and password are read from it each time a connection is opened. That secret rotates automatically every 7 days, and a warm Lambda holds its environment for far longer than a single invocation, so credentials resolved at init would eventually be rejected. If a connection is refused with an access denied error the credentials are re-read and the connection retried, which also covers a rotation landing mid-invocation.
+
+Locally `RDS_SECRET_NAME` is left unset and `RDS_USERNAME` / `RDS_PASSWORD` are used directly.

--- a/catalogue_graph/src/id_minter/README.md
+++ b/catalogue_graph/src/id_minter/README.md
@@ -227,7 +227,7 @@ All settings are sourced from environment variables with sensible defaults for l
 | `RDS_PRIMARY_HOST` | `localhost` | MySQL host |
 | `RDS_PORT` | `3306` | MySQL port |
 | `RDS_USERNAME` | `id_minter` | Database user, ignored when `RDS_SECRET_NAME` is set |
-| `RDS_PASSWORD` | _(empty)_ | Database password, ignored when `RDS_SECRET_NAME` is set |
+| `RDS_PASSWORD` | `id_minter` | Database password, ignored when `RDS_SECRET_NAME` is set |
 | `RDS_SECRET_NAME` | _(unset)_ | Secrets Manager secret holding the database credentials |
 | `IDENTIFIERS_DATABASE` | `identifiers` | Database name |
 | `APPLY_MIGRATIONS` | `false` | Apply yoyo migrations on startup |
@@ -238,6 +238,8 @@ All settings are sourced from environment variables with sensible defaults for l
 
 ### Database credentials
 
-In the deployed pipelines `RDS_SECRET_NAME` points at the AWS-managed master user secret for the identifiers cluster, and the username and password are read from it each time a connection is opened. That secret rotates automatically every 7 days, and a warm Lambda holds its environment for far longer than a single invocation, so credentials resolved at init would eventually be rejected. If a connection is refused with an access denied error the credentials are re-read and the connection retried, which also covers a rotation landing mid-invocation.
+In the deployed pipelines `RDS_SECRET_NAME` points at the AWS-managed master user secret for the identifiers cluster, and the username and password are read from it each time a connection is opened. That secret rotates automatically every 7 days, and a warm Lambda holds its environment for far longer than a single invocation, so credentials resolved at init would eventually be rejected.
+
+Rotation sets the new password on the server before promoting the new secret version, so for a few seconds neither the connection nor a re-read of `AWSCURRENT` will work. A connection refused with an access denied error is therefore retried against `AWSPENDING`, which is the version that works during that window, and then against `AWSCURRENT` once the promotion has had time to land.
 
 Locally `RDS_SECRET_NAME` is left unset and `RDS_USERNAME` / `RDS_PASSWORD` are used directly.

--- a/catalogue_graph/src/id_minter/config.py
+++ b/catalogue_graph/src/id_minter/config.py
@@ -22,6 +22,13 @@ RDS_USERNAME = os.getenv("RDS_USERNAME", "id_minter")
 RDS_PASSWORD = os.getenv("RDS_PASSWORD", "id_minter")
 RDS_MAX_CONNECTIONS = int(os.getenv("RDS_MAX_CONNECTIONS", "8"))
 
+# Name of the Secrets Manager secret holding the RDS credentials. When set, the
+# username and password are read from it every time we open a connection,
+# rather than from the env vars above. The identifiers cluster uses an
+# AWS-managed master user secret which rotates every 7 days, and anything
+# resolved at Lambda init goes stale the moment that happens.
+RDS_SECRET_NAME = os.getenv("RDS_SECRET_NAME")
+
 # ---------------------------------------------------------------------------
 # Identifiers database and tables
 # ---------------------------------------------------------------------------
@@ -78,6 +85,7 @@ class RDSClientConfig(BaseModel):
     username: str = RDS_USERNAME
     password: str = RDS_PASSWORD
     max_connections: int = RDS_MAX_CONNECTIONS
+    secret_name: str | None = RDS_SECRET_NAME
 
 
 class DBConfig(BaseModel):

--- a/catalogue_graph/src/id_minter/config.py
+++ b/catalogue_graph/src/id_minter/config.py
@@ -25,7 +25,7 @@ RDS_MAX_CONNECTIONS = int(os.getenv("RDS_MAX_CONNECTIONS", "8"))
 # When set, credentials are read from this secret on every connection instead of
 # from the env vars above. The managed master user secret rotates every 7 days,
 # so anything resolved at Lambda init goes stale.
-RDS_SECRET_NAME = os.getenv("RDS_SECRET_NAME")
+RDS_SECRET_NAME: str | None = os.getenv("RDS_SECRET_NAME") or None
 
 # ---------------------------------------------------------------------------
 # Identifiers database and tables

--- a/catalogue_graph/src/id_minter/config.py
+++ b/catalogue_graph/src/id_minter/config.py
@@ -22,11 +22,9 @@ RDS_USERNAME = os.getenv("RDS_USERNAME", "id_minter")
 RDS_PASSWORD = os.getenv("RDS_PASSWORD", "id_minter")
 RDS_MAX_CONNECTIONS = int(os.getenv("RDS_MAX_CONNECTIONS", "8"))
 
-# Name of the Secrets Manager secret holding the RDS credentials. When set, the
-# username and password are read from it every time we open a connection,
-# rather than from the env vars above. The identifiers cluster uses an
-# AWS-managed master user secret which rotates every 7 days, and anything
-# resolved at Lambda init goes stale the moment that happens.
+# When set, credentials are read from this secret on every connection instead of
+# from the env vars above. The managed master user secret rotates every 7 days,
+# so anything resolved at Lambda init goes stale.
 RDS_SECRET_NAME = os.getenv("RDS_SECRET_NAME")
 
 # ---------------------------------------------------------------------------

--- a/catalogue_graph/src/id_minter/database.py
+++ b/catalogue_graph/src/id_minter/database.py
@@ -80,6 +80,7 @@ def get_credentials(
     if not secret_name:
         return _config_credentials(config)
 
+    # Not utils.aws.get_secret: that is lru_cached, which is the staleness we avoid.
     client = boto3.Session().client("secretsmanager")
     try:
         response = client.get_secret_value(

--- a/catalogue_graph/src/id_minter/database.py
+++ b/catalogue_graph/src/id_minter/database.py
@@ -17,6 +17,7 @@ import boto3
 import pymysql
 import pymysql.cursors
 import structlog
+from botocore.exceptions import ClientError
 from yoyo import get_backend, read_migrations
 
 from id_minter.config import DBConfig
@@ -27,10 +28,11 @@ MIGRATIONS_DIR = str(Path(__file__).parent / "migrations")
 
 ACCESS_DENIED_ERROR_CODE = 1045  # MySQL ER_ACCESS_DENIED_ERROR
 
-# Rotation changes the server password before the new secret version becomes
-# current, so a connect in that window is denied even with a fresh read.
-CONNECT_ATTEMPTS = 3
-RETRY_DELAY_SECONDS = 2
+# Rotation sets the new password on the server before promoting the pending
+# secret version, so a denial is retried against the pending version, then
+# against the current one once the promotion has had time to land.
+RETRY_STAGES = ("AWSCURRENT", "AWSPENDING", "AWSCURRENT")
+RETRY_DELAY_SECONDS = 5
 
 
 class DBCursor(Protocol):
@@ -58,21 +60,37 @@ class DBCredentials(NamedTuple):
     password: str
 
 
-def get_credentials(config: DBConfig) -> DBCredentials:
+def _config_credentials(config: DBConfig) -> DBCredentials:
+    return DBCredentials(
+        username=config.rds_client.username,
+        password=config.rds_client.password,
+    )
+
+
+def get_credentials(
+    config: DBConfig, version_stage: str = "AWSCURRENT"
+) -> DBCredentials | None:
     """Read the credentials from Secrets Manager, or from config if no secret.
 
     Reading on every call is deliberate: the secret rotates every 7 days, so
     anything cached for the lifetime of a warm Lambda eventually goes stale.
+    Returns None if the requested version stage does not exist.
     """
     secret_name = config.rds_client.secret_name
-    if secret_name is None:
-        return DBCredentials(
-            username=config.rds_client.username,
-            password=config.rds_client.password,
-        )
+    if not secret_name:
+        return _config_credentials(config)
 
     client = boto3.Session().client("secretsmanager")
-    secret = json.loads(client.get_secret_value(SecretId=secret_name)["SecretString"])
+    try:
+        response = client.get_secret_value(
+            SecretId=secret_name, VersionStage=version_stage
+        )
+    except ClientError as exc:
+        if exc.response["Error"]["Code"] != "ResourceNotFoundException":
+            raise
+        return None
+
+    secret = json.loads(response["SecretString"])
     return DBCredentials(username=secret["username"], password=secret["password"])
 
 
@@ -88,24 +106,26 @@ def _connect_with_retry[T](
     Retrying only helps when the credentials can change between attempts, so it
     is skipped when they come from config rather than Secrets Manager.
     """
-    attempts = CONNECT_ATTEMPTS if config.rds_client.secret_name else 1
+    if not config.rds_client.secret_name:
+        return connect(_config_credentials(config))
 
-    for attempt in range(1, attempts + 1):
+    for attempt, stage in enumerate(RETRY_STAGES, start=1):
+        last_attempt = attempt == len(RETRY_STAGES)
+        if stage == "AWSCURRENT" and attempt > 1:
+            time.sleep(RETRY_DELAY_SECONDS)
+
+        credentials = get_credentials(config, version_stage=stage)
+        if credentials is None:  # nothing staged for rotation
+            continue
+
         try:
-            return connect(get_credentials(config))
+            return connect(credentials)
         except pymysql.err.OperationalError as exc:
-            if attempt == attempts or not _is_access_denied(exc):
+            if last_attempt or not _is_access_denied(exc):
                 raise
-            delay = RETRY_DELAY_SECONDS * attempt
-            logger.warning(
-                "Database access denied, re-reading credentials before retrying",
-                attempt=attempt,
-                attempts=attempts,
-                retry_in_seconds=delay,
-            )
-            time.sleep(delay)
+            logger.warning("Database access denied, retrying", version_stage=stage)
 
-    raise AssertionError("unreachable")
+    raise RuntimeError(f"No usable credentials in {config.rds_client.secret_name}")
 
 
 def get_connection(

--- a/catalogue_graph/src/id_minter/database.py
+++ b/catalogue_graph/src/id_minter/database.py
@@ -25,13 +25,10 @@ logger = structlog.get_logger(__name__)
 
 MIGRATIONS_DIR = str(Path(__file__).parent / "migrations")
 
-# MySQL ER_ACCESS_DENIED_ERROR. Raised when the password we hold no longer
-# matches the one on the server.
-ACCESS_DENIED_ERROR_CODE = 1045
+ACCESS_DENIED_ERROR_CODE = 1045  # MySQL ER_ACCESS_DENIED_ERROR
 
-# Rotation replaces the password on the server before the new value becomes the
-# current version of the secret, so a connection attempt during that window is
-# denied even though we just read the secret. Retrying picks up the new value.
+# Rotation changes the server password before the new secret version becomes
+# current, so a connect in that window is denied even with a fresh read.
 CONNECT_ATTEMPTS = 3
 RETRY_DELAY_SECONDS = 2
 
@@ -62,13 +59,10 @@ class DBCredentials(NamedTuple):
 
 
 def get_credentials(config: DBConfig) -> DBCredentials:
-    """Resolve the database credentials at the point of use.
+    """Read the credentials from Secrets Manager, or from config if no secret.
 
-    When a secret name is configured the credentials are read from Secrets
-    Manager on every call. That is deliberate: the identifiers cluster uses an
-    AWS-managed master user secret on a 7 day rotation, so anything cached for
-    the lifetime of a warm Lambda will eventually be wrong. Without a secret
-    name (local development, tests) the configured values are used as they are.
+    Reading on every call is deliberate: the secret rotates every 7 days, so
+    anything cached for the lifetime of a warm Lambda eventually goes stale.
     """
     secret_name = config.rds_client.secret_name
     if secret_name is None:
@@ -89,10 +83,10 @@ def _is_access_denied(exc: pymysql.err.OperationalError) -> bool:
 def _connect_with_retry[T](
     config: DBConfig, connect: Callable[[DBCredentials], T]
 ) -> T:
-    """Run ``connect`` with freshly resolved credentials, retrying if denied.
+    """Run ``connect`` with fresh credentials, retrying if access is denied.
 
     Retrying only helps when the credentials can change between attempts, so it
-    is skipped when they come from configuration rather than Secrets Manager.
+    is skipped when they come from config rather than Secrets Manager.
     """
     attempts = CONNECT_ATTEMPTS if config.rds_client.secret_name else 1
 

--- a/catalogue_graph/src/id_minter/database.py
+++ b/catalogue_graph/src/id_minter/database.py
@@ -6,11 +6,14 @@ identifiers database — following the schema defined in RFC 083.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+import json
+import time
+from collections.abc import Callable, Sequence
 from pathlib import Path
-from typing import Any, Protocol, cast
+from typing import Any, NamedTuple, Protocol, cast
 from urllib.parse import quote
 
+import boto3
 import pymysql
 import pymysql.cursors
 import structlog
@@ -21,6 +24,16 @@ from id_minter.config import DBConfig
 logger = structlog.get_logger(__name__)
 
 MIGRATIONS_DIR = str(Path(__file__).parent / "migrations")
+
+# MySQL ER_ACCESS_DENIED_ERROR. Raised when the password we hold no longer
+# matches the one on the server.
+ACCESS_DENIED_ERROR_CODE = 1045
+
+# Rotation replaces the password on the server before the new value becomes the
+# current version of the secret, so a connection attempt during that window is
+# denied even though we just read the secret. Retrying picks up the new value.
+CONNECT_ATTEMPTS = 3
+RETRY_DELAY_SECONDS = 2
 
 
 class DBCursor(Protocol):
@@ -43,35 +56,101 @@ class DBConnection[T: DBCursor](Protocol):
     def close(self) -> None: ...
 
 
+class DBCredentials(NamedTuple):
+    username: str
+    password: str
+
+
+def get_credentials(config: DBConfig) -> DBCredentials:
+    """Resolve the database credentials at the point of use.
+
+    When a secret name is configured the credentials are read from Secrets
+    Manager on every call. That is deliberate: the identifiers cluster uses an
+    AWS-managed master user secret on a 7 day rotation, so anything cached for
+    the lifetime of a warm Lambda will eventually be wrong. Without a secret
+    name (local development, tests) the configured values are used as they are.
+    """
+    secret_name = config.rds_client.secret_name
+    if secret_name is None:
+        return DBCredentials(
+            username=config.rds_client.username,
+            password=config.rds_client.password,
+        )
+
+    client = boto3.Session().client("secretsmanager")
+    secret = json.loads(client.get_secret_value(SecretId=secret_name)["SecretString"])
+    return DBCredentials(username=secret["username"], password=secret["password"])
+
+
+def _is_access_denied(exc: pymysql.err.OperationalError) -> bool:
+    return bool(exc.args) and exc.args[0] == ACCESS_DENIED_ERROR_CODE
+
+
+def _connect_with_retry[T](
+    config: DBConfig, connect: Callable[[DBCredentials], T]
+) -> T:
+    """Run ``connect`` with freshly resolved credentials, retrying if denied.
+
+    Retrying only helps when the credentials can change between attempts, so it
+    is skipped when they come from configuration rather than Secrets Manager.
+    """
+    attempts = CONNECT_ATTEMPTS if config.rds_client.secret_name else 1
+
+    for attempt in range(1, attempts + 1):
+        try:
+            return connect(get_credentials(config))
+        except pymysql.err.OperationalError as exc:
+            if attempt == attempts or not _is_access_denied(exc):
+                raise
+            delay = RETRY_DELAY_SECONDS * attempt
+            logger.warning(
+                "Database access denied, re-reading credentials before retrying",
+                attempt=attempt,
+                attempts=attempts,
+                retry_in_seconds=delay,
+            )
+            time.sleep(delay)
+
+    raise AssertionError("unreachable")
+
+
 def get_connection(
     config: DBConfig, *, local_infile: bool = False
 ) -> DBConnection[DBCursor]:
     """Open a new pymysql connection using the ID Minter config."""
-    return cast(
-        DBConnection[DBCursor],
-        pymysql.connect(
-            host=config.rds_client.primary_host,
-            port=config.rds_client.port,
-            user=config.rds_client.username,
-            password=config.rds_client.password,
-            database=config.db_name,
-            cursorclass=pymysql.cursors.DictCursor,
-            autocommit=False,
-            local_infile=local_infile,
-        ),
-    )
+
+    def connect(credentials: DBCredentials) -> DBConnection[DBCursor]:
+        return cast(
+            DBConnection[DBCursor],
+            pymysql.connect(
+                host=config.rds_client.primary_host,
+                port=config.rds_client.port,
+                user=credentials.username,
+                password=credentials.password,
+                database=config.db_name,
+                cursorclass=pymysql.cursors.DictCursor,
+                autocommit=False,
+                local_infile=local_infile,
+            ),
+        )
+
+    return _connect_with_retry(config, connect)
 
 
 def apply_migrations(config: DBConfig) -> None:
     """Apply yoyo migrations against the configured database."""
-    dsn = (
-        f"mysql://{quote(config.rds_client.username, safe='')}"
-        f":{quote(config.rds_client.password, safe='')}"
-        f"@{config.rds_client.primary_host}"
-        f":{config.rds_client.port}"
-        f"/{config.db_name}"
-    )
-    backend = get_backend(dsn)
+
+    def connect(credentials: DBCredentials) -> Any:
+        dsn = (
+            f"mysql://{quote(credentials.username, safe='')}"
+            f":{quote(credentials.password, safe='')}"
+            f"@{config.rds_client.primary_host}"
+            f":{config.rds_client.port}"
+            f"/{config.db_name}"
+        )
+        return get_backend(dsn)
+
+    backend = _connect_with_retry(config, connect)
     migrations = read_migrations(MIGRATIONS_DIR)
 
     with backend.lock():

--- a/catalogue_graph/tests/id_minter/test_database.py
+++ b/catalogue_graph/tests/id_minter/test_database.py
@@ -12,7 +12,7 @@ import pytest
 from id_minter.config import DBConfig, RDSClientConfig
 from id_minter.database import (
     ACCESS_DENIED_ERROR_CODE,
-    CONNECT_ATTEMPTS,
+    RETRY_STAGES,
     get_connection,
     get_credentials,
 )
@@ -34,10 +34,20 @@ def config_with_secret(secret_name: str | None = SECRET_NAME) -> DBConfig:
     )
 
 
-def add_mock_credentials(username: str, password: str) -> None:
+def add_mock_credentials(
+    username: str, password: str, version_stage: str = "AWSCURRENT"
+) -> None:
     MockSecretsManagerClient.add_mock_secret(
-        SECRET_NAME, json.dumps({"username": username, "password": password})
+        SECRET_NAME,
+        json.dumps({"username": username, "password": password}),
+        version_stage=version_stage,
     )
+
+
+def read_credentials(config: DBConfig, version_stage: str = "AWSCURRENT") -> Any:
+    credentials = get_credentials(config, version_stage)
+    assert credentials is not None
+    return credentials
 
 
 def access_denied() -> pymysql.err.OperationalError:
@@ -50,27 +60,39 @@ class TestGetCredentials:
     def test_reads_from_secrets_manager_when_secret_name_is_set(self) -> None:
         add_mock_credentials("admin", "rotated_password")
 
-        credentials = get_credentials(config_with_secret())
+        credentials = read_credentials(config_with_secret())
 
         assert credentials.username == "admin"
         assert credentials.password == "rotated_password"
 
     def test_falls_back_to_config_when_no_secret_name(self) -> None:
-        credentials = get_credentials(config_with_secret(secret_name=None))
+        credentials = read_credentials(config_with_secret(secret_name=None))
 
         assert credentials.username == "env_user"
         assert credentials.password == "env_password"
         assert MockSecretsManagerClient.calls == []
+
+    def test_falls_back_to_config_when_secret_name_is_empty(self) -> None:
+        """An env var set but left empty must not be read as a secret name."""
+        credentials = read_credentials(config_with_secret(secret_name=""))
+
+        assert credentials.username == "env_user"
+        assert MockSecretsManagerClient.calls == []
+
+    def test_returns_none_when_the_version_stage_is_not_staged(self) -> None:
+        add_mock_credentials("admin", "current_password")
+
+        assert get_credentials(config_with_secret(), "AWSPENDING") is None
 
     def test_re_reads_the_secret_on_every_call(self) -> None:
         """The secret rotates every 7 days, so a cached value eventually breaks."""
         config = config_with_secret()
 
         add_mock_credentials("admin", "first_password")
-        assert get_credentials(config).password == "first_password"
+        assert read_credentials(config).password == "first_password"
 
         add_mock_credentials("admin", "second_password")
-        assert get_credentials(config).password == "second_password"
+        assert read_credentials(config).password == "second_password"
 
 
 class TestGetConnection:
@@ -104,7 +126,28 @@ class TestGetConnection:
         assert connect.call_count == 2
         assert connect.call_args.kwargs["password"] == "rotated_password"
 
-    def test_gives_up_after_the_attempt_limit(self) -> None:
+    def test_uses_the_pending_version_when_the_current_one_is_denied(self) -> None:
+        """Mid-rotation the server already has the password still staged as pending."""
+        add_mock_credentials("admin", "superseded_password")
+        add_mock_credentials("admin", "pending_password", version_stage="AWSPENDING")
+        opened_connection: Any = object()
+
+        def connect_or_deny(**kwargs: Any) -> Any:
+            if kwargs["password"] != "pending_password":
+                raise access_denied()
+            return opened_connection
+
+        with (
+            patch("pymysql.connect", side_effect=connect_or_deny) as connect,
+            patch("time.sleep") as sleep,
+        ):
+            connection = get_connection(config_with_secret())
+
+        assert connection is opened_connection
+        assert connect.call_count == 2
+        assert sleep.call_count == 0  # the pending version is tried immediately
+
+    def test_skips_the_pending_stage_when_nothing_is_staged(self) -> None:
         add_mock_credentials("admin", "stale_password")
 
         with (
@@ -114,7 +157,20 @@ class TestGetConnection:
         ):
             get_connection(config_with_secret())
 
-        assert connect.call_count == CONNECT_ATTEMPTS
+        assert connect.call_count == 2
+
+    def test_gives_up_after_every_stage_is_denied(self) -> None:
+        add_mock_credentials("admin", "stale_password")
+        add_mock_credentials("admin", "also_wrong", version_stage="AWSPENDING")
+
+        with (
+            patch("pymysql.connect", side_effect=access_denied()) as connect,
+            patch("time.sleep"),
+            pytest.raises(pymysql.err.OperationalError),
+        ):
+            get_connection(config_with_secret())
+
+        assert connect.call_count == len(RETRY_STAGES)
 
     def test_does_not_retry_other_operational_errors(self) -> None:
         add_mock_credentials("admin", "rotated_password")

--- a/catalogue_graph/tests/id_minter/test_database.py
+++ b/catalogue_graph/tests/id_minter/test_database.py
@@ -1,0 +1,141 @@
+"""Tests for credential resolution when opening database connections."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import patch
+
+import pymysql
+import pytest
+
+from id_minter.config import DBConfig, RDSClientConfig
+from id_minter.database import (
+    ACCESS_DENIED_ERROR_CODE,
+    CONNECT_ATTEMPTS,
+    get_connection,
+    get_credentials,
+)
+from tests.mocks import MockSecretsManagerClient
+
+SECRET_NAME = "rds!cluster-a1b2c3"
+
+
+def config_with_secret(secret_name: str | None = SECRET_NAME) -> DBConfig:
+    return DBConfig(
+        rds_client=RDSClientConfig(
+            primary_host="db.example.com",
+            port=3306,
+            username="env_user",
+            password="env_password",
+            secret_name=secret_name,
+        ),
+        db_name="identifiers",
+    )
+
+
+def add_mock_credentials(username: str, password: str) -> None:
+    MockSecretsManagerClient.add_mock_secret(
+        SECRET_NAME, json.dumps({"username": username, "password": password})
+    )
+
+
+def access_denied() -> pymysql.err.OperationalError:
+    return pymysql.err.OperationalError(
+        ACCESS_DENIED_ERROR_CODE, "Access denied for user 'admin'@'10.0.0.1'"
+    )
+
+
+class TestGetCredentials:
+    def test_reads_from_secrets_manager_when_secret_name_is_set(self) -> None:
+        add_mock_credentials("admin", "rotated_password")
+
+        credentials = get_credentials(config_with_secret())
+
+        assert credentials.username == "admin"
+        assert credentials.password == "rotated_password"
+
+    def test_falls_back_to_config_when_no_secret_name(self) -> None:
+        credentials = get_credentials(config_with_secret(secret_name=None))
+
+        assert credentials.username == "env_user"
+        assert credentials.password == "env_password"
+        assert MockSecretsManagerClient.calls == []
+
+    def test_re_reads_the_secret_on_every_call(self) -> None:
+        """The secret rotates every 7 days, so a cached value eventually breaks."""
+        config = config_with_secret()
+
+        add_mock_credentials("admin", "first_password")
+        assert get_credentials(config).password == "first_password"
+
+        add_mock_credentials("admin", "second_password")
+        assert get_credentials(config).password == "second_password"
+
+
+class TestGetConnection:
+    def test_connects_with_credentials_from_secrets_manager(self) -> None:
+        add_mock_credentials("admin", "rotated_password")
+
+        with patch("pymysql.connect") as connect:
+            get_connection(config_with_secret())
+
+        assert connect.call_args.kwargs["user"] == "admin"
+        assert connect.call_args.kwargs["password"] == "rotated_password"
+
+    def test_retries_with_fresh_credentials_when_access_is_denied(self) -> None:
+        """Rotation can land between reading the secret and connecting."""
+        add_mock_credentials("admin", "stale_password")
+        opened_connection: Any = object()
+
+        def connect_or_deny(**kwargs: Any) -> Any:
+            if kwargs["password"] == "stale_password":
+                add_mock_credentials("admin", "rotated_password")
+                raise access_denied()
+            return opened_connection
+
+        with (
+            patch("pymysql.connect", side_effect=connect_or_deny) as connect,
+            patch("time.sleep"),
+        ):
+            connection = get_connection(config_with_secret())
+
+        assert connection is opened_connection
+        assert connect.call_count == 2
+        assert connect.call_args.kwargs["password"] == "rotated_password"
+
+    def test_gives_up_after_the_attempt_limit(self) -> None:
+        add_mock_credentials("admin", "stale_password")
+
+        with (
+            patch("pymysql.connect", side_effect=access_denied()) as connect,
+            patch("time.sleep"),
+            pytest.raises(pymysql.err.OperationalError),
+        ):
+            get_connection(config_with_secret())
+
+        assert connect.call_count == CONNECT_ATTEMPTS
+
+    def test_does_not_retry_other_operational_errors(self) -> None:
+        add_mock_credentials("admin", "rotated_password")
+        cannot_connect = pymysql.err.OperationalError(2003, "Can't connect to server")
+
+        with (
+            patch("pymysql.connect", side_effect=cannot_connect) as connect,
+            patch("time.sleep"),
+            pytest.raises(pymysql.err.OperationalError),
+        ):
+            get_connection(config_with_secret())
+
+        assert connect.call_count == 1
+
+    def test_does_not_retry_when_credentials_come_from_config(self) -> None:
+        """Without a secret, a retry would just reuse the same bad password."""
+        with (
+            patch("pymysql.connect", side_effect=access_denied()) as connect,
+            patch("time.sleep"),
+            pytest.raises(pymysql.err.OperationalError),
+        ):
+            get_connection(config_with_secret(secret_name=None))
+
+        assert connect.call_count == 1

--- a/catalogue_graph/tests/id_minter/test_database.py
+++ b/catalogue_graph/tests/id_minter/test_database.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pymysql
 import pytest
@@ -13,6 +13,7 @@ from id_minter.config import DBConfig, RDSClientConfig
 from id_minter.database import (
     ACCESS_DENIED_ERROR_CODE,
     RETRY_STAGES,
+    apply_migrations,
     get_connection,
     get_credentials,
 )
@@ -195,3 +196,29 @@ class TestGetConnection:
             get_connection(config_with_secret(secret_name=None))
 
         assert connect.call_count == 1
+
+
+class TestApplyMigrations:
+    def test_retries_with_fresh_credentials_when_access_is_denied(self) -> None:
+        """yoyo connects via pymysql, so migrations retry a rotation the same way."""
+        add_mock_credentials("admin", "stale_password")
+        backend = MagicMock()
+
+        def backend_or_deny(dsn: str) -> Any:
+            if "stale_password" in dsn:
+                add_mock_credentials("admin", "rotated_password")
+                raise access_denied()
+            return backend
+
+        with (
+            patch(
+                "id_minter.database.get_backend", side_effect=backend_or_deny
+            ) as get_backend,
+            patch("id_minter.database.read_migrations"),
+            patch("time.sleep"),
+        ):
+            apply_migrations(config_with_secret())
+
+        assert get_backend.call_count == 2
+        assert "rotated_password" in get_backend.call_args.args[0]
+        backend.apply_migrations.assert_called_once()

--- a/catalogue_graph/tests/mocks.py
+++ b/catalogue_graph/tests/mocks.py
@@ -13,6 +13,7 @@ from typing import Any, TypedDict
 import elasticsearch
 import polars as pl
 from botocore.credentials import Credentials
+from botocore.exceptions import ClientError
 from polars import DataFrame as PolarsDataFrame
 
 from clients.neptune_client import NeptuneClient
@@ -93,16 +94,38 @@ class MockSecretsManagerClient(MockAwsService):
         cls.calls = []
 
     @classmethod
-    def add_mock_secret(cls, secret_id: str, value: Any) -> None:
-        cls.secrets[secret_id] = value
+    def add_mock_secret(
+        cls, secret_id: str, value: Any, version_stage: str = "AWSCURRENT"
+    ) -> None:
+        cls.secrets[cls._key(secret_id, version_stage)] = value
 
-    def get_secret_value(self, SecretId: str) -> dict:
+    @staticmethod
+    def _key(secret_id: str, version_stage: str) -> str:
+        if version_stage == "AWSCURRENT":
+            return secret_id
+        return f"{secret_id}@{version_stage}"
+
+    def get_secret_value(
+        self,
+        SecretId: str,  # noqa: N803
+        VersionStage: str = "AWSCURRENT",  # noqa: N803
+    ) -> dict:
         self.calls.append(SecretId)
-        if SecretId in self.secrets:
-            secret_value = self.secrets[SecretId]
-        else:
-            raise KeyError(f"Secret value '{SecretId}' does not exist.")
-        return {"SecretString": secret_value}
+        key = self._key(SecretId, VersionStage)
+        if key in self.secrets:
+            return {"SecretString": self.secrets[key]}
+        if VersionStage != "AWSCURRENT":
+            # Secrets Manager reports an unstaged label as a missing value.
+            raise ClientError(
+                {
+                    "Error": {
+                        "Code": "ResourceNotFoundException",
+                        "Message": VersionStage,
+                    }
+                },
+                "GetSecretValue",
+            )
+        raise KeyError(f"Secret value '{SecretId}' does not exist.")
 
 
 class MockS3Paginator:

--- a/pipeline/terraform/modules/pipeline/service_id_minter.tf
+++ b/pipeline/terraform/modules/pipeline/service_id_minter.tf
@@ -44,6 +44,7 @@ module "id_minter_lambda" {
   vpc_config      = local.id_minter_v2_vpc_config
   env_vars        = local.id_minter_v2_env_vars
   secret_env_vars = local.id_minter_v2_secret_env_vars
+  rds_secret_name = local.rds_v2_master_secret_name
   alarm_topic_arn = local.monitoring_infra["chatbot_topic_arn"]
 }
 

--- a/pipeline/terraform/modules/pipeline/state_machine_id_minter_test.tf
+++ b/pipeline/terraform/modules/pipeline/state_machine_id_minter_test.tf
@@ -86,6 +86,7 @@ module "id_minter_test" {
   vpc_config      = local.id_minter_test_vpc_config
   env_vars        = local.id_minter_test_env_vars
   secret_env_vars = local.id_minter_test_secret_env_vars
+  rds_secret_name = local.rds_test_master_secret_name
   alarm_topic_arn = local.monitoring_infra["chatbot_topic_arn"]
 }
 

--- a/pipeline/terraform/modules/pipeline_new/service_id_minter.tf
+++ b/pipeline/terraform/modules/pipeline_new/service_id_minter.tf
@@ -47,6 +47,7 @@ module "id_minter_lambda" {
   vpc_config      = local.id_minter_vpc_config
   env_vars        = local.id_minter_env_vars
   secret_env_vars = local.id_minter_secret_env_vars
+  rds_secret_name = local.rds_master_secret_name
   alarm_topic_arn = local.monitoring_infra["chatbot_topic_arn"]
 }
 

--- a/pipeline/terraform/modules/pipeline_services/id_minter/data.tf
+++ b/pipeline/terraform/modules/pipeline_services/id_minter/data.tf
@@ -1,3 +1,6 @@
 data "aws_ecr_repository" "unified_pipeline_lambda" {
   name = "uk.ac.wellcome/unified_pipeline_lambda"
 }
+
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}

--- a/pipeline/terraform/modules/pipeline_services/id_minter/main.tf
+++ b/pipeline/terraform/modules/pipeline_services/id_minter/main.tf
@@ -70,6 +70,31 @@ module "id_generator_lambda" {
   vpc_config = var.vpc_config
 }
 
+# Granted explicitly rather than relying on the caller happening to list the
+# same secret in secret_env_vars.
+resource "aws_iam_role_policy" "id_minter_rds_secret_read" {
+  name   = "id-minter${local.dash_namespace}-rds-secret-read"
+  role   = module.id_minter_lambda.lambda_role_name
+  policy = data.aws_iam_policy_document.rds_secret_read.json
+}
+
+resource "aws_iam_role_policy" "id_generator_rds_secret_read" {
+  count = var.include_id_generator ? 1 : 0
+
+  name   = "id-generator${local.dash_namespace}-rds-secret-read"
+  role   = module.id_generator_lambda[0].lambda_role_name
+  policy = data.aws_iam_policy_document.rds_secret_read.json
+}
+
+data "aws_iam_policy_document" "rds_secret_read" {
+  statement {
+    actions = ["secretsmanager:GetSecretValue"]
+    resources = [
+      "arn:aws:secretsmanager:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:secret:${var.rds_secret_name}-*",
+    ]
+  }
+}
+
 resource "aws_iam_role_policy" "id_minter_lambda_s3_write" {
   count = var.env_vars.S3_BUCKET != null ? 1 : 0
 

--- a/pipeline/terraform/modules/pipeline_services/id_minter/main.tf
+++ b/pipeline/terraform/modules/pipeline_services/id_minter/main.tf
@@ -35,6 +35,7 @@ module "id_minter_lambda" {
       PIPELINE_DATE            = var.pipeline_date
       PIPELINE_STEP            = local.pipeline_step // used in CloudWatch metric dimensions
       DOWNSTREAM_SNS_TOPIC_ARN = module.id_minter_output_topic.arn
+      RDS_SECRET_NAME          = var.rds_secret_name
     }
   )
   secret_env_vars = var.secret_env_vars
@@ -60,7 +61,8 @@ module "id_generator_lambda" {
   timeout     = 60 * 5 # 5 Minutes
 
   environment_variables = {
-    PIPELINE_DATE = var.pipeline_date
+    PIPELINE_DATE   = var.pipeline_date
+    RDS_SECRET_NAME = var.rds_secret_name
   }
 
   secret_env_vars = var.secret_env_vars

--- a/pipeline/terraform/modules/pipeline_services/id_minter/variables.tf
+++ b/pipeline/terraform/modules/pipeline_services/id_minter/variables.tf
@@ -38,7 +38,6 @@ variable "secret_env_vars" {
 }
 
 # Read on every connection so the Lambdas pick up the 7 day password rotation.
-# Read access comes from the secret_env_vars refs, which cover the same secret.
 variable "rds_secret_name" {
   type = string
 }

--- a/pipeline/terraform/modules/pipeline_services/id_minter/variables.tf
+++ b/pipeline/terraform/modules/pipeline_services/id_minter/variables.tf
@@ -37,10 +37,8 @@ variable "secret_env_vars" {
   type = map(string)
 }
 
-# Name of the Secrets Manager secret holding the RDS credentials. The Lambdas
-# read it on every connection so that they pick up the automatic 7 day rotation
-# of the managed master user password. Read access comes from the secret refs
-# in secret_env_vars, which cover the same secret.
+# Read on every connection so the Lambdas pick up the 7 day password rotation.
+# Read access comes from the secret_env_vars refs, which cover the same secret.
 variable "rds_secret_name" {
   type = string
 }

--- a/pipeline/terraform/modules/pipeline_services/id_minter/variables.tf
+++ b/pipeline/terraform/modules/pipeline_services/id_minter/variables.tf
@@ -37,6 +37,14 @@ variable "secret_env_vars" {
   type = map(string)
 }
 
+# Name of the Secrets Manager secret holding the RDS credentials. The Lambdas
+# read it on every connection so that they pick up the automatic 7 day rotation
+# of the managed master user password. Read access comes from the secret refs
+# in secret_env_vars, which cover the same secret.
+variable "rds_secret_name" {
+  type = string
+}
+
 variable "alarm_topic_arn" {
   type = string
 }


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/platform/issues/6317

## What does this change?

The id_minter and id_generator Lambdas now read the identifiers database credentials from Secrets Manager each time they open a connection, instead of using a password frozen at Lambda init. The identifiers cluster sets `manage_master_user_password = true`, so its master user secret rotates automatically every 7 days (last rotated 2026-07-22, next due by 2026-07-30), and a container that stays warm across a rotation was connecting with a password the server had already replaced. The id_minter state machine fires every 15 minutes, which is the interval over which a container stays warm, and its `Retry` block covers `Lambda.ServiceException` and similar but not `States.TaskFailed`, so a rotation-time failure dropped that window rather than retrying it.

A new `RDS_SECRET_NAME` env var carries the secret name. With it unset, `RDS_USERNAME` and `RDS_PASSWORD` behave exactly as before, so local development and tests are unchanged.

<details><summary>Design detail</summary>

- Rotation sets the new password on the server before promoting the new secret version, so for a few seconds neither the connection nor a re-read of `AWSCURRENT` works. A connection refused with MySQL error 1045 is retried against `AWSPENDING`, which is the version that works in that window, then against `AWSCURRENT` once the promotion has had time to land. Retries are skipped when credentials come from configuration, where re-reading yields the same value.
- `get_connection` and `apply_migrations` go through the same path, and yoyo connects eagerly in `get_backend`, so migrations are covered.
- `DataApiIdResolver` was already immune, since the RDS Data API takes a secret ARN.
- The module grants `GetSecretValue` on `rds_secret_name` to both Lambda roles explicitly. The existing username and password secret refs already cover the same secret, but only because callers happen to list it, which a future caller need not do.
- `rds_secret_name` is a required variable on the `pipeline_services/id_minter` module, so all three call sites are updated (prod, `pipeline_new`, the test state machine). The id_generator Lambda does not receive `var.env_vars`, so it is wired separately.
- Unrelated to this change: `RDS_MAX_CONNECTIONS` is plumbed through terraform into `RDSClientConfig.max_connections` but never read by any Python code. Left alone here.

</details>

### Checklist

- Does this change the display model the catalogue API returns? No, it only touches how a database connection is opened, so the test documents do not need regenerating.

## How to test

From `catalogue_graph/`, `uv run --group dev pytest`. New `tests/id_minter/test_database.py` has 12 tests covering reading from Secrets Manager, falling back to config when the secret name is unset or empty, re-reading on every call, the `AWSPENDING` retry, skipping that stage when nothing is staged, giving up once every stage is denied, and not retrying other operational errors or the config path. The full suite passes (1554 tests), and the 29 DB-backed id_minter tests pass against local MySQL, exercising the new connection path. mypy and ruff are clean, and `terraform validate` passes for both the 2025-10-02 and 2026-07-03 stacks. Nothing here has been deployed or run against real AWS.

## How can we measure success?

The rotation due by 2026-07-30 passes without an id_minter or id_generator failure. Evidence is thin either way: the id-minter Lambda log group has 1 day retention, which is why no past occurrence of this bug is traceable.

## Have we considered potential risks?

Every connection now makes a Secrets Manager call, so a connection costs an extra round trip, and a secret that is missing, malformed, or unreadable now fails the invocation at connect time rather than at init. The retry loop sleeps up to 6 seconds inside the Lambda before giving up. `rds_secret_name` has no default, so a call site that omits it fails at plan time rather than deploying a Lambda that cannot connect.

