### PR TITLE
Add a schedule_enabled toggle and pause the folio adapter

### DIFF
--- a/catalogue_graph/infra/adapters/main.tf
+++ b/catalogue_graph/infra/adapters/main.tf
@@ -31,11 +31,14 @@ module "axiell" {
 }
 
 module "folio" {
-  source                 = "./modules/adapter"
-  namespace              = "folio"
-  steps_namespace        = "oai_pmh"
-  s3_bucket_name         = "wellcomecollection-platform-folio-adapter"
-  schedule_expression    = "rate(15 minutes)"
+  source              = "./modules/adapter"
+  namespace           = "folio"
+  steps_namespace     = "oai_pmh"
+  s3_bucket_name      = "wellcomecollection-platform-folio-adapter"
+  schedule_expression = "rate(15 minutes)"
+  # Paused: overlapping runs were colliding on Iceberg commits, causing a
+  # self-sustaining pileup of failed executions. Re-enable once resolved.
+  schedule_enabled       = false
   repository_url         = data.aws_ecr_repository.unified_pipeline_lambda.repository_url
   event_bus_name         = aws_cloudwatch_event_bus.event_bus.name
   ecs_cluster_arn        = aws_ecs_cluster.adapters.arn

--- a/catalogue_graph/infra/adapters/modules/adapter/schedule.tf
+++ b/catalogue_graph/infra/adapters/modules/adapter/schedule.tf
@@ -6,7 +6,7 @@ resource "aws_scheduler_schedule" "adapter_run" {
   }
 
   schedule_expression = var.schedule_expression
-  state               = "ENABLED"
+  state               = var.schedule_enabled ? "ENABLED" : "DISABLED"
 
   target {
     arn      = aws_sfn_state_machine.state_machine.arn

--- a/catalogue_graph/infra/adapters/modules/adapter/variables.tf
+++ b/catalogue_graph/infra/adapters/modules/adapter/variables.tf
@@ -19,6 +19,12 @@ variable "schedule_expression" {
   description = "Schedule pattern for adapter runs"
 }
 
+variable "schedule_enabled" {
+  type        = bool
+  default     = true
+  description = "Whether the adapter run schedule is enabled. Set false to pause a misbehaving adapter without destroying the schedule resource."
+}
+
 variable "event_bus_name" {
   type        = string
   description = "Name of the EventBridge event bus associated with the adapter"


### PR DESCRIPTION
## What does this change?

The `folio-adapter` Step Function is scheduled every 15 minutes with no concurrency guard. Runs normally finish in under a minute, but on 2026-07-30 something (likely a FOLIO data wipe/restore) made the OAI diff for one window much larger, and run duration ballooned past the 15-minute interval. Overlapping executions then started colliding on the same Iceberg table commit (`CommitFailedException: branch main has changed`), retrying, and piling up further, since each new scheduled run landed on top of the backlog rather than the source settling down on its own.

The schedule was paused by hand via `aws scheduler update-schedule` to stop the pileup and 7 stuck executions were stopped, but `schedule.tf` hardcodes `state = "ENABLED"`, so that pause was pure drift: the next `terraform apply` on this stack would have silently turned it back on.

This adds a `schedule_enabled` variable (default `true`, so every other adapter is unaffected) and sets it `false` for `folio`, so the pause is explicit in code and reviewable, rather than only living in an AWS API call.

### Checklist

- [x] Doesn't change the display model the catalogue API returns.

## How to test

`terraform validate` passes. On apply, `folio_adapter_run`'s schedule state should read `DISABLED` (`aws scheduler get-schedule --name folio_adapter_run`); all other adapter schedules are unaffected.

## How can we measure success?

The `folio-adapter-failed` CloudWatch alarm should stay quiet with the schedule off. Re-enabling is just deleting the `schedule_enabled = false` line once we're confident the source has settled and/or the adapter has a concurrency guard so this doesn't recur.

## Have we considered potential risks?

Folio harvesting is fully paused until this is reverted, so any FOLIO catalogue changes made while this is merged won't reach the pipeline. That's already true in prod since the CLI-level pause; this just makes it visible and durable.