### PR TITLE
Give the adapter rebuild download its own retry and timeout budget

### DIFF
--- a/catalogue_graph/scripts/rebuild_adapter.py
+++ b/catalogue_graph/scripts/rebuild_adapter.py
@@ -71,6 +71,12 @@ records into the adapter store."""
 PROGRESS_LOG_EVERY = 5_000
 """Records between download progress log lines."""
 
+DOWNLOAD_MAX_REQUEST_RETRIES = 5
+"""Timeout retries per request during the download. The adapters configure a
+small budget, which suits windowed harvesting because a failed window is simply
+retried; this download runs for hours and cannot resume, so one slow page
+should not end it."""
+
 EVENT_BUS_NAME = "catalogue-pipeline-adapter-event-bus"
 
 
@@ -432,7 +438,9 @@ def rebuild_adapter(
             config, datetime.now(UTC), use_rest_api_table=use_rest_api_table
         )
 
-        oai_client = config.build_oai_client()
+        oai_client = config.build_oai_client(
+            max_request_retries=DOWNLOAD_MAX_REQUEST_RETRIES
+        )
         _download_to_snapshot(oai_client, config.config, snapshot_path)
 
     # Phase 2: Items download (reads bib instance IDs from the bib snapshot).

--- a/catalogue_graph/scripts/rebuild_adapter.py
+++ b/catalogue_graph/scripts/rebuild_adapter.py
@@ -29,6 +29,7 @@ from datetime import UTC, datetime, timedelta
 from typing import NamedTuple
 
 import boto3
+import httpx
 import pyarrow as pa
 import pyarrow.compute as pc
 import pyarrow.parquet as pq
@@ -77,6 +78,12 @@ allow a single attempt, which suits windowed harvesting because a failed window
 is retried; this download runs for hours and cannot resume, so a momentarily
 slow page should not end it. Only timeouts are covered: an empty response body
 still ends the download."""
+
+DOWNLOAD_READ_TIMEOUT_SECONDS = 180.0
+"""Read timeout for download requests. Retrying alone does not help if the
+server is slow rather than momentarily unresponsive, because every attempt
+meets the same deadline. Pages normally arrive in under ten seconds, so this
+waits out a page built under load rather than discarding hours of work."""
 
 EVENT_BUS_NAME = "catalogue-pipeline-adapter-event-bus"
 
@@ -139,6 +146,23 @@ def _log_download_progress(total: int, expected: int | None, started_at: float) 
         percent=round(100 * total / expected, 1) if expected else None,
         records_per_second=round(rate, 1),
         eta_minutes=round(remaining / 60) if remaining else None,
+    )
+
+
+def _build_download_client(config: OAIPMHRuntimeConfig) -> OAIClient:
+    """Build an OAI client tuned for one long download rather than a windowed
+    harvest: more attempts, and longer to wait for each one."""
+    http_client = config.build_http_client()
+    timeout = http_client.timeout
+    http_client.timeout = httpx.Timeout(
+        connect=timeout.connect,
+        read=DOWNLOAD_READ_TIMEOUT_SECONDS,
+        write=timeout.write,
+        pool=timeout.pool,
+    )
+    return config.build_oai_client(
+        http_client=http_client,
+        max_request_retries=DOWNLOAD_MAX_REQUEST_RETRIES,
     )
 
 
@@ -439,9 +463,7 @@ def rebuild_adapter(
             config, datetime.now(UTC), use_rest_api_table=use_rest_api_table
         )
 
-        oai_client = config.build_oai_client(
-            max_request_retries=DOWNLOAD_MAX_REQUEST_RETRIES
-        )
+        oai_client = _build_download_client(config)
         _download_to_snapshot(oai_client, config.config, snapshot_path)
 
     # Phase 2: Items download (reads bib instance IDs from the bib snapshot).

--- a/catalogue_graph/scripts/rebuild_adapter.py
+++ b/catalogue_graph/scripts/rebuild_adapter.py
@@ -73,17 +73,12 @@ PROGRESS_LOG_EVERY = 5_000
 """Records between download progress log lines."""
 
 DOWNLOAD_MAX_REQUEST_RETRIES = 5
-"""Total attempts for a request that times out, so four retries. The adapters
-allow a single attempt, which suits windowed harvesting because a failed window
-is retried; this download runs for hours and cannot resume, so a momentarily
-slow page should not end it. Only timeouts are covered: an empty response body
-still ends the download."""
+"""Total attempts per timed-out request. This download cannot resume, so the
+adapters' single attempt is too brittle."""
 
 DOWNLOAD_READ_TIMEOUT_SECONDS = 180.0
-"""Read timeout for download requests. Retrying alone does not help if the
-server is slow rather than momentarily unresponsive, because every attempt
-meets the same deadline. Pages normally arrive in under ten seconds, so this
-waits out a page built under load rather than discarding hours of work."""
+"""Longer than the adapters' 60s, because retries cannot outlast a page that is
+slow on every attempt."""
 
 EVENT_BUS_NAME = "catalogue-pipeline-adapter-event-bus"
 
@@ -150,8 +145,7 @@ def _log_download_progress(total: int, expected: int | None, started_at: float) 
 
 
 def _build_download_client(config: OAIPMHRuntimeConfig) -> OAIClient:
-    """Build an OAI client tuned for one long download rather than a windowed
-    harvest: more attempts, and longer to wait for each one."""
+    """An OAI client tuned for one long download rather than a windowed harvest."""
     http_client = config.build_http_client()
     timeout = http_client.timeout
     http_client.timeout = httpx.Timeout(

--- a/catalogue_graph/scripts/rebuild_adapter.py
+++ b/catalogue_graph/scripts/rebuild_adapter.py
@@ -72,10 +72,11 @@ PROGRESS_LOG_EVERY = 5_000
 """Records between download progress log lines."""
 
 DOWNLOAD_MAX_REQUEST_RETRIES = 5
-"""Timeout retries per request during the download. The adapters configure a
-small budget, which suits windowed harvesting because a failed window is simply
-retried; this download runs for hours and cannot resume, so one slow page
-should not end it."""
+"""Total attempts for a request that times out, so four retries. The adapters
+allow a single attempt, which suits windowed harvesting because a failed window
+is retried; this download runs for hours and cannot resume, so a momentarily
+slow page should not end it. Only timeouts are covered: an empty response body
+still ends the download."""
 
 EVENT_BUS_NAME = "catalogue-pipeline-adapter-event-bus"
 

--- a/catalogue_graph/scripts/rebuild_adapter.py
+++ b/catalogue_graph/scripts/rebuild_adapter.py
@@ -144,9 +144,10 @@ def _log_download_progress(total: int, expected: int | None, started_at: float) 
     )
 
 
-def _build_download_client(config: OAIPMHRuntimeConfig) -> OAIClient:
+def _build_download_client(
+    config: OAIPMHRuntimeConfig, http_client: httpx.Client
+) -> OAIClient:
     """An OAI client tuned for one long download rather than a windowed harvest."""
-    http_client = config.build_http_client()
     timeout = http_client.timeout
     http_client.timeout = httpx.Timeout(
         connect=timeout.connect,
@@ -457,8 +458,10 @@ def rebuild_adapter(
             config, datetime.now(UTC), use_rest_api_table=use_rest_api_table
         )
 
-        oai_client = _build_download_client(config)
-        _download_to_snapshot(oai_client, config.config, snapshot_path)
+        # Held open only for the download, so a failed harvest does not leak it.
+        with config.build_http_client() as http_client:
+            oai_client = _build_download_client(config, http_client)
+            _download_to_snapshot(oai_client, config.config, snapshot_path)
 
     # Phase 2: Items download (reads bib instance IDs from the bib snapshot).
     folio_items: _FolioItems | None = None

--- a/catalogue_graph/src/adapters/extractors/oai_pmh/axiell/clients.py
+++ b/catalogue_graph/src/adapters/extractors/oai_pmh/axiell/clients.py
@@ -38,13 +38,21 @@ def build_http_client(*, token: str | None = None) -> httpx.Client:
     )
 
 
-def build_oai_client(*, http_client: httpx.Client | None = None) -> OAIClient:
+def build_oai_client(
+    *,
+    http_client: httpx.Client | None = None,
+    max_request_retries: int | None = None,
+) -> OAIClient:
     """Build an OAI-PMH client for Axiell."""
     client = http_client or build_http_client()
     return OAIClient(
         _oai_endpoint(),
         client=client,
-        max_request_retries=config.OAI_MAX_RETRIES,
+        max_request_retries=(
+            config.OAI_MAX_RETRIES
+            if max_request_retries is None
+            else max_request_retries
+        ),
         request_backoff_factor=config.OAI_BACKOFF_FACTOR,
         request_max_backoff=config.OAI_BACKOFF_MAX,
         max_transient_retries=config.OAI_TRANSIENT_RETRIES,

--- a/catalogue_graph/src/adapters/extractors/oai_pmh/axiell/runtime.py
+++ b/catalogue_graph/src/adapters/extractors/oai_pmh/axiell/runtime.py
@@ -38,12 +38,20 @@ class AxiellRuntimeConfig(OAIPMHRuntimeConfig):
         """
         return _build_axiell_http_client()
 
-    def build_oai_client(self, *, http_client: httpx.Client | None = None) -> OAIClient:
+    def build_oai_client(
+        self,
+        *,
+        http_client: httpx.Client | None = None,
+        max_request_retries: int | None = None,
+    ) -> OAIClient:
         """Build the OAI-PMH client for harvesting records.
 
         Overrides base to include Axiell-specific retry configuration.
         """
-        return _build_axiell_oai_client(http_client=http_client)
+        return _build_axiell_oai_client(
+            http_client=http_client,
+            max_request_retries=max_request_retries,
+        )
 
     def build_reconciler_table(
         self,

--- a/catalogue_graph/src/adapters/extractors/oai_pmh/folio/runtime.py
+++ b/catalogue_graph/src/adapters/extractors/oai_pmh/folio/runtime.py
@@ -40,7 +40,12 @@ class FolioRuntimeConfig(OAIPMHRuntimeConfig):
         """
         return _build_folio_http_client()
 
-    def build_oai_client(self, *, http_client: httpx.Client | None = None) -> OAIClient:
+    def build_oai_client(
+        self,
+        *,
+        http_client: httpx.Client | None = None,
+        max_request_retries: int | None = None,
+    ) -> OAIClient:
         """Build the OAI-PMH client for harvesting records.
 
         Overrides base to include FOLIO-specific retry configuration.
@@ -49,7 +54,11 @@ class FolioRuntimeConfig(OAIPMHRuntimeConfig):
         return OAIClient(
             self.get_oai_endpoint(),
             client=client,
-            max_request_retries=config.OAI_MAX_RETRIES,
+            max_request_retries=(
+                config.OAI_MAX_RETRIES
+                if max_request_retries is None
+                else max_request_retries
+            ),
             request_backoff_factor=config.OAI_BACKOFF_FACTOR,
             request_max_backoff=config.OAI_BACKOFF_MAX,
             max_transient_retries=config.OAI_TRANSIENT_RETRIES,

--- a/catalogue_graph/src/adapters/extractors/oai_pmh/runtime.py
+++ b/catalogue_graph/src/adapters/extractors/oai_pmh/runtime.py
@@ -175,10 +175,22 @@ class OAIPMHRuntimeConfig(ABC):
         table = self.build_adapter_table(use_rest_api_table=use_rest_api_table)
         return AdapterStore(table, namespace=self.config.adapter_namespace)
 
-    def build_oai_client(self, *, http_client: httpx.Client | None = None) -> OAIClient:
+    def build_oai_client(
+        self,
+        *,
+        http_client: httpx.Client | None = None,
+        max_request_retries: int | None = None,
+    ) -> OAIClient:
         """Build the OAI-PMH client for harvesting records."""
         client = http_client or self.build_http_client()
+        # Leave the upstream default in place unless a caller asks otherwise.
+        overrides = (
+            {}
+            if max_request_retries is None
+            else {"max_request_retries": max_request_retries}
+        )
         return OAIClient(
             self.get_oai_endpoint(),
             client=client,
+            **overrides,
         )

--- a/catalogue_graph/src/adapters/extractors/oai_pmh/runtime.py
+++ b/catalogue_graph/src/adapters/extractors/oai_pmh/runtime.py
@@ -183,7 +183,7 @@ class OAIPMHRuntimeConfig(ABC):
     ) -> OAIClient:
         """Build the OAI-PMH client for harvesting records."""
         client = http_client or self.build_http_client()
-        # Leave the upstream default in place unless a caller asks otherwise.
+        # Keep the upstream default unless a caller asks otherwise.
         overrides = (
             {}
             if max_request_retries is None

--- a/catalogue_graph/tests/adapters/extractors/oai_pmh/test_oai_client_factories.py
+++ b/catalogue_graph/tests/adapters/extractors/oai_pmh/test_oai_client_factories.py
@@ -107,31 +107,3 @@ def test_folio_build_oai_client_honours_request_retry_override() -> None:
     assert overridden.max_transient_retries == OAI_TRANSIENT_RETRIES
     default_client._client.close()
     overridden._client.close()
-
-
-def test_base_runtime_build_oai_client_honours_request_retry_override() -> None:
-    from adapters.extractors.oai_pmh.axiell.config import AXIELL_ADAPTER_CONFIG
-    from adapters.extractors.oai_pmh.runtime import OAIPMHRuntimeConfig
-
-    class StubRuntimeConfig(OAIPMHRuntimeConfig):
-        def build_http_client(self) -> httpx.Client:
-            return httpx.Client(transport=httpx.MockTransport(lambda _: None))  # type: ignore[arg-type]
-
-        def get_oai_endpoint(self) -> str:
-            return BASE_URL
-
-    oai_client = StubRuntimeConfig(AXIELL_ADAPTER_CONFIG).build_oai_client(
-        max_request_retries=7
-    )
-
-    assert oai_client.max_request_retries == 7
-    oai_client._client.close()
-
-
-def test_rebuild_download_asks_for_a_larger_retry_budget() -> None:
-    """The rebuild download cannot resume, so it must not inherit the small
-    windowed-harvest retry budget."""
-    from adapters.extractors.oai_pmh.axiell import config as axiell_config
-    from scripts.rebuild_adapter import DOWNLOAD_MAX_REQUEST_RETRIES
-
-    assert DOWNLOAD_MAX_REQUEST_RETRIES > axiell_config.OAI_MAX_RETRIES

--- a/catalogue_graph/tests/adapters/extractors/oai_pmh/test_oai_client_factories.py
+++ b/catalogue_graph/tests/adapters/extractors/oai_pmh/test_oai_client_factories.py
@@ -66,3 +66,72 @@ def test_axiell_runtime_delegates_to_clients_factory() -> None:
     assert isinstance(oai_client, OAIClient)
     assert oai_client.max_transient_retries == config.OAI_TRANSIENT_RETRIES
     oai_client._client.close()
+
+
+def test_axiell_build_oai_client_honours_request_retry_override() -> None:
+    from adapters.extractors.oai_pmh.axiell import clients, config
+    from adapters.extractors.oai_pmh.axiell.runtime import AXIELL_CONFIG
+
+    override = config.OAI_MAX_RETRIES + 4
+
+    with (
+        patch.object(clients, "_oai_token", return_value="test-token"),
+        patch.object(clients, "_oai_endpoint", return_value=BASE_URL),
+    ):
+        oai_client = AXIELL_CONFIG.build_oai_client(max_request_retries=override)
+
+    assert oai_client.max_request_retries == override
+    # The override must not disturb the other retry settings.
+    assert oai_client.max_transient_retries == config.OAI_TRANSIENT_RETRIES
+    assert oai_client.request_backoff_factor == config.OAI_BACKOFF_FACTOR
+    oai_client._client.close()
+
+
+def test_folio_build_oai_client_honours_request_retry_override() -> None:
+    from adapters.extractors.oai_pmh.folio import runtime as folio_runtime
+    from adapters.extractors.oai_pmh.folio.config import (
+        OAI_MAX_RETRIES,
+        OAI_TRANSIENT_RETRIES,
+    )
+
+    override = OAI_MAX_RETRIES + 4
+
+    with patch.object(folio_runtime, "_oai_endpoint", return_value=BASE_URL):
+        config_obj = folio_runtime.FOLIO_CONFIG
+        with patch.object(config_obj, "build_http_client", return_value=httpx.Client()):
+            default_client = config_obj.build_oai_client()
+            overridden = config_obj.build_oai_client(max_request_retries=override)
+
+    assert default_client.max_request_retries == max(1, OAI_MAX_RETRIES)
+    assert overridden.max_request_retries == override
+    assert overridden.max_transient_retries == OAI_TRANSIENT_RETRIES
+    default_client._client.close()
+    overridden._client.close()
+
+
+def test_base_runtime_build_oai_client_honours_request_retry_override() -> None:
+    from adapters.extractors.oai_pmh.axiell.config import AXIELL_ADAPTER_CONFIG
+    from adapters.extractors.oai_pmh.runtime import OAIPMHRuntimeConfig
+
+    class StubRuntimeConfig(OAIPMHRuntimeConfig):
+        def build_http_client(self) -> httpx.Client:
+            return httpx.Client(transport=httpx.MockTransport(lambda _: None))  # type: ignore[arg-type]
+
+        def get_oai_endpoint(self) -> str:
+            return BASE_URL
+
+    oai_client = StubRuntimeConfig(AXIELL_ADAPTER_CONFIG).build_oai_client(
+        max_request_retries=7
+    )
+
+    assert oai_client.max_request_retries == 7
+    oai_client._client.close()
+
+
+def test_rebuild_download_asks_for_a_larger_retry_budget() -> None:
+    """The rebuild download cannot resume, so it must not inherit the small
+    windowed-harvest retry budget."""
+    from adapters.extractors.oai_pmh.axiell import config as axiell_config
+    from scripts.rebuild_adapter import DOWNLOAD_MAX_REQUEST_RETRIES
+
+    assert DOWNLOAD_MAX_REQUEST_RETRIES > axiell_config.OAI_MAX_RETRIES

--- a/catalogue_graph/tests/adapters/utils/test_rebuild_adapter.py
+++ b/catalogue_graph/tests/adapters/utils/test_rebuild_adapter.py
@@ -124,7 +124,8 @@ def test_download_client_is_tuned_for_a_long_download(
     assert timeout.read > adapter_timeout.read
     # Widening the read must leave the adapter's other deadlines alone.
     assert (timeout.connect, timeout.write, timeout.pool) == (10.0, 11.0, 12.0)
-    call["http_client"].close()
+    # The download raised, so this also covers the failure path.
+    assert call["http_client"].is_closed
 
 
 def _list_records_xml(identifiers: list[str], token: str | None) -> etree._Element:

--- a/catalogue_graph/tests/adapters/utils/test_rebuild_adapter.py
+++ b/catalogue_graph/tests/adapters/utils/test_rebuild_adapter.py
@@ -81,6 +81,42 @@ def test_rebuild_refuses_local_tables_with_publish() -> None:
         )
 
 
+def test_download_asks_for_the_rebuild_retry_budget(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The download must ask for its own retry budget rather than inherit the
+    adapter's windowed-harvest default, which allows no retries at all."""
+    built_with: list[dict] = []
+
+    class _StopAfterClientBuild(Exception):
+        pass
+
+    config_stub = SimpleNamespace(
+        build_oai_client=lambda **kwargs: built_with.append(kwargs),
+        config=SimpleNamespace(),
+    )
+    monkeypatch.setattr(rebuild_adapter, "get_config", lambda adapter_type: config_stub)
+    monkeypatch.setattr("builtins.input", lambda *args: "CONFIRM")
+    monkeypatch.setattr(rebuild_adapter, "_wipe_window_store", lambda *a, **k: None)
+    monkeypatch.setattr(rebuild_adapter, "_reset_window_cursor", lambda *a, **k: None)
+
+    def stop(*args: object, **kwargs: object) -> None:
+        raise _StopAfterClientBuild
+
+    monkeypatch.setattr(rebuild_adapter, "_download_to_snapshot", stop)
+
+    with pytest.raises(_StopAfterClientBuild):
+        rebuild_adapter.rebuild_adapter(
+            "axiell",
+            use_rest_api_table=True,
+            snapshot_path=str(tmp_path / "not-yet-downloaded.parquet"),
+        )
+
+    assert built_with == [
+        {"max_request_retries": rebuild_adapter.DOWNLOAD_MAX_REQUEST_RETRIES}
+    ]
+
+
 def _list_records_xml(identifiers: list[str], token: str | None) -> etree._Element:
     """A ListRecords response in the shape the OAI-PMH client parses."""
     records = "".join(

--- a/catalogue_graph/tests/adapters/utils/test_rebuild_adapter.py
+++ b/catalogue_graph/tests/adapters/utils/test_rebuild_adapter.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
 
+import httpx
 import pyarrow.parquet as pq
 import pytest
 from lxml import etree
@@ -81,17 +82,19 @@ def test_rebuild_refuses_local_tables_with_publish() -> None:
         )
 
 
-def test_download_asks_for_the_rebuild_retry_budget(
+def test_download_client_is_tuned_for_a_long_download(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The download must ask for its own retry budget rather than inherit the
-    adapter's windowed-harvest default, which allows no retries at all."""
+    """The download must not inherit the adapter's windowed-harvest settings,
+    which allow no retries and a 60 second read."""
     built_with: list[dict] = []
+    adapter_timeout = httpx.Timeout(connect=10.0, read=60.0, write=11.0, pool=12.0)
 
     class _StopAfterClientBuild(Exception):
         pass
 
     config_stub = SimpleNamespace(
+        build_http_client=lambda: httpx.Client(timeout=adapter_timeout),
         build_oai_client=lambda **kwargs: built_with.append(kwargs),
         config=SimpleNamespace(),
     )
@@ -112,9 +115,16 @@ def test_download_asks_for_the_rebuild_retry_budget(
             snapshot_path=str(tmp_path / "not-yet-downloaded.parquet"),
         )
 
-    assert built_with == [
-        {"max_request_retries": rebuild_adapter.DOWNLOAD_MAX_REQUEST_RETRIES}
-    ]
+    assert len(built_with) == 1
+    call = built_with[0]
+    assert call["max_request_retries"] == rebuild_adapter.DOWNLOAD_MAX_REQUEST_RETRIES
+
+    timeout = call["http_client"].timeout
+    assert timeout.read == rebuild_adapter.DOWNLOAD_READ_TIMEOUT_SECONDS
+    assert timeout.read > adapter_timeout.read
+    # Widening the read must leave the adapter's other deadlines alone.
+    assert (timeout.connect, timeout.write, timeout.pool) == (10.0, 11.0, 12.0)
+    call["http_client"].close()
 
 
 def _list_records_xml(identifiers: list[str], token: str | None) -> etree._Element:


### PR DESCRIPTION
## What does this change?

The rebuild download gets its own retry budget and read timeout instead of inheriting the windowed harvesters'.

A local Axiell rebuild died at 43% of a 206,482 record harvest with `httpx.ReadTimeout`. The adapters set `max_request_retries` from `OAI_MAX_RETRIES`, which is 1, and upstream that is a total attempt count rather than a retry count, so the first timeout was fatal. One slow page ended a three and a half hour download.

Failing fast suits windowed harvesting, where a failed window is retried cheaply. The rebuild downloads the whole feed in one pass and cannot resume, because the snapshot only moves into place on success. It now injects a client with 5 attempts and a 180 second read deadline, against the adapters' 1 and 60. Only the read deadline moves, connect, write and pool are preserved, and scoping it to the injected client leaves production harvesting alone.

### Checklist

- [x] No display model change, so no test document regeneration needed.

## How to test

From `catalogue_graph/`: `uv run pytest tests/adapters/utils/test_rebuild_adapter.py tests/adapters/extractors/oai_pmh`, 231 passing, ruff and mypy clean. `test_download_client_is_tuned_for_a_long_download` drives the download branch and asserts both settings reach the client. Both assertions were mutation checked.

## How can we measure success?

A rebuild survives a slow page instead of restarting from zero.

## Have we considered potential risks?

- Only timeouts are retried. An empty response body still ends the download, and this endpoint returns intermittent "Document is empty" responses.
- Resumption token requests are re-sent after a timeout. Safe for Axiell, where tokens were verified to replay deterministically. Unverified for FOLIO, which also receives the override.
- The FOLIO items download has the same non-resumable shape and is untouched.
