### PR TITLE
Refer to related concepts by an ID that has works

### DIFF
--- a/catalogue_graph/src/ingestor/extractors/concepts/base_concepts_extractor.py
+++ b/catalogue_graph/src/ingestor/extractors/concepts/base_concepts_extractor.py
@@ -40,14 +40,7 @@ CONCEPTS_BATCH_SIZE = 40_000
 
 
 def _choose_target_id(primary_id: str, referenced_ids: set[str]) -> str:
-    """
-    Choose which ID to use when referring to a related concept.
-
-    `referenced_ids` are the IDs the graph returned for this related concept, all of which are connected to at least
-    one work (see `get_related_query`). `primary_id` is the primary of their 'same as' group, which may itself have
-    no works. Prefer the primary for consistency with the rest of the ingestor, but fall back to a referenced ID
-    when the primary is not among them.
-    """
+    """Refer to a related concept by an ID which has works. `referenced_ids` all do, the primary might not."""
     if primary_id in referenced_ids:
         return primary_id
 
@@ -167,9 +160,7 @@ class GraphBaseConceptsExtractor(GraphBaseExtractor, StreamingExtractor, ABC):
                     if related.get("relationship_type"):
                         entry["relationship_type"].add(related["relationship_type"])
 
-        # Results are merged under a primary ID, but the primary of a 'same as' group is chosen alphabetically and is
-        # not necessarily connected to any works. Concepts without works are removed from the graph (and therefore
-        # from the concepts index), so pointing at one produces a related concept which resolves to a 404.
+        # Concepts with no works are removed from the index, so referring to one would 404.
         for entries in merged_result.values():
             for primary_related_id, entry in entries.items():
                 entry["id"] = _choose_target_id(

--- a/catalogue_graph/src/ingestor/extractors/concepts/base_concepts_extractor.py
+++ b/catalogue_graph/src/ingestor/extractors/concepts/base_concepts_extractor.py
@@ -39,6 +39,21 @@ RelatedConcepts = dict[str, list[ExtractedRelatedConcept]]
 CONCEPTS_BATCH_SIZE = 40_000
 
 
+def _choose_target_id(primary_id: str, referenced_ids: set[str]) -> str:
+    """
+    Choose which ID to use when referring to a related concept.
+
+    `referenced_ids` are the IDs the graph returned for this related concept, all of which are connected to at least
+    one work (see `get_related_query`). `primary_id` is the primary of their 'same as' group, which may itself have
+    no works. Prefer the primary for consistency with the rest of the ingestor, but fall back to a referenced ID
+    when the primary is not among them.
+    """
+    if primary_id in referenced_ids:
+        return primary_id
+
+    return sorted(referenced_ids)[0]
+
+
 class GraphBaseConceptsExtractor(GraphBaseExtractor, StreamingExtractor, ABC):
     """Abstract base class for concept extraction from the catalogue graph.
 
@@ -142,14 +157,24 @@ class GraphBaseConceptsExtractor(GraphBaseExtractor, StreamingExtractor, ABC):
                     entry = merged_result[primary_id].setdefault(
                         primary_related_id,
                         {
-                            "id": primary_related_id,
                             "count": 0,
                             "relationship_type": set(),
+                            "referenced_ids": set(),
                         },
                     )
                     entry["count"] += related["count"]
+                    entry["referenced_ids"].add(related["id"])
                     if related.get("relationship_type"):
                         entry["relationship_type"].add(related["relationship_type"])
+
+        # Results are merged under a primary ID, but the primary of a 'same as' group is chosen alphabetically and is
+        # not necessarily connected to any works. Concepts without works are removed from the graph (and therefore
+        # from the concepts index), so pointing at one produces a related concept which resolves to a 404.
+        for entries in merged_result.values():
+            for primary_related_id, entry in entries.items():
+                entry["id"] = _choose_target_id(
+                    primary_related_id, entry["referenced_ids"]
+                )
 
         limit = self.neptune_params["related_to_limit"]
         sorted_result = {
@@ -157,8 +182,12 @@ class GraphBaseConceptsExtractor(GraphBaseExtractor, StreamingExtractor, ABC):
             for concept_id, entries in merged_result.items()
         }
 
-        primary_related_ids = {self.get_primary(i) for i in related_ids}
-        full_related_concepts = self.get_concepts(primary_related_ids)
+        target_ids = {
+            entry["id"]
+            for entries in merged_result.values()
+            for entry in entries.values()
+        }
+        full_related_concepts = self.get_concepts(target_ids)
 
         full_result = defaultdict(list)
         for concept_id in ids:

--- a/catalogue_graph/src/ingestor/extractors/concepts/base_concepts_extractor.py
+++ b/catalogue_graph/src/ingestor/extractors/concepts/base_concepts_extractor.py
@@ -39,12 +39,12 @@ RelatedConcepts = dict[str, list[ExtractedRelatedConcept]]
 CONCEPTS_BATCH_SIZE = 40_000
 
 
-def _choose_target_id(primary_id: str, referenced_ids: set[str]) -> str:
-    """Refer to a related concept by an ID which has works. `referenced_ids` all do, the primary might not."""
-    if primary_id in referenced_ids:
+def _choose_target_id(primary_id: str, candidate_ids: set[str]) -> str:
+    """Refer to a related concept by an ID which has works, keeping the primary whenever it has works itself."""
+    if primary_id in candidate_ids:
         return primary_id
 
-    return sorted(referenced_ids)[0]
+    return sorted(candidate_ids)[0]
 
 
 class GraphBaseConceptsExtractor(GraphBaseExtractor, StreamingExtractor, ABC):
@@ -126,6 +126,11 @@ class GraphBaseConceptsExtractor(GraphBaseExtractor, StreamingExtractor, ABC):
             for same_as_id in same_as_ids:
                 self.primary_map[same_as_id] = primary_id
 
+    def _get_work_connected_ids(self, concept_ids: Iterable[str]) -> set[str]:
+        """Return the subset of `concept_ids` connected to at least one work, as CONCEPT_TYPE_QUERY joins through
+        HAS_CONCEPT and so yields no row for a concept without works."""
+        return set(self.make_neptune_query("concept_type", concept_ids))
+
     def _get_related_concepts(
         self, query_type: ConceptQuery, ids: Iterable[str]
     ) -> RelatedConcepts:
@@ -160,12 +165,22 @@ class GraphBaseConceptsExtractor(GraphBaseExtractor, StreamingExtractor, ABC):
                     if related.get("relationship_type"):
                         entry["relationship_type"].add(related["relationship_type"])
 
-        # Concepts with no works are removed from the index, so referring to one would 404.
+        # Concepts with no works are removed from the index, so referring to one would 404. The related query
+        # collapses each 'same as' group to one arbitrary member, so ask the graph which members have works
+        # rather than relying on whichever member came back.
+        group_ids = {i for r in related_ids for i in self.get_same_as(r)}
+        work_connected_ids = self._get_work_connected_ids(group_ids)
+
         for entries in merged_result.values():
             for primary_related_id, entry in entries.items():
-                entry["id"] = _choose_target_id(
-                    primary_related_id, entry["referenced_ids"]
-                )
+                candidate_ids = {
+                    i
+                    for i in self.get_same_as(primary_related_id)
+                    if i in work_connected_ids
+                }
+                # The related query only returns concepts which have works, so these are a safe fallback.
+                candidate_ids.update(entry["referenced_ids"])
+                entry["id"] = _choose_target_id(primary_related_id, candidate_ids)
 
         limit = self.neptune_params["related_to_limit"]
         sorted_result = {

--- a/catalogue_graph/tests/ingestor/test_concepts_extractor.py
+++ b/catalogue_graph/tests/ingestor/test_concepts_extractor.py
@@ -10,7 +10,7 @@ from tests.mocks import get_mock_neptune_client
 
 SOURCE_CONCEPT_ID = "aaaaaaaa"
 
-# 'th3tx5an' sorts before 'wsg7zfsq', so it is the primary of their 'same as' group.
+# 'th3tx5an' sorts first, so it is the primary.
 UNCONNECTED_PRIMARY_ID = "th3tx5an"
 WORK_CONNECTED_ID = "wsg7zfsq"
 
@@ -37,13 +37,7 @@ def _an_extracted_concept(concept_id: str) -> ExtractedConcept:
 
 
 class StubConceptsExtractor(GraphBaseConceptsExtractor):
-    """
-    A concepts extractor with the Neptune round trips replaced by canned responses.
-
-    `related` maps a source concept ID to the related concept IDs the graph returned for it. Every ID returned by
-    the related concept queries is connected to at least one work, because those queries filter on HAS_CONCEPT.
-    `same_as_groups` maps a concept ID to the other members of its 'same as' group.
-    """
+    """Concepts extractor with canned Neptune responses. IDs in `related` all have works, as the queries filter on HAS_CONCEPT."""
 
     def __init__(
         self, related: dict[str, list[str]], same_as_groups: dict[str, list[str]]
@@ -92,12 +86,7 @@ def test_choose_target_id_falls_back_when_the_primary_is_not_referenced() -> Non
 
 
 def test_related_concept_target_skips_a_primary_with_no_works() -> None:
-    """
-    A related concept must be referred to by an ID which is connected to works.
-
-    Concepts without works are removed from the graph and deleted from the concepts index, so referring to one
-    produces a link which resolves to a 404. See platform#6388.
-    """
+    """See platform#6388: referring to a work-less concept produced a link which 404d."""
     extractor = StubConceptsExtractor(
         related={SOURCE_CONCEPT_ID: [WORK_CONNECTED_ID]},
         same_as_groups={WORK_CONNECTED_ID: [UNCONNECTED_PRIMARY_ID]},
@@ -110,7 +99,7 @@ def test_related_concept_target_skips_a_primary_with_no_works() -> None:
 
 
 def test_related_concepts_still_merge_onto_a_referenced_primary() -> None:
-    """Synonymous related concepts are merged under one entry, keeping the primary ID when it has works itself."""
+    """Synonymous related concepts still merge under the primary when it has works itself."""
     extractor = StubConceptsExtractor(
         related={SOURCE_CONCEPT_ID: [WORK_CONNECTED_ID, UNCONNECTED_PRIMARY_ID]},
         same_as_groups={

--- a/catalogue_graph/tests/ingestor/test_concepts_extractor.py
+++ b/catalogue_graph/tests/ingestor/test_concepts_extractor.py
@@ -1,0 +1,125 @@
+from collections.abc import Generator, Iterable
+from typing import Any
+
+from ingestor.extractors.concepts.base_concepts_extractor import (
+    GraphBaseConceptsExtractor,
+    _choose_target_id,
+)
+from ingestor.models.neptune.query_result import ExtractedConcept
+from tests.mocks import get_mock_neptune_client
+
+SOURCE_CONCEPT_ID = "aaaaaaaa"
+
+# 'th3tx5an' sorts before 'wsg7zfsq', so it is the primary of their 'same as' group.
+UNCONNECTED_PRIMARY_ID = "th3tx5an"
+WORK_CONNECTED_ID = "wsg7zfsq"
+
+
+def _an_extracted_concept(concept_id: str) -> ExtractedConcept:
+    return ExtractedConcept.model_validate(
+        {
+            "concept": {
+                "~id": concept_id,
+                "~entityType": "node",
+                "~labels": ["Concept"],
+                "~properties": {
+                    "id": concept_id,
+                    "label": "Labor supply",
+                    "source": "lc-subjects",
+                    "type": "Concept",
+                },
+            },
+            "source_concepts": [],
+            "linked_source_concepts": [],
+            "types": ["Concept"],
+        }
+    )
+
+
+class StubConceptsExtractor(GraphBaseConceptsExtractor):
+    """
+    A concepts extractor with the Neptune round trips replaced by canned responses.
+
+    `related` maps a source concept ID to the related concept IDs the graph returned for it. Every ID returned by
+    the related concept queries is connected to at least one work, because those queries filter on HAS_CONCEPT.
+    `same_as_groups` maps a concept ID to the other members of its 'same as' group.
+    """
+
+    def __init__(
+        self, related: dict[str, list[str]], same_as_groups: dict[str, list[str]]
+    ) -> None:
+        super().__init__(get_mock_neptune_client())
+        self.related = related
+        self.same_as_groups = same_as_groups
+
+    def get_concept_ids_to_process(self) -> Generator[str]:
+        yield from self.related
+
+    def extract_raw(self) -> Generator[Any]:
+        yield from ()
+
+    def make_neptune_query(
+        self, query_type: Any, ids: Iterable[str]
+    ) -> dict[str, dict]:
+        if query_type == "same_as_concept":
+            return {
+                i: {"same_as_ids": self.same_as_groups.get(i, [])}
+                for i in ids
+                if i in self.same_as_groups
+            }
+
+        return {
+            i: {
+                "related": [
+                    {"id": related_id, "count": 1, "relationship_type": None}
+                    for related_id in self.related[i]
+                ]
+            }
+            for i in ids
+            if i in self.related
+        }
+
+    def get_concepts(self, ids: Iterable[str]) -> dict[str, ExtractedConcept]:
+        return {i: _an_extracted_concept(i) for i in ids}
+
+
+def test_choose_target_id_prefers_the_primary_when_it_is_referenced() -> None:
+    assert _choose_target_id("abcdefgh", {"abcdefgh", "zzzzzzzz"}) == "abcdefgh"
+
+
+def test_choose_target_id_falls_back_when_the_primary_is_not_referenced() -> None:
+    assert _choose_target_id("abcdefgh", {"wwwwwwww", "zzzzzzzz"}) == "wwwwwwww"
+
+
+def test_related_concept_target_skips_a_primary_with_no_works() -> None:
+    """
+    A related concept must be referred to by an ID which is connected to works.
+
+    Concepts without works are removed from the graph and deleted from the concepts index, so referring to one
+    produces a link which resolves to a 404. See platform#6388.
+    """
+    extractor = StubConceptsExtractor(
+        related={SOURCE_CONCEPT_ID: [WORK_CONNECTED_ID]},
+        same_as_groups={WORK_CONNECTED_ID: [UNCONNECTED_PRIMARY_ID]},
+    )
+
+    result = extractor._get_related_concepts("broader_than", [SOURCE_CONCEPT_ID])
+
+    targets = [r.target.concept.properties.id for r in result[SOURCE_CONCEPT_ID]]
+    assert targets == [WORK_CONNECTED_ID]
+
+
+def test_related_concepts_still_merge_onto_a_referenced_primary() -> None:
+    """Synonymous related concepts are merged under one entry, keeping the primary ID when it has works itself."""
+    extractor = StubConceptsExtractor(
+        related={SOURCE_CONCEPT_ID: [WORK_CONNECTED_ID, UNCONNECTED_PRIMARY_ID]},
+        same_as_groups={
+            WORK_CONNECTED_ID: [UNCONNECTED_PRIMARY_ID],
+            UNCONNECTED_PRIMARY_ID: [WORK_CONNECTED_ID],
+        },
+    )
+
+    result = extractor._get_related_concepts("broader_than", [SOURCE_CONCEPT_ID])
+
+    targets = [r.target.concept.properties.id for r in result[SOURCE_CONCEPT_ID]]
+    assert targets == [UNCONNECTED_PRIMARY_ID]

--- a/catalogue_graph/tests/ingestor/test_concepts_extractor.py
+++ b/catalogue_graph/tests/ingestor/test_concepts_extractor.py
@@ -10,9 +10,9 @@ from tests.mocks import get_mock_neptune_client
 
 SOURCE_CONCEPT_ID = "aaaaaaaa"
 
-# 'th3tx5an' sorts first, so it is the primary.
-UNCONNECTED_PRIMARY_ID = "th3tx5an"
-WORK_CONNECTED_ID = "wsg7zfsq"
+# 'th3tx5an' sorts first, so it is the primary of the group.
+PRIMARY_ID = "th3tx5an"
+SIBLING_ID = "wsg7zfsq"
 
 
 def _an_extracted_concept(concept_id: str) -> ExtractedConcept:
@@ -37,14 +37,23 @@ def _an_extracted_concept(concept_id: str) -> ExtractedConcept:
 
 
 class StubConceptsExtractor(GraphBaseConceptsExtractor):
-    """Concepts extractor with canned Neptune responses. IDs in `related` all have works, as the queries filter on HAS_CONCEPT."""
+    """Concepts extractor with canned Neptune responses.
+
+    `related` maps a source concept ID to the related concept IDs the graph returned for it. The related queries
+    collapse each 'same as' group to one arbitrary member, so that is not the full set of members with works.
+    `work_connected` is the set of IDs which have works.
+    """
 
     def __init__(
-        self, related: dict[str, list[str]], same_as_groups: dict[str, list[str]]
+        self,
+        related: dict[str, list[str]],
+        same_as_groups: dict[str, list[str]],
+        work_connected: set[str],
     ) -> None:
         super().__init__(get_mock_neptune_client())
         self.related = related
         self.same_as_groups = same_as_groups
+        self.work_connected = work_connected
 
     def get_concept_ids_to_process(self) -> Generator[str]:
         yield from self.related
@@ -62,6 +71,9 @@ class StubConceptsExtractor(GraphBaseConceptsExtractor):
                 if i in self.same_as_groups
             }
 
+        if query_type == "concept_type":
+            return {i: {"types": ["Concept"]} for i in ids if i in self.work_connected}
+
         return {
             i: {
                 "related": [
@@ -77,38 +89,38 @@ class StubConceptsExtractor(GraphBaseConceptsExtractor):
         return {i: _an_extracted_concept(i) for i in ids}
 
 
-def test_choose_target_id_prefers_the_primary_when_it_is_referenced() -> None:
+def _related_targets(related_ids: list[str], work_connected: set[str]) -> list[str]:
+    extractor = StubConceptsExtractor(
+        related={SOURCE_CONCEPT_ID: related_ids},
+        same_as_groups={PRIMARY_ID: [SIBLING_ID], SIBLING_ID: [PRIMARY_ID]},
+        work_connected=work_connected,
+    )
+    result = extractor._get_related_concepts("broader_than", [SOURCE_CONCEPT_ID])
+    return [r.target.concept.properties.id for r in result[SOURCE_CONCEPT_ID]]
+
+
+def test_choose_target_id_prefers_the_primary() -> None:
     assert _choose_target_id("abcdefgh", {"abcdefgh", "zzzzzzzz"}) == "abcdefgh"
 
 
-def test_choose_target_id_falls_back_when_the_primary_is_not_referenced() -> None:
+def test_choose_target_id_falls_back_to_the_first_candidate() -> None:
     assert _choose_target_id("abcdefgh", {"wwwwwwww", "zzzzzzzz"}) == "wwwwwwww"
 
 
 def test_related_concept_target_skips_a_primary_with_no_works() -> None:
     """See platform#6388: referring to a work-less concept produced a link which 404d."""
-    extractor = StubConceptsExtractor(
-        related={SOURCE_CONCEPT_ID: [WORK_CONNECTED_ID]},
-        same_as_groups={WORK_CONNECTED_ID: [UNCONNECTED_PRIMARY_ID]},
-    )
-
-    result = extractor._get_related_concepts("broader_than", [SOURCE_CONCEPT_ID])
-
-    targets = [r.target.concept.properties.id for r in result[SOURCE_CONCEPT_ID]]
-    assert targets == [WORK_CONNECTED_ID]
+    assert _related_targets([SIBLING_ID], work_connected={SIBLING_ID}) == [SIBLING_ID]
 
 
-def test_related_concepts_still_merge_onto_a_referenced_primary() -> None:
-    """Synonymous related concepts still merge under the primary when it has works itself."""
-    extractor = StubConceptsExtractor(
-        related={SOURCE_CONCEPT_ID: [WORK_CONNECTED_ID, UNCONNECTED_PRIMARY_ID]},
-        same_as_groups={
-            WORK_CONNECTED_ID: [UNCONNECTED_PRIMARY_ID],
-            UNCONNECTED_PRIMARY_ID: [WORK_CONNECTED_ID],
-        },
-    )
+def test_related_concept_target_keeps_a_primary_which_has_works() -> None:
+    """The related query returns one arbitrary group member, which must not displace a valid primary."""
+    assert _related_targets([SIBLING_ID], work_connected={PRIMARY_ID, SIBLING_ID}) == [
+        PRIMARY_ID
+    ]
 
-    result = extractor._get_related_concepts("broader_than", [SOURCE_CONCEPT_ID])
 
-    targets = [r.target.concept.properties.id for r in result[SOURCE_CONCEPT_ID]]
-    assert targets == [UNCONNECTED_PRIMARY_ID]
+def test_related_concepts_merge_onto_one_target() -> None:
+    """Synonymous related concepts merge under a single entry rather than appearing twice."""
+    assert _related_targets(
+        [SIBLING_ID, PRIMARY_ID], work_connected={PRIMARY_ID, SIBLING_ID}
+    ) == [PRIMARY_ID]

--- a/catalogue_graph/tests/test_ingestor_loader.py
+++ b/catalogue_graph/tests/test_ingestor_loader.py
@@ -543,11 +543,12 @@ def test_ingestor_loader_with_broader_than_concepts(
         include_objects=pass_objects_to_index,
     )
 
-    # We expect a total of 15 API calls:
+    # We expect a total of 17 API calls:
     # * 12 to retrieve the same data as the `test_ingestor_loader_no_related_concepts` test case
     # * 4 to retrieve concept data for broader than concepts
+    # * 1 to find out which broader than concepts have works
     _compare_events(result, expected_event)
-    assert len(MockRequest.calls) == 16
+    assert len(MockRequest.calls) == 17
 
     expected_concept = get_catalogue_concept_mock(["broader_than"])
     s3_uri = _get_result_s3_uri(result, loader_event)
@@ -576,10 +577,10 @@ def test_ingestor_loader_with_related_to_concepts(
         include_objects=pass_objects_to_index,
     )
 
-    # Since we're including two separate groups of related concepts, we expect 4 additional API calls
+    # Since we're including two separate groups of related concepts, we expect 5 additional API calls
     # on top of those in `test_ingestor_loader_with_broader_than_concepts`
     _compare_events(result, expected_event)
-    assert len(MockRequest.calls) == 20
+    assert len(MockRequest.calls) == 22
 
     expected_concept = get_catalogue_concept_mock(["related_to", "people"])
     s3_uri = _get_result_s3_uri(result, loader_event)


### PR DESCRIPTION
## What does this change?

Closes wellcomecollection/platform#6388, which carries the problem statement, measurements and cause.

In short: the Neptune queries only return concepts that have works, but the Python merge step then reports the group under `sorted(same_as_ids)[0]`, and alphabetical order says nothing about whether a concept has works. Concepts with no works are removed from the graph and deleted from the concepts index, so the reference 404s.

The merge still happens under the primary. We now ask the graph which members of the `same as` group have works, using the `HAS_CONCEPT` join already in `CONCEPT_TYPE_QUERY`, and emit the primary whenever it has works itself, falling back to the alphabetically first member that does. No query text changes. Only groups whose primary has no works change, so index churn stays small and the emitted ID is stable across relationship types and across runs.

This stops new broken references being written. It does not repair the ones already in the index: those persist until the concepts referring to them are next re-ingested, which needs a reindex or incremental windows that touch them. Re-ingesting referring concepts when a node is removed is a separate change.

### Checklist

- [x] No change to the display model the catalogue API returns. Field shapes are untouched, only which concept ID a related concept points at, so the test documents under `catalogue_graph/document_generators/test_documents` do not need regenerating.

## How to test

`uv run --group dev pytest` from `catalogue_graph/` (1575 pass). New tests in `tests/ingestor/test_concepts_extractor.py` cover `_choose_target_id` and the merge path against canned Neptune responses. The regression test is non-vacuous: stubbing `_choose_target_id` back to the old behaviour reproduces the reported symptom, emitting `th3tx5an` instead of `wsg7zfsq`.

After deploy, open a theme page for a concept that has been re-ingested since and confirm its related concept links resolve.

## How can we measure success?

Sample related concept references out of the concepts index and request each target from `/concepts/{id}`. The ~0.2% 404 rate should fall towards zero as concepts are re-ingested.

## Have we considered potential risks?

- Costs one extra `concept_type` query per relationship type that has related concepts, so up to 8 more per batch on top of the 40 that path already issues. Hoisting the lookup so all eight relationship types share one query would remove that, at the cost of restructuring how the queries are parallelised.
- Where the primary has no works, the related concept document now comes from a sibling, so its label and identifiers come from that sibling's source concepts. Synonymous, so labels should match, but wording can differ. If the sibling has no usable label at all, `_transform_related_concept` drops the related concept silently.
- 13 of 1,172 sampled `sameAs` targets also 404. Same family of cause, not addressed here.

