### PR TITLE
Let the id-minter state machine take an explicit window

### DIFF
--- a/pipeline/terraform/modules/pipeline_new/service_id_minter.tf
+++ b/pipeline/terraform/modules/pipeline_new/service_id_minter.tf
@@ -51,6 +51,6 @@ module "id_minter_lambda" {
   alarm_topic_arn = local.monitoring_infra["chatbot_topic_arn"]
 
   # Identifier-dense windows peak ~4.5GB; 2048 OOMs.
-  lambda_memory_size = 6144
+  memory_size = 6144
 }
 

--- a/pipeline/terraform/modules/pipeline_new/service_id_minter.tf
+++ b/pipeline/terraform/modules/pipeline_new/service_id_minter.tf
@@ -49,5 +49,8 @@ module "id_minter_lambda" {
   secret_env_vars = local.id_minter_secret_env_vars
   rds_secret_name = local.rds_master_secret_name
   alarm_topic_arn = local.monitoring_infra["chatbot_topic_arn"]
+
+  # Identifier-dense windows peak ~4.5GB; 2048 OOMs.
+  lambda_memory_size = 6144
 }
 

--- a/pipeline/terraform/modules/pipeline_new/state_machine_id_minter.tf
+++ b/pipeline/terraform/modules/pipeline_new/state_machine_id_minter.tf
@@ -6,14 +6,10 @@ locals {
     States = {
       ConstructEvent = {
         Type = "Pass",
-        Output = {
-          "pipeline_date" : var.pipeline_date,
-          # window end time is 5 minutes before the scheduled time
-          "window" : {
-            "end_time" : "{% $fromMillis($toMillis($states.input.scheduled_time) - 300000) %}"
-          }
-        },
-        Next = "InvokeIdMinter"
+        # Replays may pass an explicit window and job_id; scheduled runs
+        # derive the window end from scheduled_time - 5min.
+        Output = "{% $merge([{'pipeline_date': '${var.pipeline_date}'}, {'window': $exists($states.input.window) ? $states.input.window : {'end_time': $fromMillis($toMillis($states.input.scheduled_time) - 300000)}}, $exists($states.input.job_id) ? {'job_id': $states.input.job_id} : {}]) %}",
+        Next   = "InvokeIdMinter"
       }
       InvokeIdMinter = {
         Type     = "Task"

--- a/pipeline/terraform/modules/pipeline_new/state_machine_id_minter.tf
+++ b/pipeline/terraform/modules/pipeline_new/state_machine_id_minter.tf
@@ -6,15 +6,19 @@ locals {
     States = {
       ConstructEvent = {
         Type = "Pass",
-        # Replays may pass an explicit window and job_id; scheduled runs
-        # derive the window end from scheduled_time - 5min.
+        # Replays may pass source_identifiers or an explicit window, plus a
+        # job_id; scheduled runs derive the window end from scheduled_time -
+        # 5min. Shape guards keep malformed input (e.g. window: null) from
+        # reaching the Lambda as "no window", which would mint the full index.
         Output = trimspace(<<-EOT
           {% $merge([
             {'pipeline_date': '${var.pipeline_date}'},
-            {'window': $exists($states.input.window)
-              ? $states.input.window
-              : {'end_time': $fromMillis($toMillis($states.input.scheduled_time) - 300000)}},
-            $exists($states.input.job_id) ? {'job_id': $states.input.job_id} : {}
+            $type($states.input.source_identifiers) = 'array'
+              ? {'source_identifiers': $states.input.source_identifiers}
+              : {'window': $exists($states.input.window.end_time)
+                  ? $states.input.window
+                  : {'end_time': $fromMillis($toMillis($states.input.scheduled_time) - 300000)}},
+            $type($states.input.job_id) = 'string' ? {'job_id': $states.input.job_id} : {}
           ]) %}
         EOT
         ),

--- a/pipeline/terraform/modules/pipeline_new/state_machine_id_minter.tf
+++ b/pipeline/terraform/modules/pipeline_new/state_machine_id_minter.tf
@@ -8,8 +8,17 @@ locals {
         Type = "Pass",
         # Replays may pass an explicit window and job_id; scheduled runs
         # derive the window end from scheduled_time - 5min.
-        Output = "{% $merge([{'pipeline_date': '${var.pipeline_date}'}, {'window': $exists($states.input.window) ? $states.input.window : {'end_time': $fromMillis($toMillis($states.input.scheduled_time) - 300000)}}, $exists($states.input.job_id) ? {'job_id': $states.input.job_id} : {}]) %}",
-        Next   = "InvokeIdMinter"
+        Output = trimspace(<<-EOT
+          {% $merge([
+            {'pipeline_date': '${var.pipeline_date}'},
+            {'window': $exists($states.input.window)
+              ? $states.input.window
+              : {'end_time': $fromMillis($toMillis($states.input.scheduled_time) - 300000)}},
+            $exists($states.input.job_id) ? {'job_id': $states.input.job_id} : {}
+          ]) %}
+        EOT
+        ),
+        Next = "InvokeIdMinter"
       }
       InvokeIdMinter = {
         Type     = "Task"

--- a/pipeline/terraform/modules/pipeline_services/id_minter/main.tf
+++ b/pipeline/terraform/modules/pipeline_services/id_minter/main.tf
@@ -26,7 +26,7 @@ module "id_minter_lambda" {
     command = ["id_minter.steps.id_minter.lambda_handler"]
   }
 
-  memory_size = 2048
+  memory_size = var.lambda_memory_size
   timeout     = 900
 
   environment_variables = merge(

--- a/pipeline/terraform/modules/pipeline_services/id_minter/main.tf
+++ b/pipeline/terraform/modules/pipeline_services/id_minter/main.tf
@@ -26,7 +26,7 @@ module "id_minter_lambda" {
     command = ["id_minter.steps.id_minter.lambda_handler"]
   }
 
-  memory_size = var.lambda_memory_size
+  memory_size = var.memory_size
   timeout     = 900
 
   environment_variables = merge(

--- a/pipeline/terraform/modules/pipeline_services/id_minter/variables.tf
+++ b/pipeline/terraform/modules/pipeline_services/id_minter/variables.tf
@@ -33,7 +33,7 @@ variable "env_vars" {
   })
 }
 
-variable "lambda_memory_size" {
+variable "memory_size" {
   type    = number
   default = 2048
 }

--- a/pipeline/terraform/modules/pipeline_services/id_minter/variables.tf
+++ b/pipeline/terraform/modules/pipeline_services/id_minter/variables.tf
@@ -33,6 +33,11 @@ variable "env_vars" {
   })
 }
 
+variable "lambda_memory_size" {
+  type    = number
+  default = 2048
+}
+
 variable "secret_env_vars" {
   type = map(string)
 }


### PR DESCRIPTION
## What does this change?

Lets a manually started execution of the `pipeline-<date>_id_minter` state machine pass an explicit `window` or a list of `source_identifiers`, and optionally a `job_id`, instead of only ever deriving the fixed 15-minute window from `scheduled_time`. Scheduled runs are unchanged. This matches the passthrough the graph extractors state machine already has.

Input shapes are guarded: JSONata `$exists(null)` is true, so an unguarded passthrough would have turned `window: null` (an easy serialization slip) into an unbounded full-index mint. Malformed windows now degrade to a validation failure in the Lambda; the guard behaviour is verified against jsonata 2.x for each shape.

Also raises the 2026-07-03 id-minter Lambda to 6144MB, parameterised on the shared module so production stays at 2048.

## Why

During the wellcomecollection/platform#6445 reindex, 2.6M records landed in three consecutive id-minter windows. All three failed (one timeout, two OOMs), and window mode has no backfill, so the pipeline moved on without them. Recovery means re-minting those ranges in slices small enough to fit the Lambda's 900s ceiling, which the state machine previously had no way to express.

The memory figure comes from replaying the worst window at higher memory: it peaked at 4490MB, where 2048 OOMed within seconds. 6144 leaves 37% headroom. The replay also showed throughput is unchanged by memory (the constraint is serial DB round trips, at roughly 500 identifiers/sec), so slicing is needed regardless.

A replay execution's input looks like:

```json
{"job_id": "replay-1630-slice-03", "window": {"start_time": "2026-07-30T16:32:00Z", "end_time": "2026-07-30T16:34:00Z"}}
```

`job_id` matters for concurrent slices: the Lambda's generated one is minute-granular, so two slices started in the same minute would collide on their report names.

### Checklist

- [x] Does this change the display model the catalogue API returns? No, it changes how the id-minter can be invoked, not what it produces.

## How to test

The rendered ASL validates:

```
aws stepfunctions validate-state-machine-definition --definition file://asl.json
{"result": "OK", "diagnostics": [], "truncated": false}
```

`terraform fmt -check` is clean on the changed files. Needs a manual apply of `pipeline/terraform/2026-07-03` after merge; check the plan for strays first.
