### PR TITLE
Quiesce the 2026-07-03 pipeline for the pre-reindex clear

### DIFF
--- a/pipeline/terraform/2026-07-03/main.tf
+++ b/pipeline/terraform/2026-07-03/main.tf
@@ -1,8 +1,11 @@
 module "pipeline" {
   source = "../modules/pipeline_new"
 
+  # Quiesced while the pipeline's stateful parts are cleared, so nothing writes
+  # into the state being wiped. Back on for the reindex, along with the
+  # enable_* flags below.
   reindexing_state = {
-    listen_to_reindexer = true
+    listen_to_reindexer = false
     scale_up_tasks      = true
     scale_up_matcher_db = true
   }
@@ -21,10 +24,10 @@ module "pipeline" {
   # Base AMI for ECS instances
   ami_id = "resolve:ssm:arn:aws:ssm:eu-west-1:760097843905:parameter/imagebuilder/weco-al2023-ecs-optimised-x86_64/latest"
 
-  enable_adapter_transformer_trigger = true
-  enable_id_minter_schedule          = true
-  enable_graph_pipeline_schedule     = true
-  enable_image_inferrer_schedule     = true
+  enable_adapter_transformer_trigger = false
+  enable_id_minter_schedule          = false
+  enable_graph_pipeline_schedule     = false
+  enable_image_inferrer_schedule     = false
 
   pipeline_date = local.pipeline_date // namespaces services
   graph_date    = "2026-07-03"        // namespaces graph database


### PR DESCRIPTION
## What does this change?

Phase 1 of wellcomecollection/platform#6461, quiescing the `2026-07-03` pipeline before its stateful parts are cleared for the full reindex.

The stack has been live-processing since 23 July. Its works-graph table holds 439,016 matcher entries and its indices hold 387,066 works from before the Axiell adapter store rebuild, including records the OAI feed no longer serves. All of that gets wiped, and nothing may be writing into it while that happens.

So the four schedule and trigger flags go off, along with `listen_to_reindexer`:

- `enable_adapter_transformer_trigger`, the EventBridge rule starting the transformer on `adapter.completed`
- `enable_id_minter_schedule`, the id-minter sweep and its id-pool top-up
- `enable_graph_pipeline_schedule`, the scheduled graph state machines
- `enable_image_inferrer_schedule`, the scheduled inferrer
- `reindexing_state.listen_to_reindexer`, which removes the reindex EventBridge rules and the Scala transformer queues' subscriptions to the reindex topics

`scale_up_tasks` and `scale_up_matcher_db` stay on. The reindex needs them, and the scale-down apply can only run once a day.

Missed harvest windows during the quiet period are superseded by the reindex.

This touches only the `2026-07-03` root, which has its own terraform state, so production cannot be affected by the apply.

### Checklist

- [x] Does this change the display model the catalogue API returns? No, it only toggles schedules and event rules.

## How to test

`terraform plan` in `pipeline/terraform/2026-07-03`. It should show EventBridge rules and schedules moving to disabled and the five reindex topic subscriptions being destroyed, with no resource replacements and nothing outside this pipeline date.

After the apply, no new executions should start on `transformer-2026-07-03`, `pipeline-2026-07-03_id_minter`, the `graph-*-2026-07-03` state machines, or the image inferrer.

## How can we measure success?

The `2026-07-03` queues drain to zero and stay there, which is the precondition for the queue purge and the index wipe that follow.

## Have we considered potential risks?

The pipeline stops ingesting for the duration of the clear, and the staff preview (`?elasticCluster=axiell-collections-testing`) goes empty once phase 2 wipes the indices. It currently serves 88,592 works, so that is a visible change and stakeholders need telling.

This is reverted by the same one-line-per-flag change at the end of #6461, immediately before the reindex starts.
