### PR TITLE
use boolean false instead of string in index mappings

### DIFF
--- a/index_config/mappings.empty.json
+++ b/index_config/mappings.empty.json
@@ -1,3 +1,3 @@
 {
-  "dynamic": "false"
+  "dynamic": false
 }

--- a/index_config/mappings.images_augmented.2026-04-29.json
+++ b/index_config/mappings.images_augmented.2026-04-29.json
@@ -1,5 +1,5 @@
 {
-  "dynamic": "false",
+  "dynamic": false,
   "properties": {
     "modifiedTime": {
       "type": "date"

--- a/index_config/mappings.images_indexed.2024-11-14.json
+++ b/index_config/mappings.images_indexed.2024-11-14.json
@@ -190,7 +190,7 @@
       }
     },
     "debug": {
-      "dynamic": "false",
+      "dynamic": false,
       "properties": {
         "indexedTime": {
           "type": "date"

--- a/index_config/mappings.images_initial.2026-06-15.json
+++ b/index_config/mappings.images_initial.2026-06-15.json
@@ -1,5 +1,5 @@
 {
-  "dynamic": "false",
+  "dynamic": false,
   "properties": {
     "modifiedTime": {
       "type": "date"

--- a/index_config/mappings.works_denormalised.2025-08-14.json
+++ b/index_config/mappings.works_denormalised.2025-08-14.json
@@ -1,5 +1,5 @@
 {
-  "dynamic": "false",
+  "dynamic": false,
   "properties": {
     "data": {
       "properties": {

--- a/index_config/mappings.works_identified.2023-05-26.json
+++ b/index_config/mappings.works_identified.2023-05-26.json
@@ -1,5 +1,5 @@
 {
-  "dynamic": "false",
+  "dynamic": false,
   "properties": {
     "data": {
       "properties": {
@@ -16,7 +16,7 @@
     "state": {
       "properties": {
         "sourceIdentifier": {
-          "dynamic": "false",
+          "dynamic": false,
           "properties": {
             "value": {
               "type": "keyword",

--- a/index_config/mappings.works_indexed.2024-11-14.json
+++ b/index_config/mappings.works_indexed.2024-11-14.json
@@ -126,7 +126,7 @@
       }
     },
     "debug": {
-      "dynamic": "false",
+      "dynamic": false,
       "properties": {
         "indexedTime": {
           "type": "date"
@@ -885,7 +885,7 @@
     },
     "redirectTarget": {
       "type": "object",
-      "dynamic": "false"
+      "dynamic": false
     },
     "type": {
       "type": "keyword"

--- a/index_config/mappings.works_indexed.2026-07-30.json
+++ b/index_config/mappings.works_indexed.2026-07-30.json
@@ -126,7 +126,7 @@
       }
     },
     "debug": {
-      "dynamic": "false",
+      "dynamic": false,
       "properties": {
         "indexedTime": {
           "type": "date"
@@ -885,7 +885,7 @@
     },
     "redirectTarget": {
       "type": "object",
-      "dynamic": "false"
+      "dynamic": false
     },
     "type": {
       "type": "keyword"

--- a/index_config/mappings.works_source.2026-03-25.json
+++ b/index_config/mappings.works_source.2026-03-25.json
@@ -1,5 +1,5 @@
 {
-  "dynamic": "false",
+  "dynamic": false,
   "properties": {
     "indexed_at": {
       "type": "date"
@@ -19,7 +19,7 @@
     "state": {
       "properties": {
         "sourceIdentifier": {
-          "dynamic": "false",
+          "dynamic": false,
           "properties": {
             "value": {
               "type": "keyword",


### PR DESCRIPTION
## What does this change?

Part of https://github.com/wellcomecollection/platform/issues/6461
See also https://wellcome.slack.com/archives/C02ANCYL90E/p1785401613007689

The terraform -replace command failed because of the way ES normalises "false" to false in the index mappings
in order to be able to recreate the deleted indices we had to update the mappings to match what they were being compared to, ie. the normalised ES version

This looks like a straight revert of 8321770cc68214742cb402e716225b51b80fbd2d, which quoted these same values a week ago. It isn't. The two pipeline stacks pin different versions of the `elastic/elasticstack` provider and they disagree about the type of `dynamic`:

- `2025-10-02` pins v0.7.0, which has no type coercion and compares the mapping JSON literally against what is applied. The quoting commit was fixing a permanent no-op diff on that stack.
- `2026-07-03` pins v0.16.1, which added a semantic-equality layer that always coerces string-encoded booleans back to native bools when building the planned value. Against a quoted config, the planned value and the config value no longer match, and Terraform Core rejects that outright.

Both commits were correct for the provider in front of them. Unquoting is what unblocks recreating the 2026-07-03 indices wiped as part of 6461.

<details>
<summary>The error, and why it can't be normalised away</summary>

```
Error: Provider produced invalid plan
Provider "registry.terraform.io/elastic/elasticstack" planned an invalid value for
module.elastic.module.indices["works-source-2026-07-03"].elasticstack_elasticsearch_index.the_index.mappings:
planned value cty.StringVal("{\"dynamic\":false,...") does not match config value
cty.StringVal("{\"dynamic\":\"false\",...").
```

In v0.16.1, `MappingsType.ValueFromString` to `NewMappingsValue` (`internal/elasticsearch/index/mappings_value.go`, used by `index/mapping_modifier.go`) coerces unconditionally, so no config value avoids it. Semantic equality only reconciles prior state against the plan, never config against the plan, so it cannot suppress this check. The reason the value is a string at all is upstream of the provider: both `{"dynamic": false}` and `{"dynamic": "false"}` round-trip through the go-elasticsearch typed client as `{"dynamic":"false"}`.
</details>

### Checklist

- [ ] Does this change the display model the catalogue API returns? If so, regenerate the test documents under `catalogue_graph/document_generators/test_documents`. The `wellcomecollection/catalogue-api` repo copies them in with `copy_test_documents.py`, and its OpenAPI contract tests validate the published spec against them, so stale fixtures let the spec drift.

## How to test

Run in both pipeline stacks:
```
./run_terraform.sh plan
```
2025-10-02 -> change for every index affected by the mappings in this PRs, limited to `dynamic    = "false" -> false`
2026-07-03 -> no change, mappings already applied 

## How can we measure success?

Mappings as defined in index_config are more consistent with what ES processes and accepts 

## Have we considered potential risks?

The value doesn't change, only the type 

`index_config/` is shared by both stacks, so the 2025-10-02 plan diff above is real and will sit there until someone applies production. That is expected churn rather than breakage, but the next person to plan production should not be surprised by it.
