### PR TITLE
Give the Sierra transformer room for its biggest records

### DIFF
--- a/pipeline/terraform/modules/pipeline/service_transformers.tf
+++ b/pipeline/terraform/modules/pipeline/service_transformers.tf
@@ -32,13 +32,10 @@ locals {
     sierra = {
       container_image = local.transformer_sierra_image
 
-      # The largest Sierra bibs take longer than the default 30 seconds to
-      # transform, so they get redelivered and eventually dead-lettered even
-      # though nothing failed.
+      # The biggest bibs take over 30s to transform, so they get dead-lettered.
       queue_visibility_timeout_seconds = 90
 
-      # Sierra records carry every linked item, so the biggest ones are
-      # megabytes of JSON and the task saturates the default 512/1024.
+      # Sierra records carry every linked item, so they saturate the default 512/1024.
       cpu    = 2048
       memory = 4096
     }

--- a/pipeline/terraform/modules/pipeline/service_transformers.tf
+++ b/pipeline/terraform/modules/pipeline/service_transformers.tf
@@ -31,6 +31,16 @@ locals {
 
     sierra = {
       container_image = local.transformer_sierra_image
+
+      # The largest Sierra bibs take longer than the default 30 seconds to
+      # transform, so they get redelivered and eventually dead-lettered even
+      # though nothing failed.
+      queue_visibility_timeout_seconds = 90
+
+      # Sierra records carry every linked item, so the biggest ones are
+      # megabytes of JSON and the task saturates the default 512/1024.
+      cpu    = 2048
+      memory = 4096
     }
 
     tei = {

--- a/pipeline/terraform/modules/pipeline/service_transformers.tf
+++ b/pipeline/terraform/modules/pipeline/service_transformers.tf
@@ -32,10 +32,11 @@ locals {
     sierra = {
       container_image = local.transformer_sierra_image
 
-      # The biggest bibs take over 30s to transform, so they get dead-lettered.
+      # A 30s timeout leaves no headroom over the 30s flush interval, so batches
+      # expire mid-process and dead-letter. See PipelineStorageStream.
       queue_visibility_timeout_seconds = 90
 
-      # Sierra records carry every linked item, so they saturate the default 512/1024.
+      # The default 512/1024 saturates on Sierra's volume.
       cpu    = 2048
       memory = 4096
     }

--- a/pipeline/terraform/modules/pipeline_new/service_transformers.tf
+++ b/pipeline/terraform/modules/pipeline_new/service_transformers.tf
@@ -27,6 +27,16 @@ locals {
 
     sierra = {
       container_image = local.transformer_sierra_image
+
+      # The largest Sierra bibs take longer than the default 30 seconds to
+      # transform, so they get redelivered and eventually dead-lettered even
+      # though nothing failed.
+      queue_visibility_timeout_seconds = 90
+
+      # Sierra records carry every linked item, so the biggest ones are
+      # megabytes of JSON and the task saturates the default 512/1024.
+      cpu    = 2048
+      memory = 4096
     }
 
     tei = {

--- a/pipeline/terraform/modules/pipeline_new/service_transformers.tf
+++ b/pipeline/terraform/modules/pipeline_new/service_transformers.tf
@@ -28,13 +28,10 @@ locals {
     sierra = {
       container_image = local.transformer_sierra_image
 
-      # The largest Sierra bibs take longer than the default 30 seconds to
-      # transform, so they get redelivered and eventually dead-lettered even
-      # though nothing failed.
+      # The biggest bibs take over 30s to transform, so they get dead-lettered.
       queue_visibility_timeout_seconds = 90
 
-      # Sierra records carry every linked item, so the biggest ones are
-      # megabytes of JSON and the task saturates the default 512/1024.
+      # Sierra records carry every linked item, so they saturate the default 512/1024.
       cpu    = 2048
       memory = 4096
     }

--- a/pipeline/terraform/modules/pipeline_new/service_transformers.tf
+++ b/pipeline/terraform/modules/pipeline_new/service_transformers.tf
@@ -28,10 +28,11 @@ locals {
     sierra = {
       container_image = local.transformer_sierra_image
 
-      # The biggest bibs take over 30s to transform, so they get dead-lettered.
+      # A 30s timeout leaves no headroom over the 30s flush interval, so batches
+      # expire mid-process and dead-letter. See PipelineStorageStream.
       queue_visibility_timeout_seconds = 90
 
-      # Sierra records carry every linked item, so they saturate the default 512/1024.
+      # The default 512/1024 saturates on Sierra's volume.
       cpu    = 2048
       memory = 4096
     }


### PR DESCRIPTION
## What does this change?

Sierra was the only transformer left on every default: a 30 second visibility timeout,
512 CPU and 1024 MB. METS and TEI already run at 90 seconds. This gives Sierra 90 seconds
and METS's task size.

`PipelineStorageStream` documents the invariant that `(Message Expiry) - (Flush Interval)`
must cover processing `(Batch Size - 1)` messages. Transformers run a 30 second flush
interval and a batch size of 100, so a 30 second timeout leaves a budget of exactly zero:
batches expire mid-process and dead-letter on the fourth receive with nothing having
failed. `TransformerWorker_ProcessMessage_failure` was zero throughout.

The Sierra DLQ has held 18 to 50 messages every day for the last 30 days, spiking to 156
on 2026-07-28 when a bulk item edit put roughly 1M messages on the queue. calm and miro
share the config, but their DLQs are empty across those 30 days, so this stops at Sierra.

The task size bump is separate. Through the 2026-07-28 backlog the task sat at 100% CPU
for 18 hours while memory stayed flat at 54%. Memory goes to 4096 because Fargate
requires it at 2048 CPU.

### Checklist

- [x] Does this change the display model the catalogue API returns? No, so no test
  documents need regenerating.

## How to test

`terraform plan` on the 2025-10-02 and 2026-07-03 stacks shows the Sierra queue at a 90
second timeout and the task definition at 2048/4096, and nothing else.

## How can we measure success?

The Sierra input DLQ stops accumulating messages that have no matching
`TransformerWorker_ProcessMessage_failure`.

## Have we considered potential risks?

On 2026-07-03 `scale_up_tasks = true` and `max_capacity` defaults to 12, so Sierra's peak
goes from 12 x 0.5 vCPU to 12 x 2 vCPU. Worth checking account vCPU quota and Fargate
Spot placement for the larger size. Outside a reindex, transformers run one task.

Inert until someone applies both stacks, and either apply picks up other unapplied
changes there.
