### PR TITLE
Add Axiell as a reindex target

### DIFF
--- a/infrastructure/critical/es_cluster.tf
+++ b/infrastructure/critical/es_cluster.tf
@@ -7,6 +7,11 @@ module "es_cluster_2026_07_03" {
 
   cluster_date = "2026-07-03"
 
+  # Sized for the full reindex, matching what 2025-10-02 scales to for one.
+  # Back to the 4g x 3 default once platform#6445 is signed off.
+  memory     = "30g"
+  node_count = 2
+
   traffic_filter_ids = [
     local.shared_infra["ec_platform_privatelink_traffic_filter_id"],
     local.shared_infra["ec_catalogue_privatelink_traffic_filter_id"],

--- a/reindexer/scripts/README.md
+++ b/reindexer/scripts/README.md
@@ -52,9 +52,14 @@ Examples
   - uv run start_reindex.py --src notmiro --dst catalogue --mode complete --calm-input-file ./third_party_archives.txt
 
 Notes
-- Valid sources: all, notmiro, ebsco, miro, sierra, mets, calm, tei.
+- Valid sources: all, notmiro, ebsco, axiell, miro, sierra, mets, calm, tei.
   - `all` reindexes every source in `SOURCES` plus any EventBridge targets
-    (currently just `ebsco`).
+    (`ebsco` and `axiell`).
+  - `ebsco` and `axiell` are adapter sources: rather than scanning a table,
+    they publish a `weco.pipeline.reindex.requested` event that re-runs the
+    adapter transformer over the whole adapter store. The event carries a
+    `job_id`, printed when it is sent, which is how the resulting transformer
+    run is traced.
   - `notmiro` is the same as `all` but skips Miro. Miro is normally run
     separately, last, once everything else has gone through the
     matcher/merger -- running it at the same time as other sources risks

--- a/reindexer/scripts/eventbridge.py
+++ b/reindexer/scripts/eventbridge.py
@@ -1,28 +1,44 @@
 import json
+from datetime import datetime
 
 EVENTBUS_NAME = "catalogue-pipeline-adapter-event-bus"
 EVENTBRIDGE_SOURCE = "weco.pipeline.reindex"
-EVENTBRIDGE_REINDEX_TARGETS = ["ebsco"]
+EVENTBRIDGE_REINDEX_TARGETS = ["ebsco", "axiell"]
 EVENT_REQUESTED_DETAIL_TYPE = "weco.pipeline.reindex.requested"
 
 
-def send_eventbridge_reindex_event(session, reindex_target):
+def create_job_id(reindex_target):
+    """Match the adapters' job id format, prefixed so a reindex is recognisable."""
+    return f"reindex-{reindex_target}-{datetime.now().strftime('%Y%m%dT%H%M')}"
+
+
+def send_eventbridge_reindex_event(session, reindex_target, job_id=None):
     """
     Send an AWS EventBridge event to trigger a re-index
 
-    Not all re-indexes are triggered by EventBridge events. At present
-    the only re-indexes triggered by EventBridge is the EBSCO adapter.
+    Not all re-indexes are triggered by EventBridge events. The adapter
+    sources (EBSCO, Axiell) use this path; the rest go through the reindexer
+    itself.
+
+    Returns the job_id the event carried, which is how the resulting
+    transformer run is traced.
     """
 
     if reindex_target not in EVENTBRIDGE_REINDEX_TARGETS:
         raise ValueError(f"Invalid reindex target: {reindex_target}")
+
+    job_id = job_id or create_job_id(reindex_target)
 
     response = session.client("events").put_events(
         Entries=[
             {
                 "Source": EVENTBRIDGE_SOURCE,
                 "DetailType": EVENT_REQUESTED_DETAIL_TYPE,
-                "Detail": json.dumps({"reindex_targets": [reindex_target]}),
+                # job_id is required: the trigger reads $.detail.job_id, and the
+                # transformer event model rejects a run without one.
+                "Detail": json.dumps(
+                    {"reindex_targets": [reindex_target], "job_id": job_id}
+                ),
                 "EventBusName": EVENTBUS_NAME,
             }
         ]
@@ -30,3 +46,5 @@ def send_eventbridge_reindex_event(session, reindex_target):
 
     if response["FailedEntryCount"] > 0:
         raise RuntimeError(f"Failed to send EventBridge event: {response}")
+
+    return job_id

--- a/reindexer/scripts/pyproject.toml
+++ b/reindexer/scripts/pyproject.toml
@@ -14,3 +14,9 @@ dependencies = [
   "tenacity",
   "tqdm",
 ]
+
+[dependency-groups]
+dev = ["pytest"]
+
+[tool.pytest.ini_options]
+testpaths = ["."]

--- a/reindexer/scripts/start_reindex.py
+++ b/reindexer/scripts/start_reindex.py
@@ -240,7 +240,8 @@ def start_reindex(ctx, src, dst, mode, input_file, calm_input_file):
 
         if src in EVENTBRIDGE_REINDEX_TARGETS:
             print(f"Starting an eventbridge reindex {src} ~> {dst}")
-            send_eventbridge_reindex_event(session, src)
+            job_id = send_eventbridge_reindex_event(session, src)
+            print(f"Sent reindex event for {src} with job_id {job_id}")
         else:
             for source in SOURCES.keys():
                 if source == "miro" and src == "notmiro":
@@ -256,7 +257,8 @@ def start_reindex(ctx, src, dst, mode, input_file, calm_input_file):
 
             for reindex_target in EVENTBRIDGE_REINDEX_TARGETS:
                 print(f"Starting an eventbridge reindex {reindex_target} ~> {dst}")
-                send_eventbridge_reindex_event(session, reindex_target)
+                job_id = send_eventbridge_reindex_event(session, reindex_target)
+                print(f"Sent reindex event for {reindex_target} with job_id {job_id}")
 
         return
 

--- a/reindexer/scripts/test_eventbridge.py
+++ b/reindexer/scripts/test_eventbridge.py
@@ -1,0 +1,81 @@
+import json
+
+import pytest
+
+from eventbridge import (
+    EVENTBRIDGE_REINDEX_TARGETS,
+    send_eventbridge_reindex_event,
+)
+
+
+class FakeEventsClient:
+    def __init__(self, failed_entry_count=0):
+        self.failed_entry_count = failed_entry_count
+        self.entries = None
+
+    def put_events(self, Entries):
+        self.entries = Entries
+        return {"FailedEntryCount": self.failed_entry_count}
+
+
+class FakeSession:
+    def __init__(self, client):
+        self._client = client
+
+    def client(self, name):
+        assert name == "events"
+        return self._client
+
+
+def send(target, failed_entry_count=0, **kwargs):
+    client = FakeEventsClient(failed_entry_count)
+    job_id = send_eventbridge_reindex_event(FakeSession(client), target, **kwargs)
+    return client, job_id
+
+
+@pytest.mark.parametrize("target", ["ebsco", "axiell"])
+def test_sends_a_matching_event_for_each_adapter_source(target):
+    client, job_id = send(target)
+
+    (entry,) = client.entries
+    assert entry["Source"] == "weco.pipeline.reindex"
+    assert entry["DetailType"] == "weco.pipeline.reindex.requested"
+    assert entry["EventBusName"] == "catalogue-pipeline-adapter-event-bus"
+
+    # The trigger matches on reindex_targets and reads $.detail.job_id, which the
+    # transformer requires. An event missing either cannot start a run.
+    assert json.loads(entry["Detail"]) == {
+        "reindex_targets": [target],
+        "job_id": job_id,
+    }
+
+
+def test_uses_a_caller_supplied_job_id():
+    client, job_id = send("axiell", job_id="reindex-axiell-manual")
+
+    assert job_id == "reindex-axiell-manual"
+    assert json.loads(client.entries[0]["Detail"])["job_id"] == "reindex-axiell-manual"
+
+
+def test_generated_job_id_names_the_target():
+    _, job_id = send("axiell")
+
+    assert job_id.startswith("reindex-axiell-")
+
+
+def test_rejects_an_unknown_target_without_sending():
+    client = FakeEventsClient()
+
+    with pytest.raises(ValueError, match="folio"):
+        send_eventbridge_reindex_event(FakeSession(client), "folio")
+
+    assert client.entries is None
+
+
+def test_raises_when_the_event_is_not_accepted():
+    with pytest.raises(RuntimeError):
+        send("axiell", failed_entry_count=1)
+
+
+def test_axiell_is_a_reindex_target():
+    assert "axiell" in EVENTBRIDGE_REINDEX_TARGETS

--- a/reindexer/scripts/uv.lock
+++ b/reindexer/scripts/uv.lock
@@ -88,6 +88,18 @@ wheels = [
 ]
 
 [[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
 name = "humanize"
 version = "4.12.3"
 source = { registry = "https://pypi.org/simple" }
@@ -97,12 +109,66 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jmespath"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/00/2a/e867e8531cf3e36b41201936b7fa7ba7b5702dbef42922193f05c8976cd6/jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe", size = 25843, upload-time = "2022-06-17T18:00:12.224Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980", size = 20256, upload-time = "2022-06-17T18:00:10.251Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -143,6 +209,11 @@ dependencies = [
     { name = "tqdm" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "boto3" },
@@ -153,6 +224,9 @@ requires-dist = [
     { name = "tenacity" },
     { name = "tqdm" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest" }]
 
 [[package]]
 name = "six"
@@ -179,6 +253,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0a/d4/2b0cd0fe285e14b36db076e78c93766ff1d529d70408bd1d2a5a84f1d929/tenacity-9.1.2.tar.gz", hash = "sha256:1169d376c297e7de388d18b4481760d478b0e99a777cad3a9c86e556f4b697cb", size = 48036, upload-time = "2025-04-02T08:25:09.966Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/30/643397144bfbfec6f6ef821f36f33e57d35946c44a2352d3c9f0ae847619/tenacity-9.1.2-py3-none-any.whl", hash = "sha256:f77bf36710d8b73a50b2dd155c97b870017ad21afe6ab300326b0371b3b05138", size = 28248, upload-time = "2025-04-02T08:25:07.678Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What does this change?

Adds Axiell as a reindex target, so wellcomecollection/platform#6445 can reindex the source it is mainly about.

`EVENTBRIDGE_REINDEX_TARGETS` listed only `ebsco`, so `--src axiell` was rejected and `--src all` skipped it entirely. Axiell reindexes exactly as EBSCO does: instead of scanning a table, it publishes `weco.pipeline.reindex.requested`, which the adapter transformer's trigger picks up and re-runs over the whole adapter store. The receiving rule already exists and is enabled, with the pattern `{"detail": {"reindex_targets": ["axiell"]}}`.

**Adding it surfaced a second problem.** The script never sent a `job_id`, but:

- `BaseAdapterEvent` in `catalogue_graph/src/adapters/models/events.py` declares `job_id: str` as required, described there as "a required job_id for run tracking"
- both reindex rules transform their input with `"job_id": "$.detail.job_id"`, so the template had nothing to populate from

So a reindex event as previously sent could not have produced a valid transformer run. Neither rule has ever fired, in either pipeline (no `TriggeredRules`, `Invocations` or `FailedInvocations` datapoints in 14 days), which is why nobody has hit it. The event now carries a `job_id` and the script prints it, which is also how the resulting run is traced through its manifests.

The id follows the adapters' own format with a prefix that makes a reindex recognisable in the shared manifest bucket: `reindex-axiell-20260730T1553`.

### Checklist

- [x] Does this change the display model the catalogue API returns? No, it only changes how a reindex is triggered.

## How to test

The event shape, without sending anything, using a fake session:

```
uv run python -c "
import eventbridge as eb
class C:
    def put_events(self, Entries): print(Entries[0]['Detail']); return {'FailedEntryCount': 0}
class S:
    def client(self, n): return C()
eb.send_eventbridge_reindex_event(S(), 'axiell')
"
{"reindex_targets": ["axiell"], "job_id": "reindex-axiell-20260730T1553"}
```

That matches the deployed rule pattern for `axiell-reindex-2026-07-03-trigger`, and `$.detail.job_id` now resolves. Unknown targets are still rejected.

For real: `uv run start_reindex.py --src axiell --dst catalogue --mode complete`.

## How can we measure success?

The `axiell-reindex-2026-07-03-trigger` rule shows an invocation rather than nothing, and a `transformer-2026-07-03` execution starts carrying the printed `job_id`.

## Have we considered potential risks?

**`--src all` now includes Axiell**, which is the intent, but it means an `all` reindex sends two adapter events rather than one. Both are idempotent re-runs over the adapter store.

**Production cannot be reached by this.** `axiell-reindex-2025-10-02-trigger`, `ebsco-reindex-2025-10-02-trigger` and `folio-reindex-2025-10-02-trigger` are all `DISABLED`, from taking production out of reindexing. Only the `2026-07-03` rules are enabled, so the event fans out to the new pipeline alone. Worth re-checking at the moment of use rather than trusting this note.
