### PR TITLE
Give the Sierra transformer a core per concurrent record

### DIFF
--- a/pipeline/terraform/modules/pipeline/service_transformers.tf
+++ b/pipeline/terraform/modules/pipeline/service_transformers.tf
@@ -36,9 +36,10 @@ locals {
       # expire mid-process and dead-letter. See PipelineStorageStream.
       queue_visibility_timeout_seconds = 90
 
-      # The default 512/1024 saturates on Sierra's volume.
-      cpu    = 2048
-      memory = 4096
+      # The stream transforms pipeline_storage.parallelism (10) records at once,
+      # so Sierra's big records starve on fewer cores.
+      cpu    = 4096
+      memory = 8192
     }
 
     tei = {

--- a/pipeline/terraform/modules/pipeline_new/service_transformers.tf
+++ b/pipeline/terraform/modules/pipeline_new/service_transformers.tf
@@ -32,9 +32,10 @@ locals {
       # expire mid-process and dead-letter. See PipelineStorageStream.
       queue_visibility_timeout_seconds = 90
 
-      # The default 512/1024 saturates on Sierra's volume.
-      cpu    = 2048
-      memory = 4096
+      # The stream transforms pipeline_storage.parallelism (10) records at once,
+      # so Sierra's big records starve on fewer cores.
+      cpu    = 4096
+      memory = 8192
     }
 
     tei = {


### PR DESCRIPTION
## What does this change?

Follow-up to #3507, which took the Sierra transformer from 512/1024 to 2048/4096 and cut
per-record time from about 15 seconds to 1.5. It is still pinned at 100% CPU.

The stream transforms records through `mapAsyncUnordered(config.parallelism)`
(`PipelineStorageStream.scala:155`) and parallelism defaults to 10
(`PipelineStorageStreamBuilder.scala:25`), with no override in the transformer's
environment. So the app attempts 10 concurrent transforms on 2 cores. This gives it 4.

Sierra's largest bibs carry every linked item in one blob: bib `2043277` is 2.05 MB
against a typical 8 to 15 KB, and those are the records that saturate a task.

## How to test

`terraform plan` on the 2025-10-02 and 2026-07-03 stacks shows the Sierra task definition
moving to 4096/8192, and nothing else.

## How can we measure success?

Transformer throughput per task on large Sierra records. #3507 gave roughly 14x going from
512 to 2048; this should give a further gain until parallelism rather than cores is the
limit.

## Have we considered potential risks?

Cost is bounded: `min_capacity` is 0, so the service scales to zero when its queue drains,
and Fargate bills per second. We pay for the larger task only while there is work.

On 2026-07-03 `scale_up_tasks = true` and `max_capacity` defaults to 12, so peak goes from
24 to 48 vCPU. The account's Fargate On-Demand vCPU quota is 4000, so this is about 1% of
it.

Inert until someone applies both stacks.
