### PR TITLE
Use /authn/login-with-expiry OKAPI endpoint

### DIFF
--- a/catalogue_graph/scripts/run_axiell_folio_sync_local.sh
+++ b/catalogue_graph/scripts/run_axiell_folio_sync_local.sh
@@ -15,7 +15,7 @@
 # CHANGESET_IDS wins if both are set. Any extra args are forwarded to the module:
 #   CHANGESET_IDS=<changeset_id> ./run_axiell_folio_sync_local.sh              # Dry run (default)
 #   CHANGESET_IDS=<changeset_id> ./run_axiell_folio_sync_local.sh --live       # Write to prod FOLIO
-#   CHANGESET_IDS="<changeset_id> def456" ./run_axiell_folio_sync_local.sh     # Multiple changesets
+#   CHANGESET_IDS="<changeset_id> <changeset_id2>" ./run_axiell_folio_sync_local.sh     # Multiple changesets
 #   SAMPLE_LIMIT=10 ./run_axiell_folio_sync_local.sh --live            # Sample 10 active records
 #   FOLIO_TARGET=dev CHANGESET_IDS=<changeset_id> ./run_axiell_folio_sync_local.sh  # Target dev FOLIO
 #   AWS_PROFILE=my-profile CHANGESET_IDS=<changeset_id> ./run_axiell_folio_sync_local.sh --live
@@ -55,10 +55,10 @@ case "$FOLIO_TARGET" in
       --query 'Parameter.Value' \
       --output text)"
 
-    OKAPI_URL="$(echo "$CREDS" | jq -r .url)"
-    OKAPI_TENANT="$(echo "$CREDS" | jq -r .tenant)"
-    OKAPI_USERNAME="$(echo "$CREDS" | jq -r .username)"
-    OKAPI_PASSWORD="$(echo "$CREDS" | jq -r .password)"
+    OKAPI_URL="$(echo "$CREDS" | jq -re '.url // empty')"
+    OKAPI_TENANT="$(echo "$CREDS" | jq -re '.tenant // empty')"
+    OKAPI_USERNAME="$(echo "$CREDS" | jq -re '.username // empty')"
+    OKAPI_PASSWORD="$(echo "$CREDS" | jq -re '.password // empty')"
     ;;
   dev)
     # folio-dev-server sandbox, reached over the SSM tunnel (scripts/tunnel.sh in the

--- a/catalogue_graph/scripts/run_axiell_folio_sync_local.sh
+++ b/catalogue_graph/scripts/run_axiell_folio_sync_local.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# Run the Axiell -> FOLIO sync locally. Targets prod (EBSCO) FOLIO by default;
+# set FOLIO_TARGET=dev to target the folio-dev-server sandbox instead.
+#
+# For prod, fetches the OKAPI credentials SecureString from SSM. For dev, points
+# at the sandbox over the SSM tunnel and reads diku_admin from Secrets Manager.
+# Either way it runs adapters.steps.axiell_folio_sync.axiell_folio_sync via uv.
+#
+# By default this is a DRY RUN (no writes to FOLIO). Pass --live to write.
+#
+# Set CHANGESET_IDS to the changeset id(s) to process (space-separated for
+# multiple), OR set SAMPLE_LIMIT=N to instead process a sample of N active
+# records (no changesets — a smoke test that reads no deletion facts).
+# CHANGESET_IDS wins if both are set. Any extra args are forwarded to the module:
+#   CHANGESET_IDS=<changeset_id> ./run_axiell_folio_sync_local.sh              # Dry run (default)
+#   CHANGESET_IDS=<changeset_id> ./run_axiell_folio_sync_local.sh --live       # Write to prod FOLIO
+#   CHANGESET_IDS="<changeset_id> def456" ./run_axiell_folio_sync_local.sh     # Multiple changesets
+#   SAMPLE_LIMIT=10 ./run_axiell_folio_sync_local.sh --live            # Sample 10 active records
+#   FOLIO_TARGET=dev CHANGESET_IDS=<changeset_id> ./run_axiell_folio_sync_local.sh  # Target dev FOLIO
+#   AWS_PROFILE=my-profile CHANGESET_IDS=<changeset_id> ./run_axiell_folio_sync_local.sh --live
+#
+# FOLIO_TARGET=dev expects an SSM tunnel to the sandbox exposing Kong on
+# localhost:8000 (run scripts/tunnel.sh in the folio-dev-server repo first).
+#
+set -euo pipefail
+
+AWS_PROFILE="${AWS_PROFILE:-platform-developer}"
+AWS_REGION="${AWS_REGION:-eu-west-1}"
+FOLIO_TARGET="${FOLIO_TARGET:-prod}"
+OKAPI_SECRET_PARAM="${OKAPI_SECRET_PARAM:-/catalogue_pipeline/axiell-folio-sync/okapi_credentials}"
+JOB_ID="${JOB_ID:-local-test-$(date +%s)}"
+CHANGESET_IDS="${CHANGESET_IDS:-}"
+SAMPLE_LIMIT="${SAMPLE_LIMIT:-}"
+
+if [[ -z "$CHANGESET_IDS" && -z "$SAMPLE_LIMIT" ]]; then
+  echo "Set CHANGESET_IDS (space-separated for multiple) or SAMPLE_LIMIT=N." >&2
+  echo "Usage: CHANGESET_IDS=<id> $0 [--live] [extra args]" >&2
+  echo "   or: SAMPLE_LIMIT=<n> $0 [--live] [extra args]" >&2
+  exit 2
+fi
+
+export AWS_PROFILE AWS_REGION
+
+# Resolve repo layout: this script lives in catalogue_graph/scripts/
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CATALOGUE_GRAPH_DIR="$(dirname "$SCRIPT_DIR")"
+
+case "$FOLIO_TARGET" in
+  prod)
+    echo "Fetching OKAPI credentials from SSM: $OKAPI_SECRET_PARAM (profile=$AWS_PROFILE region=$AWS_REGION)" >&2
+    CREDS="$(aws ssm get-parameter \
+      --name "$OKAPI_SECRET_PARAM" \
+      --with-decryption \
+      --query 'Parameter.Value' \
+      --output text)"
+
+    OKAPI_URL="$(echo "$CREDS" | jq -r .url)"
+    OKAPI_TENANT="$(echo "$CREDS" | jq -r .tenant)"
+    OKAPI_USERNAME="$(echo "$CREDS" | jq -r .username)"
+    OKAPI_PASSWORD="$(echo "$CREDS" | jq -r .password)"
+    ;;
+  dev)
+    # folio-dev-server sandbox, reached over the SSM tunnel (scripts/tunnel.sh in the
+    # folio-dev-server repo forwards Kong :8000 to localhost:8000). Password comes from
+    # the same Secrets Manager entry scripts/password.sh reads.
+    DEV_OKAPI_URL="${DEV_OKAPI_URL:-http://localhost:8000}"
+    DEV_OKAPI_TENANT="${DEV_OKAPI_TENANT:-diku}"
+    DEV_OKAPI_USERNAME="${DEV_OKAPI_USERNAME:-diku_admin}"
+    DEV_SECRET_NAME="${DEV_SECRET_NAME:-folio-sandbox/diku-admin-password}"
+
+    echo "Fetching dev diku_admin password from Secrets Manager: $DEV_SECRET_NAME (profile=$AWS_PROFILE region=$AWS_REGION)" >&2
+    OKAPI_PASSWORD="$(aws secretsmanager get-secret-value \
+      --secret-id "$DEV_SECRET_NAME" \
+      --query SecretString \
+      --output text)"
+    OKAPI_URL="$DEV_OKAPI_URL"
+    OKAPI_TENANT="$DEV_OKAPI_TENANT"
+    OKAPI_USERNAME="$DEV_OKAPI_USERNAME"
+    echo "NOTE: dev target needs an SSM tunnel to the sandbox exposing $OKAPI_URL (scripts/tunnel.sh)." >&2
+    ;;
+  *)
+    echo "Unknown FOLIO_TARGET '$FOLIO_TARGET' (expected 'prod' or 'dev')." >&2
+    exit 2
+    ;;
+esac
+export OKAPI_URL OKAPI_TENANT OKAPI_USERNAME OKAPI_PASSWORD
+
+echo "Target FOLIO ($FOLIO_TARGET): $OKAPI_URL (tenant=$OKAPI_TENANT)" >&2
+
+# Default args; forward anything the caller passes. Callers can add --live,
+# override --job-id, etc. With CHANGESET_IDS set we run changeset mode (the ids
+# are word-split intentionally so each becomes a --changeset-ids value); with
+# only SAMPLE_LIMIT set we run sample mode over active records.
+DEFAULT_ARGS=(
+  --use-cli
+  --job-id "$JOB_ID"
+  --use-rest-api-table
+)
+if [[ -n "$CHANGESET_IDS" ]]; then
+  # shellcheck disable=SC2206
+  CHANGESET_ID_ARGS=($CHANGESET_IDS)
+  DEFAULT_ARGS+=(--changeset-ids "${CHANGESET_ID_ARGS[@]}")
+  echo "Mode: changesets (${CHANGESET_ID_ARGS[*]})" >&2
+else
+  DEFAULT_ARGS+=(--sample-limit "$SAMPLE_LIMIT")
+  echo "Mode: sample of $SAMPLE_LIMIT active record(s)" >&2
+fi
+
+cd "$CATALOGUE_GRAPH_DIR"
+echo "Running sync (job-id=$JOB_ID). Dry run unless --live is passed." >&2
+exec uv run python -m adapters.steps.axiell_folio_sync.axiell_folio_sync \
+  "${DEFAULT_ARGS[@]}" "$@"

--- a/catalogue_graph/src/adapters/extractors/oai_pmh/folio/README.md
+++ b/catalogue_graph/src/adapters/extractors/oai_pmh/folio/README.md
@@ -75,7 +75,7 @@ The enrichment step has a local CLI (defaults to local Iceberg tables; pass
 are read from `FOLIO_INVENTORY_URL` / `FOLIO_INVENTORY_USERNAME` /
 `FOLIO_INVENTORY_PASSWORD` / `FOLIO_INVENTORY_TENANT` when set, otherwise from SSM, so
 you can point at a dev or mock endpoint without AWS. The enrichment client logs in to
-OKAPI itself (POST `/authn/login`) and refreshes on 401. These are OKAPI inventory
+OKAPI itself (POST `/authn/login-with-expiry`) and refreshes on 401. These are OKAPI inventory
 credentials, not the OAI feed token; to read them from SSM use
 `AWS_PROFILE=platform-developer`.
 

--- a/catalogue_graph/src/adapters/extractors/oai_pmh/folio/config.py
+++ b/catalogue_graph/src/adapters/extractors/oai_pmh/folio/config.py
@@ -145,7 +145,7 @@ ITEMS_LOCAL_TABLE_NAME = os.getenv(
 SSM_INVENTORY_URL = os.getenv(
     "FOLIO_SSM_INVENTORY_URL", "/catalogue_pipeline/folio/inventory_api_url"
 )
-# OKAPI login credentials: the enricher authenticates itself (POST /authn/login) and
+# OKAPI login credentials: the enricher authenticates itself (POST /authn/login-with-expiry) and
 # refreshes on 401, rather than using a short-lived static token.
 SSM_INVENTORY_USERNAME = os.getenv(
     "FOLIO_SSM_INVENTORY_USERNAME", "/catalogue_pipeline/folio/inventory_username"

--- a/catalogue_graph/src/adapters/extractors/oai_pmh/folio/enrichment/runtime.py
+++ b/catalogue_graph/src/adapters/extractors/oai_pmh/folio/enrichment/runtime.py
@@ -81,7 +81,7 @@ def build_inventory_http_client() -> httpx.Client:
     """Build an authenticated client for mod-inventory-storage.
 
     ``enrichedInstances`` is an OKAPI/mod-inventory-storage endpoint. OKAPI tokens are
-    short-lived, so the client logs in itself (POST ``/authn/login`` with the
+    short-lived, so the client logs in itself (POST ``/authn/login-with-expiry`` with the
     username/password from ``FOLIO_INVENTORY_*``/SSM) and refreshes on 401, sending
     ``x-okapi-token`` plus ``x-okapi-tenant``. The URL, credentials and tenant all come
     from ``FOLIO_INVENTORY_*`` env vars when set, otherwise SSM.

--- a/catalogue_graph/src/clients/folio_client/client.py
+++ b/catalogue_graph/src/clients/folio_client/client.py
@@ -2,10 +2,11 @@
 
 Used by the Axiell to Folio sync for Inventory upserts. Authentication is the
 shared service-account OKAPI login (:class:`~clients.folio_client.OkapiAuth`):
-``POST /authn/login`` -> ``x-okapi-token``, sent as ``x-okapi-token`` /
-``x-okapi-tenant`` on every request and refreshed once on a 401. The same auth
-is used by the FOLIO inventory enrichment client, so the whole pipeline shares
-one OKAPI auth implementation over ``httpx``.
+``POST /authn/login-with-expiry`` -> ``folioAccessToken`` cookie, whose token is
+replayed as the ``x-okapi-token`` header (alongside the ``x-okapi-tenant`` header)
+on every request and refreshed once on a 401. The same auth is used by the FOLIO
+inventory enrichment client, so the whole pipeline shares one OKAPI auth
+implementation over ``httpx``.
 
 A single ``FolioClient`` (and its underlying ``httpx.Client``) can be reused
 across warm Lambda invocations.

--- a/catalogue_graph/src/clients/folio_client/okapi_auth.py
+++ b/catalogue_graph/src/clients/folio_client/okapi_auth.py
@@ -1,13 +1,12 @@
 """OKAPI login auth for FOLIO clients.
 
-FOLIO services sit behind OKAPI, whose tokens are short-lived, so a static token
-is not viable for a scheduled adapter. This performs the OKAPI login itself
-(POST ``/authn/login`` with username/password, read the ``x-okapi-token`` response
-header) and re-authenticates once on a 401.
+Handles login to OKAPI (POST ``/authn/login-with-expiry`` with username/password)
+and re-authenticates on 401 errors since tokens are short-lived.
 
-It is an :class:`httpx.Auth`, shared across FOLIO clients: the streaming inventory
-client (``FolioInventoryClient``) and the JSON :class:`~clients.folio_client.FolioClient`
-both compose it onto an ``httpx.Client``.
+Extracts the token from the ``folioAccessToken`` cookie (or ``x-okapi-token`` header
+as fallback) and replays it as the ``x-okapi-token`` request header.
+
+Shared across FOLIO clients via :class:`httpx.Auth`.
 """
 
 from __future__ import annotations
@@ -36,7 +35,7 @@ class OkapiAuth(httpx.Auth):
             raise ValueError(
                 "OKAPI auth requires base_url, tenant, username and password"
             )
-        self._login_url = f"{base_url.rstrip('/')}/authn/login"
+        self._login_url = f"{base_url.rstrip('/')}/authn/login-with-expiry"
         self._tenant = tenant
         self._username = username
         self._password = password
@@ -53,9 +52,16 @@ class OkapiAuth(httpx.Auth):
     def _store_token(self, response: httpx.Response) -> None:
         if response.status_code not in (200, 201):
             raise OkapiLoginError(f"OKAPI login failed ({response.status_code})")
-        token = response.headers.get("x-okapi-token")
+        # /authn/login-with-expiry on Eureka/Keycloak (both prod and the dev sandbox)
+        # delivers the token in the folioAccessToken cookie, not an x-okapi-token header.
+        # Prefer the header if a gateway ever returns one, else read the cookie.
+        token = response.headers.get("x-okapi-token") or response.cookies.get(
+            "folioAccessToken"
+        )
         if not token:
-            raise OkapiLoginError("OKAPI login returned no x-okapi-token header")
+            raise OkapiLoginError(
+                "OKAPI login returned no x-okapi-token header or folioAccessToken cookie"
+            )
         self._token = token
 
     def _apply(self, request: httpx.Request) -> None:

--- a/catalogue_graph/src/clients/folio_client/okapi_auth.py
+++ b/catalogue_graph/src/clients/folio_client/okapi_auth.py
@@ -3,8 +3,8 @@
 Handles login to OKAPI (POST ``/authn/login-with-expiry`` with username/password)
 and re-authenticates on 401 errors since tokens are short-lived.
 
-Extracts the token from the ``folioAccessToken`` cookie (or ``x-okapi-token`` header
-as fallback) and replays it as the ``x-okapi-token`` request header.
+Extracts the token from the ``folioAccessToken`` cookie and replays it as the
+``x-okapi-token`` request header.
 
 Shared across FOLIO clients via :class:`httpx.Auth`.
 """
@@ -53,13 +53,11 @@ class OkapiAuth(httpx.Auth):
         if response.status_code not in (200, 201):
             raise OkapiLoginError(f"OKAPI login failed ({response.status_code})")
         # /authn/login-with-expiry on Eureka/Keycloak (both prod and the dev sandbox)
-        # delivers the token in the folioAccessToken cookie, not an x-okapi-token header.
-        # Prefer the cookie, with a fallback to x-okapi-token for gateways that still return it.
-        token = response.cookies.get("folioAccessToken") or response.headers.get("x-okapi-token")
+        # always delivers the token in the folioAccessToken cookie, never an
+        # x-okapi-token response header, so the cookie is the only source we read.
+        token = response.cookies.get("folioAccessToken")
         if not token:
-            raise OkapiLoginError(
-                "OKAPI login returned no x-okapi-token header or folioAccessToken cookie"
-            )
+            raise OkapiLoginError("OKAPI login returned no folioAccessToken cookie")
         self._token = token
 
     def _apply(self, request: httpx.Request) -> None:

--- a/catalogue_graph/src/clients/folio_client/okapi_auth.py
+++ b/catalogue_graph/src/clients/folio_client/okapi_auth.py
@@ -54,10 +54,8 @@ class OkapiAuth(httpx.Auth):
             raise OkapiLoginError(f"OKAPI login failed ({response.status_code})")
         # /authn/login-with-expiry on Eureka/Keycloak (both prod and the dev sandbox)
         # delivers the token in the folioAccessToken cookie, not an x-okapi-token header.
-        # Prefer the header if a gateway ever returns one, else read the cookie.
-        token = response.headers.get("x-okapi-token") or response.cookies.get(
-            "folioAccessToken"
-        )
+        # Prefer the cookie, with a fallback to x-okapi-token for gateways that still return it.
+        token = response.cookies.get("folioAccessToken") or response.headers.get("x-okapi-token")
         if not token:
             raise OkapiLoginError(
                 "OKAPI login returned no x-okapi-token header or folioAccessToken cookie"

--- a/catalogue_graph/tests/clients/folio_client/test_client.py
+++ b/catalogue_graph/tests/clients/folio_client/test_client.py
@@ -24,8 +24,10 @@ def _client_with(handler: Callable[[httpx.Request], httpx.Response]) -> FolioCli
 
 def test_request_logs_in_then_returns_status_and_json() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
-        if request.url.path == "/authn/login":
-            return httpx.Response(201, headers={"x-okapi-token": "tok"})
+        if request.url.path == "/authn/login-with-expiry":
+            return httpx.Response(
+                201, headers={"set-cookie": "folioAccessToken=tok; Path=/"}
+            )
         assert request.headers["x-okapi-token"] == "tok"
         assert request.headers["x-okapi-tenant"] == "t1"
         return httpx.Response(200, json={"id": "x"})
@@ -41,8 +43,10 @@ def test_request_reauthenticates_once_on_401() -> None:
     seen: list[str] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
-        if request.url.path == "/authn/login":
-            return httpx.Response(200, headers={"x-okapi-token": next(tokens)})
+        if request.url.path == "/authn/login-with-expiry":
+            return httpx.Response(
+                201, headers={"set-cookie": f"folioAccessToken={next(tokens)}; Path=/"}
+            )
         seen.append(request.headers["x-okapi-token"])
         if len(seen) == 1:
             return httpx.Response(401)
@@ -58,8 +62,10 @@ def test_request_reauthenticates_once_on_401() -> None:
 
 def test_request_empty_body_returns_empty_dict() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
-        if request.url.path == "/authn/login":
-            return httpx.Response(200, headers={"x-okapi-token": "tok"})
+        if request.url.path == "/authn/login-with-expiry":
+            return httpx.Response(
+                201, headers={"set-cookie": "folioAccessToken=tok; Path=/"}
+            )
         return httpx.Response(204)  # OKAPI writes often return 204 no content
 
     status, data = _client_with(handler).request(

--- a/catalogue_graph/tests/clients/folio_client/test_okapi_auth.py
+++ b/catalogue_graph/tests/clients/folio_client/test_okapi_auth.py
@@ -75,25 +75,26 @@ def test_reauthenticates_once_on_401_via_cookie() -> None:
     assert data_calls == ["cookie-tok-1", "cookie-tok-2"]
 
 
-def test_falls_back_to_x_okapi_token_header() -> None:
-    # Tolerant fallback: if a gateway ever returns the token in an x-okapi-token
-    # header instead of the cookie, use it. Not what prod/dev currently do.
+def test_login_returning_x_okapi_token_header_only_raises() -> None:
+    # /authn/login-with-expiry only ever sets the folioAccessToken cookie, so a
+    # response carrying only an x-okapi-token header (and no cookie) is treated as
+    # a missing token — we deliberately do not read the header.
     def handler(request: httpx.Request) -> httpx.Response:
         if request.url.path == "/authn/login-with-expiry":
             return httpx.Response(201, headers={"x-okapi-token": "header-tok"})
-        assert request.headers["x-okapi-token"] == "header-tok"
         return httpx.Response(200, json={"ok": True})
 
     client = httpx.Client(auth=_auth(), transport=httpx.MockTransport(handler))
+    with pytest.raises(OkapiLoginError, match="no folioAccessToken cookie"):
+        client.get(f"{BASE}/x")
 
-    assert client.get(f"{BASE}/x").status_code == 200
 
-
-def test_login_without_token_header_or_cookie_raises() -> None:
+def test_login_without_token_cookie_raises() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200)  # no x-okapi-token header or folioAccessToken cookie
+        return httpx.Response(200)  # no folioAccessToken cookie
+
     client = httpx.Client(auth=_auth(), transport=httpx.MockTransport(handler))
-    with pytest.raises(OkapiLoginError, match="no x-okapi-token"):
+    with pytest.raises(OkapiLoginError, match="no folioAccessToken cookie"):
         client.get(f"{BASE}/x")
 
 

--- a/catalogue_graph/tests/clients/folio_client/test_okapi_auth.py
+++ b/catalogue_graph/tests/clients/folio_client/test_okapi_auth.py
@@ -91,8 +91,7 @@ def test_falls_back_to_x_okapi_token_header() -> None:
 
 def test_login_without_token_header_or_cookie_raises() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200)  # no x-okapi-token header
-
+        return httpx.Response(200)  # no x-okapi-token header or folioAccessToken cookie
     client = httpx.Client(auth=_auth(), transport=httpx.MockTransport(handler))
     with pytest.raises(OkapiLoginError, match="no x-okapi-token"):
         client.get(f"{BASE}/x")

--- a/catalogue_graph/tests/clients/folio_client/test_okapi_auth.py
+++ b/catalogue_graph/tests/clients/folio_client/test_okapi_auth.py
@@ -15,16 +15,34 @@ def _auth() -> OkapiAuth:
     return OkapiAuth(base_url=BASE, tenant="t1", username="u", password="p")
 
 
-def test_logs_in_then_applies_token() -> None:
+def _login_with_expiry_response(access_token: str) -> httpx.Response:
+    """A realistic ``/authn/login-with-expiry`` response.
+
+    Eureka/Keycloak (both prod and the dev sandbox) returns no x-okapi-token
+    header; it sets the access token in the ``folioAccessToken`` cookie, plus a
+    ``folioRefreshToken`` we do not use (we re-login on 401 instead).
+    """
+    return httpx.Response(
+        201,
+        headers=[
+            ("set-cookie", f"folioAccessToken={access_token}; Path=/; HttpOnly"),
+            ("set-cookie", "folioRefreshToken=refresh-tok; Path=/authn; HttpOnly"),
+        ],
+    )
+
+
+def test_logs_in_via_cookie_then_applies_token() -> None:
+    # The production path: log in at /authn/login-with-expiry, read the token
+    # from the folioAccessToken cookie, replay it as the x-okapi-token header.
     seen: list[str] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
         seen.append(request.url.path)
-        if request.url.path == "/authn/login":
+        if request.url.path == "/authn/login-with-expiry":
             assert request.headers["x-okapi-tenant"] == "t1"
             assert json.loads(request.content) == {"username": "u", "password": "p"}
-            return httpx.Response(201, headers={"x-okapi-token": "tok-1"})
-        assert request.headers["x-okapi-token"] == "tok-1"
+            return _login_with_expiry_response("cookie-tok")
+        assert request.headers["x-okapi-token"] == "cookie-tok"
         assert request.headers["x-okapi-tenant"] == "t1"
         return httpx.Response(200, json={"ok": True})
 
@@ -32,16 +50,18 @@ def test_logs_in_then_applies_token() -> None:
     response = client.get(f"{BASE}/oai-pmh-view/enrichedInstances")
 
     assert response.status_code == 200
-    assert seen == ["/authn/login", "/oai-pmh-view/enrichedInstances"]
+    assert seen == ["/authn/login-with-expiry", "/oai-pmh-view/enrichedInstances"]
 
 
-def test_reauthenticates_once_on_401() -> None:
-    tokens = iter(["tok-1", "tok-2"])
+def test_reauthenticates_once_on_401_via_cookie() -> None:
+    # The short-lived cookie token expires mid-run: a 401 triggers one re-login,
+    # and the retry must carry the freshly-issued cookie token.
+    tokens = iter(["cookie-tok-1", "cookie-tok-2"])
     data_calls: list[str] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
-        if request.url.path == "/authn/login":
-            return httpx.Response(200, headers={"x-okapi-token": next(tokens)})
+        if request.url.path == "/authn/login-with-expiry":
+            return _login_with_expiry_response(next(tokens))
         data_calls.append(request.headers["x-okapi-token"])
         if len(data_calls) == 1:
             return httpx.Response(401)
@@ -52,10 +72,24 @@ def test_reauthenticates_once_on_401() -> None:
 
     assert response.status_code == 200
     # First attempt with the stale token, then one retry with the refreshed token.
-    assert data_calls == ["tok-1", "tok-2"]
+    assert data_calls == ["cookie-tok-1", "cookie-tok-2"]
 
 
-def test_login_without_token_header_raises() -> None:
+def test_falls_back_to_x_okapi_token_header() -> None:
+    # Tolerant fallback: if a gateway ever returns the token in an x-okapi-token
+    # header instead of the cookie, use it. Not what prod/dev currently do.
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/authn/login-with-expiry":
+            return httpx.Response(201, headers={"x-okapi-token": "header-tok"})
+        assert request.headers["x-okapi-token"] == "header-tok"
+        return httpx.Response(200, json={"ok": True})
+
+    client = httpx.Client(auth=_auth(), transport=httpx.MockTransport(handler))
+
+    assert client.get(f"{BASE}/x").status_code == 200
+
+
+def test_login_without_token_header_or_cookie_raises() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(200)  # no x-okapi-token header
 

--- a/catalogue_graph/tests/clients/folio_client/test_okapi_auth.py
+++ b/catalogue_graph/tests/clients/folio_client/test_okapi_auth.py
@@ -80,9 +80,7 @@ def test_login_returning_x_okapi_token_header_only_raises() -> None:
     # response carrying only an x-okapi-token header (and no cookie) is treated as
     # a missing token — we deliberately do not read the header.
     def handler(request: httpx.Request) -> httpx.Response:
-        if request.url.path == "/authn/login-with-expiry":
-            return httpx.Response(201, headers={"x-okapi-token": "header-tok"})
-        return httpx.Response(200, json={"ok": True})
+        return httpx.Response(201, headers={"x-okapi-token": "header-tok"})
 
     client = httpx.Client(auth=_auth(), transport=httpx.MockTransport(handler))
     with pytest.raises(OkapiLoginError, match="no folioAccessToken cookie"):


### PR DESCRIPTION
### What does this change?

Switches the FOLIO OKAPI authentication from the deprecated `POST /authn/login` endpoint to `POST /authn/login-with-expiry`.

The old endpoint returned the token in an `x-okapi-token` response header. The new endpoint (used by Eureka/Keycloak in both production and the dev sandbox) delivers it exclusively via a `folioAccessToken` cookie. The token is still replayed as the `x-okapi-token` request header on every subsequent call, so downstream behaviour is unchanged.

Changes:
- `okapi_auth.py`: updated login URL and `_store_token` to read exclusively from the `folioAccessToken` cookie (header fallback removed after code review, as the new endpoint never returns a header token)
- `client.py`, `config.py`, `enrichment/runtime.py`: updated doc comments to reference the new endpoint
- `test_okapi_auth.py`, `test_client.py`: updated tests to exercise the cookie-based token flow
- `oai_pmh/folio/README.md`: updated documentation to reference the correct endpoint
- Added a `run_axiell_folio_sync_local.sh` helper script for local development runs

### How to test

Unit tests cover the updated token extraction logic:

```bash
cd catalogue_graph
uv run pytest tests/clients/folio_client/
```

End-to-end: run the Axiell→FOLIO sync or the FOLIO enrichment step against a FOLIO sandbox and confirm authentication succeeds without a 401 loop.

### How can we measure success?

No `OkapiLoginError` in CloudWatch logs after deployment; the Axiell→FOLIO sync and FOLIO enrichment Lambda runs complete without authentication failures.

### Have we considered potential risks?

- The `x-okapi-token` header fallback was deliberately removed after code review: `login-with-expiry` on both prod and sandbox always returns a cookie, never a header token, so the fallback was dead code that could mask misconfiguration.
- If the `folioAccessToken` cookie is absent, `OkapiLoginError` is raised with a clear message, so failures remain visible.
