### PR TITLE
Let the 2026-07-03 id-minter cluster be destroyed without a final snapshot

### DIFF
--- a/infrastructure/critical/modules/id-minter-rds/main.tf
+++ b/infrastructure/critical/modules/id-minter-rds/main.tf
@@ -47,6 +47,7 @@ module "identifiers_v2_serverless_rds_cluster" {
   master_password    = null
 
   snapshot_identifier = var.snapshot_identifier
+  skip_final_snapshot = var.skip_final_snapshot
 
   manage_master_user_password = true
 

--- a/infrastructure/critical/modules/id-minter-rds/variables.tf
+++ b/infrastructure/critical/modules/id-minter-rds/variables.tf
@@ -39,3 +39,9 @@ variable "snapshot_identifier" {
   type        = string
   default     = null
 }
+
+variable "skip_final_snapshot" {
+  description = "Drop the cluster's data on destroy. Only for restored copies."
+  type        = bool
+  default     = false
+}

--- a/infrastructure/critical/modules/rds-serverless/main.tf
+++ b/infrastructure/critical/modules/rds-serverless/main.tf
@@ -17,6 +17,8 @@ resource "aws_rds_cluster" "serverless" {
   enable_http_endpoint = true
   deletion_protection  = true
 
+  skip_final_snapshot = var.skip_final_snapshot
+
   manage_master_user_password = var.manage_master_user_password
 
   serverlessv2_scaling_configuration {

--- a/infrastructure/critical/modules/rds-serverless/variables.tf
+++ b/infrastructure/critical/modules/rds-serverless/variables.tf
@@ -33,10 +33,10 @@ variable "snapshot_identifier" {
   default = null
 }
 
-# Destroy fails without this, as no final snapshot name is set.
 variable "skip_final_snapshot" {
-  type    = bool
-  default = false
+  description = "If true, allow destroy without creating a final snapshot. When false, destroy will fail unless the module is extended to set final_snapshot_identifier."
+  type        = bool
+  default     = false
 }
 
 

--- a/infrastructure/critical/modules/rds-serverless/variables.tf
+++ b/infrastructure/critical/modules/rds-serverless/variables.tf
@@ -33,6 +33,12 @@ variable "snapshot_identifier" {
   default = null
 }
 
+# Destroy fails without this, as no final snapshot name is set.
+variable "skip_final_snapshot" {
+  type    = bool
+  default = false
+}
+
 
 variable "max_scaling_capacity" {
   type    = number

--- a/infrastructure/critical/rds_id_minter.tf
+++ b/infrastructure/critical/rds_id_minter.tf
@@ -35,6 +35,9 @@ module "id_minter_rds_2026_07_03" {
   # Restore from production on July 14, 2026, 04:41 (UTC+01:00)
   snapshot_identifier = "awsbackup:job-a03d7ad1-17f3-4f12-6993-1c7a19cda33d"
 
+  # A restored copy of production; its contents are never worth keeping.
+  skip_final_snapshot = true
+
   vpc_id             = local.vpc_id_new
   private_subnet_ids = local.private_subnets_new
   admin_cidr_ingress = local.admin_cidr_ingress


### PR DESCRIPTION
## What does this change?

Unblocks phase 3 of wellcomecollection/platform#6461, which respins the `2026-07-03` id-minter cluster from a current production snapshot.

Changing `snapshot_identifier` forces a replacement, and a targeted plan confirms that part works: five `delete/create` resources inside `module.id_minter_rds_2026_07_03` and nothing under the production or test modules. The destroy half is the problem. `skip_final_snapshot` was never set in the `rds-serverless` module, so the provider default of `false` applies, and `final_snapshot_identifier` is unset too. AWS rejects that pair on delete. Run phase 3 as it stands and the apply fails partway, leaving deletion protection already disabled and the old cluster still standing.

`skip_final_snapshot` now threads through `rds-serverless` and `id-minter-rds`, defaulting to `false` so production and test keep exactly today's behaviour, and is set to `true` on the `2026-07-03` cluster alone.

Skipping the snapshot rather than naming one is deliberate. That cluster is a restored copy of production, respun whenever we want closer ID parity, so its own contents are not worth keeping. The recovery path is unchanged either way: restore again from `id-minter-backup-vault`.

### Checklist

- [x] Does this change the display model the catalogue API returns? No, it only changes RDS destroy behaviour.

## How to test

`terraform plan` in `infrastructure/critical`. Across the whole stack exactly one resource changes:

```
# module.id_minter_rds_2026_07_03.module.identifiers_v2_serverless_rds_cluster.aws_rds_cluster.serverless
# will be updated in-place
  ~ skip_final_snapshot = false -> true
```

In place, no replacement, and nothing under `module.id_minter_rds` or `module.id_minter_rds_test`.

## How can we measure success?

Phase 3's replacement apply runs to completion instead of failing on the destroy. Until then this is inert: it only changes what happens when that cluster is deleted.

## Have we considered potential risks?

The `2026-07-03` cluster can now be destroyed without leaving a snapshot behind, which is the point. It still has `deletion_protection = true`, so a destroy needs a deliberate `modify-db-cluster --no-deletion-protection` first, and that gate is unchanged.

Production and test keep the default, so neither can be destroyed without a final snapshot name. If we later want that safety on `2026-07-03` too, `final_snapshot_identifier` is the variable to add.
