### PR TITLE
Size the 2026-07-03 ES cluster for the full reindex

### DIFF
--- a/infrastructure/critical/es_cluster.tf
+++ b/infrastructure/critical/es_cluster.tf
@@ -8,7 +8,7 @@ module "es_cluster_2026_07_03" {
   cluster_date = "2026-07-03"
 
   # Sized for the full reindex, matching what 2025-10-02 scales to for one.
-  # Back to the 4g x 3 default once platform#6445 is signed off.
+  # Back to the 4g across 3 zones default once wellcomecollection/platform#6445 is signed off.
   memory     = "30g"
   node_count = 2
 

--- a/infrastructure/critical/es_cluster.tf
+++ b/infrastructure/critical/es_cluster.tf
@@ -7,6 +7,11 @@ module "es_cluster_2026_07_03" {
 
   cluster_date = "2026-07-03"
 
+  # Sized for the full reindex, matching what 2025-10-02 scales to for one.
+  # Back to the 4g x 3 default once platform#6445 is signed off.
+  memory     = "30g"
+  node_count = 2
+
   traffic_filter_ids = [
     local.shared_infra["ec_platform_privatelink_traffic_filter_id"],
     local.shared_infra["ec_catalogue_privatelink_traffic_filter_id"],


### PR DESCRIPTION
## What does this change?

Sizes the `2026-07-03` Elasticsearch cluster for the full reindex in wellcomecollection/platform#6445, from the module defaults of 4g across 3 zones to **30g across 2**.

That cluster has been running on `es-cluster` module defaults since it was built, which is an idling size. The reindex pushes roughly 2.8M source records through it: Sierra 1,817,925, Miro 421,608, METS 364,449, Axiell 206,526, TEI 1,563, plus EBSCO and 39,374 CALM ids.

Production already treats this as a scale-up job. `modules/pipeline` has a `scale_up_elastic_cluster` flag that takes `2025-10-02` from 4g x 3 to **30g x 2** for a reindex, on the same `aws-cpu-optimized-arm` deployment template. The `2026-07-03` stack has no equivalent lever: its `reindexing_state` object only carries `listen_to_reindexer`, `scale_up_tasks` and `scale_up_matcher_db`, because the cluster lives in `infrastructure/critical` rather than in the pipeline stack. So this sets the size directly and matches the profile production uses for the same work.

### Checklist

- [x] Does this change the display model the catalogue API returns? No, it changes cluster capacity only.

## How to test

`./run_terraform.sh plan` in `infrastructure/critical`. Exactly one resource changes, in place:

```
# module.es_cluster_2026_07_03.ec_deployment.cluster will be updated in-place
  ~ size       = "4g" -> "30g"
  ~ zone_count = 3 -> 2

Plan: 0 to add, 1 to change, 0 to destroy.
```

Note `./run_terraform.sh` rather than plain `terraform`: this stack needs `EC_API_KEY` for the `ec` provider, which the wrapper supplies.

## How can we measure success?

The reindex completes without the cluster becoming the bottleneck, and index counts approach production's. If 30g x 2 still proves tight, the same two lines are how we go further.

## Have we considered potential risks?

**Cost.** This goes from 12g of hot tier to 60g, and it should not be left there. Reverting to the defaults is part of #6445 section F, alongside `scale_up_tasks` and `scale_up_matcher_db`. Production's own comment on the equivalent flag notes 30GB is expensive and the reindex data is ephemeral.

**Dropping from 3 zones to 2** matches what production does for a reindex, and mirrors its reasoning: during a reindex the cluster is not depended on for anything and the data is reproducible. With the indices currently empty there is no shard movement to worry about.

**Nothing production-facing is affected.** This cluster serves only the `2026-07-03` pipeline and the staff preview toggle, which reads an index that is empty until the reindex fills it. Production's cluster is created by the `2025-10-02` stack and is not in `infrastructure/critical` at all.
