### PR TITLE
do not subscribe to calm_adapter_topic if disable variable is true

### DIFF
--- a/pipeline/terraform/2026-07-03/main.tf
+++ b/pipeline/terraform/2026-07-03/main.tf
@@ -21,10 +21,11 @@ module "pipeline" {
   # Base AMI for ECS instances
   ami_id = "resolve:ssm:arn:aws:ssm:eu-west-1:760097843905:parameter/imagebuilder/weco-al2023-ecs-optimised-x86_64/latest"
 
-  enable_adapter_transformer_trigger = true
-  enable_id_minter_schedule          = true
-  enable_graph_pipeline_schedule     = true
-  enable_image_inferrer_schedule     = true
+  enable_adapter_transformer_trigger           = true
+  disable_calm_transformer_topic_subscriptions = true
+  enable_id_minter_schedule                    = true
+  enable_graph_pipeline_schedule               = true
+  enable_image_inferrer_schedule               = true
 
   pipeline_date = local.pipeline_date // namespaces services
   graph_date    = "2026-07-03"        // namespaces graph database

--- a/pipeline/terraform/modules/pipeline_new/service_transformers.tf
+++ b/pipeline/terraform/modules/pipeline_new/service_transformers.tf
@@ -63,7 +63,12 @@ module "transformers" {
 
   source_name = each.key
 
-  adapter_config      = local.adapter_config[each.key]
+  adapter_config = merge(
+    local.adapter_config[each.key],
+    {
+      topics = var.disable_calm_transformer_topic_subscriptions && each.key == "calm" ? [] : local.adapter_config[each.key].topics
+    }
+  )
   listen_to_reindexer = var.reindexing_state.listen_to_reindexer
 
   queue_visibility_timeout_seconds = lookup(each.value, "queue_visibility_timeout_seconds", 30)

--- a/pipeline/terraform/modules/pipeline_new/variables.tf
+++ b/pipeline/terraform/modules/pipeline_new/variables.tf
@@ -78,6 +78,12 @@ variable "enable_adapter_transformer_trigger" {
   description = "Whether the EventBridge rule that starts the transformer on <adapter>.adapter.completed events is enabled."
 }
 
+variable "disable_calm_transformer_topic_subscriptions" {
+  type        = bool
+  default     = false
+  description = "When true, the calm transformer does not subscribe its input queue to adapter topics in everyday mode."
+}
+
 variable "enable_id_minter_schedule" {
   type        = bool
   default     = false

--- a/pipeline/terraform/modules/transformer/main.tf
+++ b/pipeline/terraform/modules/transformer/main.tf
@@ -39,4 +39,3 @@ module "transformer" {
 
   trigger_values = var.trigger_values
 }
-


### PR DESCRIPTION
## What does this change?

This updates the `pipeline_new` transformer wiring so the CALM transformer can skip adapter-topic subscriptions in everyday mode for the `2026-07-03` stack, without changing behaviour in the older `2025-10-02` stack.

Specifically:

- adds a new `pipeline_new` module variable:
  - `disable_calm_transformer_topic_subscriptions` (default `false`)
- in `modules/pipeline_new/service_transformers.tf`, overrides `adapter_config.topics` to `[]` only when:
  - `each.key == "calm"` and
  - `disable_calm_transformer_topic_subscriptions = true`
- enables that flag in `pipeline/terraform/2026-07-03/main.tf`
- leaves `listen_to_reindexer` logic unchanged, so when reindex subscriptions are enabled in stack config, CALM can still subscribe to the reindex topic

Net effect:

- `2026-07-03` (`pipeline_new`) can disable CALM adapter/deletions topic subscriptions.
- `2025-10-02` (`pipeline`) is unaffected and keeps existing subscription behaviour.

### Checklist

- [ ] Does this change the display model the catalogue API returns? If so, regenerate the test documents under `catalogue_graph/document_generators/test_documents`. The `wellcomecollection/catalogue-api` repo copies them in with `copy_test_documents.py`, and its OpenAPI contract tests validate the published spec against them, so stale fixtures let the spec drift.

## How to test

From repo root:

1. Check formatting of touched Terraform files:
   - `terraform fmt -check pipeline/terraform/modules/pipeline_new/service_transformers.tf pipeline/terraform/modules/pipeline_new/variables.tf pipeline/terraform/2026-07-03/main.tf`

2. In `pipeline/terraform/2026-07-03`, run a plan and confirm CALM adapter/deletions subscriptions are not present when the disable flag is set:
   - `./run_terraform.sh plan`
   - check there is no create/update for CALM input subscriptions to `calm_adapter_topic` / `calm_deletions_topic`

3. (Optional regression check) In `pipeline/terraform/2025-10-02`, run plan and confirm existing subscription behaviour is unchanged:
   - `./run_terraform.sh plan`

## How can we measure success?

- In everyday operation for `2026-07-03`, the CALM transformer input queue should no longer receive messages from CALM adapter/deletions topics.
- Reindex behaviour remains available via the existing reindexer subscription controls.
- No unexpected subscription changes appear in the `2025-10-02` stack.

## Have we considered potential risks?

- **Risk:** accidental behaviour drift across stacks.
  - **Mitigation:** change is isolated to `pipeline_new` and explicitly enabled only in `2026-07-03/main.tf`.
