### PR TITLE
Create new works index

### DIFF
--- a/index_config/analysis.works_indexed.2026-07-30.json
+++ b/index_config/analysis.works_indexed.2026-07-30.json
@@ -1,0 +1,385 @@
+{
+  "filter": {
+    "pattern_replace_g_j": {
+      "pattern": "g",
+      "type": "pattern_replace",
+      "replacement": "j"
+    },
+    "pattern_replace_j_i": {
+      "pattern": "j",
+      "type": "pattern_replace",
+      "replacement": "i"
+    },
+    "french_elision": {
+      "type": "elision",
+      "articles": [
+        "l",
+        "m",
+        "t",
+        "qu",
+        "n",
+        "s",
+        "j",
+        "d",
+        "c",
+        "jusqu",
+        "quoiqu",
+        "lorsqu",
+        "puisqu"
+      ],
+      "articles_case": "true"
+    },
+    "pattern_replace_uu_w": {
+      "pattern": "uu",
+      "type": "pattern_replace",
+      "replacement": "w"
+    },
+    "pattern_replace_vv_w": {
+      "pattern": "vv",
+      "type": "pattern_replace",
+      "replacement": "w"
+    },
+    "hindi_stemmer": {
+      "type": "stemmer",
+      "language": "hindi"
+    },
+    "pattern_replace_v_u": {
+      "pattern": "v",
+      "type": "pattern_replace",
+      "replacement": "u"
+    },
+    "german_stemmer": {
+      "type": "stemmer",
+      "language": "light_german"
+    },
+    "english_stemmer": {
+      "type": "stemmer",
+      "language": "english"
+    },
+    "italian_elision": {
+      "type": "elision",
+      "articles": [
+        "c",
+        "l",
+        "all",
+        "dall",
+        "dell",
+        "nell",
+        "sull",
+        "coll",
+        "pell",
+        "gl",
+        "agl",
+        "dagl",
+        "degl",
+        "negl",
+        "sugl",
+        "un",
+        "m",
+        "t",
+        "s",
+        "v",
+        "d"
+      ],
+      "articles_case": "true"
+    },
+    "asciifolding": {
+      "type": "asciifolding"
+    },
+    "possessive_english": {
+      "type": "stemmer",
+      "language": "possessive_english"
+    },
+    "spanish_stemmer": {
+      "type": "stemmer",
+      "language": "light_spanish"
+    },
+    "arabic_stemmer": {
+      "type": "stemmer",
+      "language": "arabic"
+    },
+    "french_stemmer": {
+      "type": "stemmer",
+      "language": "light_french"
+    },
+    "italian_stemmer": {
+      "type": "stemmer",
+      "language": "light_italian"
+    },
+    "word_delimiter": {
+      "type": "word_delimiter_graph",
+      "preserve_original": "true"
+    },
+    "bengali_stemmer": {
+      "type": "stemmer",
+      "language": "bengali"
+    },
+    "long_query_token_limiter": {
+      "type": "limit",
+      "max_token_count": 75
+    }
+  },
+  "tokenizer": {
+    "dot_hierarchy": {
+      "type": "path_hierarchy",
+      "delimiter": "."
+    }
+  },
+  "analyzer": {
+    "german": {
+      "filter": [
+        "word_delimiter",
+        "long_query_token_limiter",
+        "lowercase",
+        "german_normalization",
+        "german_stemmer"
+      ],
+      "char_filter": [
+        "slash_remover"
+      ],
+      "tokenizer": "whitespace"
+    },
+    "spanish": {
+      "filter": [
+        "word_delimiter",
+        "long_query_token_limiter",
+        "lowercase",
+        "spanish_stemmer"
+      ],
+      "char_filter": [
+        "slash_remover"
+      ],
+      "tokenizer": "whitespace"
+    },
+    "swappable_characters": {
+      "filter": [
+        "word_delimiter",
+        "long_query_token_limiter",
+        "asciifolding",
+        "lowercase",
+        "pattern_replace_vv_w",
+        "pattern_replace_uu_w",
+        "pattern_replace_v_u",
+        "pattern_replace_j_i",
+        "pattern_replace_g_j"
+      ],
+      "char_filter": [
+        "slash_remover"
+      ],
+      "type": "custom",
+      "tokenizer": "whitespace"
+    },
+    "lowercase": {
+      "filter": [
+        "asciifolding",
+        "word_delimiter",
+        "lowercase"
+      ],
+      "char_filter": [
+        "slash_remover"
+      ],
+      "type": "custom",
+      "tokenizer": "whitespace"
+    },
+    "lowercase_token_limited": {
+      "filter": [
+        "asciifolding",
+        "word_delimiter",
+        "long_query_token_limiter",
+        "lowercase"
+      ],
+      "char_filter": [
+        "slash_remover"
+      ],
+      "type": "custom",
+      "tokenizer": "whitespace"
+    },
+    "italian": {
+      "filter": [
+        "italian_elision",
+        "word_delimiter",
+        "long_query_token_limiter",
+        "lowercase",
+        "italian_stemmer"
+      ],
+      "char_filter": [
+        "slash_remover"
+      ],
+      "tokenizer": "whitespace"
+    },
+    "lowercase_whitespace_tokens": {
+      "filter": [
+        "lowercase"
+      ],
+      "type": "custom",
+      "tokenizer": "whitespace"
+    },
+    "path_analyzer": {
+      "filter": [
+        "asciifolding",
+        "lowercase"
+      ],
+      "type": "custom",
+      "tokenizer": "path_hierarchy"
+    },
+    "dot_path_analyzer": {
+      "filter": [
+        "asciifolding",
+        "lowercase"
+      ],
+      "type": "custom",
+      "tokenizer": "dot_hierarchy"
+    },
+    "persian": {
+      "filter": [
+        "word_delimiter",
+        "long_query_token_limiter",
+        "lowercase",
+        "decimal_digit",
+        "arabic_normalization",
+        "persian_normalization"
+      ],
+      "char_filter": [
+        "zero_width_spaces",
+        "slash_remover"
+      ],
+      "tokenizer": "whitespace"
+    },
+    "cased": {
+      "filter": [
+        "asciifolding",
+        "word_delimiter",
+        "long_query_token_limiter"
+      ],
+      "char_filter": [
+        "slash_remover"
+      ],
+      "type": "custom",
+      "tokenizer": "whitespace"
+    },
+    "arabic": {
+      "filter": [
+        "word_delimiter",
+        "long_query_token_limiter",
+        "lowercase",
+        "decimal_digit",
+        "arabic_normalization",
+        "arabic_stemmer"
+      ],
+      "char_filter": [
+        "slash_remover"
+      ],
+      "tokenizer": "whitespace"
+    },
+    "bengali": {
+      "filter": [
+        "word_delimiter",
+        "long_query_token_limiter",
+        "lowercase",
+        "decimal_digit",
+        "indic_normalization",
+        "bengali_normalization",
+        "bengali_stemmer"
+      ],
+      "char_filter": [
+        "slash_remover"
+      ],
+      "tokenizer": "whitespace"
+    },
+    "english": {
+      "filter": [
+        "possessive_english",
+        "asciifolding",
+        "word_delimiter",
+        "lowercase",
+        "english_stemmer"
+      ],
+      "char_filter": [
+        "slash_remover"
+      ],
+      "tokenizer": "whitespace"
+    },
+    "english_token_limited": {
+      "filter": [
+        "possessive_english",
+        "asciifolding",
+        "word_delimiter",
+        "long_query_token_limiter",
+        "lowercase",
+        "english_stemmer"
+      ],
+      "char_filter": [
+        "slash_remover"
+      ],
+      "tokenizer": "whitespace"
+    },
+    "hindi": {
+      "filter": [
+        "word_delimiter",
+        "long_query_token_limiter",
+        "lowercase",
+        "decimal_digit",
+        "indic_normalization",
+        "hindi_normalization",
+        "hindi_stemmer"
+      ],
+      "char_filter": [
+        "slash_remover"
+      ],
+      "tokenizer": "whitespace"
+    },
+    "french": {
+      "filter": [
+        "french_elision",
+        "word_delimiter",
+        "long_query_token_limiter",
+        "lowercase",
+        "french_stemmer"
+      ],
+      "char_filter": [
+        "slash_remover"
+      ],
+      "tokenizer": "whitespace"
+    },
+    "base": {
+      "filter": [
+        "word_delimiter",
+        "long_query_token_limiter"
+      ],
+      "char_filter": [
+        "slash_remover"
+      ],
+      "type": "custom",
+      "tokenizer": "whitespace"
+    },
+    "normalized_whole_phrase": {
+      "filter": [
+        "asciifolding",
+        "lowercase"
+      ],
+      "char_filter": [
+        "remove_punctuation"
+      ],
+      "tokenizer": "keyword"
+    }
+  },
+  "char_filter": {
+    "slash_remover": {
+      "pattern": "/",
+      "type": "pattern_replace",
+      "replacement": ""
+    },
+    "remove_punctuation": {
+      "pattern": "[^\\p{L}\\p{Nd}\\s]",
+      "_name": "Removes non-letter, non-numeric, and non-whitespace characters. Respects other character sets.",
+      "type": "pattern_replace",
+      "replacement": ""
+    },
+    "zero_width_spaces": {
+      "type": "mapping",
+      "mappings": [
+        "\\u200C=>\\u0020"
+      ]
+    }
+  }
+}

--- a/index_config/mappings.works_indexed.2026-07-30.json
+++ b/index_config/mappings.works_indexed.2026-07-30.json
@@ -1,0 +1,894 @@
+{
+  "dynamic": "strict",
+  "properties": {
+    "aggregatableValues": {
+      "properties": {
+        "availabilities": {
+          "type": "nested",
+          "properties": {
+            "id": {
+              "type": "keyword",
+              "eager_global_ordinals": true
+            },
+            "label": {
+              "type": "keyword",
+              "eager_global_ordinals": true
+            }
+          }
+        },
+        "contributors": {
+          "properties": {
+            "agent": {
+              "type": "nested",
+              "properties": {
+                "id": {
+                  "type": "keyword",
+                  "eager_global_ordinals": true
+                },
+                "label": {
+                  "type": "keyword",
+                  "eager_global_ordinals": true
+                }
+              }
+            }
+          }
+        },
+        "genres": {
+          "type": "nested",
+          "properties": {
+            "id": {
+              "type": "keyword",
+              "eager_global_ordinals": true
+            },
+            "label": {
+              "type": "keyword",
+              "eager_global_ordinals": true
+            }
+          }
+        },
+        "items": {
+          "properties": {
+            "locations": {
+              "properties": {
+                "license": {
+                  "type": "nested",
+                  "properties": {
+                    "id": {
+                      "type": "keyword",
+                      "eager_global_ordinals": true
+                    },
+                    "label": {
+                      "type": "keyword",
+                      "eager_global_ordinals": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "languages": {
+          "type": "nested",
+          "properties": {
+            "id": {
+              "type": "keyword",
+              "eager_global_ordinals": true
+            },
+            "label": {
+              "type": "keyword",
+              "eager_global_ordinals": true
+            }
+          }
+        },
+        "production": {
+          "properties": {
+            "dates": {
+              "type": "nested",
+              "properties": {
+                "id": {
+                  "type": "keyword",
+                  "eager_global_ordinals": true
+                },
+                "label": {
+                  "type": "keyword",
+                  "eager_global_ordinals": true
+                }
+              }
+            }
+          }
+        },
+        "subjects": {
+          "type": "nested",
+          "properties": {
+            "id": {
+              "type": "keyword",
+              "eager_global_ordinals": true
+            },
+            "label": {
+              "type": "keyword",
+              "eager_global_ordinals": true
+            }
+          }
+        },
+        "workType": {
+          "type": "nested",
+          "properties": {
+            "id": {
+              "type": "keyword",
+              "eager_global_ordinals": true
+            },
+            "label": {
+              "type": "keyword",
+              "eager_global_ordinals": true
+            }
+          }
+        }
+      }
+    },
+    "debug": {
+      "dynamic": "false",
+      "properties": {
+        "indexedTime": {
+          "type": "date"
+        },
+        "mergeCandidates": {
+          "properties": {
+            "id": {
+              "properties": {
+                "canonicalId": {
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "display": {
+      "type": "object",
+      "enabled": false
+    },
+    "filterableValues": {
+      "properties": {
+        "availabilities": {
+          "properties": {
+            "id": {
+              "type": "keyword"
+            }
+          }
+        },
+        "contributors": {
+          "properties": {
+            "agent": {
+              "properties": {
+                "label": {
+                  "type": "keyword"
+                },
+                "id": {
+                  "type": "keyword"
+                },
+                "sourceIdentifier": {
+                  "type": "keyword",
+                  "normalizer": "lowercase"
+                }
+              }
+            }
+          }
+        },
+        "format": {
+          "properties": {
+            "id": {
+              "type": "keyword"
+            }
+          }
+        },
+        "genres": {
+          "properties": {
+            "concepts": {
+              "properties": {
+                "id": {
+                  "type": "keyword"
+                },
+                "sourceIdentifier": {
+                  "type": "keyword",
+                  "normalizer": "lowercase"
+                }
+              }
+            },
+            "label": {
+              "type": "keyword"
+            }
+          }
+        },
+        "identifiers": {
+          "properties": {
+            "value": {
+              "type": "keyword"
+            }
+          }
+        },
+        "items": {
+          "properties": {
+            "id": {
+              "type": "keyword"
+            },
+            "identifiers": {
+              "properties": {
+                "value": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "locations": {
+              "properties": {
+                "accessConditions": {
+                  "properties": {
+                    "status": {
+                      "properties": {
+                        "id": {
+                          "type": "keyword"
+                        }
+                      }
+                    }
+                  }
+                },
+                "license": {
+                  "properties": {
+                    "id": {
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "locationType": {
+                  "properties": {
+                    "id": {
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "createdDate": {
+                  "type": "date"
+                }
+              }
+            }
+          }
+        },
+        "languages": {
+          "properties": {
+            "id": {
+              "type": "keyword"
+            }
+          }
+        },
+        "partOf": {
+          "properties": {
+            "id": {
+              "type": "keyword"
+            },
+            "title": {
+              "type": "keyword"
+            }
+          }
+        },
+        "production": {
+          "properties": {
+            "dates": {
+              "properties": {
+                "range": {
+                  "properties": {
+                    "from": {
+                      "type": "date"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "subjects": {
+          "properties": {
+            "concepts": {
+              "properties": {
+                "id": {
+                  "type": "keyword"
+                },
+                "sourceIdentifier": {
+                  "type": "keyword",
+                  "normalizer": "lowercase"
+                }
+              }
+            },
+            "label": {
+              "type": "keyword"
+            }
+          }
+        },
+        "workType": {
+          "type": "keyword"
+        }
+      }
+    },
+    "query": {
+      "properties": {
+        "alternativeTitles": {
+          "type": "text",
+          "fields": {
+            "arabic": {
+              "type": "text",
+              "analyzer": "arabic"
+            },
+            "base": {
+              "type": "text",
+              "analyzer": "base"
+            },
+            "bengali": {
+              "type": "text",
+              "analyzer": "bengali"
+            },
+            "cased": {
+              "type": "text",
+              "analyzer": "cased"
+            },
+            "english": {
+              "type": "text",
+              "analyzer": "english",
+              "search_analyzer": "english_token_limited"
+            },
+            "french": {
+              "type": "text",
+              "analyzer": "french"
+            },
+            "german": {
+              "type": "text",
+              "analyzer": "german"
+            },
+            "hindi": {
+              "type": "text",
+              "analyzer": "hindi"
+            },
+            "italian": {
+              "type": "text",
+              "analyzer": "italian"
+            },
+            "persian": {
+              "type": "text",
+              "analyzer": "persian"
+            },
+            "spanish": {
+              "type": "text",
+              "analyzer": "spanish"
+            },
+            "swappable_characters": {
+              "type": "text",
+              "analyzer": "swappable_characters"
+            }
+          },
+          "analyzer": "lowercase",
+          "search_analyzer": "lowercase_token_limited"
+        },
+        "collectionPath": {
+          "properties": {
+            "label": {
+              "type": "keyword",
+              "normalizer": "lowercase",
+              "fields": {
+                "path": {
+                  "type": "text",
+                  "analyzer": "path_analyzer",
+                  "search_analyzer": "lowercase_whitespace_tokens"
+                }
+              }
+            },
+            "path": {
+              "type": "keyword",
+              "normalizer": "lowercase",
+              "fields": {
+                "path": {
+                  "type": "text",
+                  "analyzer": "path_analyzer",
+                  "search_analyzer": "lowercase_whitespace_tokens"
+                }
+              }
+            }
+          }
+        },
+        "contributors": {
+          "properties": {
+            "agent": {
+              "properties": {
+                "label": {
+                  "type": "text",
+                  "analyzer": "english",
+                  "search_analyzer": "english_token_limited"
+                }
+              }
+            }
+          }
+        },
+        "description": {
+          "type": "text",
+          "fields": {
+            "arabic": {
+              "type": "text",
+              "analyzer": "arabic"
+            },
+            "base": {
+              "type": "text",
+              "analyzer": "base"
+            },
+            "bengali": {
+              "type": "text",
+              "analyzer": "bengali"
+            },
+            "cased": {
+              "type": "text",
+              "analyzer": "cased"
+            },
+            "english": {
+              "type": "text",
+              "analyzer": "english",
+              "search_analyzer": "english_token_limited"
+            },
+            "french": {
+              "type": "text",
+              "analyzer": "french"
+            },
+            "german": {
+              "type": "text",
+              "analyzer": "german"
+            },
+            "hindi": {
+              "type": "text",
+              "analyzer": "hindi"
+            },
+            "italian": {
+              "type": "text",
+              "analyzer": "italian"
+            },
+            "persian": {
+              "type": "text",
+              "analyzer": "persian"
+            },
+            "spanish": {
+              "type": "text",
+              "analyzer": "spanish"
+            }
+          },
+          "analyzer": "lowercase",
+          "search_analyzer": "lowercase_token_limited"
+        },
+        "edition": {
+          "type": "text",
+          "analyzer": "english",
+          "search_analyzer": "english_token_limited"
+        },
+        "genres": {
+          "properties": {
+            "concepts": {
+              "properties": {
+                "label": {
+                  "type": "text",
+                  "analyzer": "english",
+                  "search_analyzer": "english_token_limited"
+                }
+              }
+            }
+          }
+        },
+        "id": {
+          "type": "keyword",
+          "normalizer": "lowercase"
+        },
+        "identifiers": {
+          "properties": {
+            "value": {
+              "type": "keyword",
+              "normalizer": "lowercase"
+            }
+          }
+        },
+        "images": {
+          "properties": {
+            "id": {
+              "type": "keyword",
+              "normalizer": "lowercase"
+            },
+            "identifiers": {
+              "properties": {
+                "value": {
+                  "type": "keyword",
+                  "normalizer": "lowercase"
+                }
+              }
+            }
+          }
+        },
+        "items": {
+          "properties": {
+            "id": {
+              "type": "keyword",
+              "normalizer": "lowercase"
+            },
+            "identifiers": {
+              "properties": {
+                "value": {
+                  "type": "keyword",
+                  "normalizer": "lowercase"
+                }
+              }
+            },
+            "shelfmark": {
+              "properties": {
+                "value": {
+                  "type": "keyword",
+                  "normalizer": "lowercase",
+                  "fields": {
+                    "path": {
+                      "type": "text",
+                      "analyzer": "path_analyzer",
+                      "search_analyzer": "lowercase_whitespace_tokens"
+                    },
+                    "dot_path": {
+                      "type": "text",
+                      "analyzer": "dot_path_analyzer",
+                      "search_analyzer": "lowercase_whitespace_tokens"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "languages": {
+          "properties": {
+            "label": {
+              "type": "text",
+              "analyzer": "lowercase",
+              "search_analyzer": "lowercase_token_limited"
+            }
+          }
+        },
+        "lettering": {
+          "type": "text",
+          "fields": {
+            "arabic": {
+              "type": "text",
+              "analyzer": "arabic"
+            },
+            "base": {
+              "type": "text",
+              "analyzer": "base"
+            },
+            "bengali": {
+              "type": "text",
+              "analyzer": "bengali"
+            },
+            "cased": {
+              "type": "text",
+              "analyzer": "cased"
+            },
+            "english": {
+              "type": "text",
+              "analyzer": "english",
+              "search_analyzer": "english_token_limited"
+            },
+            "french": {
+              "type": "text",
+              "analyzer": "french"
+            },
+            "german": {
+              "type": "text",
+              "analyzer": "german"
+            },
+            "hindi": {
+              "type": "text",
+              "analyzer": "hindi"
+            },
+            "italian": {
+              "type": "text",
+              "analyzer": "italian"
+            },
+            "persian": {
+              "type": "text",
+              "analyzer": "persian"
+            },
+            "spanish": {
+              "type": "text",
+              "analyzer": "spanish"
+            },
+            "swappable_characters": {
+              "type": "text",
+              "analyzer": "swappable_characters"
+            }
+          },
+          "analyzer": "lowercase",
+          "search_analyzer": "lowercase_token_limited"
+        },
+        "notes": {
+          "properties": {
+            "contents": {
+              "type": "text",
+              "fields": {
+                "arabic": {
+                  "type": "text",
+                  "analyzer": "arabic"
+                },
+                "base": {
+                  "type": "text",
+                  "analyzer": "base"
+                },
+                "bengali": {
+                  "type": "text",
+                  "analyzer": "bengali"
+                },
+                "cased": {
+                  "type": "text",
+                  "analyzer": "cased"
+                },
+                "english": {
+                  "type": "text",
+                  "analyzer": "english",
+                  "search_analyzer": "english_token_limited"
+                },
+                "french": {
+                  "type": "text",
+                  "analyzer": "french"
+                },
+                "german": {
+                  "type": "text",
+                  "analyzer": "german"
+                },
+                "hindi": {
+                  "type": "text",
+                  "analyzer": "hindi"
+                },
+                "italian": {
+                  "type": "text",
+                  "analyzer": "italian"
+                },
+                "persian": {
+                  "type": "text",
+                  "analyzer": "persian"
+                },
+                "spanish": {
+                  "type": "text",
+                  "analyzer": "spanish"
+                },
+                "swappable_characters": {
+                  "type": "text",
+                  "analyzer": "swappable_characters"
+                }
+              },
+              "analyzer": "lowercase",
+              "search_analyzer": "lowercase_token_limited"
+            }
+          }
+        },
+        "partOf": {
+          "properties": {
+            "title": {
+              "type": "text",
+              "fields": {
+                "arabic": {
+                  "type": "text",
+                  "analyzer": "arabic"
+                },
+                "base": {
+                  "type": "text",
+                  "analyzer": "base"
+                },
+                "bengali": {
+                  "type": "text",
+                  "analyzer": "bengali"
+                },
+                "cased": {
+                  "type": "text",
+                  "analyzer": "cased"
+                },
+                "english": {
+                  "type": "text",
+                  "analyzer": "english",
+                  "search_analyzer": "english_token_limited"
+                },
+                "french": {
+                  "type": "text",
+                  "analyzer": "french"
+                },
+                "german": {
+                  "type": "text",
+                  "analyzer": "german"
+                },
+                "hindi": {
+                  "type": "text",
+                  "analyzer": "hindi"
+                },
+                "italian": {
+                  "type": "text",
+                  "analyzer": "italian"
+                },
+                "persian": {
+                  "type": "text",
+                  "analyzer": "persian"
+                },
+                "spanish": {
+                  "type": "text",
+                  "analyzer": "spanish"
+                },
+                "swappable_characters": {
+                  "type": "text",
+                  "analyzer": "swappable_characters"
+                }
+              },
+              "analyzer": "lowercase",
+              "search_analyzer": "lowercase_token_limited"
+            }
+          }
+        },
+        "physicalDescription": {
+          "type": "text",
+          "analyzer": "english",
+          "search_analyzer": "english_token_limited"
+        },
+        "production": {
+          "properties": {
+            "label": {
+              "type": "text",
+              "fields": {
+                "arabic": {
+                  "type": "text",
+                  "analyzer": "arabic"
+                },
+                "base": {
+                  "type": "text",
+                  "analyzer": "base"
+                },
+                "bengali": {
+                  "type": "text",
+                  "analyzer": "bengali"
+                },
+                "cased": {
+                  "type": "text",
+                  "analyzer": "cased"
+                },
+                "english": {
+                  "type": "text",
+                  "analyzer": "english",
+                  "search_analyzer": "english_token_limited"
+                },
+                "french": {
+                  "type": "text",
+                  "analyzer": "french"
+                },
+                "german": {
+                  "type": "text",
+                  "analyzer": "german"
+                },
+                "hindi": {
+                  "type": "text",
+                  "analyzer": "hindi"
+                },
+                "italian": {
+                  "type": "text",
+                  "analyzer": "italian"
+                },
+                "persian": {
+                  "type": "text",
+                  "analyzer": "persian"
+                },
+                "spanish": {
+                  "type": "text",
+                  "analyzer": "spanish"
+                },
+                "swappable_characters": {
+                  "type": "text",
+                  "analyzer": "swappable_characters"
+                }
+              },
+              "analyzer": "lowercase",
+              "search_analyzer": "lowercase_token_limited"
+            }
+          }
+        },
+        "referenceNumber": {
+          "type": "keyword",
+          "normalizer": "lowercase",
+          "fields": {
+            "path": {
+              "type": "text",
+              "analyzer": "path_analyzer",
+              "search_analyzer": "lowercase_whitespace_tokens"
+            }
+          }
+        },
+        "sourceIdentifier": {
+          "properties": {
+            "value": {
+              "type": "keyword",
+              "normalizer": "lowercase"
+            }
+          }
+        },
+        "subjects": {
+          "properties": {
+            "concepts": {
+              "properties": {
+                "label": {
+                  "type": "text",
+                  "analyzer": "english",
+                  "search_analyzer": "english_token_limited"
+                }
+              }
+            }
+          }
+        },
+        "title": {
+          "type": "text",
+          "fields": {
+            "arabic": {
+              "type": "text",
+              "analyzer": "arabic"
+            },
+            "base": {
+              "type": "text",
+              "analyzer": "base"
+            },
+            "bengali": {
+              "type": "text",
+              "analyzer": "bengali"
+            },
+            "cased": {
+              "type": "text",
+              "analyzer": "cased"
+            },
+            "english": {
+              "type": "text",
+              "analyzer": "english",
+              "search_analyzer": "english_token_limited"
+            },
+            "french": {
+              "type": "text",
+              "analyzer": "french"
+            },
+            "german": {
+              "type": "text",
+              "analyzer": "german"
+            },
+            "hindi": {
+              "type": "text",
+              "analyzer": "hindi"
+            },
+            "italian": {
+              "type": "text",
+              "analyzer": "italian"
+            },
+            "normalized_whole_phrase": {
+              "type": "text",
+              "analyzer": "normalized_whole_phrase"
+            },
+            "persian": {
+              "type": "text",
+              "analyzer": "persian"
+            },
+            "spanish": {
+              "type": "text",
+              "analyzer": "spanish"
+            },
+            "swappable_characters": {
+              "type": "text",
+              "analyzer": "swappable_characters"
+            }
+          },
+          "analyzer": "lowercase",
+          "search_analyzer": "lowercase_token_limited"
+        }
+      }
+    },
+    "redirectTarget": {
+      "type": "object",
+      "dynamic": "false"
+    },
+    "type": {
+      "type": "keyword"
+    }
+  }
+}

--- a/pipeline/terraform/2025-10-02/main.tf
+++ b/pipeline/terraform/2025-10-02/main.tf
@@ -27,9 +27,9 @@ module "pipeline" {
     (local.pipeline_date) = {
       works = {
         // prod transformers - prod id_minter
-        source = "works_source.2026-03-25"
+        source       = "works_source.2026-03-25"
         // prod id_minter - prod matcher_merger
-        identified = "works_identified.2023-05-26"
+        identified   = "works_identified.2023-05-26"
         // prod matcher_merger - prod graph/ingestor/indexer
         denormalised = "works_denormalised.2025-08-14"
       }
@@ -39,11 +39,11 @@ module "pipeline" {
         // modifiedTime-mapped images-initial-2026-06-15 (see the 2026-06-15 entry below),
         // so nothing writes this index any more. Remove this `initial` entry to delete the
         // old index once we're confident the new path is the source of truth.
-        initial = "empty"
+        initial   = "empty"
         // scala images ingestor - to be deleted when the service is removed
         augmented = "empty"
         // scala images ingestor - to be deleted when the service is removed
-        indexed = "images_indexed.2024-11-14"
+        indexed   = "images_indexed.2024-11-14"
       }
     }
     "2025-10-09" = {
@@ -86,7 +86,7 @@ module "pipeline" {
         // separate operational step. Remove this augmented entry once the index has been deleted.
         augmented = "images_augmented.2026-04-29"
         // prod graph/ingestor/indexer - prod API
-        indexed = "images_indexed.2024-11-14"
+        indexed   = "images_indexed.2024-11-14"
       }
     }
     // Indexes for the new Python image-inferrer state machine.
@@ -105,7 +105,13 @@ module "pipeline" {
         initial   = "images_initial.2026-06-15"
         augmented = "images_augmented.2026-04-29"
       }
-    }
+    },
+    "2026-07-30" = {
+      works = {
+        // Mappings to include new archive-related fields. Future prod index.
+        indexed = "works_indexed.2026-07-30"
+      }
+    },
   }
 
   allow_delete_indices = false

--- a/pipeline/terraform/2025-10-02/main.tf
+++ b/pipeline/terraform/2025-10-02/main.tf
@@ -27,9 +27,9 @@ module "pipeline" {
     (local.pipeline_date) = {
       works = {
         // prod transformers - prod id_minter
-        source       = "works_source.2026-03-25"
+        source = "works_source.2026-03-25"
         // prod id_minter - prod matcher_merger
-        identified   = "works_identified.2023-05-26"
+        identified = "works_identified.2023-05-26"
         // prod matcher_merger - prod graph/ingestor/indexer
         denormalised = "works_denormalised.2025-08-14"
       }
@@ -39,11 +39,11 @@ module "pipeline" {
         // modifiedTime-mapped images-initial-2026-06-15 (see the 2026-06-15 entry below),
         // so nothing writes this index any more. Remove this `initial` entry to delete the
         // old index once we're confident the new path is the source of truth.
-        initial   = "empty"
+        initial = "empty"
         // scala images ingestor - to be deleted when the service is removed
         augmented = "empty"
         // scala images ingestor - to be deleted when the service is removed
-        indexed   = "images_indexed.2024-11-14"
+        indexed = "images_indexed.2024-11-14"
       }
     }
     "2025-10-09" = {
@@ -86,7 +86,7 @@ module "pipeline" {
         // separate operational step. Remove this augmented entry once the index has been deleted.
         augmented = "images_augmented.2026-04-29"
         // prod graph/ingestor/indexer - prod API
-        indexed   = "images_indexed.2024-11-14"
+        indexed = "images_indexed.2024-11-14"
       }
     }
     // Indexes for the new Python image-inferrer state machine.


### PR DESCRIPTION
## What does this change?

https://github.com/wellcomecollection/platform/issues/6469

Create a new final works index (2026-07-30) with new index mappings (2026-07-30). At the moment, the new mappings file is a placeholder identical to the production file, but it will be modified in a future PR to include archive-related fields, supporting new archive browsing features in the frontend.

### Checklist

- [ ] Does this change the display model the catalogue API returns? If so, regenerate the test documents under `catalogue_graph/document_generators/test_documents`. The `wellcomecollection/catalogue-api` repo copies them in with `copy_test_documents.py`, and its OpenAPI contract tests validate the published spec against them, so stale fixtures let the spec drift.

## How to test

Run `terraform plan` and verify the output.

## How can we measure success?

New works index which can be used to test new archive filters.

## Have we considered potential risks?

* Running `terraform apply` will rotate Elasticsearch API keys reading/writing the final works index (`works-indexed-*`), including the key used by the catalogue API. This should be safe: we made the API resilient to key rotations.
* We are working on a parallel pipeline stack (2026-07-03), which currently does not include the new index with the new mappings. Creating the index in the new stack would mean blocking the release of the archive tweaks until we are ready to switch to the new stack. Instead, we can release the archive filters as part of the existing stack and then backfill the final works index in the new stack (after updating its mappings) before switching to it.