### PR TITLE
Widen graph extractor ES search retry to a time budget

### DIFF
--- a/catalogue_graph/src/core/source.py
+++ b/catalogue_graph/src/core/source.py
@@ -13,6 +13,7 @@ import backoff
 import requests
 import structlog
 from elasticsearch import Elasticsearch
+from elasticsearch.exceptions import ApiError, TransportError
 from pydantic import BaseModel
 
 import config
@@ -48,18 +49,33 @@ class MultiGZipSource(BaseSource):
             yield from source.stream_raw()
 
 
-ES_REQUESTS_BACKOFF_RETRIES = int(os.environ.get("REQUESTS_BACKOFF_RETRIES", "3"))
-ES_REQUESTS_BACKOFF_INTERVAL = 10
+# Transient ES statuses worth retrying; a 4xx (e.g. bad query) is permanent.
+RETRIABLE_ES_STATUS_CODES = frozenset({429, 502, 503, 504})
+
+# Time budget for retrying a single search: a blip must not fail the extractor and
+# lose a window that has no backfill. Kept under the 15m PIT keep-alive.
+ES_REQUESTS_BACKOFF_MAX_TIME = float(os.environ.get("REQUESTS_BACKOFF_MAX_TIME", "300"))
+ES_REQUESTS_BACKOFF_MAX_INTERVAL = 30
 
 
 class ErrorSentinel(BaseModel):
     exception: Any
 
 
+def _giveup_es_request(exc: Exception) -> bool:
+    if isinstance(exc, ApiError):
+        return exc.status_code not in RETRIABLE_ES_STATUS_CODES
+    return False
+
+
 def _on_request_backoff(backoff_details: Any) -> None:
-    exception_name = type(backoff_details["exception"]).__name__
+    exc = backoff_details["exception"]
     logger.warning(
-        "Elasticsearch request failed, retrying", exception_name=exception_name
+        "Elasticsearch request failed, retrying",
+        exception_name=type(exc).__name__,
+        status_code=getattr(exc, "status_code", None),
+        elapsed_seconds=round(backoff_details["elapsed"]),
+        tries=backoff_details["tries"],
     )
 
 
@@ -92,11 +108,13 @@ class ElasticSource(BaseSource):
             self.pit_id = pit["id"]
 
     @backoff.on_exception(
-        backoff.constant,
-        Exception,
-        max_tries=ES_REQUESTS_BACKOFF_RETRIES,
-        interval=ES_REQUESTS_BACKOFF_INTERVAL,
+        backoff.expo,
+        (TransportError, ApiError),
+        max_time=ES_REQUESTS_BACKOFF_MAX_TIME,
+        max_value=ES_REQUESTS_BACKOFF_MAX_INTERVAL,
+        giveup=_giveup_es_request,
         on_backoff=_on_request_backoff,
+        jitter=backoff.full_jitter,
     )
     def search(self, slice_index: int, search_after: str | None = None) -> list[dict]:
         body: dict[str, Any] = {

--- a/catalogue_graph/src/core/source.py
+++ b/catalogue_graph/src/core/source.py
@@ -118,7 +118,9 @@ class ElasticSource(BaseSource):
         on_backoff=_on_request_backoff,
         jitter=backoff.full_jitter,
     )
-    def search(self, slice_index: int, search_after: str | None = None) -> list[dict]:
+    def search(
+        self, slice_index: int, search_after: list[Any] | None = None
+    ) -> list[dict]:
         body: dict[str, Any] = {
             "query": self.query,
             "size": self.batch_size,

--- a/catalogue_graph/src/core/source.py
+++ b/catalogue_graph/src/core/source.py
@@ -49,8 +49,9 @@ class MultiGZipSource(BaseSource):
             yield from source.stream_raw()
 
 
-# Transient ES statuses worth retrying; a 4xx (e.g. bad query) is permanent.
-RETRIABLE_ES_STATUS_CODES = frozenset({429, 502, 503, 504})
+# The two 4xx statuses that clear on a retry; every other 4xx is a permanent
+# problem (bad query, missing index, bad credentials) and fails fast.
+RETRIABLE_4XX_STATUS_CODES = frozenset({408, 429})
 
 # Time budget for retrying a single search: a blip must not fail the extractor and
 # lose a window that has no backfill. Kept under the 15m PIT keep-alive.
@@ -64,7 +65,8 @@ class ErrorSentinel(BaseModel):
 
 def _giveup_es_request(exc: Exception) -> bool:
     if isinstance(exc, ApiError):
-        return exc.status_code not in RETRIABLE_ES_STATUS_CODES
+        status = exc.status_code
+        return 400 <= status < 500 and status not in RETRIABLE_4XX_STATUS_CODES
     return False
 
 

--- a/catalogue_graph/tests/core/test_source_search_retry.py
+++ b/catalogue_graph/tests/core/test_source_search_retry.py
@@ -1,0 +1,100 @@
+from unittest.mock import MagicMock
+
+import pytest
+from _pytest.monkeypatch import MonkeyPatch
+from elastic_transport import ApiResponseMeta, HttpHeaders
+from elasticsearch.exceptions import ApiError
+from elasticsearch.exceptions import ConnectionError as ESConnectionError
+
+from core.source import ElasticSource, _giveup_es_request
+
+
+def _api_error(status: int) -> ApiError:
+    meta = ApiResponseMeta(
+        status=status,
+        http_version="1.1",
+        headers=HttpHeaders({}),
+        duration=0.0,
+        node=None,  # type: ignore[arg-type]
+    )
+    return ApiError("search_phase_execution_exception", meta=meta, body=None)
+
+
+def _make_source() -> ElasticSource:
+    # pit_id supplied so construction does not open a real PIT.
+    return ElasticSource(
+        es_client=MagicMock(),
+        index_name="images-augmented-x",
+        query={"match_all": {}},
+        pit_id="pit-123",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _no_backoff_sleep(monkeypatch: MonkeyPatch) -> None:
+    # Skip real backoff waits.
+    monkeypatch.setattr("time.sleep", lambda *_a, **_k: None)
+
+
+def test_search_retries_transient_503_then_succeeds() -> None:
+    source = _make_source()
+    source.es_client.search.side_effect = [  # type: ignore[attr-defined]
+        _api_error(503),
+        {"hits": {"hits": [{"_id": "1", "sort": [1]}]}},
+    ]
+
+    hits = source.search(slice_index=0)
+
+    assert source.es_client.search.call_count == 2  # type: ignore[attr-defined]
+    assert hits == [{"_id": "1", "sort": [1]}]
+
+
+def test_search_retries_transient_connection_error() -> None:
+    source = _make_source()
+    source.es_client.search.side_effect = [  # type: ignore[attr-defined]
+        ESConnectionError("dropped keep-alive"),
+        {"hits": {"hits": []}},
+    ]
+
+    hits = source.search(slice_index=0)
+
+    assert source.es_client.search.call_count == 2  # type: ignore[attr-defined]
+    assert hits == []
+
+
+def test_search_gives_up_immediately_on_non_retriable_status() -> None:
+    source = _make_source()
+    source.es_client.search.side_effect = _api_error(400)  # type: ignore[attr-defined]
+
+    with pytest.raises(ApiError):
+        source.search(slice_index=0)
+
+    assert source.es_client.search.call_count == 1  # type: ignore[attr-defined]
+
+
+@pytest.mark.parametrize(
+    ("exc", "expected_giveup"),
+    [
+        (_api_error(503), False),
+        (_api_error(429), False),
+        (_api_error(502), False),
+        (_api_error(504), False),
+        (_api_error(400), True),
+        (_api_error(404), True),
+        (ESConnectionError("transport"), False),
+    ],
+)
+def test_giveup_predicate(exc: Exception, expected_giveup: bool) -> None:
+    assert _giveup_es_request(exc) is expected_giveup
+
+
+def test_search_refreshes_pit_id_from_response() -> None:
+    source = _make_source()
+    source.es_client.search.return_value = {  # type: ignore[attr-defined]
+        "hits": {"hits": []},
+        "pit_id": "pit-456",
+    }
+
+    source.search(slice_index=0)
+
+    assert source.pit_id == "pit-456"

--- a/catalogue_graph/tests/core/test_source_search_retry.py
+++ b/catalogue_graph/tests/core/test_source_search_retry.py
@@ -75,17 +75,34 @@ def test_search_gives_up_immediately_on_non_retriable_status() -> None:
 @pytest.mark.parametrize(
     ("exc", "expected_giveup"),
     [
-        (_api_error(503), False),
-        (_api_error(429), False),
+        # Every 5xx is a blip worth retrying, not just the ones seen so far.
+        (_api_error(500), False),
         (_api_error(502), False),
+        (_api_error(503), False),
         (_api_error(504), False),
+        (_api_error(408), False),
+        (_api_error(429), False),
         (_api_error(400), True),
+        (_api_error(401), True),
+        (_api_error(403), True),
         (_api_error(404), True),
         (ESConnectionError("transport"), False),
     ],
 )
 def test_giveup_predicate(exc: Exception, expected_giveup: bool) -> None:
     assert _giveup_es_request(exc) is expected_giveup
+
+
+def test_search_retries_500_shard_failure() -> None:
+    source = _make_source()
+    source.es_client.search.side_effect = [  # type: ignore[attr-defined]
+        _api_error(500),
+        {"hits": {"hits": []}},
+    ]
+
+    source.search(slice_index=0)
+
+    assert source.es_client.search.call_count == 2  # type: ignore[attr-defined]
 
 
 def test_search_refreshes_pit_id_from_response() -> None:


### PR DESCRIPTION
## What does this change?

A transient `ApiError(503, 'search_phase_execution_exception')` in the `catalogue_images` edges extractor failed the whole graph incremental run on 2026-07-28 (`graph-pipeline-incremental-run-failed-2025-10-02`). The extractors map tolerates no failures, and windows are schedule-derived with no backfill, so a failed run drops that 15 minute window permanently. This one happened to be empty.

The search already retried, but 3 tries at a fixed 10s interval gave about 20s of cover. `ElasticSource.search` now retries against a time budget (`REQUESTS_BACKOFF_MAX_TIME`, default 300s) with jittered exponential backoff capped at 30s. The retried set narrows from bare `Exception` to transport errors plus any API error that is not a permanent 4xx, so a bad query or a missing index still fails on the first call. Retry logs carry status code, elapsed seconds and try count.

<details><summary>Design notes</summary>

- 300s stays under the 15m PIT `keep_alive`, which is only refreshed on a successful search. The ECS heartbeat runs on its own thread, so a search parked in backoff does not breach `HeartbeatSeconds`.
- Retriable statuses are an exclusion, not an allowlist. An allowlist misses cases such as the 500 that some `search_phase_execution_exception` variants return.
- The budget also applies to `IdMintingSource` and `MergedWorksSource`, which run in 900s Lambdas. A late stall there ends as a Lambda timeout rather than a clean exception. Both rely on SQS redelivery either way, and the env var can be set lower per deployment.
- The ES budget got its own env var because `REQUESTS_BACKOFF_RETRIES` is read verbatim by the Neptune and SPARQL clients. Neither variable is set in terraform, so nothing needs redeploying.
- `Open PIT` is still a place a blip could lose a window: its Step Functions Retry covers infra errors but not ES API errors. Follow-up.

</details>

### Checklist

- [x] Display model unchanged, so there are no test documents to regenerate.

## How to test

From `catalogue_graph/`: `uv run --group dev pytest tests/core/test_source_search_retry.py`. Covers a transient 503 and a connection error retrying then succeeding, a 400 failing after exactly one call, PIT id refresh, and the give-up predicate across statuses.

## How can we measure success?

Fewer `graph-pipeline-incremental-run-failed-2025-10-02` alarms caused by a single 5xx. Recovered blips now surface as "Elasticsearch request failed, retrying" warnings rather than a failed run.

## Have we considered potential risks?

An unhealthy cluster now parks a search in backoff for up to 5 minutes instead of 20 seconds. That delays a failure rather than creating one, and permanent errors fail faster than before.
