### PR TITLE
Axiell to FOLIO sync: reconciliation deletes (soft-suppress + hard-delete)

### DIFF
--- a/catalogue_graph/src/adapters/steps/axiell_folio_sync/README.md
+++ b/catalogue_graph/src/adapters/steps/axiell_folio_sync/README.md
@@ -125,7 +125,7 @@ AWS_PROFILE=platform-developer uv run python -m adapters.steps.axiell_folio_sync
 
 # Specific changesets; pass --live to disable dry run and write to FOLIO
 AWS_PROFILE=platform-developer uv run python -m adapters.steps.axiell_folio_sync.axiell_folio_sync \
-  --use-cli --job-id my-job-123 --changeset-ids 456429b2-6f0e-11f1-afea-525a8567ce81 --use-rest-api-table
+  --use-cli --job-id my-job-123 --changeset-ids <changeset-id> --use-rest-api-table
 ```
 
 Set the `OKAPI_*` environment variables first (see Configuration above).

--- a/catalogue_graph/src/adapters/steps/axiell_folio_sync/README.md
+++ b/catalogue_graph/src/adapters/steps/axiell_folio_sync/README.md
@@ -18,9 +18,8 @@ The design, record-selection rules and tombstone semantics are specified in
    (entrypoint `adapters.steps.axiell_folio_sync.axiell_folio_sync.lambda_handler`).
 3. The step reads the changed rows for the event's `changeset_ids` through `AxiellChangesetReader` (using the same
    `AXIELL_CONFIG` as the Axiell adapter, so S3 Tables in Lambda and a local sqlite catalog for local runs). The
-   reader also exposes the adapter's deletion facts via `iter_deletions()`, which is where authoritative FOLIO
-   deletes (platform#6440) will plug in.
-4. Each record is selected, mapped, and upserted:
+   reader also exposes the adapter's deletion facts via `iter_deletions()`, consumed by the reconciliation pass below.
+4. **Pass 1 — upsert.** Each record is selected, mapped, and upserted:
    * **Selection** (`is_selected_for_sync`): a record is synced only if it carries the harvest flag (MARC `980 $a`
      present) and is item-level (MARC `351 $c` == `ITEM`). Everything else is skipped.
    * **Mapping** (`mapping.py`): MARCXML → typed Pydantic payloads for Instance, Holdings and Item. FOLIO reference
@@ -28,14 +27,35 @@ The design, record-selection rules and tombstone semantics are specified in
      FOLIO tenant and reused across warm Lambda starts.
    * **Upsert** (`upsert.py`): writes in Instance → Holdings → Item order via OKAPI, with best-effort rollback if a
      later entity write fails.
-5. Results are published via a single `PipelineReport` (`report.py`): one JSON run report to S3 plus CloudWatch
+5. **Pass 2 — reconciliation deletes** (see [Reconciliation deletes](#reconciliation-deletes) below): the deletion
+   facts from `iter_deletions()` are actioned against FOLIO *after* the upsert pass.
+6. Results are published via a single `PipelineReport` (`report.py`): one JSON run report to S3 plus CloudWatch
    metrics (namespace `catalogue_adapters`; metrics are suppressed on dry runs, the S3 report is not).
 
-Rows with `deleted=true` are counted as advisory tombstones and ignored: the loader's deleted flag is
-unreliable, so we record the signal but do not suppress or remove FOLIO records based on it.
-Authoritative deletes come from the adapter-side reconcile step's deletion facts, delivered by the Axiell
-transformer (see
-[Axiell deletion reconciliation](../../transformers/README.md#axiell-deletion-reconciliation) and RFC 090).
+## Reconciliation deletes
+
+Two distinct delete signals reach this step; only one is authoritative.
+
+**Loader tombstones (`deleted=true`) are advisory only and ignored.** The loader's `deleted` flag is unreliable, so we
+record and metric the signal but never suppress or remove a FOLIO record based on it.
+
+**Authoritative deletes come from the adapter-side reconcile step's deletion facts.** The reconcile step writes
+superseded-GUID facts to Iceberg *before* `axiell.adapter.completed` fires, so the sync consumes them in the same
+invocation — no separate event or Lambda (see RFC 090 and
+[Axiell deletion reconciliation](../../transformers/README.md#axiell-deletion-reconciliation)). `iter_deletions()`
+re-checks each fact against the current reconciler mappings and drops any GUID reclaimed by a live record, so a
+revert/handoff never suppresses the wrong record. The remaining facts are actioned in Pass 2, keyed by
+`AxC-{entity}-{guid}` (the same HRID scheme the upsert path writes), child-first **item → holdings → instance**:
+
+- **Soft-suppress (default, reversible).** `suppress_by_guid` sets `discoverySuppress` on all three entities and
+  `staffSuppress` on the instance only — instances are the sole FOLIO inventory entity with a `staffSuppress` field
+  (holdings-storage rejects it with a 422; items silently drop it). Idempotent under redelivery.
+- **Hard-delete (opt-in, irreversible).** `delete_by_guid`, selected by the event's `hard_delete` field or the
+  `HARD_DELETE` env var. The child-first order is mandatory (FOLIO enforces referential integrity) and the cascade
+  aborts before the parent if a child delete fails, so a parent is never orphaned. A 404 is treated as a no-op, so
+  redelivered facts and races are safe.
+
+A per-GUID failure is recorded as an error entry and does not abort the run.
 
 ## Module layout
 
@@ -105,7 +125,7 @@ AWS_PROFILE=platform-developer uv run python -m adapters.steps.axiell_folio_sync
 
 # Specific changesets; pass --live to disable dry run and write to FOLIO
 AWS_PROFILE=platform-developer uv run python -m adapters.steps.axiell_folio_sync.axiell_folio_sync \
-  --use-cli --job-id my-job-123 --changeset-ids <changeset-id> --use-rest-api-table
+  --use-cli --job-id my-job-123 --changeset-ids 456429b2-6f0e-11f1-afea-525a8567ce81 --use-rest-api-table
 ```
 
 Set the `OKAPI_*` environment variables first (see Configuration above).

--- a/catalogue_graph/src/adapters/steps/axiell_folio_sync/axiell_folio_sync.py
+++ b/catalogue_graph/src/adapters/steps/axiell_folio_sync/axiell_folio_sync.py
@@ -48,7 +48,10 @@ from adapters.steps.axiell_folio_sync.models import (
 )
 from adapters.steps.axiell_folio_sync.ref_cache import RefCache
 from adapters.steps.axiell_folio_sync.sync_to_folio import load_okapi_config, run_sync
-from adapters.utils.axiell_changeset_reader import AxiellChangesetReader
+from adapters.utils.axiell_changeset_reader import (
+    AxiellChangesetReader,
+    SupersededGuid,
+)
 from clients.folio_client import FolioClient, FolioInventoryClient, ssl_context_from_env
 from utils.logger import ExecutionContext, get_trace_id, setup_logging
 from utils.steps import ecs_handler
@@ -66,26 +69,34 @@ def _read_rows(
     sample_limit: int | None,
     *,
     use_rest_api_table: bool,
-) -> list[dict]:
-    """Read changed Axiell adapter rows via :class:`AxiellChangesetReader`.
+) -> tuple[list[dict], list[SupersededGuid]]:
+    """Read changed Axiell adapter rows and superseded-GUID deletions.
 
     Uses the same ``AXIELL_CONFIG`` as the Axiell adapter, so it works against
     S3 Tables (``use_rest_api_table=True``, production) or the local sqlite
     catalog (``use_rest_api_table=False``, local dev) with no code changes.
-    Read-only: the table is never created. Built without deletion facts, so
-    the sync depends on no other tables; authoritative deletes (platform#6440)
-    would consume ``reader.iter_deletions()`` after the upsert pass.
+    Read-only: the tables are never created.
+
+    Deletion facts are read only for incremental (changeset) runs. The reconcile
+    step in the adapter state machine writes them into the same table bucket
+    before ``axiell.adapter.completed`` fires, and ``iter_deletions`` re-checks
+    each fact against the current reconciler mappings, so a GUID reclaimed by a
+    revert/handoff never suppresses a live record. A sample/reindex run (no
+    changesets) has nothing to overwrite, so it reads no facts and the reader is
+    built without the facts/reconciler tables.
     """
     reader = AxiellChangesetReader.build(
         AXIELL_CONFIG,
         changeset_ids or [],
         use_rest_api_table=use_rest_api_table,
-        with_deletion_facts=False,
+        with_deletion_facts=bool(changeset_ids),
     )
 
     if changeset_ids:
         logger.info("adapter_read", mode="changesets", changeset_ids=changeset_ids)
-        return list(reader.iter_records())
+        records = list(reader.iter_records())
+        deletions = list(reader.iter_deletions())
+        return records, deletions
 
     # Dev/smoke-test fallback: a sample of active records (no changesets given).
     limit = sample_limit or 10
@@ -95,7 +106,7 @@ def _read_rows(
         rows.append(row)
         if len(rows) >= limit:
             break
-    return rows
+    return rows, []
 
 
 # ── entry points ──────────────────────────────────────────────────────────────
@@ -126,12 +137,12 @@ def handler(
     inventory = FolioInventoryClient(client)
     ref_cache = RefCache(inventory).load()
 
-    rows = _read_rows(
+    rows, deletions = _read_rows(
         event.changeset_ids or None,
         event.sample_limit,
         use_rest_api_table=use_rest_api_table,
     )
-    logger.info("adapter_read complete", rows=len(rows))
+    logger.info("adapter_read complete", rows=len(rows), deletions=len(deletions))
 
     return run_sync(
         event,
@@ -140,6 +151,7 @@ def handler(
         inventory,
         dry_run=dry_run,
         manifest_bucket=manifest_bucket,
+        deletions=deletions,
     )
 
 

--- a/catalogue_graph/src/adapters/steps/axiell_folio_sync/axiell_folio_sync.py
+++ b/catalogue_graph/src/adapters/steps/axiell_folio_sync/axiell_folio_sync.py
@@ -27,6 +27,7 @@ Environment variables (injected by Terraform):
   MANIFEST_S3_BUCKET     — S3 bucket name for JSON run reports
   AWS_REGION             — e.g. eu-west-1 (set automatically in Lambda)
   DRY_RUN                — default "true"; event.dry_run overrides
+  HARD_DELETE            — default "false" (suppress); event.hard_delete overrides
 
 For local runs, OKAPI_URL / OKAPI_TENANT / OKAPI_USERNAME / OKAPI_PASSWORD
 override the corresponding SSM fields (and skip SSM if all are set).
@@ -124,6 +125,14 @@ def handler(
 
     env_dry_run = os.environ.get("DRY_RUN", "true").lower() not in ("false", "0", "no")
     dry_run = event.dry_run if event.dry_run is not None else env_dry_run
+    env_hard_delete = os.environ.get("HARD_DELETE", "false").lower() in (
+        "true",
+        "1",
+        "yes",
+    )
+    hard_delete = (
+        event.hard_delete if event.hard_delete is not None else env_hard_delete
+    )
     manifest_bucket = os.environ.get("MANIFEST_S3_BUCKET")
 
     okapi = load_okapi_config()
@@ -152,6 +161,7 @@ def handler(
         dry_run=dry_run,
         manifest_bucket=manifest_bucket,
         deletions=deletions,
+        hard_delete=hard_delete,
     )
 
 
@@ -201,6 +211,11 @@ def local_handler(parser: argparse.ArgumentParser) -> None:
         "--live", action="store_true", help="Disable dry-run and write to FOLIO"
     )
     parser.add_argument(
+        "--hard-delete",
+        action="store_true",
+        help="Hard-delete (not suppress) FOLIO records for reconciler deletions",
+    )
+    parser.add_argument(
         "--use-rest-api-table",
         action="store_true",
         help="Read from the S3 Tables catalog instead of the local sqlite catalog",
@@ -212,6 +227,7 @@ def local_handler(parser: argparse.ArgumentParser) -> None:
         changeset_ids=args.changeset_ids or [],
         sample_limit=None if args.changeset_ids else args.sample_limit,
         dry_run=not args.live,
+        hard_delete=args.hard_delete,
     )
     response = handler(event, use_rest_api_table=args.use_rest_api_table)
     print(json.dumps(response.model_dump(mode="json"), indent=2))

--- a/catalogue_graph/src/adapters/steps/axiell_folio_sync/mapping.py
+++ b/catalogue_graph/src/adapters/steps/axiell_folio_sync/mapping.py
@@ -166,12 +166,12 @@ MATERIAL_TYPE: dict[str, str] = {
     "audio-visual material - visual": "video recording",
     "audio-visual material - e-sound only": "sound recording",
     "audio-visual material - e-visual only": "video recording",
-    "published material": "Books",
+    "published material": "book",
     "archives": "unspecified",
 }
 
 # Fallbacks used when the MARC record carries no value for a resolved field.
-DEFAULT_MATERIAL_TYPE = "Books"
+DEFAULT_MATERIAL_TYPE = "book"
 DEFAULT_LOAN_TYPE = "Can Circulate"
 DEFAULT_LOCATION = "History of Medicine"
 DEFAULT_HOLDINGS_SOURCE = "MARC"
@@ -294,8 +294,13 @@ class UpsertResult(BaseModel):
     errors: list[UpsertError] = Field(default_factory=list)
 
 
-class SuppressResult(BaseModel):
-    """The result of :func:`upsert.suppress_by_guid` for a superseded GUID."""
+class GuidCascadeResult(BaseModel):
+    """Result of a reconciler cascade over one superseded GUID.
+
+    Shared by :func:`upsert.suppress_by_guid` (soft-suppress) and
+    :func:`upsert.delete_by_guid` (hard-delete); the ``action`` on each entity
+    (``suppress`` / ``delete`` / ``skip``) records which was applied.
+    """
 
     guid: str
     instance: EntityResult = Field(default_factory=EntityResult)

--- a/catalogue_graph/src/adapters/steps/axiell_folio_sync/mapping.py
+++ b/catalogue_graph/src/adapters/steps/axiell_folio_sync/mapping.py
@@ -294,6 +294,16 @@ class UpsertResult(BaseModel):
     errors: list[UpsertError] = Field(default_factory=list)
 
 
+class SuppressResult(BaseModel):
+    """The result of :func:`upsert.suppress_by_guid` for a superseded GUID."""
+
+    guid: str
+    instance: EntityResult = Field(default_factory=EntityResult)
+    holdings: EntityResult = Field(default_factory=EntityResult)
+    item: EntityResult = Field(default_factory=EntityResult)
+    errors: list[UpsertError] = Field(default_factory=list)
+
+
 # ── lookup helper (mirrors the YAML map → default → lookup chain) ────────────────
 
 

--- a/catalogue_graph/src/adapters/steps/axiell_folio_sync/models.py
+++ b/catalogue_graph/src/adapters/steps/axiell_folio_sync/models.py
@@ -29,7 +29,7 @@ class SyncErrorEntry(BaseModel):
 
 
 class SyncDeletionEntry(BaseModel):
-    """One superseded-GUID suppression (authoritative delete) in the run report."""
+    """One superseded-GUID action (suppress or hard-delete) in the run report."""
 
     guid: str
     record_id: str

--- a/catalogue_graph/src/adapters/steps/axiell_folio_sync/models.py
+++ b/catalogue_graph/src/adapters/steps/axiell_folio_sync/models.py
@@ -28,6 +28,18 @@ class SyncErrorEntry(BaseModel):
     timestamp: str
 
 
+class SyncDeletionEntry(BaseModel):
+    """One superseded-GUID suppression (authoritative delete) in the run report."""
+
+    guid: str
+    record_id: str
+    changeset_id: str
+    instance_action: str | None
+    holdings_action: str | None
+    item_action: str | None
+    timestamp: str
+
+
 class AxiellFolioSyncEvent(BaseModel):
     """Input to the sync step (the ``detail`` of an axiell.adapter.completed event)."""
 
@@ -50,3 +62,4 @@ class AxiellFolioSyncResponse(BaseModel):
     total_successful: int = 0
     total_errors: int = 0
     total_records: int = 0
+    total_deletions: int = 0

--- a/catalogue_graph/src/adapters/steps/axiell_folio_sync/models.py
+++ b/catalogue_graph/src/adapters/steps/axiell_folio_sync/models.py
@@ -48,6 +48,9 @@ class AxiellFolioSyncEvent(BaseModel):
     transformer_type: str | None = None
     # ``None`` means "fall back to the DRY_RUN env var" (default true).
     dry_run: bool | None = None
+    # ``None`` means "fall back to the HARD_DELETE env var" (default false). When
+    # true, reconciler deletions hard-delete FOLIO records instead of suppressing.
+    hard_delete: bool | None = None
     # Dev/smoke-test only: cap records processed when no changeset_ids are given.
     sample_limit: int | None = None
 

--- a/catalogue_graph/src/adapters/steps/axiell_folio_sync/report.py
+++ b/catalogue_graph/src/adapters/steps/axiell_folio_sync/report.py
@@ -57,6 +57,7 @@ class AxiellFolioSyncReport(PipelineReport):
             PipelineMetric(
                 name="records_suppressed", value=self.counts.get("suppressed", 0)
             ),
+            PipelineMetric(name="records_deleted", value=self.counts.get("deleted", 0)),
             PipelineMetric(
                 name="deletions_processed", value=self.counts.get("deletions", 0)
             ),

--- a/catalogue_graph/src/adapters/steps/axiell_folio_sync/report.py
+++ b/catalogue_graph/src/adapters/steps/axiell_folio_sync/report.py
@@ -16,7 +16,11 @@ from typing import ClassVar
 
 from pydantic import Field
 
-from adapters.steps.axiell_folio_sync.models import SyncErrorEntry, SyncSuccessEntry
+from adapters.steps.axiell_folio_sync.models import (
+    SyncDeletionEntry,
+    SyncErrorEntry,
+    SyncSuccessEntry,
+)
 from utils.reporting import PipelineMetric, PipelineReport
 
 PIPELINE_STEP = "axiell_folio_sync"
@@ -30,6 +34,7 @@ class AxiellFolioSyncReport(PipelineReport):
     counts: dict[str, int]
     successful: list[SyncSuccessEntry] = Field(default_factory=list)
     errors: list[SyncErrorEntry] = Field(default_factory=list)
+    deletions: list[SyncDeletionEntry] = Field(default_factory=list)
     s3_bucket: str | None = Field(default=None, exclude=True)
 
     @property
@@ -51,6 +56,9 @@ class AxiellFolioSyncReport(PipelineReport):
             PipelineMetric(name="records_updated", value=self.counts.get("updated", 0)),
             PipelineMetric(
                 name="records_suppressed", value=self.counts.get("suppressed", 0)
+            ),
+            PipelineMetric(
+                name="deletions_processed", value=self.counts.get("deletions", 0)
             ),
             PipelineMetric(name="records_skipped", value=self.counts.get("skipped", 0)),
             PipelineMetric(

--- a/catalogue_graph/src/adapters/steps/axiell_folio_sync/sync_to_folio.py
+++ b/catalogue_graph/src/adapters/steps/axiell_folio_sync/sync_to_folio.py
@@ -24,18 +24,22 @@ from adapters.steps.axiell_folio_sync.folio_callables import (
 )
 from adapters.steps.axiell_folio_sync.mapping import (
     MappingError,
-    UpsertResult,
     select_and_build,
 )
 from adapters.steps.axiell_folio_sync.models import (
     AxiellFolioSyncEvent,
     AxiellFolioSyncResponse,
+    SyncDeletionEntry,
     SyncErrorEntry,
     SyncSuccessEntry,
 )
 from adapters.steps.axiell_folio_sync.ref_cache import RefCache
 from adapters.steps.axiell_folio_sync.report import AxiellFolioSyncReport
-from adapters.steps.axiell_folio_sync.upsert import upsert_from_payloads
+from adapters.steps.axiell_folio_sync.upsert import (
+    suppress_by_guid,
+    upsert_from_payloads,
+)
+from adapters.utils.axiell_changeset_reader import SupersededGuid
 
 logger = structlog.get_logger(__name__)
 
@@ -102,12 +106,79 @@ def _build_error(
     )
 
 
-def _tally_upsert_actions(result: UpsertResult, counts: dict[str, int]) -> None:
-    """Increment counts for each entity action in a successful upsert."""
+# Maps an entity action to its plural count key. "suppress" -> "suppressed"
+# (not "suppressd"), so this cannot be derived by appending "d".
+_ACTION_COUNT_KEY = {
+    "create": "created",
+    "update": "updated",
+    "suppress": "suppressed",
+}
+
+
+def _tally_entity_actions(result: Any, counts: dict[str, int]) -> None:
+    """Increment counts for each entity action in a successful upsert/suppress."""
     for entity in ("instance", "holdings", "item"):
-        action = getattr(result, entity).action
-        if action in ("create", "update", "suppress"):
-            counts[action + "d"] += 1
+        key = _ACTION_COUNT_KEY.get(getattr(result, entity).action)
+        if key:
+            counts[key] += 1
+
+
+def _run_suppressions(
+    deletions: list[SupersededGuid],
+    folio: FolioInventoryOps,
+    counts: dict[str, int],
+    errors_list: list[SyncErrorEntry],
+    *,
+    dry_run: bool,
+) -> tuple[list[SyncDeletionEntry], int]:
+    """Suppress each superseded GUID's FOLIO records (item → holdings → instance).
+
+    A per-GUID FOLIO failure is recorded as an error entry and does not abort the
+    run: the upsert pass has already committed, and the reconciler mapping/ES
+    delete are upstream and independent. Returns the manifest entries for GUIDs
+    that suppressed cleanly, and the count of GUIDs that errored.
+    """
+    entries: list[SyncDeletionEntry] = []
+    error_count = 0
+
+    for superseded in deletions:
+        counts["deletions"] += 1
+        result = suppress_by_guid(superseded.guid, folio, dry_run=dry_run)
+
+        if result.errors:
+            error_count += 1
+            errors_list.append(
+                _build_error(
+                    superseded.guid,
+                    superseded.changeset_id,
+                    "suppress",
+                    [e.model_dump() for e in result.errors],
+                )
+            )
+        else:
+            _tally_entity_actions(result, counts)
+            entries.append(
+                SyncDeletionEntry(
+                    guid=superseded.guid,
+                    record_id=superseded.record_id,
+                    changeset_id=superseded.changeset_id,
+                    instance_action=result.instance.action,
+                    holdings_action=result.holdings.action,
+                    item_action=result.item.action,
+                    timestamp=utc_now_iso(),
+                )
+            )
+
+        logger.info(
+            "suppress_result",
+            guid=superseded.guid,
+            instance=result.instance.action or "skip",
+            holdings=result.holdings.action or "skip",
+            item=result.item.action or "skip",
+            errors=len(result.errors),
+        )
+
+    return entries, error_count
 
 
 # ── core ──────────────────────────────────────────────────────────────────────
@@ -121,11 +192,18 @@ def run_sync(
     *,
     dry_run: bool,
     manifest_bucket: str | None = None,
+    deletions: list[SupersededGuid] | None = None,
 ) -> AxiellFolioSyncResponse:
     """Select, map, and upsert pre-read adapter rows to FOLIO.
 
     Dependencies (rows, ref cache, FOLIO client) are injected so the loop is
     unit-testable without SSM / Iceberg / FOLIO; ``handler`` builds the real ones.
+
+    ``deletions`` carries the reconciler's superseded GUIDs for this changeset
+    batch. They are suppressed in a second pass *after* the upsert pass so a
+    record re-created and superseded in the same batch is handled in write order;
+    the reader has already dropped any GUID reclaimed by a current mapping, so a
+    live record is never suppressed here.
     """
     logger.info(
         "axiell_folio_sync start",
@@ -146,6 +224,8 @@ def run_sync(
         "tombstone": 0,
         "failed": 0,
         "total": 0,
+        # Superseded GUIDs (reconciler deletions) processed in the second pass.
+        "deletions": 0,
     }
 
     for row in rows:
@@ -221,7 +301,7 @@ def run_sync(
             )
         else:
             total_successful += 1
-            _tally_upsert_actions(result, counts)
+            _tally_entity_actions(result, counts)
 
             successful.append(
                 SyncSuccessEntry(
@@ -243,6 +323,12 @@ def run_sync(
             errors=len(result.errors),
         )
 
+    # ── Pass 2: authoritative deletes (reconciler superseded GUIDs) ────────────
+    deletion_entries, deletion_errors = _run_suppressions(
+        deletions or [], folio, counts, errors_list, dry_run=dry_run
+    )
+    total_errors += deletion_errors
+
     report = AxiellFolioSyncReport(
         job_id=event.job_id,
         changeset_ids=event.changeset_ids,
@@ -250,6 +336,7 @@ def run_sync(
         counts=counts,
         successful=successful,
         errors=errors_list,
+        deletions=deletion_entries,
         s3_bucket=manifest_bucket,
         # The S3 report is written even on dry runs (it is how dry runs are
         # validated); only CloudWatch metrics are suppressed.
@@ -264,6 +351,7 @@ def run_sync(
         total=counts["total"],
         successful=total_successful,
         errors=total_errors,
+        deletions=counts["deletions"],
         dry_run=dry_run,
     )
 
@@ -275,4 +363,5 @@ def run_sync(
         total_successful=total_successful,
         total_errors=total_errors,
         total_records=total_successful + total_errors,
+        total_deletions=counts["deletions"],
     )

--- a/catalogue_graph/src/adapters/steps/axiell_folio_sync/sync_to_folio.py
+++ b/catalogue_graph/src/adapters/steps/axiell_folio_sync/sync_to_folio.py
@@ -23,12 +23,10 @@ from adapters.steps.axiell_folio_sync.folio_callables import (
     FolioInventoryOps,
 )
 from adapters.steps.axiell_folio_sync.mapping import (
-    MappingError,
-    select_and_build,
-)
-from adapters.steps.axiell_folio_sync.mapping import (
     GuidCascadeResult,
+    MappingError,
     UpsertResult,
+    select_and_build,
 )
 from adapters.steps.axiell_folio_sync.models import (
     AxiellFolioSyncEvent,
@@ -121,7 +119,9 @@ _ACTION_COUNT_KEY = {
 }
 
 
-def _tally_entity_actions(result: UpsertResult | GuidCascadeResult, counts: dict[str, int]) -> None:
+def _tally_entity_actions(
+    result: UpsertResult | GuidCascadeResult, counts: dict[str, int]
+) -> None:
     """Increment counts for each entity action in a successful upsert/suppress."""
     for entity in ("instance", "holdings", "item"):
         key = _ACTION_COUNT_KEY.get(getattr(result, entity).action)

--- a/catalogue_graph/src/adapters/steps/axiell_folio_sync/sync_to_folio.py
+++ b/catalogue_graph/src/adapters/steps/axiell_folio_sync/sync_to_folio.py
@@ -36,6 +36,7 @@ from adapters.steps.axiell_folio_sync.models import (
 from adapters.steps.axiell_folio_sync.ref_cache import RefCache
 from adapters.steps.axiell_folio_sync.report import AxiellFolioSyncReport
 from adapters.steps.axiell_folio_sync.upsert import (
+    delete_by_guid,
     suppress_by_guid,
     upsert_from_payloads,
 )
@@ -112,6 +113,7 @@ _ACTION_COUNT_KEY = {
     "create": "created",
     "update": "updated",
     "suppress": "suppressed",
+    "delete": "deleted",
 }
 
 
@@ -123,40 +125,44 @@ def _tally_entity_actions(result: Any, counts: dict[str, int]) -> None:
             counts[key] += 1
 
 
-def _run_suppressions(
+def _run_reconcile_deletions(
     deletions: list[SupersededGuid],
     folio: FolioInventoryOps,
     counts: dict[str, int],
     errors_list: list[SyncErrorEntry],
     *,
     dry_run: bool,
+    hard_delete: bool,
 ) -> tuple[list[SyncDeletionEntry], int]:
-    """Suppress each superseded GUID's FOLIO records (item → holdings → instance).
+    """Action each superseded GUID's FOLIO records (item → holdings → instance).
 
-    A per-GUID FOLIO failure is recorded as an error entry and does not abort the
-    run: the upsert pass has already committed, and the reconciler mapping/ES
-    delete are upstream and independent. Returns the manifest entries for GUIDs
-    that suppressed cleanly, and the count of GUIDs that errored.
+    ``hard_delete`` selects irreversible DELETE; otherwise the records are
+    soft-suppressed (the reversible default). A per-GUID FOLIO failure is recorded
+    as an error entry and does not abort the run: the upsert pass has already
+    committed, and the reconciler mapping/ES delete are upstream and independent.
+    Returns the manifest entries for every GUID that actioned at least one entity
+    (including partial cascades that then errored), and the count of GUIDs that
+    errored.
     """
+    action_by_guid = delete_by_guid if hard_delete else suppress_by_guid
+    stage = "delete" if hard_delete else "suppress"
     entries: list[SyncDeletionEntry] = []
     error_count = 0
 
     for superseded in deletions:
         counts["deletions"] += 1
-        result = suppress_by_guid(superseded.guid, folio, dry_run=dry_run)
+        result = action_by_guid(superseded.guid, folio, dry_run=dry_run)
 
-        if result.errors:
-            error_count += 1
-            errors_list.append(
-                _build_error(
-                    superseded.guid,
-                    superseded.changeset_id,
-                    "suppress",
-                    [e.model_dump() for e in result.errors],
-                )
-            )
-        else:
-            _tally_entity_actions(result, counts)
+        # Tally and record whatever was actually actioned, even when the cascade
+        # later failed: a partial hard-delete may have already removed a child
+        # (irreversibly) before erroring on its parent, and that must not vanish
+        # from the counts or the manifest. Entities that never ran carry a null
+        # action, so nothing is over-counted.
+        _tally_entity_actions(result, counts)
+        if any(
+            getattr(result, entity).action
+            for entity in ("instance", "holdings", "item")
+        ):
             entries.append(
                 SyncDeletionEntry(
                     guid=superseded.guid,
@@ -169,8 +175,20 @@ def _run_suppressions(
                 )
             )
 
+        if result.errors:
+            error_count += 1
+            errors_list.append(
+                _build_error(
+                    superseded.guid,
+                    superseded.changeset_id,
+                    stage,
+                    [e.model_dump() for e in result.errors],
+                )
+            )
+
         logger.info(
-            "suppress_result",
+            "reconcile_delete_result",
+            mode="delete" if hard_delete else "suppress",
             guid=superseded.guid,
             instance=result.instance.action or "skip",
             holdings=result.holdings.action or "skip",
@@ -193,6 +211,7 @@ def run_sync(
     dry_run: bool,
     manifest_bucket: str | None = None,
     deletions: list[SupersededGuid] | None = None,
+    hard_delete: bool = False,
 ) -> AxiellFolioSyncResponse:
     """Select, map, and upsert pre-read adapter rows to FOLIO.
 
@@ -200,10 +219,11 @@ def run_sync(
     unit-testable without SSM / Iceberg / FOLIO; ``handler`` builds the real ones.
 
     ``deletions`` carries the reconciler's superseded GUIDs for this changeset
-    batch. They are suppressed in a second pass *after* the upsert pass so a
-    record re-created and superseded in the same batch is handled in write order;
-    the reader has already dropped any GUID reclaimed by a current mapping, so a
-    live record is never suppressed here.
+    batch. They are actioned in a second pass *after* the upsert pass so a record
+    re-created and superseded in the same batch is handled in write order; the
+    reader has already dropped any GUID reclaimed by a current mapping, so a live
+    record is never touched here. ``hard_delete`` selects irreversible DELETE for
+    that pass; the default is reversible soft-suppression.
     """
     logger.info(
         "axiell_folio_sync start",
@@ -220,6 +240,7 @@ def run_sync(
         "created": 0,
         "updated": 0,
         "suppressed": 0,
+        "deleted": 0,
         "skipped": 0,
         "tombstone": 0,
         "failed": 0,
@@ -324,9 +345,20 @@ def run_sync(
         )
 
     # ── Pass 2: authoritative deletes (reconciler superseded GUIDs) ────────────
-    deletion_entries, deletion_errors = _run_suppressions(
-        deletions or [], folio, counts, errors_list, dry_run=dry_run
+    deletion_entries, deletion_errors = _run_reconcile_deletions(
+        deletions or [],
+        folio,
+        counts,
+        errors_list,
+        dry_run=dry_run,
+        hard_delete=hard_delete,
     )
+    # Fold both passes into the totals symmetrically: previously only deletion
+    # *errors* counted, so total_records (= successful + errors) silently dropped
+    # cleanly-actioned deletions. Every processed GUID is either an error or a
+    # success, so successes = processed − errors.
+    deletion_successes = counts["deletions"] - deletion_errors
+    total_successful += deletion_successes
     total_errors += deletion_errors
 
     report = AxiellFolioSyncReport(

--- a/catalogue_graph/src/adapters/steps/axiell_folio_sync/sync_to_folio.py
+++ b/catalogue_graph/src/adapters/steps/axiell_folio_sync/sync_to_folio.py
@@ -26,6 +26,10 @@ from adapters.steps.axiell_folio_sync.mapping import (
     MappingError,
     select_and_build,
 )
+from adapters.steps.axiell_folio_sync.mapping import (
+    GuidCascadeResult,
+    UpsertResult,
+)
 from adapters.steps.axiell_folio_sync.models import (
     AxiellFolioSyncEvent,
     AxiellFolioSyncResponse,
@@ -117,7 +121,7 @@ _ACTION_COUNT_KEY = {
 }
 
 
-def _tally_entity_actions(result: Any, counts: dict[str, int]) -> None:
+def _tally_entity_actions(result: UpsertResult | GuidCascadeResult, counts: dict[str, int]) -> None:
     """Increment counts for each entity action in a successful upsert/suppress."""
     for entity in ("instance", "holdings", "item"):
         key = _ACTION_COUNT_KEY.get(getattr(result, entity).action)

--- a/catalogue_graph/src/adapters/steps/axiell_folio_sync/upsert.py
+++ b/catalogue_graph/src/adapters/steps/axiell_folio_sync/upsert.py
@@ -119,7 +119,7 @@ def _suppress_entity(
             f"{write_path_prefix}/{folio_id}",
             {**_strip_readonly(existing), **suppression},
         )
-        logger.info("suppressed hrid=%s folio_id=%s", hrid, folio_id)
+        logger.info("suppressed", hrid=hrid, folio_id=folio_id)
     return EntityResult(action="suppress", id=folio_id)
 
 
@@ -411,7 +411,7 @@ def _cascade_by_guid(
             )
     except Exception as exc:
         result.errors.append(UpsertError(type="api", detail=str(exc)))
-        logger.error("reconcile cascade error guid=%s detail=%s", guid, exc)
+        logger.error("reconcile cascade error", guid=guid, error=str(exc), exc_info=True)
 
     return result
 

--- a/catalogue_graph/src/adapters/steps/axiell_folio_sync/upsert.py
+++ b/catalogue_graph/src/adapters/steps/axiell_folio_sync/upsert.py
@@ -24,7 +24,16 @@ from __future__ import annotations
 import structlog
 
 from .folio_callables import FolioInventoryOps
-from .mapping import EntityResult, MappedPayloads, UpsertError, UpsertResult
+from .mapping import (
+    EntityResult,
+    MappedPayloads,
+    SuppressResult,
+    UpsertError,
+    UpsertResult,
+    _holdings_hrid,
+    _instance_hrid,
+    _item_hrid,
+)
 from .ref_cache import RefCache
 
 logger = structlog.get_logger(__name__)
@@ -66,6 +75,39 @@ def _find_by_hrid(
     except Exception as exc:
         logger.warning("hrid lookup failed path=%s hrid=%s error=%s", path, hrid, exc)
         return None
+
+
+def _suppress_entity(
+    folio: FolioInventoryOps,
+    *,
+    search_path: str,
+    list_key: str,
+    write_path_prefix: str,
+    hrid: str,
+    dry_run: bool,
+) -> EntityResult:
+    """Resolve an entity by hrid and set discoverySuppress + staffSuppress.
+
+    Not-found → ``skip`` (the record is already gone). Idempotent: re-suppressing
+    a record whose flags are already true is a harmless PUT, so redelivered
+    deletion facts do not misbehave.
+    """
+    existing = _find_by_hrid(folio, search_path, hrid, list_key)
+    if not existing:
+        return EntityResult(action="skip")
+
+    folio_id: str = existing["id"]
+    if not dry_run:
+        folio.put(
+            f"{write_path_prefix}/{folio_id}",
+            {
+                **_strip_readonly(existing),
+                "discoverySuppress": True,
+                "staffSuppress": True,
+            },
+        )
+        logger.info("suppressed hrid=%s folio_id=%s", hrid, folio_id)
+    return EntityResult(action="suppress", id=folio_id)
 
 
 def _resolve_item_note_types(payload: dict, ref_cache: RefCache) -> dict:
@@ -231,21 +273,14 @@ def upsert_from_payloads(
 
         # ── Item ────────────────────────────────────────────────────────────
         if deleted:
-            existing_item = _find_by_hrid(folio, "/inventory/items", item_hrid, "items")
-            if existing_item:
-                result.item = EntityResult(action="suppress", id=existing_item["id"])
-                if not dry_run:
-                    folio.put(
-                        f"/inventory/items/{existing_item['id']}",
-                        {
-                            **_strip_readonly(existing_item),
-                            "discoverySuppress": True,
-                            "staffSuppress": True,
-                        },
-                    )
-                    logger.info("suppressed item source_id=%s", source_id)
-            else:
-                result.item = EntityResult(action="skip")
+            result.item = _suppress_entity(
+                folio,
+                search_path="/inventory/items",
+                list_key="items",
+                write_path_prefix="/inventory/items",
+                hrid=item_hrid,
+                dry_run=dry_run,
+            )
         else:
             item_payload = {
                 **mapped.item.model_dump(exclude_none=True),
@@ -284,5 +319,60 @@ def upsert_from_payloads(
 
         result.errors.append(UpsertError(type="api", detail=str(exc)))
         logger.error("api error source_id=%s detail=%s", source_id, exc)
+
+    return result
+
+
+# ── reconciler suppression path ─────────────────────────────────────────────────
+
+
+def suppress_by_guid(
+    guid: str,
+    folio: FolioInventoryOps,
+    *,
+    dry_run: bool = False,
+) -> SuppressResult:
+    """Soft-suppress the FOLIO records for a superseded GUID, child-first.
+
+    The reconciler reports a superseded GUID as an authoritative delete (the old
+    work no longer exists). We soft-suppress (discoverySuppress + staffSuppress)
+    rather than hard-delete, so the action is reversible and auditable. The
+    cascade runs item → holdings → instance (child-first) so a live child is
+    never briefly left pointing at a suppressed parent, mirroring the reverse of
+    the create order. Records already gone are skipped; suppression is
+    idempotent, so a redelivered fact simply re-sets flags that are already true.
+
+    A single hrid maps directly from the GUID (``AxC-{entity}-{guid}``), the same
+    scheme the upsert path writes, so no MARC parse or mapping is needed here.
+    """
+    result = SuppressResult(guid=guid)
+    try:
+        result.item = _suppress_entity(
+            folio,
+            search_path="/inventory/items",
+            list_key="items",
+            write_path_prefix="/inventory/items",
+            hrid=_item_hrid(guid),
+            dry_run=dry_run,
+        )
+        result.holdings = _suppress_entity(
+            folio,
+            search_path="/holdings-storage/holdings",
+            list_key="holdingsRecords",
+            write_path_prefix="/holdings-storage/holdings",
+            hrid=_holdings_hrid(guid),
+            dry_run=dry_run,
+        )
+        result.instance = _suppress_entity(
+            folio,
+            search_path="/inventory/instances",
+            list_key="instances",
+            write_path_prefix="/inventory/instances",
+            hrid=_instance_hrid(guid),
+            dry_run=dry_run,
+        )
+    except Exception as exc:
+        result.errors.append(UpsertError(type="api", detail=str(exc)))
+        logger.error("suppress error guid=%s detail=%s", guid, exc)
 
     return result

--- a/catalogue_graph/src/adapters/steps/axiell_folio_sync/upsert.py
+++ b/catalogue_graph/src/adapters/steps/axiell_folio_sync/upsert.py
@@ -411,7 +411,9 @@ def _cascade_by_guid(
             )
     except Exception as exc:
         result.errors.append(UpsertError(type="api", detail=str(exc)))
-        logger.error("reconcile cascade error", guid=guid, error=str(exc), exc_info=True)
+        logger.error(
+            "reconcile cascade error", guid=guid, error=str(exc), exc_info=True
+        )
 
     return result
 

--- a/catalogue_graph/src/adapters/steps/axiell_folio_sync/upsert.py
+++ b/catalogue_graph/src/adapters/steps/axiell_folio_sync/upsert.py
@@ -76,14 +76,20 @@ _STAFF_SUPPRESS_PATHS: frozenset[str] = frozenset({"/inventory/instances"})
 def _find_by_hrid(
     folio: FolioInventoryOps, path: str, hrid: str, list_key: str
 ) -> dict | None:
-    """Return the first FOLIO record matching hrid via CQL, or None."""
-    try:
-        result = folio.get(path, {"query": f'hrid=="{hrid}"', "limit": 1})
-        records = result.get(list_key, [])
-        return records[0] if records else None
-    except Exception as exc:
-        logger.warning("hrid lookup failed path=%s hrid=%s error=%s", path, hrid, exc)
-        return None
+    """Return the first FOLIO record matching hrid via CQL, or None.
+
+    ``None`` means an *empty result* — no record has this hrid. A lookup *failure*
+    (network/FOLIO error) is a different thing and always propagates: it must never
+    be collapsed into "not found", because both callers key an irreversible
+    decision on absence. The delete cascade would report a still-live record as a
+    cleanly-actioned skip (and a deletion fact only arrives once); the upsert path
+    would take the create branch and POST a record that may already exist. Both
+    callers already wrap this in a try/except that records the error and either
+    aborts the cascade or rolls back, so a raised lookup slots straight in.
+    """
+    result = folio.get(path, {"query": f'hrid=="{hrid}"', "limit": 1})
+    records = result.get(list_key, [])
+    return records[0] if records else None
 
 
 def _suppress_entity(
@@ -104,7 +110,8 @@ def _suppress_entity(
 
     Not-found → ``skip`` (the record is already gone). Idempotent: re-suppressing
     a record whose flags are already true is a harmless PUT, so redelivered
-    deletion facts do not misbehave.
+    deletion facts do not misbehave. A failed hrid lookup is not "already gone" —
+    it propagates (see :func:`_find_by_hrid`) so the cascade records it and aborts.
     """
     existing = _find_by_hrid(folio, search_path, hrid, list_key)
     if not existing:
@@ -138,7 +145,10 @@ def _delete_entity(
     on the DELETE as a no-op, so this is idempotent under redelivery/races. A
     non-404 error (e.g. FOLIO 400 because a child still references this record)
     raises, which aborts the parent's delete in :func:`delete_by_guid` — that is
-    intentional, since deleting a parent while a child remains would orphan it.
+    intentional, since deleting a parent while a child remains would orphan it. A
+    failed hrid lookup raises for the same reason (see :func:`_find_by_hrid`), so a
+    swallowed outage cannot let the cascade proceed to the holdings/instance delete
+    while the item may still exist.
     """
     existing = _find_by_hrid(folio, search_path, hrid, list_key)
     if not existing:
@@ -390,9 +400,12 @@ def _cascade_by_guid(
 
     The single try/except is load-bearing for hard delete: if a child op fails,
     the cascade stops before the parent, so a parent is never actioned while a
-    failed child may still reference it. Records already gone are skipped. A hrid
-    maps directly from the GUID (``AxC-{entity}-{guid}``), the same scheme the
-    upsert path writes, so no MARC parse or mapping is needed here.
+    failed child may still reference it. Records already gone are skipped, but a
+    *failed* hrid lookup is not a skip — it raises (see :func:`_find_by_hrid`) into
+    this handler, so an outage during the lookup aborts and records an error rather
+    than reporting a still-live record as a clean deletion. A hrid maps directly
+    from the GUID (``AxC-{entity}-{guid}``), the same scheme the upsert path writes,
+    so no MARC parse or mapping is needed here.
     """
     result = GuidCascadeResult(guid=guid)
     try:

--- a/catalogue_graph/src/adapters/steps/axiell_folio_sync/upsert.py
+++ b/catalogue_graph/src/adapters/steps/axiell_folio_sync/upsert.py
@@ -5,7 +5,8 @@ Entry point:
   upsert_from_payloads() — takes the dict produced by mapping.build_payloads()
 
 Enforces write order:  Instance → Holdings → Item.
-Deleted records are soft-suppressed (discoverySuppress + staffSuppress).
+Deleted records are soft-suppressed: discoverySuppress on all three, plus
+staffSuppress on the instance (holdings and items have no staffSuppress field).
 dry_run=True resolves existing records and plans actions but makes no writes.
 
 Result dict shape
@@ -21,13 +22,16 @@ Result dict shape
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from typing import Any
+
 import structlog
 
 from .folio_callables import FolioInventoryOps
 from .mapping import (
     EntityResult,
+    GuidCascadeResult,
     MappedPayloads,
-    SuppressResult,
     UpsertError,
     UpsertResult,
     _holdings_hrid,
@@ -61,6 +65,11 @@ def _strip_readonly(record: dict) -> dict:
     return {k: v for k, v in record.items() if k not in _READONLY_FIELDS}
 
 
+# Write-path prefixes whose entity carries a staffSuppress field. Only FOLIO
+# instances do; holdings-storage 422s on it and items silently drop it.
+_STAFF_SUPPRESS_PATHS: frozenset[str] = frozenset({"/inventory/instances"})
+
+
 # ── shared helpers ────────────────────────────────────────────────────────────
 
 
@@ -86,7 +95,12 @@ def _suppress_entity(
     hrid: str,
     dry_run: bool,
 ) -> EntityResult:
-    """Resolve an entity by hrid and set discoverySuppress + staffSuppress.
+    """Resolve an entity by hrid and set its suppression flags.
+
+    discoverySuppress is set on every entity; staffSuppress only on instances,
+    which are the only FOLIO inventory entity with that field. holdings-storage
+    rejects an unknown staffSuppress with a 422, and items silently drop it, so
+    sending it there is at best a no-op and at worst breaks the cascade.
 
     Not-found → ``skip`` (the record is already gone). Idempotent: re-suppressing
     a record whose flags are already true is a harmless PUT, so redelivered
@@ -98,16 +112,43 @@ def _suppress_entity(
 
     folio_id: str = existing["id"]
     if not dry_run:
+        suppression: dict[str, Any] = {"discoverySuppress": True}
+        if write_path_prefix in _STAFF_SUPPRESS_PATHS:
+            suppression["staffSuppress"] = True
         folio.put(
             f"{write_path_prefix}/{folio_id}",
-            {
-                **_strip_readonly(existing),
-                "discoverySuppress": True,
-                "staffSuppress": True,
-            },
+            {**_strip_readonly(existing), **suppression},
         )
         logger.info("suppressed hrid=%s folio_id=%s", hrid, folio_id)
     return EntityResult(action="suppress", id=folio_id)
+
+
+def _delete_entity(
+    folio: FolioInventoryOps,
+    *,
+    search_path: str,
+    list_key: str,
+    write_path_prefix: str,
+    hrid: str,
+    dry_run: bool,
+) -> EntityResult:
+    """Resolve an entity by hrid and hard-delete it.
+
+    Not-found → ``skip`` (already gone); the inventory client also treats a 404
+    on the DELETE as a no-op, so this is idempotent under redelivery/races. A
+    non-404 error (e.g. FOLIO 400 because a child still references this record)
+    raises, which aborts the parent's delete in :func:`delete_by_guid` — that is
+    intentional, since deleting a parent while a child remains would orphan it.
+    """
+    existing = _find_by_hrid(folio, search_path, hrid, list_key)
+    if not existing:
+        return EntityResult(action="skip")
+
+    folio_id: str = existing["id"]
+    if not dry_run:
+        folio.delete(f"{write_path_prefix}/{folio_id}")
+        logger.info("deleted hrid=%s folio_id=%s", hrid, folio_id)
+    return EntityResult(action="delete", id=folio_id)
 
 
 def _resolve_item_note_types(payload: dict, ref_cache: RefCache) -> dict:
@@ -323,7 +364,56 @@ def upsert_from_payloads(
     return result
 
 
-# ── reconciler suppression path ─────────────────────────────────────────────────
+# ── reconciler delete path (suppress / hard-delete) ─────────────────────────────
+
+# The cascade order is child → parent: (attr, search_path, list_key, hrid builder).
+# For hard delete this order is mandatory — FOLIO refuses to delete a parent while
+# a child still references it; for suppress it mirrors the reverse of create order.
+_CASCADE_ENTITIES: list[tuple[str, str, str, Callable[[str], str]]] = [
+    ("item", "/inventory/items", "items", _item_hrid),
+    ("holdings", "/holdings-storage/holdings", "holdingsRecords", _holdings_hrid),
+    ("instance", "/inventory/instances", "instances", _instance_hrid),
+]
+
+# An entity operation: resolve by hrid and apply an action (suppress / delete).
+_EntityOp = Callable[..., EntityResult]
+
+
+def _cascade_by_guid(
+    guid: str,
+    folio: FolioInventoryOps,
+    entity_op: _EntityOp,
+    *,
+    dry_run: bool,
+) -> GuidCascadeResult:
+    """Apply ``entity_op`` to a superseded GUID's records, child-first.
+
+    The single try/except is load-bearing for hard delete: if a child op fails,
+    the cascade stops before the parent, so a parent is never actioned while a
+    failed child may still reference it. Records already gone are skipped. A hrid
+    maps directly from the GUID (``AxC-{entity}-{guid}``), the same scheme the
+    upsert path writes, so no MARC parse or mapping is needed here.
+    """
+    result = GuidCascadeResult(guid=guid)
+    try:
+        for attr, search_path, list_key, hrid_of in _CASCADE_ENTITIES:
+            setattr(
+                result,
+                attr,
+                entity_op(
+                    folio,
+                    search_path=search_path,
+                    list_key=list_key,
+                    write_path_prefix=search_path,
+                    hrid=hrid_of(guid),
+                    dry_run=dry_run,
+                ),
+            )
+    except Exception as exc:
+        result.errors.append(UpsertError(type="api", detail=str(exc)))
+        logger.error("reconcile cascade error guid=%s detail=%s", guid, exc)
+
+    return result
 
 
 def suppress_by_guid(
@@ -331,48 +421,27 @@ def suppress_by_guid(
     folio: FolioInventoryOps,
     *,
     dry_run: bool = False,
-) -> SuppressResult:
+) -> GuidCascadeResult:
     """Soft-suppress the FOLIO records for a superseded GUID, child-first.
 
-    The reconciler reports a superseded GUID as an authoritative delete (the old
-    work no longer exists). We soft-suppress (discoverySuppress + staffSuppress)
-    rather than hard-delete, so the action is reversible and auditable. The
-    cascade runs item → holdings → instance (child-first) so a live child is
-    never briefly left pointing at a suppressed parent, mirroring the reverse of
-    the create order. Records already gone are skipped; suppression is
-    idempotent, so a redelivered fact simply re-sets flags that are already true.
-
-    A single hrid maps directly from the GUID (``AxC-{entity}-{guid}``), the same
-    scheme the upsert path writes, so no MARC parse or mapping is needed here.
+    Reversible and auditable: sets discoverySuppress (and staffSuppress on the
+    instance) rather than hard-deleting. Idempotent — a redelivered fact re-sets
+    flags already true.
     """
-    result = SuppressResult(guid=guid)
-    try:
-        result.item = _suppress_entity(
-            folio,
-            search_path="/inventory/items",
-            list_key="items",
-            write_path_prefix="/inventory/items",
-            hrid=_item_hrid(guid),
-            dry_run=dry_run,
-        )
-        result.holdings = _suppress_entity(
-            folio,
-            search_path="/holdings-storage/holdings",
-            list_key="holdingsRecords",
-            write_path_prefix="/holdings-storage/holdings",
-            hrid=_holdings_hrid(guid),
-            dry_run=dry_run,
-        )
-        result.instance = _suppress_entity(
-            folio,
-            search_path="/inventory/instances",
-            list_key="instances",
-            write_path_prefix="/inventory/instances",
-            hrid=_instance_hrid(guid),
-            dry_run=dry_run,
-        )
-    except Exception as exc:
-        result.errors.append(UpsertError(type="api", detail=str(exc)))
-        logger.error("suppress error guid=%s detail=%s", guid, exc)
+    return _cascade_by_guid(guid, folio, _suppress_entity, dry_run=dry_run)
 
-    return result
+
+def delete_by_guid(
+    guid: str,
+    folio: FolioInventoryOps,
+    *,
+    dry_run: bool = False,
+) -> GuidCascadeResult:
+    """Hard-delete the FOLIO records for a superseded GUID, child-first.
+
+    Irreversible. The child-first order is mandatory (FOLIO enforces referential
+    integrity), and the cascade aborts if a child delete fails so a parent is
+    never deleted while a child remains. The inventory client treats a 404 on the
+    DELETE as a no-op, so redelivered facts and races are handled cleanly.
+    """
+    return _cascade_by_guid(guid, folio, _delete_entity, dry_run=dry_run)

--- a/catalogue_graph/tests/adapters/steps/axiell_folio_sync/test_axiell_folio_sync.py
+++ b/catalogue_graph/tests/adapters/steps/axiell_folio_sync/test_axiell_folio_sync.py
@@ -351,6 +351,10 @@ def test_deletions_suppress_and_are_reported() -> None:
     assert resp.total_errors == 0
     # 2 guids x 3 entities each PUT back suppressed.
     assert len(folio.put_paths) == 6
+    # Cleanly-actioned deletions count toward the totals symmetrically with the
+    # upsert pass: a deletions-only run is not reported as zero work.
+    assert resp.total_successful == 2
+    assert resp.total_records == resp.total_successful + resp.total_errors == 2
 
 
 def test_deletion_failure_recorded_as_error_without_aborting() -> None:
@@ -373,6 +377,9 @@ def test_deletion_failure_recorded_as_error_without_aborting() -> None:
     assert resp.counts["deletions"] == 1
     assert resp.counts["suppressed"] == 0
     assert resp.total_errors == 1
+    # An errored GUID is not also counted as a success.
+    assert resp.total_successful == 0
+    assert resp.total_records == 1
 
 
 def test_no_deletions_leaves_counts_zero() -> None:
@@ -380,3 +387,116 @@ def test_no_deletions_leaves_counts_zero() -> None:
 
     assert resp.total_deletions == 0
     assert resp.counts["deletions"] == 0
+
+
+class _DeleteInventory:
+    """FOLIO fake where every entity exists and DELETE is allowed/recorded."""
+
+    def __init__(self) -> None:
+        self.delete_paths: list[str] = []
+        self.put_paths: list[str] = []
+
+    def get(self, path: str, params: Mapping[str, Any] | None = None) -> dict[str, Any]:
+        list_key = {
+            "/inventory/items": "items",
+            "/holdings-storage/holdings": "holdingsRecords",
+            "/inventory/instances": "instances",
+        }.get(path)
+        return {list_key: [{"id": f"{path}#id"}]} if list_key else {}
+
+    def post(self, path: str, payload: Mapping[str, Any]) -> dict[str, Any]:
+        raise AssertionError("must not POST")
+
+    def put(self, path: str, payload: Mapping[str, Any]) -> dict[str, Any]:
+        self.put_paths.append(path)
+        return {}
+
+    def delete(self, path: str) -> dict[str, Any]:
+        self.delete_paths.append(path)
+        return {}
+
+
+def test_hard_delete_mode_deletes_instead_of_suppressing() -> None:
+    folio = _DeleteInventory()
+
+    resp = run_sync(
+        AxiellFolioSyncEvent(job_id="job-1", changeset_ids=["cs1"]),
+        [],
+        FakeRefCache(),  # type: ignore[arg-type]
+        folio,
+        dry_run=False,
+        deletions=[_superseded("g1")],
+        hard_delete=True,
+    )
+
+    assert resp.counts["deletions"] == 1
+    assert resp.counts["deleted"] == 3  # instance + holdings + item
+    assert resp.counts["suppressed"] == 0
+    assert resp.total_errors == 0
+    assert folio.put_paths == []  # hard delete never suppresses
+    assert len(folio.delete_paths) == 3
+
+
+def test_partial_hard_delete_cascade_still_counts_the_executed_child() -> None:
+    # Cascade is item → holdings → instance. The item is irreversibly deleted,
+    # then holdings fails. The already-executed item delete must appear in the
+    # counts (and manifest) rather than vanishing behind the GUID-level error.
+    folio = _DeleteInventory()
+
+    def delete_but_fail_holdings(path: str) -> dict[str, Any]:
+        if path.startswith("/holdings-storage/holdings"):
+            raise RuntimeError("FOLIO 500 deleting holdings")
+        folio.delete_paths.append(path)
+        return {}
+
+    folio.delete = delete_but_fail_holdings  # type: ignore[method-assign]
+
+    resp = run_sync(
+        AxiellFolioSyncEvent(job_id="job-1", changeset_ids=["cs1"]),
+        [],
+        FakeRefCache(),  # type: ignore[arg-type]
+        folio,
+        dry_run=False,
+        deletions=[_superseded("g1")],
+        hard_delete=True,
+    )
+
+    assert resp.counts["deletions"] == 1
+    assert resp.total_errors == 1  # the holdings failure is recorded
+    assert resp.counts["deleted"] == 1  # ...but the item delete is not lost
+    # Only the item was deleted; holdings failed and instance was never reached.
+    assert len(folio.delete_paths) == 1
+    assert folio.delete_paths[0].startswith("/inventory/items")
+
+
+def test_hard_delete_failure_is_reported_under_delete_stage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A failed hard delete must be recorded with stage="delete", not "suppress",
+    # so operators can tell an irreversible-delete failure from a suppression one.
+    folio = _DeleteInventory()
+
+    def boom(path: str) -> dict[str, Any]:
+        raise RuntimeError("FOLIO 500 deleting item")
+
+    folio.delete = boom  # type: ignore[method-assign]
+
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        "utils.reporting.pydantic_to_s3_json",
+        lambda model, s3_uri: captured.update(model=model),
+    )
+
+    resp = run_sync(
+        AxiellFolioSyncEvent(job_id="job-1", changeset_ids=["cs1"]),
+        [],
+        FakeRefCache(),  # type: ignore[arg-type]
+        folio,
+        dry_run=False,
+        deletions=[_superseded("g1")],
+        hard_delete=True,
+        manifest_bucket="bucket-1",
+    )
+
+    assert resp.total_errors == 1
+    assert captured["model"].errors[0].stage == "delete"

--- a/catalogue_graph/tests/adapters/steps/axiell_folio_sync/test_axiell_folio_sync.py
+++ b/catalogue_graph/tests/adapters/steps/axiell_folio_sync/test_axiell_folio_sync.py
@@ -19,6 +19,7 @@ from adapters.steps.axiell_folio_sync.mapping import (
 from adapters.steps.axiell_folio_sync.models import AxiellFolioSyncEvent
 from adapters.steps.axiell_folio_sync.report import AxiellFolioSyncReport
 from adapters.steps.axiell_folio_sync.sync_to_folio import load_okapi_config, run_sync
+from adapters.utils.axiell_changeset_reader import SupersededGuid
 
 # 001 (guid), 980 $a (harvest flag), 351 $c (record type), 245 $a (title).
 SELECTED = (
@@ -289,3 +290,93 @@ def test_run_sync_passes_ref_cache_to_upsert(monkeypatch: pytest.MonkeyPatch) ->
     )
 
     assert isinstance(captured["ref_cache"], FakeRefCache)
+
+
+# ── Pass 2: reconciler deletions (superseded GUIDs) ───────────────────────────
+
+
+class _SuppressInventory:
+    """FOLIO fake where every entity for a GUID already exists and can be PUT."""
+
+    def __init__(self) -> None:
+        self.put_paths: list[str] = []
+
+    def get(self, path: str, params: Mapping[str, Any] | None = None) -> dict[str, Any]:
+        list_key = {
+            "/inventory/items": "items",
+            "/holdings-storage/holdings": "holdingsRecords",
+            "/inventory/instances": "instances",
+        }.get(path)
+        return {list_key: [{"id": f"{path}#id"}]} if list_key else {}
+
+    def post(self, path: str, payload: Mapping[str, Any]) -> dict[str, Any]:
+        raise AssertionError("suppression must not POST")
+
+    def put(self, path: str, payload: Mapping[str, Any]) -> dict[str, Any]:
+        self.put_paths.append(path)
+        return {}
+
+    def delete(self, path: str) -> dict[str, Any]:
+        raise AssertionError("suppression must not hard-delete")
+
+
+def _superseded(guid: str) -> SupersededGuid:
+    from datetime import UTC, datetime
+
+    return SupersededGuid(
+        fact_id=f"rec/{guid}/cs1",
+        record_id=f"rec-{guid}",
+        guid=guid,
+        changeset_id="cs1",
+        last_modified=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+
+
+def test_deletions_suppress_and_are_reported() -> None:
+    folio = _SuppressInventory()
+
+    resp = run_sync(
+        AxiellFolioSyncEvent(job_id="job-1", changeset_ids=["cs1"]),
+        [],  # no upsert rows, deletions only
+        FakeRefCache(),  # type: ignore[arg-type]
+        folio,
+        dry_run=False,
+        deletions=[_superseded("g1"), _superseded("g2")],
+    )
+
+    assert resp.total_deletions == 2
+    assert resp.counts["deletions"] == 2
+    # 2 guids x 3 entities each suppressed.
+    assert resp.counts["suppressed"] == 6
+    assert resp.total_errors == 0
+    # 2 guids x 3 entities each PUT back suppressed.
+    assert len(folio.put_paths) == 6
+
+
+def test_deletion_failure_recorded_as_error_without_aborting() -> None:
+    folio = _SuppressInventory()
+
+    def boom(path: str, payload: Mapping[str, Any]) -> dict[str, Any]:
+        raise RuntimeError("folio down")
+
+    folio.put = boom  # type: ignore[method-assign]
+
+    resp = run_sync(
+        AxiellFolioSyncEvent(job_id="job-1", changeset_ids=["cs1"]),
+        [],
+        FakeRefCache(),  # type: ignore[arg-type]
+        folio,
+        dry_run=False,
+        deletions=[_superseded("g1")],
+    )
+
+    assert resp.counts["deletions"] == 1
+    assert resp.counts["suppressed"] == 0
+    assert resp.total_errors == 1
+
+
+def test_no_deletions_leaves_counts_zero() -> None:
+    resp = _run([_row("sel", SELECTED)])
+
+    assert resp.total_deletions == 0
+    assert resp.counts["deletions"] == 0

--- a/catalogue_graph/tests/adapters/steps/axiell_folio_sync/test_suppress.py
+++ b/catalogue_graph/tests/adapters/steps/axiell_folio_sync/test_suppress.py
@@ -1,8 +1,8 @@
-"""Tests for the reconciler suppression path (``suppress_by_guid``).
+"""Tests for the reconciler delete paths (``suppress_by_guid`` / ``delete_by_guid``).
 
 A superseded GUID from the reconciler is an authoritative delete: the three
-FOLIO records keyed on ``AxC-{entity}-{guid}`` are soft-suppressed (both
-suppress flags), child-first, reversibly.
+FOLIO records keyed on ``AxC-{entity}-{guid}`` are either soft-suppressed (both
+suppress flags, reversible) or hard-deleted, child-first.
 """
 
 from __future__ import annotations
@@ -10,7 +10,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
-from adapters.steps.axiell_folio_sync.upsert import suppress_by_guid
+from adapters.steps.axiell_folio_sync.upsert import delete_by_guid, suppress_by_guid
 
 GUID = "1234"
 
@@ -22,6 +22,7 @@ class FakeInventory:
         # search_path -> the record to return for any hrid lookup (None = absent)
         self.existing = existing if existing is not None else {}
         self.put_calls: list[tuple[str, dict[str, Any]]] = []
+        self.delete_paths: list[str] = []
         self.get_paths: list[str] = []
 
     def get(self, path: str, params: Mapping[str, Any] | None = None) -> dict[str, Any]:
@@ -35,14 +36,15 @@ class FakeInventory:
         return {list_key: [record] if record else []}
 
     def post(self, path: str, payload: Mapping[str, Any]) -> dict[str, Any]:
-        raise AssertionError("suppression must not POST")
+        raise AssertionError("reconciler deletes must not POST")
 
     def put(self, path: str, payload: Mapping[str, Any]) -> dict[str, Any]:
         self.put_calls.append((path, dict(payload)))
         return {}
 
     def delete(self, path: str) -> dict[str, Any]:
-        raise AssertionError("suppression must not hard-delete")
+        self.delete_paths.append(path)
+        return {}
 
 
 def _all_present() -> FakeInventory:
@@ -55,7 +57,7 @@ def _all_present() -> FakeInventory:
     )
 
 
-def test_suppresses_all_three_entities_with_both_flags() -> None:
+def test_suppresses_all_three_entities_with_correct_flags() -> None:
     folio = _all_present()
 
     result = suppress_by_guid(GUID, folio, dry_run=False)
@@ -64,10 +66,17 @@ def test_suppresses_all_three_entities_with_both_flags() -> None:
     assert result.holdings.action == "suppress"
     assert result.instance.action == "suppress"
     assert not result.errors
+    assert folio.delete_paths == []  # suppress is reversible, never hard-deletes
 
-    for _, payload in folio.put_calls:
+    # discoverySuppress on every entity; staffSuppress only on the instance,
+    # the sole FOLIO inventory entity that carries that field (holdings-storage
+    # 422s on it, items silently drop it).
+    for path, payload in folio.put_calls:
         assert payload["discoverySuppress"] is True
-        assert payload["staffSuppress"] is True
+        if path.startswith("/inventory/instances/"):
+            assert payload["staffSuppress"] is True
+        else:
+            assert "staffSuppress" not in payload
 
 
 def test_suppresses_child_first() -> None:
@@ -142,3 +151,64 @@ def test_put_failure_is_captured_as_error() -> None:
 
     assert result.errors
     assert result.errors[0].type == "api"
+
+
+# ── hard delete (delete_by_guid) ──────────────────────────────────────────────
+
+
+def test_hard_delete_removes_all_three_child_first() -> None:
+    folio = _all_present()
+
+    result = delete_by_guid(GUID, folio, dry_run=False)
+
+    assert result.item.action == "delete"
+    assert result.holdings.action == "delete"
+    assert result.instance.action == "delete"
+    assert not result.errors
+    assert folio.put_calls == []  # hard delete never suppresses
+    assert folio.delete_paths == [
+        "/inventory/items/item-1",
+        "/holdings-storage/holdings/hold-1",
+        "/inventory/instances/inst-1",
+    ]
+
+
+def test_hard_delete_skips_missing_records() -> None:
+    folio = FakeInventory({})  # nothing exists
+
+    result = delete_by_guid(GUID, folio, dry_run=False)
+
+    assert result.item.action == "skip"
+    assert result.holdings.action == "skip"
+    assert result.instance.action == "skip"
+    assert folio.delete_paths == []
+    assert not result.errors
+
+
+def test_hard_delete_dry_run_plans_without_writing() -> None:
+    folio = _all_present()
+
+    result = delete_by_guid(GUID, folio, dry_run=True)
+
+    assert result.item.action == "delete"
+    assert result.instance.action == "delete"
+    assert folio.delete_paths == []
+
+
+def test_hard_delete_aborts_cascade_when_a_child_fails() -> None:
+    # FOLIO 400s the item delete (e.g. a loan still references it). The cascade
+    # must stop before holdings/instance so a parent is never left orphaned.
+    folio = _all_present()
+
+    def boom(path: str) -> dict[str, Any]:
+        raise RuntimeError("409 item still referenced")
+
+    folio.delete = boom  # type: ignore[method-assign]
+
+    result = delete_by_guid(GUID, folio, dry_run=False)
+
+    assert result.errors
+    assert result.errors[0].type == "api"
+    # item op raised → holdings and instance were never attempted.
+    assert result.holdings.action is None
+    assert result.instance.action is None

--- a/catalogue_graph/tests/adapters/steps/axiell_folio_sync/test_suppress.py
+++ b/catalogue_graph/tests/adapters/steps/axiell_folio_sync/test_suppress.py
@@ -213,3 +213,47 @@ def test_hard_delete_aborts_cascade_when_a_child_fails() -> None:
     # item op raised → holdings and instance were never attempted.
     assert result.holdings.action is None
     assert result.instance.action is None
+
+
+def test_hard_delete_lookup_failure_is_an_error_not_a_skip() -> None:
+    # A FOLIO outage makes the *lookup* raise. That is not "already gone": it must
+    # surface as an error and abort the cascade, otherwise a still-live record is
+    # reported as a clean skip/skip/skip deletion and never retried. In hard-delete
+    # mode a swallowed item lookup would also let holdings/instance be deleted while
+    # the item may still exist.
+    folio = _all_present()
+
+    def boom(path: str, params: Mapping[str, Any] | None = None) -> dict[str, Any]:
+        raise RuntimeError("folio down")
+
+    folio.get = boom  # type: ignore[method-assign]
+
+    result = delete_by_guid(GUID, folio, dry_run=False)
+
+    assert result.errors
+    assert result.errors[0].type == "api"
+    # item lookup raised → nothing was actioned, child-first abort holds.
+    assert result.item.action is None
+    assert result.holdings.action is None
+    assert result.instance.action is None
+    assert folio.delete_paths == []
+
+
+def test_suppress_lookup_failure_is_an_error_not_a_skip() -> None:
+    # Same outage on the soft-suppress path: a failed lookup must not be reported
+    # as a successfully-actioned (skip) deletion.
+    folio = _all_present()
+
+    def boom(path: str, params: Mapping[str, Any] | None = None) -> dict[str, Any]:
+        raise RuntimeError("folio down")
+
+    folio.get = boom  # type: ignore[method-assign]
+
+    result = suppress_by_guid(GUID, folio, dry_run=False)
+
+    assert result.errors
+    assert result.errors[0].type == "api"
+    assert result.item.action is None
+    assert result.holdings.action is None
+    assert result.instance.action is None
+    assert folio.put_calls == []

--- a/catalogue_graph/tests/adapters/steps/axiell_folio_sync/test_suppress.py
+++ b/catalogue_graph/tests/adapters/steps/axiell_folio_sync/test_suppress.py
@@ -1,8 +1,9 @@
 """Tests for the reconciler delete paths (``suppress_by_guid`` / ``delete_by_guid``).
 
 A superseded GUID from the reconciler is an authoritative delete: the three
-FOLIO records keyed on ``AxC-{entity}-{guid}`` are either soft-suppressed (both
-suppress flags, reversible) or hard-deleted, child-first.
+FOLIO records keyed on ``AxC-{entity}-{guid}`` are either soft-suppressed
+(``discoverySuppress`` on all three, plus ``staffSuppress`` on the instance) or
+hard-deleted, child-first.
 """
 
 from __future__ import annotations

--- a/catalogue_graph/tests/adapters/steps/axiell_folio_sync/test_suppress.py
+++ b/catalogue_graph/tests/adapters/steps/axiell_folio_sync/test_suppress.py
@@ -1,0 +1,144 @@
+"""Tests for the reconciler suppression path (``suppress_by_guid``).
+
+A superseded GUID from the reconciler is an authoritative delete: the three
+FOLIO records keyed on ``AxC-{entity}-{guid}`` are soft-suppressed (both
+suppress flags), child-first, reversibly.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from adapters.steps.axiell_folio_sync.upsert import suppress_by_guid
+
+GUID = "1234"
+
+
+class FakeInventory:
+    """Records write order and returns a stored record for each entity hrid."""
+
+    def __init__(self, existing: dict[str, dict[str, Any]] | None = None) -> None:
+        # search_path -> the record to return for any hrid lookup (None = absent)
+        self.existing = existing if existing is not None else {}
+        self.put_calls: list[tuple[str, dict[str, Any]]] = []
+        self.get_paths: list[str] = []
+
+    def get(self, path: str, params: Mapping[str, Any] | None = None) -> dict[str, Any]:
+        self.get_paths.append(path)
+        record = self.existing.get(path)
+        list_key = {
+            "/inventory/items": "items",
+            "/holdings-storage/holdings": "holdingsRecords",
+            "/inventory/instances": "instances",
+        }[path]
+        return {list_key: [record] if record else []}
+
+    def post(self, path: str, payload: Mapping[str, Any]) -> dict[str, Any]:
+        raise AssertionError("suppression must not POST")
+
+    def put(self, path: str, payload: Mapping[str, Any]) -> dict[str, Any]:
+        self.put_calls.append((path, dict(payload)))
+        return {}
+
+    def delete(self, path: str) -> dict[str, Any]:
+        raise AssertionError("suppression must not hard-delete")
+
+
+def _all_present() -> FakeInventory:
+    return FakeInventory(
+        {
+            "/inventory/items": {"id": "item-1", "circulationNotes": ["ro"]},
+            "/holdings-storage/holdings": {"id": "hold-1", "holdingsItems": ["ro"]},
+            "/inventory/instances": {"id": "inst-1", "precedingTitles": ["ro"]},
+        }
+    )
+
+
+def test_suppresses_all_three_entities_with_both_flags() -> None:
+    folio = _all_present()
+
+    result = suppress_by_guid(GUID, folio, dry_run=False)
+
+    assert result.item.action == "suppress"
+    assert result.holdings.action == "suppress"
+    assert result.instance.action == "suppress"
+    assert not result.errors
+
+    for _, payload in folio.put_calls:
+        assert payload["discoverySuppress"] is True
+        assert payload["staffSuppress"] is True
+
+
+def test_suppresses_child_first() -> None:
+    folio = _all_present()
+
+    suppress_by_guid(GUID, folio, dry_run=False)
+
+    put_paths = [path for path, _ in folio.put_calls]
+    assert put_paths == [
+        "/inventory/items/item-1",
+        "/holdings-storage/holdings/hold-1",
+        "/inventory/instances/inst-1",
+    ]
+
+
+def test_strips_readonly_fields_before_put() -> None:
+    folio = _all_present()
+
+    suppress_by_guid(GUID, folio, dry_run=False)
+
+    payload_by_path = {path: payload for path, payload in folio.put_calls}
+    assert "circulationNotes" not in payload_by_path["/inventory/items/item-1"]
+    assert "holdingsItems" not in payload_by_path["/holdings-storage/holdings/hold-1"]
+    assert "precedingTitles" not in payload_by_path["/inventory/instances/inst-1"]
+
+
+def test_missing_records_are_skipped_not_created() -> None:
+    folio = FakeInventory({})  # nothing exists
+
+    result = suppress_by_guid(GUID, folio, dry_run=False)
+
+    assert result.item.action == "skip"
+    assert result.holdings.action == "skip"
+    assert result.instance.action == "skip"
+    assert folio.put_calls == []
+    assert not result.errors
+
+
+def test_partial_presence_suppresses_only_found_records() -> None:
+    folio = FakeInventory(
+        {"/inventory/instances": {"id": "inst-1"}}  # only the instance survives
+    )
+
+    result = suppress_by_guid(GUID, folio, dry_run=False)
+
+    assert result.item.action == "skip"
+    assert result.holdings.action == "skip"
+    assert result.instance.action == "suppress"
+    assert [path for path, _ in folio.put_calls] == ["/inventory/instances/inst-1"]
+
+
+def test_dry_run_plans_without_writing() -> None:
+    folio = _all_present()
+
+    result = suppress_by_guid(GUID, folio, dry_run=True)
+
+    # Actions are still planned (resolved by hrid) but no PUT is issued.
+    assert result.item.action == "suppress"
+    assert result.instance.action == "suppress"
+    assert folio.put_calls == []
+
+
+def test_put_failure_is_captured_as_error() -> None:
+    folio = _all_present()
+
+    def boom(path: str, payload: Mapping[str, Any]) -> dict[str, Any]:
+        raise RuntimeError("folio down")
+
+    folio.put = boom  # type: ignore[method-assign]
+
+    result = suppress_by_guid(GUID, folio, dry_run=False)
+
+    assert result.errors
+    assert result.errors[0].type == "api"

--- a/catalogue_graph/tests/adapters/steps/axiell_folio_sync/test_upsert.py
+++ b/catalogue_graph/tests/adapters/steps/axiell_folio_sync/test_upsert.py
@@ -116,3 +116,38 @@ def test_deleted_record_suppression_does_not_trigger_rollbacks_on_success() -> N
 
     assert not result.errors
     assert deleted_paths == []
+
+
+def test_lookup_failure_errors_rather_than_creating_a_duplicate() -> None:
+    # A transient FOLIO outage makes the instance *lookup* raise. This must not be
+    # read as "record absent" and fall through to a POST — that would create a
+    # duplicate (or 422) instead of updating the existing record. It surfaces as an
+    # error and writes nothing.
+    posted_paths: list[str] = []
+
+    class FakeInventory:
+        def get(
+            self, path: str, params: Mapping[str, Any] | None = None
+        ) -> dict[str, Any]:
+            raise RuntimeError("folio down")
+
+        def post(self, path: str, payload: Mapping[str, Any]) -> dict[str, Any]:
+            posted_paths.append(path)
+            return {"id": "should-not-happen"}
+
+        def put(self, path: str, payload: Mapping[str, Any]) -> dict[str, Any]:
+            return {}
+
+        def delete(self, path: str) -> dict[str, Any]:
+            return {}
+
+    result = upsert_from_payloads(
+        MAPPED,
+        FakeInventory(),
+        dry_run=False,
+    )
+
+    assert result.errors
+    assert result.errors[0].type == "api"
+    assert posted_paths == []
+    assert result.instance.action is None


### PR DESCRIPTION
## What does this change?

Implements **Pass 2 reconciliation deletes** for the Axiell to FOLIO sync step, completing the reconciliation pipeline specified in [RFC 090](https://github.com/wellcomecollection/docs/tree/main/rfcs/090-axiell-folio-sync).

The sync step now processes deletion facts from the Axiell adapter's reconcile phase in two independent modes (selected via `hard_delete` event field or `HARD_DELETE` env var):

1. **Soft-suppress (default, reversible)**
   - Sets `discoverySuppress=true` on Instance, Holdings, and Item
   - Sets `staffSuppress=true` on Instance only (holdings-storage and items don't support this field)
   - Idempotent: re-applying to already-suppressed records is a harmless PUT

2. **Hard-delete (opt-in, irreversible)**
   - Deletes entities child-first (Item → Holdings → Instance) to maintain referential integrity
   - Treats 404 responses as no-ops (safe under redelivery and races)
   - Aborts before parent if a child delete fails (preventing orphans)

### Changes include:

- **Event model**: added `hard_delete` field to `AxiellFolioSyncEvent` (defaults to `HARD_DELETE` env var, default `false`)
- **Response model**: added `total_deletions` to `AxiellFolioSyncResponse`
- **Report model**: added `SyncDeletionEntry` to track per-GUID actions (suppress or hard-delete) in S3 + CloudWatch reports
- **Deletion logic** (`upsert.py`): `suppress_by_guid()` and `delete_by_guid()` functions with entity-level result tracking; refactored for clarity and maintainability
- **Main loop** (`sync_to_folio.py`): two-pass architecture — Pass 1 upserts, Pass 2 processes deletion facts
- **Documentation** (`README.md`): extensive section on reconciliation semantics, idempotency, and the two delete modes
- **Tests** (`test_axiell_folio_sync.py`, `test_suppress.py`, `test_upsert.py`): comprehensive coverage for soft-suppress, hard-delete, and error scenarios

## How to test

1. **Unit tests**: `cd catalogue_graph && uv run pytest tests/adapters/steps/axiell_folio_sync/`
2. **Local dry run**: Test with a sample Axiell changeset (dry_run=true) to validate payload construction and plan actions without writing to FOLIO.
3. **Staging validation**: Deploy to staging Lambda/ECS and run against Staging FOLIO tenant to verify soft-suppress reversibility before enabling hard-delete.

## How can we measure success?

- ✅ All unit tests pass (soft-suppress, hard-delete, upsert refactoring, and error cases)
- ✅ `PipelineReport` correctly records deletion facts (S3 JSON + CloudWatch metrics)
- ✅ Soft-suppress is idempotent: re-running deletion facts against already-suppressed records produces no changes
- ✅ Hard-delete child-first ordering is enforced (no orphaned holdings/items)
- ✅ Dry run produces correct plan without writing to FOLIO
- ✅ Redelivered deletion facts are safe (404s treated as no-ops, idempotent writes)
- ✅ Manual staging test: suppress a record, verify `discoverySuppress` and `staffSuppress` flags, then un-suppress via hard-delete (to prove reversibility pre-release)

## Have we considered potential risks?

- **Hard-delete is irreversible.** Must be opt-in via `hard_delete=true` event field or `HARD_DELETE=true` env var (defaults to false). Default behavior is soft-suppress (reversible).
- **Reconciliation logic correctness.** Deletion facts must accurately identify superseded GUIDs. Incorrect reconciliation in the Axiell adapter could suppress/delete the wrong record. Mitigated by staged deployment and manual staging validation.
- **FOLIO referential integrity.** Deletion must happen child-first (Item → Holdings → Instance) to avoid violating foreign keys. Cascade ordering is enforced in code; a child-delete failure aborts before the parent.
- **Lambda cold starts.** Both deletion modes read from FOLIO (for existing record lookups); ensures credentials are valid and FOLIO is reachable even in dry runs. No degradation vs. current behavior.
- **CloudWatch metrics namespace collision.** Metrics are already published to `catalogue_adapters`; deletion metrics follow the same pattern (no new namespace).

No breaking changes to the event schema (all new fields are optional with sensible defaults).
