### PR TITLE
Keep the reindexer's SNS Subject inside the 100 character limit

### DIFF
--- a/reindexer/scripts/start_reindex.py
+++ b/reindexer/scripts/start_reindex.py
@@ -128,7 +128,8 @@ def publish_messages(job_config_id, topic_arn, parameters):
             TopicArn=topic_arn,
             MessageStructure="json",
             Message=json.dumps({"default": json.dumps(to_publish)}),
-            Subject=f"Source: {__file__}",
+            # Basename, not the full path: SNS caps Subject at 100 characters.
+            Subject=f"Source: {os.path.basename(__file__)}",
         )
         assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200, resp
 


### PR DESCRIPTION
## What does this change?

`start_reindex.py` set the SNS `Subject` to the full `__file__` path. SNS caps `Subject` at 100 characters, and since Python 3.9 `__file__` is always absolute, so the reindexer aborted on its first publish from any checkout with a long path. Every git worktree qualifies. Using the basename keeps the identifying part and stays well inside the limit.

This was hit while starting the Miro reindex for wellcomecollection/platform#6445: the worktree path produced a 134 character Subject and `botocore.errorfactory.InvalidParameterException: Invalid parameter: Subject`. It fails on the first message, so no reindex was ever half-started, but the script was unusable from that path.

### Checklist

- [x] Does this change the display model the catalogue API returns? No. It changes an SNS message attribute on an operator script and nothing about the documents we produce.

## How to test

No automated test. Verified by re-running the previously failing reindex command from the same worktree path and watching all 469 Miro segment messages publish, after which the reindex ran normally.

## How can we measure success?

The reindexer runs from a worktree instead of failing immediately.

## Have we considered potential risks?

Low. The Subject is informational only, nothing consumes it, and the failure mode being fixed was total rather than partial.
