### PR TITLE
Raise the 2026-07-03 id-minter RDS ceiling to 32 ACU

### DIFF
--- a/infrastructure/critical/rds_id_minter.tf
+++ b/infrastructure/critical/rds_id_minter.tf
@@ -43,5 +43,7 @@ module "id_minter_rds_2026_07_03" {
   admin_cidr_ingress = local.admin_cidr_ingress
   engine_version     = "8.0.mysql_aurora.3.10.3"
 
+  max_scaling_capacity = 32
+
   master_username = data.aws_ssm_parameter.rds_username.value
 }


### PR DESCRIPTION
## What does this change?

Raises `max_scaling_capacity` for the `identifiers-v2-serverless-2026-07-03` cluster from the 16 ACU module default to 32. Production and test keep the default.

## Why

The wellcomecollection/platform#6445 reindex recovery replays the failed id-minter windows as 4 concurrent Step Functions executions (see #3524). Under that load the cluster pins at 16/16 ACU with 90-97% CPU, making the database the throughput ceiling for the remaining ~30M identifier mints.

The change was applied live on 2026-07-31 with `--apply-immediately` to unblock the running recovery (Serverless v2 max raises are online, no restart); this PR records it so the next `infrastructure/critical` apply is a no-op rather than a silent revert. Scale-down after the reindex is tracked with the other #6445 teardown items.

### Checklist

- [x] Does this change the display model the catalogue API returns? No.

## How to test

`terraform fmt -check` clean. The live cluster already reports `{MinCapacity: 0.5, MaxCapacity: 32}`, so plan should show no change after merge.