### PR TITLE
Suppress in-progress Axiell records before requiring a RefNo

### DIFF
--- a/catalogue_graph/src/adapters/transformers/builders/axiell_work_builder.py
+++ b/catalogue_graph/src/adapters/transformers/builders/axiell_work_builder.py
@@ -77,8 +77,8 @@ class AxiellWorkBuilder(MarcXmlWorkBuilder):
 
         # Records prefixed with AMSG (Archives and Manuscripts Resource Guides) are not
         # actual archives but instead guides for researchers, so we suppress them here.
-        ref_no = self.reference_number
-        return ref_no is not None and ref_no.startswith("AMSG")
+        alt_ref_no = self.reference_number
+        return alt_ref_no is not None and alt_ref_no.startswith("AMSG")
 
     @property
     def source_identifier_type(self) -> Id:

--- a/catalogue_graph/src/adapters/transformers/builders/axiell_work_builder.py
+++ b/catalogue_graph/src/adapters/transformers/builders/axiell_work_builder.py
@@ -67,16 +67,18 @@ class AxiellWorkBuilder(MarcXmlWorkBuilder):
     """Work builder for Axiell (MARC XML) records."""
 
     def _is_suppresssed(self) -> bool:
+        # If a record does not have a status, or if its status is not listed in
+        # NON_SUPPRESSED_STATUSES, we suppress it. Checked before anything touching
+        # collection_path: newly created records legitimately lack a RefNo, and
+        # suppressing them must not require one.
+        catalogue_status = extract_catalogue_status(self.record)
+        if catalogue_status not in NON_SUPPRESSED_STATUSES:
+            return True
+
         # Records prefixed with AMSG (Archives and Manuscripts Resource Guides) are not
         # actual archives but instead guides for researchers, so we suppress them here.
         ref_no = self.reference_number
-        if ref_no is not None and ref_no.startswith("AMSG"):
-            return True
-
-        catalogue_status = extract_catalogue_status(self.record)
-
-        # If a record does not have a status, or if its status is not listed in NON_SUPPRESSED_STATUSES, we suppress it
-        return catalogue_status not in NON_SUPPRESSED_STATUSES
+        return ref_no is not None and ref_no.startswith("AMSG")
 
     @property
     def source_identifier_type(self) -> Id:

--- a/catalogue_graph/tests/adapters/transformers/axiell/conftest.py
+++ b/catalogue_graph/tests/adapters/transformers/axiell/conftest.py
@@ -6,6 +6,7 @@ from pymarc.record import Field, Indicators, Record, Subfield
 def make_axiell_record(
     identifier: str = "test001",
     catalogue_status: str | None = "catalogued",
+    ref_no: str | None = "TestRefNo",
 ) -> Record:
     """Minimal valid Axiell MARC record with all required fields."""
     record = Record()
@@ -14,9 +15,12 @@ def make_axiell_record(
         Field(tag="245", subfields=[Subfield(code="a", value="Test Title")])
     )
     record.add_field(Field(tag="005", data="18530821094530.0"))
-    record.add_field(
-        Field(tag="035", subfields=[Subfield(code="a", value="(Calm RefNo)TestRefNo")])
-    )
+    if ref_no is not None:
+        record.add_field(
+            Field(
+                tag="035", subfields=[Subfield(code="a", value=f"(Calm RefNo){ref_no}")]
+            )
+        )
     record.add_field(Field(tag="351", subfields=[Subfield(code="c", value="Item")]))
 
     if catalogue_status is not None:

--- a/catalogue_graph/tests/adapters/transformers/axiell/test_suppression.py
+++ b/catalogue_graph/tests/adapters/transformers/axiell/test_suppression.py
@@ -46,6 +46,21 @@ def test_missing_status_yields_deleted_work() -> None:
     )
 
 
+@pytest.mark.parametrize("status", ["draft", "in progress", None])
+def test_suppressed_record_without_ref_no_yields_deleted_work(
+    status: str | None,
+) -> None:
+    """Cataloguers create records before assigning a RefNo; suppression must not fail on them."""
+    record = make_axiell_record(catalogue_status=status, ref_no=None)
+    assert isinstance(_transform(record), DeletedSourceWork)
+
+
+def test_catalogued_record_without_ref_no_raises() -> None:
+    record = make_axiell_record(catalogue_status="catalogued", ref_no=None)
+    with pytest.raises(ValueError, match="Missing RefNo"):
+        _transform(record)
+
+
 def test_amsg_alt_ref_no_suppresses_regardless_of_status() -> None:
     record = make_axiell_record()
     record = _with_alt_ref_no(record, "AMSG-Research-Guide-001")


### PR DESCRIPTION
## What does this change?

The `axiell-transformer-failures-2026-07-03` alarm started firing on 2026-07-28 and stayed on. Every failure was "Missing RefNo on work ...", all from one block of around 42 newly created records (prirefs from collect:110206483 onward) where a cataloguer had entered a fresh archive hierarchy top-down: catalogue status "In progress", no RefNo assigned yet.

`AxiellWorkBuilder._is_suppresssed()` tested the AMSG AltRefNo prefix before it looked at catalogue status. That prefix test reads `reference_number`, which resolves through `collection_path` and raises when the record has no RefNo, so records that were going to be suppressed anyway blew up the transform instead.

Catalogue status is now checked first. An in-progress record emits a suppression tombstone like any other suppressed record. A catalogued record with no RefNo still raises, because that is a genuine data error and should stay loud.

### Checklist

- [x] No change to the display model the catalogue API returns, so the test documents under `catalogue_graph/document_generators/test_documents` do not need regenerating.

## How to test

From `catalogue_graph/`, run `uv run --group dev pytest tests/adapters` (985 pass). The new suppression cases cover draft, in progress and absent status with no RefNo, and pin that a catalogued record with no RefNo still raises.

## How can we measure success?

`axiell-transformer-failures-2026-07-03` clears once this is deployed and the next window covering those prirefs runs. Those records should appear as suppressed works rather than as transform failures.

## Have we considered potential risks?

The AMSG prefix check is now only reached for records with a non-suppressed status. That is a no-op: an AMSG record with a suppressed status was already being suppressed by the status branch, it just got there via a different return.

This narrows the alarm rather than silencing it. A missing RefNo on a catalogued record still fails the transform, so a real cataloguing error is still visible.
