### PR TITLE
Chunk id-minter lookups by (OntologyType, SourceSystem)

### DIFF
--- a/catalogue_graph/src/id_minter/resolvers/minting_resolver.py
+++ b/catalogue_graph/src/id_minter/resolvers/minting_resolver.py
@@ -9,6 +9,9 @@ Minting IdResolver implementation supporting:
 
 from __future__ import annotations
 
+from collections import defaultdict
+from itertools import batched
+
 import structlog
 
 from id_minter.config import DBConfig
@@ -16,6 +19,9 @@ from id_minter.database import DBConnection, DBCursor, get_connection
 from id_minter.models.identifier import MintRequest, SourceIdentifierKey
 
 logger = structlog.get_logger(__name__)
+
+# Larger chunks exhaust MySQL's range optimizer budget, degrading to a full index scan.
+LOOKUP_CHUNK_SIZE = 1000
 
 
 class MintingResolver:
@@ -81,32 +87,39 @@ class MintingResolver:
         if not source_ids:
             return {}
 
+        return self._lookup_chunked(source_ids)
+
+    def _lookup_chunked(
+        self,
+        source_ids: list[SourceIdentifierKey],
+        for_share: bool = False,
+    ) -> dict[SourceIdentifierKey, str]:
+        """Chunked lookup. FOR SHARE joins whatever transaction is open on self.conn."""
+        groups: dict[tuple[str, str], set[str]] = defaultdict(set)
+        for ontology_type, source_system, source_id in source_ids:
+            groups[(ontology_type, source_system)].add(source_id)
+
+        suffix = " FOR SHARE" if for_share else ""
         cursor = self.conn.cursor()
 
-        # Build query with IN clause for batch lookup of mixed ontology types
-        # Using tuple comparison: (OntologyType, SourceSystem, SourceId) IN ((?, ?, ?), ...)
-        placeholders = ", ".join(["(%s, %s, %s)"] * len(source_ids))
-        params = []
-        for ontology_type, source_system, source_id in source_ids:
-            params.extend([ontology_type, source_system, source_id])
-
-        cursor.execute(
-            f"""
-            SELECT OntologyType, SourceSystem, SourceId, CanonicalId 
-            FROM identifiers 
-            WHERE (OntologyType, SourceSystem, SourceId) IN ({placeholders})
-        """,
-            params,
-        )
-
-        results = cursor.fetchall()
-
-        return {
-            SourceIdentifierKey(
-                row["OntologyType"], row["SourceSystem"], row["SourceId"]
-            ): row["CanonicalId"]
-            for row in results
-        }
+        result: dict[SourceIdentifierKey, str] = {}
+        # Sorted probes are far faster than random order against a large index.
+        for (ontology_type, source_system), values in sorted(groups.items()):
+            for chunk in batched(sorted(values), LOOKUP_CHUNK_SIZE):
+                placeholders = ", ".join(["%s"] * len(chunk))
+                cursor.execute(
+                    f"SELECT OntologyType, SourceSystem, SourceId, CanonicalId"
+                    f" FROM identifiers"
+                    f" WHERE OntologyType = %s AND SourceSystem = %s"
+                    f" AND SourceId IN ({placeholders}){suffix}",
+                    [ontology_type, source_system, *chunk],
+                )
+                for row in cursor.fetchall():
+                    key = SourceIdentifierKey(
+                        row["OntologyType"], row["SourceSystem"], row["SourceId"]
+                    )
+                    result[key] = row["CanonicalId"]
+        return result
 
     def mint_ids(self, requests: list[MintRequest]) -> dict[SourceIdentifierKey, str]:
         """
@@ -374,25 +387,7 @@ class MintingResolver:
             # MySQL's REPEATABLE READ isolation would return the transaction's
             # snapshot, missing rows committed by other transactions since ours
             # started.
-            placeholders = ", ".join(["(%s, %s, %s)"] * len(needs_new_id))
-            params = []
-            for ontology_type, source_system, source_id in needs_new_id:
-                params.extend([ontology_type, source_system, source_id])
-            cursor.execute(
-                f"""
-                SELECT OntologyType, SourceSystem, SourceId, CanonicalId
-                FROM identifiers
-                WHERE (OntologyType, SourceSystem, SourceId) IN ({placeholders})
-                FOR SHARE
-            """,
-                params,
-            )
-            actual = {
-                SourceIdentifierKey(
-                    row["OntologyType"], row["SourceSystem"], row["SourceId"]
-                ): row["CanonicalId"]
-                for row in cursor.fetchall()
-            }
+            actual = self._lookup_chunked(needs_new_id, for_share=True)
 
             # Step 7: Mark only used IDs as 'assigned'
             # ---------------------------------------------------------------------


### PR DESCRIPTION
## What does this change?

The id-minter flattened a 500-work batch into one lookup carrying up to ~21,000 row-constructor tuples (`WHERE (OntologyType, SourceSystem, SourceId) IN ((%s,%s,%s), ...)`). MySQL's range optimizer needs roughly 2KB per tuple, so past ~4,000 tuples the default 8MB `range_optimizer_max_mem_size` is exceeded and the range plan is discarded. Ref access is not available as a fallback either, because the pymysql connection is utf8mb4 while the columns are latin1. What is left is a full index scan of the 50,537,580-row identifiers table: 2 to 6 seconds per SELECT, pinning the database through a reindex even though 99.97% of lookups are hits (2,419,158 identifiers looked up, 776 new).

`lookup_ids` and the FOR SHARE race-detection re-read now take the shape the sibling `DataApiIdResolver` already uses: group keys by (OntologyType, SourceSystem), sort the SourceIds, and issue equality plus single-column IN queries in chunks of 1,000. Every query stays on the range plan, and sorted probes measured 45x faster than random order on the live table (5.4ms vs 247ms for 1,000 keys), where the old code randomised order via `list(set(...))`.

Relates to wellcomecollection/platform#6445, the reindex whose recovery surfaced this.

<details><summary>Deeper rationale and known follow-ups</summary>

- The deleted Scala id-minter avoided this query shape on purpose: its `IdentifiersDao` carried comments saying large mixed IN lists cause full index scans and that client-side grouping was "many, many orders of magnitude faster". That defence did not survive the Python port, so this is a relearned lesson rather than a new finding.
- The utf8mb4 connection against latin1 columns is left alone. It only bites once the range budget is blown, which this change prevents, and aligning it would move encoding failures client-side: pymysql maps MySQL latin1 to cp1252, so the 15 stored ids like `žižek` and `ricœur` that sit outside ISO-8859-1 are fine, but genuinely out-of-repertoire input such as CJK would raise `UnicodeEncodeError` instead of being coerced. Worth a follow-up, not this PR.
- Pre-existing, not introduced or fixed here: result keys are rebuilt from the DB row values, so under the case-insensitive `latin1_swedish_ci` primary key a stored row whose casing differs from the requested key matches SQL-side but then misses the Python dict lookup, silently dropping the id. Recorded here so it is not lost.

</details>

### Checklist

- [ ] Does this change the display model the catalogue API returns? No. This changes how canonical IDs are looked up, not what is produced, so the test documents do not need regenerating.

## How to test

Deployed to the 2026-07-03 id-minter Lambda via the `:dev` tag and measured against the identical workload (the platform#6445 reindex recovery, same slices, same 6-way concurrency), so the code change was the only variable:

| Metric | Before | After |
|---|---|---|
| Dense slice runtime | 660 to 920s, ~14% hitting the 900s Lambda timeout | 60 to 80s |
| Identifier throughput | ~460/sec | ~7,500/sec |
| Works throughput | ~20/sec | ~141/sec |
| Peak Lambda memory | 4,490 MB | 1,783 MB |
| Timeouts | frequent | zero |

A smoke slice did 390,220 identifiers in 51.8s, `failure_count` 0, no per-work fallback. For correctness, the old and new query shapes were run against the live table over a 700-key sample deliberately including all 50 of the non-ASCII stored ids, and returned byte-identical results, 700/700 found. Locally, `uv run pytest tests/id_minter` passes (146 tests against the docker MySQL) and mypy and ruff are clean.

## How can we measure success?

id-minter Lambda duration and peak memory for dense slices, which should sit well inside the 900s timeout rather than at ~14% timeouts, and Aurora CPU during the remainder of the 6445 reindex.

## Have we considered potential risks?

The query shape is the only thing that changes: same signature, found-only results, and the same transaction boundaries, since transactions are connection-scoped and the FOR SHARE re-read joins the open mint transaction either way. It does trade one large statement for several small ones, so the re-read now holds its row locks across a handful of statements rather than one, still within the same transaction and now for far less wall-clock time. The local benchmark script showed only 10 to 18% on a small loopback table, which cannot reproduce the 50M-row scan pathology, so the live measurements above are the real evidence.
