### PR TITLE
Don't fail the ingestor indexer step on benign version conflicts

### DIFF
--- a/catalogue_graph/src/ingestor/steps/ingestor_indexer.py
+++ b/catalogue_graph/src/ingestor/steps/ingestor_indexer.py
@@ -41,6 +41,18 @@ RECORD_CLASSES: dict[IngestorType, type[IndexableRecord]] = {
 }
 
 
+def _is_version_conflict(error: dict[str, typing.Any]) -> bool:
+    """True if a bulk error is a benign `external_gte` version conflict (the
+    document already has a version >= the one we tried to write)."""
+    for action_result in error.values():
+        if (
+            action_result.get("error", {}).get("type")
+            == "version_conflict_engine_exception"
+        ):
+            return True
+    return False
+
+
 def _get_objects_to_index(
     base_event: IngestorStepEvent,
 ) -> Generator[IngestorIndexerObject]:
@@ -125,19 +137,32 @@ def handler(
         total_success_count += success_count
         all_es_errors += es_errors
 
+    version_conflicts = [e for e in all_es_errors if _is_version_conflict(e)]
+    other_errors = [e for e in all_es_errors if not _is_version_conflict(e)]
+
+    if version_conflicts:
+        logger.warning(
+            "Skipped documents already at a newer version (version conflict)",
+            count=len(version_conflicts),
+        )
+
     event_payload = event.model_dump(exclude={"objects_to_index"})
 
     logger.info("Preparing indexer pipeline report")
-    report = IndexerReport(**event_payload, success_count=total_success_count)
+    report = IndexerReport(
+        **event_payload,
+        success_count=total_success_count,
+        version_conflict_count=len(version_conflicts),
+    )
     report.publish()
 
-    if all_es_errors:
+    if other_errors:
         logger.error(
             "Bulk indexing errors encountered",
-            total_errors=len(all_es_errors),
-            first_errors=all_es_errors[:5],
+            total_errors=len(other_errors),
+            first_errors=other_errors[:5],
         )
-        raise RuntimeError(f"Bulk indexing failed with {len(all_es_errors)} error(s)")
+        raise RuntimeError(f"Bulk indexing failed with {len(other_errors)} error(s)")
 
     return IngestorIndexerMonitorLambdaEvent(
         **event_payload,

--- a/catalogue_graph/src/utils/reporting.py
+++ b/catalogue_graph/src/utils/reporting.py
@@ -168,10 +168,16 @@ class LoaderReport(IngestorReport):
 class IndexerReport(IngestorReport):
     label: ClassVar[str] = "indexer"
     success_count: int
+    version_conflict_count: int = 0
 
     @property
     def metrics(self) -> list[PipelineMetric]:
-        return [PipelineMetric(name="success_count", value=self.success_count)]
+        return [
+            PipelineMetric(name="success_count", value=self.success_count),
+            PipelineMetric(
+                name="version_conflict_count", value=self.version_conflict_count
+            ),
+        ]
 
 
 class DeletionReport(IngestorReport):

--- a/catalogue_graph/tests/mocks.py
+++ b/catalogue_graph/tests/mocks.py
@@ -421,6 +421,7 @@ class MockElasticsearchClient:
     inputs: list[dict] = []
     pit_index: str
     queries: list[dict] = []
+    bulk_errors: list[dict] = []
 
     def __init__(
         self, config: dict, api_key: str, timeout: float | None = None
@@ -440,13 +441,16 @@ class MockElasticsearchClient:
         # Accept elasticsearch.helpers.bulk extra parameters to avoid TypeError in tests
         for op in operations:
             cls.inputs.append(op)
-        return (len(cls.inputs), [])  # emulate success_count, no errors
+        errors = cls.bulk_errors
+        cls.bulk_errors = []
+        return (len(cls.inputs) - len(errors), errors)
 
     @classmethod
     def reset_mocks(cls) -> None:
         cls.inputs = []
         cls.indexed_documents = defaultdict(dict[str, dict])
         cls.queries = []
+        cls.bulk_errors = []
 
     @classmethod
     def index(cls, index: str, id: str, document: dict) -> None:  # noqa: A003

--- a/catalogue_graph/tests/test_ingestor_indexer.py
+++ b/catalogue_graph/tests/test_ingestor_indexer.py
@@ -107,6 +107,7 @@ def test_ingestor_indexer_discovers_parquet_objects(record_type: IngestorType) -
         "ids": None,
         "pit_ids": {"merged": None, "augmented": None},
         "success_count": len(expected_inputs),
+        "version_conflict_count": 0,
     }
 
 
@@ -173,7 +174,97 @@ def test_ingestor_indexer_handles_explicit_objects(record_type: IngestorType) ->
         "ids": None,
         "pit_ids": {"merged": None, "augmented": None},
         "success_count": len(expected_inputs),
+        "version_conflict_count": 0,
     }
+
+
+def _make_bulk_error(error_type: str, doc_id: str = "conflicted-id") -> dict[str, Any]:
+    return {
+        "index": {
+            "_index": "works-indexed",
+            "_id": doc_id,
+            "status": 409,
+            "error": {"type": error_type, "reason": "mock reason"},
+        }
+    }
+
+
+@freeze_time("2025-01-01T12:00:00Z")
+def test_ingestor_indexer_ignores_version_conflicts() -> None:
+    record_type: IngestorType = "works"
+    pipeline_date = "2025-01-01"
+    index_date = "2025-01-01"
+    job_id = "20250930T0930"
+    event = IngestorIndexerLambdaEvent(
+        ingestor_type=record_type,
+        pipeline_date=pipeline_date,
+        graph_date=pipeline_date,
+        index_dates=PipelineIndexDates.model_validate({record_type: index_date}),
+        job_id=job_id,
+        objects_to_index=None,
+    )
+
+    prefix = event.get_path_prefix()
+    bucket = config.CATALOGUE_GRAPH_S3_BUCKET
+    key = f"{prefix}/00000000-00000010.parquet"
+    s3_uri = f"s3://{bucket}/{key}"
+
+    parquet_bytes = load_fixture(f"ingestor/{record_type}/00000000-00000010.parquet")
+    MockS3Client.add_list_objects_response(
+        bucket=bucket,
+        prefix=prefix,
+        contents=[{"Key": key, "Size": len(parquet_bytes)}],
+    )
+    MockSmartOpen.mock_s3_file(s3_uri, parquet_bytes)
+
+    mock_es_secrets(f"{record_type}_ingestor", pipeline_date)
+    expected_inputs = load_json_fixture(f"ingestor/{record_type}/mock_es_inputs.json")
+    MockElasticsearchClient.bulk_errors = [
+        _make_bulk_error("version_conflict_engine_exception")
+    ]
+
+    result = handler(event)
+
+    assert result.success_count == len(expected_inputs) - 1
+
+    report = _read_indexer_report(event)
+    assert report["version_conflict_count"] == 1
+    assert report["success_count"] == len(expected_inputs) - 1
+
+
+@freeze_time("2025-01-01T12:00:00Z")
+def test_ingestor_indexer_raises_on_non_conflict_errors() -> None:
+    record_type: IngestorType = "works"
+    pipeline_date = "2025-01-01"
+    index_date = "2025-01-01"
+    job_id = "20250930T0930"
+    event = IngestorIndexerLambdaEvent(
+        ingestor_type=record_type,
+        pipeline_date=pipeline_date,
+        graph_date=pipeline_date,
+        index_dates=PipelineIndexDates.model_validate({record_type: index_date}),
+        job_id=job_id,
+        objects_to_index=None,
+    )
+
+    prefix = event.get_path_prefix()
+    bucket = config.CATALOGUE_GRAPH_S3_BUCKET
+    key = f"{prefix}/00000000-00000010.parquet"
+    s3_uri = f"s3://{bucket}/{key}"
+
+    parquet_bytes = load_fixture(f"ingestor/{record_type}/00000000-00000010.parquet")
+    MockS3Client.add_list_objects_response(
+        bucket=bucket,
+        prefix=prefix,
+        contents=[{"Key": key, "Size": len(parquet_bytes)}],
+    )
+    MockSmartOpen.mock_s3_file(s3_uri, parquet_bytes)
+
+    mock_es_secrets(f"{record_type}_ingestor", pipeline_date)
+    MockElasticsearchClient.bulk_errors = [_make_bulk_error("mapper_parsing_exception")]
+
+    with pytest.raises(RuntimeError, match="Bulk indexing failed with 1 error"):
+        handler(event)
 
 
 def test_ingestor_indexer_failure_invalid_data_concepts() -> None:


### PR DESCRIPTION
## What does this change?

Elasticsearch's `external_gte` versioning rejects individual documents whose version is already superseded by a concurrent writer — this is expected behaviour, not a real failure. The ingestor indexer step (`catalogue_graph/src/ingestor/steps/ingestor_indexer.py`) previously treated *any* non-empty bulk error list as fatal, failing the whole window (and losing its data, since failed windows aren't automatically retried) even when the only "errors" were harmless version conflicts.

This change splits bulk errors into `version_conflict_engine_exception`s (logged as a warning, no longer fatal) and everything else (still raises `RuntimeError` and fails the step, as before). It also adds a `version_conflict_count` field to `IndexerReport`, published through the existing S3 report and CloudWatch metric pipeline (alongside `success_count`), so conflict volume stays visible without needing to fail the step.

### Checklist

- [ ] Does this change the display model the catalogue API returns? If so, regenerate the test documents under `catalogue_graph/document_generators/test_documents`. The `wellcomecollection/catalogue-api` repo copies them in with `copy_test_documents.py`, and its OpenAPI contract tests validate the published spec against them, so stale fixtures let the spec drift.

## How to test

- `uv run pytest tests/test_ingestor_indexer.py tests/adapters/transformers/test_reporting.py` (from `catalogue_graph/`) — includes two new tests: one confirming a window with only version-conflict errors succeeds and reports the conflict count, one confirming any other bulk error type still raises.
- `uv run ruff check` / `uv run ruff format --check` / `uv run mypy` on the changed files.

## How can we measure success?

- The `works` ingestor (and any other ingestor type) should stop failing Step Functions executions purely due to version conflicts — check the `graph-pipeline-ingestor-<date>` executions for a drop in `IngestorLoaderError`/bulk-indexing failures.
- The new `version_conflict_count` CloudWatch metric (namespace `catalogue_graph_pipeline`, dimensioned by `ingestor_type`/`index_date` like `success_count`) gives visibility into how often this happens per run.

## Have we considered potential risks?

- Only `version_conflict_engine_exception` is treated as non-fatal; every other Elasticsearch bulk error type (mapping errors, illegal arguments, etc.) still fails the step exactly as before, so genuine data/indexing problems aren't silently swallowed.
- This does not change indexing behaviour or document versions — it only changes whether the step raises when the *only* errors present are conflicts Elasticsearch was already going to reject regardless.
