### PR TITLE
Re-enable the 2026-07-03 pipeline after the clear

### DIFF
--- a/pipeline/terraform/2026-07-03/main.tf
+++ b/pipeline/terraform/2026-07-03/main.tf
@@ -1,11 +1,8 @@
 module "pipeline" {
   source = "../modules/pipeline_new"
 
-  # Quiesced while the pipeline's stateful parts are cleared, so nothing writes
-  # into the state being wiped. Back on for the reindex, along with the
-  # enable_* flags below.
   reindexing_state = {
-    listen_to_reindexer = false
+    listen_to_reindexer = true
     scale_up_tasks      = true
     scale_up_matcher_db = true
   }
@@ -24,10 +21,10 @@ module "pipeline" {
   # Base AMI for ECS instances
   ami_id = "resolve:ssm:arn:aws:ssm:eu-west-1:760097843905:parameter/imagebuilder/weco-al2023-ecs-optimised-x86_64/latest"
 
-  enable_adapter_transformer_trigger = false
-  enable_id_minter_schedule          = false
-  enable_graph_pipeline_schedule     = false
-  enable_image_inferrer_schedule     = false
+  enable_adapter_transformer_trigger = true
+  enable_id_minter_schedule          = true
+  enable_graph_pipeline_schedule     = true
+  enable_image_inferrer_schedule     = true
 
   pipeline_date = local.pipeline_date // namespaces services
   graph_date    = "2026-07-03"        // namespaces graph database


### PR DESCRIPTION
> **Do not apply until the reindex is ready to start.** Merging is safe; the apply is the hand-over point.

## What does this change?

The final step of wellcomecollection/platform#6461. Restores the four schedule and trigger flags and `reindexing_state.listen_to_reindexer`, so the `2026-07-03` pipeline can take the full reindex in wellcomecollection/platform#6445.

This is an exact revert of #3513: `git diff` against the pre-quiesce commit is empty.

The clear behind it is finished and verified. Seven of the eight indices are empty, the works-graph and matcher lock tables are empty, the four Neptune catalogue labels are at zero with the ontology intact, the id-minter is respun from this morning's production snapshot, and all three terraform stacks plan clean.

### Checklist

- [x] Does this change the display model the catalogue API returns? No, it only toggles schedules and event rules.

## How to test

`terraform plan` in `pipeline/terraform/2026-07-03` should be the mirror of #3513: nine schedules and rules moving to `ENABLED`, five reindex topic subscriptions created, five queue policies regaining the reindex topic in their `aws:SourceArn` condition, and no replacements.

## How can we measure success?

After the apply, the pipeline accepts reindex events again and the schedules resume, which is the precondition for #6445 section C.

## Have we considered potential risks?

**The apply is the live moment, not the merge.** Terraform apply for this stack is manual, so merging changes nothing by itself. It does mean the change sits armed in `main`: anyone who applies this stack for an unrelated reason turns the pipeline back on. That is less destructive than it sounds, since the reindex overwrites everything anyway, but it would start processing the legacy transformer trickle through the clean baseline and undo the point of the clear.

`works-source-2026-07-03` is not empty and never was going to be. `listen_to_reindexer` only removes the reindex topic subscriptions, so the Scala transformers kept their live adapter-output subscriptions throughout and have been writing current records into `works-source` all along. It stood at 2,310 documents at the time of verification. Nothing progressed past it, because the id-minter schedule was off.

Once this is applied, confirm production is still out of reindexing before any reindex event is published. It was verified out at the time of writing: no `2025-10-02` queue subscribes to any of the five reindex topics.
