### PR TITLE
Skip and alarm on permanently undownloadable images in the inferrer

### DIFF
--- a/catalogue_graph/src/inferrer/models.py
+++ b/catalogue_graph/src/inferrer/models.py
@@ -72,11 +72,11 @@ class FindWorkEvent(BasePipelineEvent):
 
 
 class InferenceManagerResult(BaseModel):
-    # An inference task is all-or-nothing: if any requested image cannot be
-    # fully and validly augmented the task fails, so on success `processed`
-    # (initial images found) equals `augmented` (documents written).
+    # All-or-nothing except permanently undownloadable assets, which are
+    # skipped and counted, so processed = augmented + download_failure_count.
     processed: int
     augmented: int
+    download_failure_count: int = 0
 
 
 class FindWorkResult(BaseModel):

--- a/catalogue_graph/src/inferrer/reporting.py
+++ b/catalogue_graph/src/inferrer/reporting.py
@@ -1,0 +1,39 @@
+from typing import ClassVar
+
+from pydantic import Field
+
+from utils.reporting import PipelineMetric, PipelineReport
+
+
+class InferenceReport(PipelineReport):
+    """CloudWatch metrics for an inference task; download_failure_count is alarmed."""
+
+    label: ClassVar[str] = "inference_manager"
+
+    pipeline_date: str
+    augmented_count: int
+    download_failure_count: int
+
+    # Metrics only; per-task S3 reports would be noise at partition granularity.
+    publish_to_s3: bool = Field(default=False, exclude=True)
+
+    @property
+    def publish_to_cloudwatch(self) -> bool:
+        return self.pipeline_date != "dev"
+
+    @property
+    def metric_namespace(self) -> str:
+        return "catalogue_graph_pipeline"
+
+    @property
+    def metric_dimensions(self) -> dict:
+        return {"pipeline_date": self.pipeline_date}
+
+    @property
+    def metrics(self) -> list[PipelineMetric]:
+        return [
+            PipelineMetric(name="augmented_count", value=self.augmented_count),
+            PipelineMetric(
+                name="download_failure_count", value=self.download_failure_count
+            ),
+        ]

--- a/catalogue_graph/src/inferrer/steps/inference_manager.py
+++ b/catalogue_graph/src/inferrer/steps/inference_manager.py
@@ -22,6 +22,8 @@ from elasticsearch import Elasticsearch
 
 from inferrer.adapters import FEATURE_VECTOR_SIZE, INFERRERS, call_inferrer
 from inferrer.image_downloader import (
+    ImageDownloadError,
+    _TransientImageDownloadError,
     delete_image,
     download_image,
     file_url,
@@ -31,6 +33,7 @@ from inferrer.models import (
     InferenceManagerResult,
     InitialImage,
 )
+from inferrer.reporting import InferenceReport
 from ingestor.models.augmented.image import (
     AugmentedImage,
     AugmentedImageState,
@@ -167,11 +170,28 @@ def handler(
 
     images = retrieve_initial_images(es_client, initial_index, ids)
 
-    # All-or-nothing: if any image fails to download, fails an inferrer, or would
-    # produce a poisoned doc, the exception propagates and fails the whole task
-    # (the state machine then retries). We never index a partial/poisoned batch.
+    # All-or-nothing, with one carve-out: an image whose asset permanently fails
+    # to download (e.g. a 404) is skipped and counted, since it would otherwise
+    # deterministically block every other image in the task on each retry. Any
+    # transient download error, inferrer failure, or poisoned doc still fails
+    # the whole task. We never index a partial/poisoned batch.
+    def augment_or_skip(image: InitialImage) -> AugmentedImage | None:
+        try:
+            return augment_image(image)
+        except _TransientImageDownloadError:
+            raise
+        except ImageDownloadError as e:
+            logger.warning(
+                "Skipping image whose asset cannot be downloaded",
+                image_id=image.state.canonical_id,
+                error=str(e),
+            )
+            return None
+
     with ThreadPoolExecutor(max_workers=IMAGE_PARALLELISM) as pool:
-        augmented = list(pool.map(augment_image, images))
+        results = list(pool.map(augment_or_skip, images))
+    augmented = [a for a in results if a is not None]
+    download_failure_count = len(results) - len(augmented)
 
     for image in augmented:
         if image.state.augmented_time is None:
@@ -194,8 +214,18 @@ def handler(
         "Inference complete",
         processed=len(images),
         augmented=len(augmented),
+        download_failures=download_failure_count,
     )
-    return InferenceManagerResult(processed=len(images), augmented=len(augmented))
+    InferenceReport(
+        pipeline_date=event.pipeline_date,
+        augmented_count=len(augmented),
+        download_failure_count=download_failure_count,
+    ).publish()
+    return InferenceManagerResult(
+        processed=len(images),
+        augmented=len(augmented),
+        download_failure_count=download_failure_count,
+    )
 
 
 def event_validator(raw_input: str) -> InferenceManagerEvent:

--- a/catalogue_graph/tests/inferrer/test_inference_manager.py
+++ b/catalogue_graph/tests/inferrer/test_inference_manager.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 
 from inferrer.adapters import FEATURE_VECTOR_SIZE, INFERRERS
-from inferrer.image_downloader import file_url, local_image_path
+from inferrer.image_downloader import ImageDownloadError, file_url, local_image_path
 from inferrer.models import InferenceManagerEvent
 from inferrer.steps import inference_manager
 from inferrer.steps.inference_manager import (
@@ -20,7 +20,12 @@ from tests.inferrer.factories import (
     initial_image_doc,
     make_initial_image,
 )
-from tests.mocks import MockElasticsearchClient, MockRequest, mock_es_secrets
+from tests.mocks import (
+    MockCloudwatchClient,
+    MockElasticsearchClient,
+    MockRequest,
+    mock_es_secrets,
+)
 from utils.aws import pydantic_to_s3_json
 
 PIPELINE_DATE = "2026-06-01"
@@ -187,3 +192,65 @@ def test_event_validator_parses_inline_event() -> None:
     assert resolved.ids == ["a"]
     assert resolved.pipeline_date == PIPELINE_DATE
     assert resolved.graph_date == "2026-01-01"
+
+
+def test_handler_skips_permanently_undownloadable_image(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A 404 asset is skipped and counted; the rest of the batch still indexes."""
+    monkeypatch.setattr(inference_manager, "IMAGES_ROOT", str(tmp_path))
+    mock_es_secrets("inferrer", PIPELINE_DATE)
+
+    good = make_initial_image("imgA", INFO_JSON_URL)
+    bad_info = "http://iiif.test/image/imgGone/info.json"
+    bad_thumb = "http://iiif.test/image/imgGone/full/!400,400/0/default.jpg"
+    for cid, url in [("imgA", INFO_JSON_URL), ("imgGone", bad_info)]:
+        MockElasticsearchClient.index(
+            index=f"images-initial-{PIPELINE_DATE}",
+            id=cid,
+            document=initial_image_doc(cid, url),
+        )
+    MockRequest.mock_response(method="GET", url=THUMBNAIL_URL, content_bytes=b"jpeg")
+    MockRequest.mock_response(method="GET", url=bad_thumb, status_code=404)
+    _mock_inferrers(file_url(local_image_path(good, str(tmp_path))))
+
+    event = InferenceManagerEvent(
+        pipeline_date=PIPELINE_DATE, graph_date=PIPELINE_DATE, ids=["imgA", "imgGone"]
+    )
+    result = inference_manager.handler(event, es_mode="private")
+
+    assert result.processed == 2
+    assert result.augmented == 1
+    assert result.download_failure_count == 1
+    indexed = MockElasticsearchClient.inputs
+    assert [d["_id"] for d in indexed] == ["imgA"]
+    reported = [
+        m
+        for m in MockCloudwatchClient.metrics_reported
+        if m["metric_name"] == "download_failure_count"
+    ]
+    assert reported and reported[-1]["value"] == 1
+    assert reported[-1]["dimensions"]["pipeline_step"] == "inference_manager"
+
+
+def test_handler_still_fails_on_transient_download_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A retry-exhausted transient failure (e.g. 503) still fails the task."""
+    monkeypatch.setattr(inference_manager, "IMAGES_ROOT", str(tmp_path))
+    monkeypatch.setattr("time.sleep", lambda *_a, **_k: None)
+    mock_es_secrets("inferrer", PIPELINE_DATE)
+
+    MockElasticsearchClient.index(
+        index=f"images-initial-{PIPELINE_DATE}",
+        id="imgA",
+        document=initial_image_doc("imgA", INFO_JSON_URL),
+    )
+    MockRequest.mock_response(method="GET", url=THUMBNAIL_URL, status_code=503)
+
+    event = InferenceManagerEvent(
+        pipeline_date=PIPELINE_DATE, graph_date=PIPELINE_DATE, ids=["imgA"]
+    )
+    with pytest.raises(ImageDownloadError):
+        inference_manager.handler(event, es_mode="private")
+    assert MockElasticsearchClient.inputs == []

--- a/pipeline/terraform/modules/pipeline_new/ecs_task_inference_manager.tf
+++ b/pipeline/terraform/modules/pipeline_new/ecs_task_inference_manager.tf
@@ -182,3 +182,37 @@ resource "aws_iam_role_policy" "inference_manager_s3_read" {
   role   = module.inference_manager_ecs_task.task_role_name
   policy = data.aws_iam_policy_document.inference_manager_s3_read.json
 }
+
+# The task publishes augmented_count and download_failure_count metrics.
+data "aws_iam_policy_document" "inference_manager_cloudwatch_write" {
+  statement {
+    actions   = ["cloudwatch:PutMetricData"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "inference_manager_cloudwatch_write" {
+  role   = module.inference_manager_ecs_task.task_role_name
+  policy = data.aws_iam_policy_document.inference_manager_cloudwatch_write.json
+}
+
+# Skipped downloads succeed the task, so the state machine alarm cannot see
+# them; alarm on the metric instead.
+resource "aws_cloudwatch_metric_alarm" "image_inferrer_download_failures" {
+  alarm_name          = "image-inferrer-download-failures-${var.pipeline_date}"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "download_failure_count"
+  namespace           = "catalogue_graph_pipeline"
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 0
+  alarm_description   = "The image inferrer skipped images whose assets permanently failed to download"
+
+  dimensions = {
+    pipeline_date = var.pipeline_date
+    pipeline_step = "inference_manager"
+  }
+
+  alarm_actions = [local.monitoring_infra["chatbot_topic_arn"]]
+}

--- a/pipeline/terraform/modules/pipeline_new/ecs_task_inference_manager.tf
+++ b/pipeline/terraform/modules/pipeline_new/ecs_task_inference_manager.tf
@@ -188,6 +188,12 @@ data "aws_iam_policy_document" "inference_manager_cloudwatch_write" {
   statement {
     actions   = ["cloudwatch:PutMetricData"]
     resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "cloudwatch:namespace"
+      values   = ["catalogue_graph_pipeline"]
+    }
   }
 }
 


### PR DESCRIPTION
## What does this change?

An inference task was all-or-nothing: one image whose asset 404s fails the whole task, and because partitioning is deterministic, the same healthy neighbours are sacrificed on every retry. Exactly three missing IIIF assets held 364 healthy Miro images out of `images-augmented` during the wellcomecollection/platform#6445 reindex, unrecoverable by any number of replays.

A permanent download failure (a non-retryable response such as a 404, or an image with no IIIF location) is now skipped and counted. Transient failures, inferrer errors and poisoned docs still fail the task, and no partial or poisoned batch is ever indexed.

Skipping succeeds the task, which would blind the state machine failure alarm, so visibility moves to a metric:

- the task publishes `download_failure_count` and `augmented_count` to the `catalogue_graph_pipeline` namespace, mirroring the adapter transformers
- the task role gains `cloudwatch:PutMetricData`, which it previously lacked
- a new alarm on `download_failure_count > 0` notifies the chatbot topic, the same shape as the live `*-transformer-failures-*` alarms

### Checklist

- [ ] Does this change the display model the catalogue API returns? No. It changes which failures stop an inference batch, not what an augmented document contains.

## How to test

`uv run pytest tests/inferrer` passes (34 tests, two new: a 404 neighbour is skipped and counted while the rest of the batch indexes and the metric records; a retry-exhausted 503 still fails the task and indexes nothing). ruff, mypy and `terraform fmt` clean.

## How can we measure success?

After deploy plus a terraform apply of `2026-07-03` (the metric grant and alarm ship inert without it), replaying the three affected inferrer windows should take `images-augmented` from 122,891 to 123,252, leaving only the three genuinely assetless images, and the new alarm should fire once as they are skipped, which doubles as its live test.

## Have we considered potential risks?

The skip is deliberately narrow: only non-transient `ImageDownloadError` is caught, so outages (5xx, network) still fail loudly and retry. The residual risk is an asset that fails permanently but recoverably (e.g. a transient 403), which would mis-classify as permanent; the image would be picked up by any later window that touches it, and the alarm makes the occurrence visible.
