### PR TITLE
Run adapter transform on ECS

### DIFF
--- a/catalogue_graph/src/adapters/steps/transformer.py
+++ b/catalogue_graph/src/adapters/steps/transformer.py
@@ -31,6 +31,7 @@ from adapters.utils.adapter_store import AdapterStore
 from adapters.utils.axiell_changeset_reader import AxiellChangesetReader
 from utils.elasticsearch import ElasticsearchMode, get_client, get_standard_index_name
 from utils.logger import ExecutionContext, get_trace_id, setup_logging
+from utils.steps import ecs_handler
 
 logger = structlog.get_logger(__name__)
 
@@ -211,8 +212,7 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     ).model_dump(mode="json")
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser(description="Transform adapter data")
+def local_handler(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--transformer-type",
         required=True,
@@ -247,8 +247,8 @@ def main() -> None:
     parser.add_argument(
         "--es-mode",
         type=str,
-        help="Where to index source work documents. 'private' matches the Lambda, and needs to run inside the VPC.",
-        choices=typing.get_args(ElasticsearchMode),
+        help="Where to index source work documents. Use 'public' to connect to the production cluster.",
+        choices=["local", "public"],
         default="local",
     )
     parser.add_argument(
@@ -279,4 +279,22 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(description="Transform adapter data")
+    parser.add_argument(
+        "--use-cli",
+        action="store_true",
+        help="Whether to invoke the local CLI handler instead of the ECS handler.",
+    )
+    args, _ = parser.parse_known_args()
+
+    if args.use_cli:
+        local_handler(parser)
+    else:
+        # This will automatically use `es_mode=private`
+        ecs_handler(
+            arg_parser=parser,
+            handler=handler,
+            event_validator=TransformerEvent.model_validate_json,
+            pipeline_step="adapter_transformer",
+            use_rest_api_table=True,
+        )

--- a/catalogue_graph/src/adapters/steps/transformer.py
+++ b/catalogue_graph/src/adapters/steps/transformer.py
@@ -247,8 +247,8 @@ def main() -> None:
     parser.add_argument(
         "--es-mode",
         type=str,
-        help="Where to index source work documents. Use 'public' to connect to the production cluster.",
-        choices=["local", "public"],
+        help="Where to index source work documents. 'private' matches the Lambda, and needs to run inside the VPC.",
+        choices=typing.get_args(ElasticsearchMode),
         default="local",
     )
     parser.add_argument(

--- a/pipeline/terraform/modules/pipeline_new/ecs_task_transformer.tf
+++ b/pipeline/terraform/modules/pipeline_new/ecs_task_transformer.tf
@@ -1,0 +1,60 @@
+# A full-store transform (a reindex, which carries no changeset ids) does not fit
+# in the transformer Lambda's 600s. Harvests and rebuilds arrive pre-chunked into
+# changesets and stay on the Lambda.
+module "transformer_ecs_task" {
+  source = "../ecs_task"
+
+  task_name = "${local.namespace}-transformer"
+  image     = "${data.aws_ecr_repository.unified_pipeline_task.repository_url}:env.${var.pipeline_date}"
+
+  cpu    = 4096
+  memory = 16384
+
+  environment = {
+    PIPELINE_DATE = var.pipeline_date
+    INDEX_DATE    = var.index_dates.source
+    S3_PREFIX     = "prod"
+  }
+}
+
+resource "aws_iam_role_policy" "transformer_task_iceberg_read" {
+  role   = module.transformer_ecs_task.task_role_name
+  policy = data.aws_iam_policy_document.all_adapter_s3tables_read.json
+}
+
+resource "aws_iam_role_policy" "transformer_task_s3_read" {
+  role   = module.transformer_ecs_task.task_role_name
+  policy = data.aws_iam_policy_document.all_adapter_buckets_read.json
+}
+
+resource "aws_iam_role_policy" "transformer_task_s3_write" {
+  role   = module.transformer_ecs_task.task_role_name
+  policy = data.aws_iam_policy_document.all_adapter_buckets_write.json
+}
+
+resource "aws_iam_role_policy" "transformer_task_pipeline_storage_secret_read" {
+  role   = module.transformer_ecs_task.task_role_name
+  policy = data.aws_iam_policy_document.all_transformer_pipeline_storage_secrets.json
+}
+
+resource "aws_iam_role_policy" "transformer_task_cloudwatch_write" {
+  role   = module.transformer_ecs_task.task_role_name
+  policy = data.aws_iam_policy_document.transformer_lambda_cloudwatch_write.json
+}
+
+# ecs:runTask.sync needs more than the ecs_task module's invoke policy grants: it
+# polls the task and manages an EventBridge rule to hear about completion.
+data "aws_iam_policy_document" "transformer_run_task_sync" {
+  statement {
+    effect  = "Allow"
+    actions = ["ecs:StopTask", "ecs:DescribeTasks"]
+    # ECS task ARNs are only known at run time.
+    resources = ["*"]
+  }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["events:PutTargets", "events:PutRule", "events:DescribeRule"]
+    resources = ["arn:aws:events:eu-west-1:${data.aws_caller_identity.current.account_id}:rule/StepFunctionsGetEventsForECSTaskRule"]
+  }
+}

--- a/pipeline/terraform/modules/pipeline_new/ecs_task_transformer.tf
+++ b/pipeline/terraform/modules/pipeline_new/ecs_task_transformer.tf
@@ -1,6 +1,5 @@
-# A full-store transform (a reindex, which carries no changeset ids) does not fit
-# in the transformer Lambda's 600s. Harvests and rebuilds arrive pre-chunked into
-# changesets and stay on the Lambda.
+# Every adapter transform runs here. A reindex carries no changeset ids and has to
+# stream the whole adapter store, which does not fit in the Lambda's 600s.
 module "transformer_ecs_task" {
   source = "../ecs_task"
 
@@ -42,19 +41,20 @@ resource "aws_iam_role_policy" "transformer_task_cloudwatch_write" {
   policy = data.aws_iam_policy_document.transformer_lambda_cloudwatch_write.json
 }
 
-# ecs:runTask.sync needs more than the ecs_task module's invoke policy grants: it
-# polls the task and manages an EventBridge rule to hear about completion.
-data "aws_iam_policy_document" "transformer_run_task_sync" {
-  statement {
-    effect  = "Allow"
-    actions = ["ecs:StopTask", "ecs:DescribeTasks"]
-    # ECS task ARNs are only known at run time.
-    resources = ["*"]
-  }
+# The task reports completion with the Step Functions task token it is handed.
+resource "aws_iam_role_policy" "transformer_task_token" {
+  role   = module.transformer_ecs_task.task_role_name
+  policy = data.aws_iam_policy_document.transformer_task_token.json
+}
 
+data "aws_iam_policy_document" "transformer_task_token" {
   statement {
-    effect    = "Allow"
-    actions   = ["events:PutTargets", "events:PutRule", "events:DescribeRule"]
-    resources = ["arn:aws:events:eu-west-1:${data.aws_caller_identity.current.account_id}:rule/StepFunctionsGetEventsForECSTaskRule"]
+    effect = "Allow"
+    actions = [
+      "states:SendTaskSuccess",
+      "states:SendTaskFailure",
+      "states:SendTaskHeartbeat",
+    ]
+    resources = ["*"]
   }
 }

--- a/pipeline/terraform/modules/pipeline_new/state_machine_transformers.tf
+++ b/pipeline/terraform/modules/pipeline_new/state_machine_transformers.tf
@@ -70,13 +70,29 @@ resource "aws_iam_role_policy" "transformer_lambda_pipeline_storage_secret_read"
 # State Machine Definition
 locals {
   transformer_state_machine_definition = jsonencode({
-    StartAt = "Run transformer"
+    StartAt = "Whole store or a changeset?"
     States = {
+      # A reindex sends no changeset ids, so the run has to stream the whole
+      # adapter store. That does not fit in the Lambda's 600s, and a timeout is
+      # not retried, so it goes to a Fargate task with no time limit instead.
+      "Whole store or a changeset?" = {
+        Type       = "Choice"
+        InputPath  = "$.detail"
+        Default    = "Run transformer on ECS"
+        OutputPath = "$"
+        Choices = [
+          {
+            Variable  = "$.changeset_ids[0]"
+            IsPresent = true
+            Next      = "Run transformer"
+          }
+        ]
+      }
+
       "Run transformer" = {
-        Type      = "Task"
-        Resource  = module.transformer_lambda.lambda.arn
-        InputPath = "$.detail"
-        Next      = "Success"
+        Type     = "Task"
+        Resource = module.transformer_lambda.lambda.arn
+        Next     = "Success"
         Retry = [
           {
             ErrorEquals     = ["Lambda.ServiceException", "Lambda.AWSLambdaException", "Lambda.SdkClientException"]
@@ -86,6 +102,47 @@ locals {
           }
         ]
       }
+
+      # runTask.sync rather than waitForTaskToken: nothing downstream reads the
+      # result, and .sync surfaces a task that never starts instead of hanging
+      # on a token that is never sent.
+      "Run transformer on ECS" = {
+        Type     = "Task"
+        Resource = "arn:aws:states:::ecs:runTask.sync"
+        Next     = "Success"
+        Retry = [
+          {
+            ErrorEquals     = ["ECS.AmazonECSException", "ECS.InvalidParameterException"]
+            IntervalSeconds = 30
+            MaxAttempts     = 3
+            BackoffRate     = 2.0
+          }
+        ]
+        Parameters = {
+          Cluster        = aws_ecs_cluster.cluster.arn
+          TaskDefinition = module.transformer_ecs_task.task_definition_arn
+          LaunchType     = "FARGATE"
+          NetworkConfiguration = {
+            AwsvpcConfiguration = {
+              AssignPublicIp = "DISABLED"
+              Subnets        = local.network_config.subnets
+              SecurityGroups = [
+                aws_security_group.egress.id,
+                local.network_config.ec_privatelink_security_group_id,
+              ]
+            }
+          }
+          Overrides = {
+            ContainerOverrides = [
+              {
+                "Name"      = "${local.namespace}-transformer"
+                "Command.$" = "States.Array('/app/src/adapters/steps/transformer.py', '--transformer-type', $.transformer_type, '--job-id', $.job_id, '--use-rest-api-table', '--es-mode', 'private')"
+              }
+            ]
+          }
+        }
+      }
+
       "Success" = {
         Type = "Succeed"
       }
@@ -125,6 +182,8 @@ module "transformer_state_machine" {
     "read_ebsco_adapter_bucket"  = data.aws_iam_policy_document.adapter_bucket_read["ebsco"].json
     "read_axiell_adapter_bucket" = data.aws_iam_policy_document.adapter_bucket_read["axiell"].json
     "read_folio_adapter_bucket"  = data.aws_iam_policy_document.adapter_bucket_read["folio"].json
+    "run_transformer_ecs_task"   = module.transformer_ecs_task.invoke_policy_document
+    "transformer_run_task_sync"  = data.aws_iam_policy_document.transformer_run_task_sync.json
   }
 }
 

--- a/pipeline/terraform/modules/pipeline_new/state_machine_transformers.tf
+++ b/pipeline/terraform/modules/pipeline_new/state_machine_transformers.tf
@@ -69,56 +69,28 @@ resource "aws_iam_role_policy" "transformer_lambda_pipeline_storage_secret_read"
 
 # State Machine Definition
 locals {
+  # A whole-store transform (a reindex, which carries no changeset ids) has to
+  # stream the entire adapter store in one run, which does not fit in a Lambda.
+  # Rather than route by size, every transform runs as a Fargate task.
   transformer_state_machine_definition = jsonencode({
-    StartAt = "Whole store or a changeset?"
+    QueryLanguage = "JSONata"
+    StartAt       = "Run transformer"
     States = {
-      # A reindex sends no changeset ids, so the run has to stream the whole
-      # adapter store. That does not fit in the Lambda's 600s, and a timeout is
-      # not retried, so it goes to a Fargate task with no time limit instead.
-      "Whole store or a changeset?" = {
-        Type       = "Choice"
-        InputPath  = "$.detail"
-        Default    = "Run transformer on ECS"
-        OutputPath = "$"
-        Choices = [
-          {
-            Variable  = "$.changeset_ids[0]"
-            IsPresent = true
-            Next      = "Run transformer"
-          }
-        ]
-      }
-
       "Run transformer" = {
-        Type     = "Task"
-        Resource = module.transformer_lambda.lambda.arn
-        Next     = "Success"
+        Type             = "Task"
+        Resource         = "arn:aws:states:::ecs:runTask.waitForTaskToken"
+        TimeoutSeconds   = local.transformer_task_token_timeout_seconds
+        HeartbeatSeconds = local.transformer_task_token_heartbeat_seconds
+        Next             = "Success"
         Retry = [
           {
-            ErrorEquals     = ["Lambda.ServiceException", "Lambda.AWSLambdaException", "Lambda.SdkClientException"]
-            IntervalSeconds = 2
-            MaxAttempts     = 3
-            BackoffRate     = 2.0
-          }
-        ]
-      }
-
-      # runTask.sync rather than waitForTaskToken: nothing downstream reads the
-      # result, and .sync surfaces a task that never starts instead of hanging
-      # on a token that is never sent.
-      "Run transformer on ECS" = {
-        Type     = "Task"
-        Resource = "arn:aws:states:::ecs:runTask.sync"
-        Next     = "Success"
-        Retry = [
-          {
-            ErrorEquals     = ["ECS.AmazonECSException", "ECS.InvalidParameterException"]
+            ErrorEquals     = ["States.TaskFailed", "States.Timeout"]
             IntervalSeconds = 30
             MaxAttempts     = 3
             BackoffRate     = 2.0
           }
         ]
-        Parameters = {
+        Arguments = {
           Cluster        = aws_ecs_cluster.cluster.arn
           TaskDefinition = module.transformer_ecs_task.task_definition_arn
           LaunchType     = "FARGATE"
@@ -135,8 +107,12 @@ locals {
           Overrides = {
             ContainerOverrides = [
               {
-                "Name"      = "${local.namespace}-transformer"
-                "Command.$" = "States.Array('/app/src/adapters/steps/transformer.py', '--transformer-type', $.transformer_type, '--job-id', $.job_id, '--use-rest-api-table', '--es-mode', 'private')"
+                Name = "${local.namespace}-transformer"
+                Command = [
+                  "/app/src/adapters/steps/transformer.py",
+                  "--event", "{% $string($states.input.detail) %}",
+                  "--task-token", "{% $states.context.Task.Token %}"
+                ]
               }
             ]
           }
@@ -148,6 +124,12 @@ locals {
       }
     }
   })
+
+  # The task heartbeats every 60s, so the state notices a dead task in minutes
+  # rather than waiting out the timeout. The timeout is the backstop for a run
+  # that never starts heartbeating at all.
+  transformer_task_token_timeout_seconds   = 12 * 60 * 60
+  transformer_task_token_heartbeat_seconds = 5 * 60
 
   transformer_types = {
     ebsco = {
@@ -183,7 +165,6 @@ module "transformer_state_machine" {
     "read_axiell_adapter_bucket" = data.aws_iam_policy_document.adapter_bucket_read["axiell"].json
     "read_folio_adapter_bucket"  = data.aws_iam_policy_document.adapter_bucket_read["folio"].json
     "run_transformer_ecs_task"   = module.transformer_ecs_task.invoke_policy_document
-    "transformer_run_task_sync"  = data.aws_iam_policy_document.transformer_run_task_sync.json
   }
 }
 


### PR DESCRIPTION
## What does this change?

Moves the adapter transformer from a Lambda to a Fargate task, for every transform rather than only large ones.

A reindex sends no changeset ids, so the transformer has to stream, MARCXML-transform and bulk-index the **entire** adapter store in a single run. For Axiell that is 206,526 records in a Lambda capped at `Timeout=600`, needing roughly 344 records/sec sustained just to finish.

If it overruns, it does not recover. The state machine's `Retry` covers `Lambda.ServiceException`, `Lambda.AWSLambdaException` and `Lambda.SdkClientException`; a timeout is none of those. The run fails partway, leaves the index half-populated, writes no `TransformerReport`, and cannot fire the `transformer-failures` alarm because `failure_count` is only published on success. So wellcomecollection/platform#6445 could not have reindexed Axiell as things stood.

## Why every transform, rather than routing by size

An earlier version of this branch kept chunked runs on the Lambda and sent only whole-store runs to ECS. Routing by size meant two code paths to reason about and a branch condition (`changeset_ids` present or not) quietly carrying the safety story: an adapter event that legitimately arrived with no changesets would have started a full-store transform instead of a quick no-op.

One path is simpler and the task is cheap to start. Harvest-sized runs are no worse off.

## How

The task runs `ecs_handler` from `utils/steps`, the same entrypoint the graph extractor, both ingestors and the EBSCO loader use, rather than a bespoke argv. Following the existing handler brings three things this needs for free:

- the event arrives as JSON, so changeset ids survive without inventing a way to splat a variable-length list into a command
- `es_mode` defaults to `private`, which is what the Lambda ran with. A hand-rolled CLI could not reach that: `--es-mode` offers only `local` and `public`
- the task heartbeats every 60s, so a dead task is noticed in minutes

That last point is what makes `waitForTaskToken` the right call here, matching the sibling state machines. Without heartbeats it would have been the risky option, since a task that never starts leaves the state hanging. `HeartbeatSeconds` is 5 minutes with a 12 hour timeout as the backstop, the same figures the graph extractor and ingestors use.

The task definition reuses the `ecs_task` module and the same unified image the graph steps run, at 4096 CPU and 16384 memory, mirroring the adapter loader.

### Checklist

- [x] Does this change the display model the catalogue API returns? No, it changes where a transform runs, not what it produces.

## How to test

`uv run pytest tests/adapters` passes (1008 tests); mypy and ruff are clean on the changed file.

The rendered ASL validates:

```
aws stepfunctions validate-state-machine-definition --definition file://asl.json
{"result": "OK", "diagnostics": [], "truncated": false}
```

Once applied, both paths exercise the same state: an `adapter.completed` event from a harvest, and `uv run start_reindex.py --src axiell --dst catalogue --mode complete` (needs wellcomecollection/catalogue-pipeline#3520) for the whole-store case.

## How can we measure success?

A full Axiell reindex completes instead of timing out, and `works-source-2026-07-03` reaches roughly 206k Axiell records with a `TransformerReport` written. Harvest-sized transforms keep working as they do now.

## Have we considered potential risks?

**Every adapter transform changes shape at once**, including the routine harvest path that currently works. That is the trade for having one path rather than two, but it does mean the blast radius is all adapter sources rather than just reindexes.

**A Fargate task starts slower than a Lambda.** For a 15-minute harvest window carrying a handful of records, the run is now dominated by task startup. Worth watching that window processing still comfortably fits its schedule.

**The Lambda is deliberately left in place.** It is no longer invoked, but nothing has exercised the ECS path against real data, so it stays as the way back. It should be removed once this has run a real reindex and a few days of harvests.

**Sizing is a starting point.** If a full Axiell run needs more than 16GB, that is one variable.
