### PR TITLE
Bound SAME_AS traversals to 8 hops

### DIFF
--- a/catalogue_graph/src/ingestor/queries/concept_queries.py
+++ b/catalogue_graph/src/ingestor/queries/concept_queries.py
@@ -15,13 +15,17 @@ CONCEPT_TYPE_QUERY = """
     RETURN concept.id AS id, COLLECT(concept_type) AS types
 """
 
+# SAME_AS hops are bounded: unbounded traversal enumerates edge-distinct paths,
+# which explodes combinatorially in dense clusters and exceeds the Neptune query
+# timeout. The deepest real cluster needs 5 hops (measured 2026-08-01), so 8 is
+# lossless with headroom.
 SOURCE_CONCEPT_QUERY = """
     UNWIND $ids AS id
     MATCH (concept:Concept {`~id`: id})
-    MATCH (concept)-[:HAS_SOURCE_CONCEPT]->(linked_source_concept)-[:SAME_AS*0..]->(source_concept)
+    MATCH (concept)-[:HAS_SOURCE_CONCEPT]->(linked_source_concept)-[:SAME_AS*0..8]->(source_concept)
 
-    RETURN 
-        concept.id AS id, 
+    RETURN
+        concept.id AS id,
         collect(DISTINCT linked_source_concept) AS linked_source_concepts,
         collect(DISTINCT source_concept) AS source_concepts
 """
@@ -30,7 +34,7 @@ SOURCE_CONCEPT_QUERY = """
 SAME_AS_CONCEPT_QUERY = """
     UNWIND $ids AS id
     MATCH (concept:Concept {`~id`: id})
-    MATCH (concept)-[:HAS_SOURCE_CONCEPT]->(linked_source_concept)-[:SAME_AS*0..]->(source_concept)
+    MATCH (concept)-[:HAS_SOURCE_CONCEPT]->(linked_source_concept)-[:SAME_AS*0..8]->(source_concept)
     MATCH (source_concept)<-[:HAS_SOURCE_CONCEPT]-(same_as_concept)
     WHERE same_as_concept <> concept
 


### PR DESCRIPTION
## What does this change?

Bounds the `[:SAME_AS*0..]` traversal in `SAME_AS_CONCEPT_QUERY` and `SOURCE_CONCEPT_QUERY` to `*0..8`. The related-concept queries in the same file already bound this traversal at `*0..2`; these two were the only unbounded ones left.

## Why

openCypher enumerates edge-distinct paths, not visited nodes, so a dense `SAME_AS` cluster explodes combinatorially. The Andrew J. Offutt pseudonym cluster (15 authority records for one author's pen names, 28 mutual edges) yields billions of paths, so any ingestor batch touching it exceeds Neptune's 120s query timeout and fails its whole window. This lost ~2,900 works during the wellcomecollection/platform#6445 reindex, five attempts out of five, including on an idle cluster. Raising the timeout cannot help.

## Choosing 8

A bound of N is lossless if every cluster member is within N hops by shortest path. A census of all 3.55M `SAME_AS` edges (2026-08-01) found:

- deepest real cluster: 5 hops (Wikidata/LCSH/MeSH agriculture terms), the only one past 4
- 29 clusters need 4 hops; the remaining 1.76M need 3 or fewer
- depth stays shallow structurally: edges only connect Wikidata items to LoC/MeSH equivalents

So 8 covers the observed maximum with three hops of headroom. If reconciliation ever deepens chains, an exceeded bound degrades gracefully (a missing synonym on a healthy document) rather than failing windows.

### Checklist

- [ ] Does this change the display model the catalogue API returns? No: results are identical for every cluster in the current graph, only enumeration cost changes.

## How to test

- `uv run pytest tests/ingestor tests/test_ingestor_loader.py tests/test_ingestor_indexer.py` passes (78 tests); ruff and mypy clean
- against the live 2026-07-03 cluster: the culprit concept goes from a 120s timeout to 1.1s, and the exact 5,686-id batch that reproduced the window failure completes in 23s

## How can we measure success?

After the ingestor image deploys, replaying the lost window (`graph-pipeline-incremental-2026-07-03`, 2026-07-31T08:50:30Z to 08:50:45Z) should succeed and close the last gap between `works-denormalised` and `works-indexed`.

## Have we considered potential risks?

Truncation is the only theoretical risk and the census shows it cannot trigger on current data. Without the bound the failure recurs: the graph holds other dense clusters, including a node with `SAME_AS` out-degree 50.
