### PR TITLE
Wipe the deletion facts store during an adapter rebuild

### DIFF
--- a/catalogue_graph/scripts/README.md
+++ b/catalogue_graph/scripts/README.md
@@ -47,8 +47,10 @@ events carrying changeset ids that exist only on your machine.
      downstream cost: every changeset read scans most of a just-rebuilt table,
      and each published event triggers a transformer run per wired pipeline.
 
-   - *(Axiell only)* Wipe the reconciler store and reconcile the batch
-     changesets, rebuilding the GUID mapping baseline.
+   - *(Axiell only)* Wipe the reconciler store and the deletion facts store,
+     then reconcile the batch changesets, rebuilding the GUID mapping baseline.
+     Facts are read by changeset id, and the rebuild replaces every id, so
+     facts written before it can never be delivered.
 
    - *(FOLIO only)* Wipe and repopulate the items store.
 

--- a/catalogue_graph/scripts/rebuild_adapter.py
+++ b/catalogue_graph/scripts/rebuild_adapter.py
@@ -499,6 +499,8 @@ def rebuild_adapter(
             adapter_type, use_rest_api_table=use_rest_api_table
         )
         _wipe_store(reconcile_runtime.reconciler_store, store_name="reconciler store")
+        # Facts are read by changeset id, and the rebuild replaces every id.
+        _wipe_store(reconcile_runtime.facts_store, store_name="deletion facts store")
         _run_reconcile(reconcile_runtime, adapter_type, job_id, changeset_ids)
 
     if not skip_publish_event:

--- a/catalogue_graph/tests/adapters/utils/test_rebuild_adapter.py
+++ b/catalogue_graph/tests/adapters/utils/test_rebuild_adapter.py
@@ -24,6 +24,7 @@ from adapters.utils.window_store import WindowStore
 from adapters.utils.window_summary import WindowSummary
 from tests.adapters.conftest import (
     adapter_records_to_table,
+    deletion_facts_records_to_table,
 )
 
 
@@ -256,7 +257,7 @@ def test_rebuild_adapter_orchestration_axiell(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """End-to-end resume-path run: the store is wiped and rebuilt from the
+    """End-to-end resume-path run: the stores are wiped and rebuilt from the
     snapshot only, reconcile runs over the load changesets, and every load
     changeset is published."""
     adapter_store = AdapterStore(temporary_table, "test_namespace")
@@ -282,12 +283,23 @@ def test_rebuild_adapter_orchestration_axiell(
             tags={"published_at": now.isoformat()},
         )
     )
+    facts_store = DeletionFactsStore(deletion_facts_temporary_table, "test_namespace")
+    # A fact tagged with a changeset id the rebuild is about to replace.
+    facts_store.append_facts(
+        deletion_facts_records_to_table(
+            [
+                {
+                    "record_id": "stale",
+                    "guid": "guid-old-1",
+                    "changeset": "pre-rebuild-changeset",
+                }
+            ]
+        )
+    )
     reconcile_runtime = ReconcileRuntime(
         adapter_store=adapter_store,
         reconciler_store=ReconcilerStore(reconciler_temporary_table, "test_namespace"),
-        facts_store=DeletionFactsStore(
-            deletion_facts_temporary_table, "test_namespace"
-        ),
+        facts_store=facts_store,
         adapter_name="axiell",
         namespace="test_namespace",
     )
@@ -341,6 +353,9 @@ def test_rebuild_adapter_orchestration_axiell(
         for row in adapter_store.get_all_records().to_pylist()
     )
     assert rows == [("kept", "kept content v2"), ("new", "new content")]
+
+    # The pre-rebuild fact is undeliverable once its changeset is gone.
+    assert facts_store.get_all_records().num_rows == 0
 
     assert len(reconciled) == 1
     assert published == [[changeset_id] for changeset_id in reconciled[0]]


### PR DESCRIPTION
## What does this change?

The adapter rebuild wipes the window status table, the adapter store and the reconciler store. It now wipes the deletion facts store too.

Deletion facts are derived state describing the relationship between adapter store contents and reconciler mappings, and they are written by the same reconcile step that writes the mappings. Their sole read path is `get_records_by_changesets` in `src/adapters/utils/axiell_changeset_reader.py`, so a fact is only ever reachable by changeset id. A rebuild replaces every changeset id in the adapter store, so a fact written before a rebuild can never be delivered afterwards: no transformer will run for a changeset that no longer exists. They are orphans, and they accumulate across every rebuild.

Wiping the reconciler store but not the facts store was an asymmetry with no stated rationale. This makes the pair consistent.

The wipe happens before `_run_reconcile`, in the same place and for the same reason as the reconciler store wipe. The reconcile runtime is still built after the load, because a pyiceberg handle is pinned to the snapshot it opened at.

<details>
<summary>The counter-argument</summary>

If the facts table is regarded as an append-only audit trail rather than a delivery queue, wiping it destroys history. The case for wiping is that undeliverable rows are not an audit trail anyone can act on: nothing downstream can ever read them, and they only grow.
</details>

### Checklist

- [x] Does this change the display model the catalogue API returns? No, it only changes which rows survive in an internal Iceberg store, so the test documents need no regeneration.

## How to test

`uv run pytest tests/adapters/utils/test_rebuild_adapter.py` from `catalogue_graph/`. `test_rebuild_adapter_orchestration_axiell` seeds a deletion fact tagged with a pre-rebuild changeset id and asserts the store is empty afterwards. Removing the wipe from the script fails that assertion.

## How can we measure success?

After the next rebuild, the deletion facts store holds no rows tagged with changeset ids that predate it.

## Have we considered potential risks?

The production rebuild on 2026-07-29 left 5 facts behind, attached to changeset ids from 22 to 24 July that the rebuild had replaced. One of the five carried a GUID that is an active mapping again in the new baseline, which the existing `_reclaimed_guids` guard would skip; the other four referenced records no longer in the store at all. So the rows this deletes are already inert.

The wipe is namespace-scoped, like the other store wipes, and only runs on the Axiell path. `_wipe_store` logs the pre-wipe snapshot id for Iceberg time travel if a rollback is needed.
