### PR TITLE
Scale the 2026-07-03 pipeline back down after the reindex

### DIFF
--- a/infrastructure/critical/es_cluster.tf
+++ b/infrastructure/critical/es_cluster.tf
@@ -7,10 +7,8 @@ module "es_cluster_2026_07_03" {
 
   cluster_date = "2026-07-03"
 
-  # Sized for the full reindex, matching what 2025-10-02 scales to for one.
-  # Back to the 4g across 3 zones default once wellcomecollection/platform#6445 is signed off.
-  memory     = "30g"
-  node_count = 2
+  memory     = "4g"
+  node_count = 3
 
   traffic_filter_ids = [
     local.shared_infra["ec_platform_privatelink_traffic_filter_id"],

--- a/pipeline/terraform/2026-07-03/main.tf
+++ b/pipeline/terraform/2026-07-03/main.tf
@@ -3,8 +3,8 @@ module "pipeline" {
 
   reindexing_state = {
     listen_to_reindexer = true
-    scale_up_tasks      = true
-    scale_up_matcher_db = true
+    scale_up_tasks      = false
+    scale_up_matcher_db = false
   }
 
   index_dates = {


### PR DESCRIPTION
## What does this change?

Reverts the wellcomecollection/platform#6445 reindex sizing now the load is complete: `scale_up_tasks` and `scale_up_matcher_db` to false in the `2026-07-03` stack, and the `2026-07-03` ES cluster from 30g x 2 back to the 4g x 3 default, as the sizing comment from wellcomecollection/catalogue-pipeline#3519 promised.

`listen_to_reindexer` stays true so targeted replays remain possible.

### Checklist

- [ ] Does this change the display model the catalogue API returns? No.

## How to test

Two manual applies after merge: `pipeline/terraform/2026-07-03` (scale flags) and `infrastructure/critical` (ES cluster; the plan change can only run once a day). Both plans should show only the scale-down resources.

## Have we considered potential risks?

The matcher DynamoDB drops to steady-state provisioned capacity and the inference cluster to smaller instances; both only matter under bulk load, which has ended. The ES downsize shrinks hot-tier headroom for the comparison work in wellcomecollection/platform#6464, which reads the indices but writes nothing, so the idle sizing is appropriate.