### PR TITLE
Fix handling of date type q and partial years in EBSCO transformer

### DIFF
--- a/catalogue_graph/src/adapters/transformers/ebsco/parsers/field008.py
+++ b/catalogue_graph/src/adapters/transformers/ebsco/parsers/field008.py
@@ -126,7 +126,7 @@ class Field008:
         >>> Field008("||||||m191u195u").maximal_date_range
         '1910-1959'
 
-        Date type q represents a questionable date between two years. 
+        Date type q represents a questionable date between two years.
         We treat it as a range like d and m
         >>> Field008("||||||q19251956").maximal_date_range
         '1925-1956'
@@ -163,7 +163,7 @@ class Field008:
             return f"{date_1.replace('u', '0')}-{date_2.replace('u', '9')}"
 
         if date_type == "q":
-            # q means a questionable date between date 1 and date 2, 
+            # q means a questionable date between date 1 and date 2,
             # but we will treat it like d and m
             date_2 = self.raw_field.date_2
             return f"{date_1.replace('u', '0')}-{date_2.replace('u', '9')}"

--- a/catalogue_graph/src/adapters/transformers/ebsco/parsers/field008.py
+++ b/catalogue_graph/src/adapters/transformers/ebsco/parsers/field008.py
@@ -125,6 +125,11 @@ class Field008:
         '1900-2009'
         >>> Field008("||||||m191u195u").maximal_date_range
         '1910-1959'
+
+        Date type q represents a questionable date between two years. 
+        We treat it as a range like d and m
+        >>> Field008("||||||q19251956").maximal_date_range
+        '1925-1956'
         """
         date_type = self.raw_field.date_type
         if date_type in "n|":
@@ -154,6 +159,12 @@ class Field008:
             # but for our purposes, they both represent a range.
             # d is an actual range of publication of a continuing resource
             # m is a pair of dates for a multipart item.
+            date_2 = self.raw_field.date_2
+            return f"{date_1.replace('u', '0')}-{date_2.replace('u', '9')}"
+
+        if date_type == "q":
+            # q means a questionable date between date 1 and date 2, 
+            # but we will treat it like d and m
             date_2 = self.raw_field.date_2
             return f"{date_1.replace('u', '0')}-{date_2.replace('u', '9')}"
 

--- a/catalogue_graph/src/adapters/transformers/ebsco/parsers/field008.py
+++ b/catalogue_graph/src/adapters/transformers/ebsco/parsers/field008.py
@@ -154,17 +154,12 @@ class Field008:
                 return f"{date_1.replace('u', '0')}-{date_1.replace('u', '9')}"
             return date_1
 
-        if date_type in "dm":
-            # these two have subtly different meanings in MARC,
-            # but for our purposes, they both represent a range.
+        if date_type in "dmq":
+            # d, m, and q all have subtly different meanings in MARC,
+            # for our purposes, we will treat all three the same, as a range of dates.
             # d is an actual range of publication of a continuing resource
-            # m is a pair of dates for a multipart item.
-            date_2 = self.raw_field.date_2
-            return f"{date_1.replace('u', '0')}-{date_2.replace('u', '9')}"
-
-        if date_type == "q":
-            # q means a questionable date between date 1 and date 2,
-            # but we will treat it like d and m
+            # m is a pair of dates for a multipart item
+            # q is a questionable date between two years
             date_2 = self.raw_field.date_2
             return f"{date_1.replace('u', '0')}-{date_2.replace('u', '9')}"
 

--- a/catalogue_graph/src/adapters/transformers/ebsco/parsers/period.py
+++ b/catalogue_graph/src/adapters/transformers/ebsco/parsers/period.py
@@ -9,7 +9,16 @@ from models.pipeline.identifier import Identifiable, Unidentifiable
 # or &amp;#41; (rparen) as the numbers 40 and 41 respectively.
 RE_DISCARD = re.compile(r"(&(amp;)?.+?;)")
 
-RE_KEEP = re.compile(r"\d{2,4}|-")
+# A digit run immediately followed by just enough dashes to pad it to a
+# 4-character year is a MARC convention for an unknown trailing digit, e.g.
+# "182-" (the 1820s), "19--" (the 1900s). The specific 3+1/2+2/1+3
+# alternatives must come before the general `\d{2,4}` fallback, otherwise a
+# *complete* 4-digit year followed by a real range-separator dash (e.g.
+# "1956-", meaning "1956 onwards") would be mistaken for a partial year.
+RE_KEEP = re.compile(r"\d{3}-(?!-)|\d{2}-{2}(?!-)|\d-{3}(?!-)|\d{2,4}|-")
+
+# Matches a partial year: 1-3 digits padded to 4 characters with dashes.
+RE_PARTIAL_YEAR = re.compile(r"^\d{1,3}-{1,3}$")
 
 # matcher for "nth century" with any single trailing punctuation
 # actually matches any character at all directly after century, but
@@ -31,11 +40,23 @@ def parse_period(
     giving a concrete date/time range.
     >>> parse_period("1988-1990")
     Period(id=Unidentifiable(canonical_id=None, type='Unidentifiable'), label='1988-1990', type='Period', range=DateTimeRange(from_time='1988-01-01T00:00:00Z', to_time='1990-12-31T23:59:59.999999999Z', label='1988-1990'))
+
+    Messy/partial years are recovered where possible.
+    >>> parse_period("1825-[19--?]").range
+    DateTimeRange(from_time='1825-01-01T00:00:00Z', to_time='1999-12-31T23:59:59.999999999Z', label='1825-[19--?]')
+
+    Anything else degrades to a label-only Period rather than raising.
+    >>> parse_period("mid century")
+    Period(id=Unidentifiable(canonical_id=None, type='Unidentifiable'), label='mid century', type='Period', range=None)
     """
     range_fn = century_to_range if "century" in period else to_range
+    try:
+        date_range = range_fn(period)
+    except ValueError:
+        date_range = None
     return Period(
         label=period,
-        range=range_fn(period),
+        range=date_range,
         type="Period",
         id=identifier if identifier else Unidentifiable(),
     )
@@ -92,6 +113,26 @@ def to_range(period: str) -> DateTimeRange:
     '1977'
     >>> r.to_time[:4]
     '1986'
+
+    A trailing dash on a partial year is a MARC convention for an unknown
+    trailing digit - "182-" means somewhere in the 1820s.
+    >>> r = to_range("182-")
+    >>> r.from_time
+    '1820-01-01T00:00:00Z'
+    >>> r.to_time
+    '1829-12-31T23:59:59.999999999Z'
+
+    An open lower bound.
+    >>> r = to_range("- 1792")
+    >>> r.to_time
+    '1792-12-31T23:59:59.999999999Z'
+
+    An abbreviated end year.
+    >>> r = to_range("1742 - 44")
+    >>> r.from_time
+    '1742-01-01T00:00:00Z'
+    >>> r.to_time
+    '1744-12-31T23:59:59.999999999Z'
     """
     from_part, to_part = crack(preprocess(period))
     return DateTimeRange.model_validate(
@@ -142,6 +183,12 @@ def preprocess(period: str) -> str:
     A year might only be two digits, with the century being implied
     >>> preprocess("1961-72 [v. 3, c1973]")
     '1961 - 72 1973'
+
+    A trailing "--" is kept attached to its digits as a single unknown-digit
+    token, rather than being split into separate hyphens by the range
+    separator logic.
+    >>> preprocess("1825-[19--?]")
+    '1825 - 19--'
     """
     return " ".join(RE_KEEP.findall(RE_DISCARD.sub("", period)))
 
@@ -182,29 +229,55 @@ def crack(range_string: str) -> tuple[str, str]:
     It is also possible that the to part consists of multiple years, not all of them being complete
     >>> crack("1961 - 72 1973")
     ('1961', '1973')
+
+    A partial year with no explicit end is its own decade/century - both
+    bounds resolve from the same placeholder (see start_of_year/end_of_year).
+    >>> crack("182-")
+    ('182-', '182-')
+
+    A partial year can appear as the "to" part of a range too.
+    >>> crack("1825 - 19--")
+    ('1825', '19--')
+
+    Non-year content (e.g. roman numerals) can leave a meaningless standalone
+    hyphen behind; it's discarded in favour of the real separator.
+    >>> crack("- 1788 - 1789")
+    ('1788', '1789')
+
+    A trailing hyphen left the same way isn't an abbreviated end year either.
+    >>> crack("1794 - -")
+    ('1794', '')
     """
-    # if it's hyphenated - partition will put the parts in the right place.
-    (from_part, sep, to_part) = range_string.partition("-")
-    from_part = from_part.strip()
-    to_part = to_part.strip()
+    # Split on whitespace rather than partitioning on "-" directly: a
+    # partial year like "19--" has its dashes glued to its digits, so only a
+    # standalone "-" (its own space-separated part) is a real separator.
+    parts = range_string.split(" ")
 
-    if from_part and sep and to_part:
-        # If from_part consists of multiple year entries (e.g. "2024 2025"), extract the lowest one
-        from_part = min(from_part.split(" "))
+    if "-" in parts:
+        # A leading "-" with nothing before it is either an open lower bound
+        # ("- 1812") or a leftover from discarded non-year content preceding
+        # the real range - only the latter if another "-" remains to split on.
+        while parts[0] == "-" and parts.count("-") > 1:
+            parts = parts[1:]
+
+        separator = parts.index("-")
+        from_parts = parts[:separator]
+        # A bare "-" here is noise, not a digit to fill in as an end year.
+        to_parts = [part for part in parts[separator + 1 :] if part != "-"]
+        from_part = min(from_parts) if from_parts else ""
         # Fill in any implied missing numbers in the to part.
-        to_part = max(
-            fill_year_prefix(from_part, to_year) for to_year in to_part.split(" ")
+        to_part = (
+            max(fill_year_prefix(from_part, to_year) for to_year in to_parts)
+            if from_part and to_parts
+            else max(to_parts, default="")
         )
+    elif len(parts) == 1:
+        # it's just one date (or a lone partial year, standing for its own range)
+        from_part = to_part = parts[0]
+    else:
+        from_part, to_part = min(parts), max(parts)
 
-    if not sep:
-        parts = from_part.split(" ")
-        if len(parts) == 1:
-            # it's just one date
-            to_part = from_part
-        else:
-            from_part = min(parts)
-            to_part = max(parts)
-    return from_part.strip(), to_part.strip()
+    return from_part, to_part
 
 
 def fill_year_prefix(from_year: str, to_year: str) -> str:
@@ -235,11 +308,33 @@ def fill_year_prefix(from_year: str, to_year: str) -> str:
     return to_year
 
 
+def resolve_partial_year(year: str, fill: str) -> str:
+    """
+    Fill a partial year's unknown trailing digits with `fill` - "0" resolves
+    the start of its decade/century/millennium, "9" the end.
+    >>> resolve_partial_year("182-", "0")
+    '1820'
+    >>> resolve_partial_year("182-", "9")
+    '1829'
+    >>> resolve_partial_year("19--", "9")
+    '1999'
+
+    A complete year is returned unchanged.
+    >>> resolve_partial_year("1980", "9")
+    '1980'
+    """
+    if RE_PARTIAL_YEAR.fullmatch(year):
+        return year.replace("-", fill)
+    return year
+
+
 def start_of_year(year: str) -> str:
+    year = resolve_partial_year(year, "0")
     return (datetime(int(year), 1, 1) if year else datetime.min).isoformat() + "Z"
 
 
 def end_of_year(year: str) -> str:
+    year = resolve_partial_year(year, "9")
     return (
         (
             datetime(int(year), 12, 31, 23, 59, 59, 1000000 - 1)

--- a/catalogue_graph/src/adapters/transformers/ebsco/parsers/period.py
+++ b/catalogue_graph/src/adapters/transformers/ebsco/parsers/period.py
@@ -7,18 +7,15 @@ from models.pipeline.identifier import Identifiable, Unidentifiable
 # Explicitly discard SGML escape sequences and doubly-escaped sequences.
 # This prevents the RE_KEEP sequence misinterpreting &#40; (lparen)
 # or &amp;#41; (rparen) as the numbers 40 and 41 respectively.
-RE_DISCARD = re.compile(r"(&(amp;)?.+?;)")
+#
+# Square brackets are also discarded. They're already meaningless to RE_KEEP
+# (only digits and hyphens survive), but a bracket sitting between two digits
+# of the same year - e.g. "1[841-1849]", really "1841-1849" with a stray
+# bracket inserted - would otherwise split what should be a single 4-digit
+# year into an isolated "1" (dropped, being a single digit) and "841".
+RE_DISCARD = re.compile(r"(&(amp;)?.+?;)|[\[\]]")
 
-# A digit run immediately followed by just enough dashes to pad it to a
-# 4-character year is a MARC convention for an unknown trailing digit, e.g.
-# "182-" (the 1820s), "19--" (the 1900s). The specific 3+1/2+2/1+3
-# alternatives must come before the general `\d{2,4}` fallback, otherwise a
-# *complete* 4-digit year followed by a real range-separator dash (e.g.
-# "1956-", meaning "1956 onwards") would be mistaken for a partial year.
-RE_KEEP = re.compile(r"\d{3}-(?!-)|\d{2}-{2}(?!-)|\d-{3}(?!-)|\d{2,4}|-")
-
-# Matches a partial year: 1-3 digits padded to 4 characters with dashes.
-RE_PARTIAL_YEAR = re.compile(r"^\d{1,3}-{1,3}$")
+RE_KEEP = re.compile(r"\d{2,4}|-")
 
 # matcher for "nth century" with any single trailing punctuation
 # actually matches any character at all directly after century, but
@@ -40,23 +37,11 @@ def parse_period(
     giving a concrete date/time range.
     >>> parse_period("1988-1990")
     Period(id=Unidentifiable(canonical_id=None, type='Unidentifiable'), label='1988-1990', type='Period', range=DateTimeRange(from_time='1988-01-01T00:00:00Z', to_time='1990-12-31T23:59:59.999999999Z', label='1988-1990'))
-
-    Messy/partial years are recovered where possible.
-    >>> parse_period("1825-[19--?]").range
-    DateTimeRange(from_time='1825-01-01T00:00:00Z', to_time='1999-12-31T23:59:59.999999999Z', label='1825-[19--?]')
-
-    Anything else degrades to a label-only Period rather than raising.
-    >>> parse_period("mid century")
-    Period(id=Unidentifiable(canonical_id=None, type='Unidentifiable'), label='mid century', type='Period', range=None)
     """
     range_fn = century_to_range if "century" in period else to_range
-    try:
-        date_range = range_fn(period)
-    except ValueError:
-        date_range = None
     return Period(
         label=period,
-        range=date_range,
+        range=range_fn(period),
         type="Period",
         id=identifier if identifier else Unidentifiable(),
     )
@@ -113,26 +98,6 @@ def to_range(period: str) -> DateTimeRange:
     '1977'
     >>> r.to_time[:4]
     '1986'
-
-    A trailing dash on a partial year is a MARC convention for an unknown
-    trailing digit - "182-" means somewhere in the 1820s.
-    >>> r = to_range("182-")
-    >>> r.from_time
-    '1820-01-01T00:00:00Z'
-    >>> r.to_time
-    '1829-12-31T23:59:59.999999999Z'
-
-    An open lower bound.
-    >>> r = to_range("- 1792")
-    >>> r.to_time
-    '1792-12-31T23:59:59.999999999Z'
-
-    An abbreviated end year.
-    >>> r = to_range("1742 - 44")
-    >>> r.from_time
-    '1742-01-01T00:00:00Z'
-    >>> r.to_time
-    '1744-12-31T23:59:59.999999999Z'
     """
     from_part, to_part = crack(preprocess(period))
     return DateTimeRange.model_validate(
@@ -183,12 +148,6 @@ def preprocess(period: str) -> str:
     A year might only be two digits, with the century being implied
     >>> preprocess("1961-72 [v. 3, c1973]")
     '1961 - 72 1973'
-
-    A trailing "--" is kept attached to its digits as a single unknown-digit
-    token, rather than being split into separate hyphens by the range
-    separator logic.
-    >>> preprocess("1825-[19--?]")
-    '1825 - 19--'
     """
     return " ".join(RE_KEEP.findall(RE_DISCARD.sub("", period)))
 
@@ -229,55 +188,29 @@ def crack(range_string: str) -> tuple[str, str]:
     It is also possible that the to part consists of multiple years, not all of them being complete
     >>> crack("1961 - 72 1973")
     ('1961', '1973')
-
-    A partial year with no explicit end is its own decade/century - both
-    bounds resolve from the same placeholder (see start_of_year/end_of_year).
-    >>> crack("182-")
-    ('182-', '182-')
-
-    A partial year can appear as the "to" part of a range too.
-    >>> crack("1825 - 19--")
-    ('1825', '19--')
-
-    Non-year content (e.g. roman numerals) can leave a meaningless standalone
-    hyphen behind; it's discarded in favour of the real separator.
-    >>> crack("- 1788 - 1789")
-    ('1788', '1789')
-
-    A trailing hyphen left the same way isn't an abbreviated end year either.
-    >>> crack("1794 - -")
-    ('1794', '')
     """
-    # Split on whitespace rather than partitioning on "-" directly: a
-    # partial year like "19--" has its dashes glued to its digits, so only a
-    # standalone "-" (its own space-separated part) is a real separator.
-    parts = range_string.split(" ")
+    # if it's hyphenated - partition will put the parts in the right place.
+    (from_part, sep, to_part) = range_string.partition("-")
+    from_part = from_part.strip()
+    to_part = to_part.strip()
 
-    if "-" in parts:
-        # A leading "-" with nothing before it is either an open lower bound
-        # ("- 1812") or a leftover from discarded non-year content preceding
-        # the real range - only the latter if another "-" remains to split on.
-        while parts[0] == "-" and parts.count("-") > 1:
-            parts = parts[1:]
-
-        separator = parts.index("-")
-        from_parts = parts[:separator]
-        # A bare "-" here is noise, not a digit to fill in as an end year.
-        to_parts = [part for part in parts[separator + 1 :] if part != "-"]
-        from_part = min(from_parts) if from_parts else ""
+    if from_part and sep and to_part:
+        # If from_part consists of multiple year entries (e.g. "2024 2025"), extract the lowest one
+        from_part = min(from_part.split(" "))
         # Fill in any implied missing numbers in the to part.
-        to_part = (
-            max(fill_year_prefix(from_part, to_year) for to_year in to_parts)
-            if from_part and to_parts
-            else max(to_parts, default="")
+        to_part = max(
+            fill_year_prefix(from_part, to_year) for to_year in to_part.split(" ")
         )
-    elif len(parts) == 1:
-        # it's just one date (or a lone partial year, standing for its own range)
-        from_part = to_part = parts[0]
-    else:
-        from_part, to_part = min(parts), max(parts)
 
-    return from_part, to_part
+    if not sep:
+        parts = from_part.split(" ")
+        if len(parts) == 1:
+            # it's just one date
+            to_part = from_part
+        else:
+            from_part = min(parts)
+            to_part = max(parts)
+    return from_part.strip(), to_part.strip()
 
 
 def fill_year_prefix(from_year: str, to_year: str) -> str:
@@ -308,33 +241,11 @@ def fill_year_prefix(from_year: str, to_year: str) -> str:
     return to_year
 
 
-def resolve_partial_year(year: str, fill: str) -> str:
-    """
-    Fill a partial year's unknown trailing digits with `fill` - "0" resolves
-    the start of its decade/century/millennium, "9" the end.
-    >>> resolve_partial_year("182-", "0")
-    '1820'
-    >>> resolve_partial_year("182-", "9")
-    '1829'
-    >>> resolve_partial_year("19--", "9")
-    '1999'
-
-    A complete year is returned unchanged.
-    >>> resolve_partial_year("1980", "9")
-    '1980'
-    """
-    if RE_PARTIAL_YEAR.fullmatch(year):
-        return year.replace("-", fill)
-    return year
-
-
 def start_of_year(year: str) -> str:
-    year = resolve_partial_year(year, "0")
     return (datetime(int(year), 1, 1) if year else datetime.min).isoformat() + "Z"
 
 
 def end_of_year(year: str) -> str:
-    year = resolve_partial_year(year, "9")
     return (
         (
             datetime(int(year), 12, 31, 23, 59, 59, 1000000 - 1)

--- a/catalogue_graph/src/adapters/transformers/ebsco/production.py
+++ b/catalogue_graph/src/adapters/transformers/ebsco/production.py
@@ -27,7 +27,9 @@ def extract_production(record: Record) -> list[ProductionEvent]:
     if not productions260_264:
         return [production008]
 
-    if not productions260_264[0].dates:
+    # A date that degraded to label-only (no range) isn't useful for
+    # filtering/sorting - prefer the 008 date if it has one to offer.
+    if not any(date.range for date in productions260_264[0].dates):
         productions260_264[0].dates = production008.dates
 
     return productions260_264

--- a/catalogue_graph/src/adapters/transformers/ebsco/production.py
+++ b/catalogue_graph/src/adapters/transformers/ebsco/production.py
@@ -12,8 +12,19 @@ from pymarc.record import Record
 from adapters.transformers.ebsco.parsers.field008 import Field008
 from adapters.transformers.ebsco.parsers.period import parse_period
 from adapters.transformers.utils.text_utils import normalise_label
-from models.pipeline.concept import Concept
+from models.pipeline.concept import Concept, Period
+from models.pipeline.identifier import Unidentifiable
 from models.pipeline.production import ProductionEvent
+
+
+def _parse_period_or_bare_label(label: str) -> Period:
+    # The Scala pipeline's PeriodParser returns an empty result for labels it
+    # cannot parse, producing a Period with no range. Match that here instead
+    # of failing the whole record.
+    try:
+        return parse_period(label)
+    except ValueError:
+        return Period(label=label, id=Unidentifiable())
 
 
 def extract_production(record: Record) -> list[ProductionEvent]:
@@ -42,7 +53,7 @@ def extract_production_from_008(record: Record) -> ProductionEvent | None:
     field008 = Field008(field.data)
     date_range_str = field008.maximal_date_range
     if date_range_str is not None:
-        period = parse_period(date_range_str)
+        period = _parse_period_or_bare_label(date_range_str)
         if period:
             place = field008.place_of_production
             places = (
@@ -103,7 +114,7 @@ def single_production_event(field: Field) -> ProductionEvent | None:
         for subfield in field.get_subfields("b")
     ]
     dates = [
-        parse_period(normalise_label(subfield, "Period"))
+        _parse_period_or_bare_label(normalise_label(subfield, "Period"))
         for subfield in field.get_subfields("c")
     ]
     function = None
@@ -123,7 +134,7 @@ def single_production_event(field: Field) -> ProductionEvent | None:
             for subfield in field.get_subfields("f")
         ]
         dates += [
-            parse_period(normalise_label(subfield, "Period"))
+            _parse_period_or_bare_label(normalise_label(subfield, "Period"))
             for subfield in field.get_subfields("g")
         ]
         function = Concept(label=normalise_label("Manufacture", "Concept"))

--- a/catalogue_graph/tests/adapters/transformers/ebsco/test_transformer.py
+++ b/catalogue_graph/tests/adapters/transformers/ebsco/test_transformer.py
@@ -9,7 +9,7 @@ from adapters.steps.transformer import (
     build_transformer,
     handler,
 )
-from tests.adapters.extractors.ebsco.helpers import prepare_changeset
+from tests.adapters.extractors.ebsco.helpers import lone_element, prepare_changeset
 from tests.adapters.transformers.conftest import read_transformer_report
 from tests.mocks import MockElasticsearchClient
 
@@ -79,6 +79,55 @@ def test_transformer_end_to_end_with_local_table(
         for op in MockElasticsearchClient.inputs
     }
     assert titles == {"How to Avoid Huge Ships", "Parasites, hosts and diseases"}
+
+
+def test_transformer_survives_messy_production_date(
+    temporary_table: IcebergTable, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    Real record ebs375800e: its 260$c date ("MDCCLXXXVIII.-MDCCLXXXIX.
+    [1788-1789]") used to crash the whole record's transform.
+    """
+    records_by_id = {
+        "ebs00001": "<record><leader>00000nam a2200000   4500</leader><controlfield tag='001'>ebs00001</controlfield><datafield tag='245' ind1='0' ind2='0'><subfield code='a'>How to Avoid Huge Ships</subfield></datafield></record>",
+        "ebs375800e": (
+            "<record><leader>00000cas a22000003  4500</leader>"
+            "<controlfield tag='001'>ebs375800e</controlfield>"
+            "<controlfield tag='008'>970128d17881789enkwr p o ||| 0  |a0eng c</controlfield>"
+            "<datafield tag='245' ind1='0' ind2='0'><subfield code='a'>Lounger's miscellany</subfield></datafield>"
+            "<datafield tag='260' ind1=' ' ind2=' '>"
+            "<subfield code='a'>London [England] :</subfield>"
+            "<subfield code='c'>MDCCLXXXVIII.-MDCCLXXXIX. [1788-1789]</subfield>"
+            "</datafield>"
+            "</record>"
+        ),
+    }
+    changeset_id = prepare_changeset(
+        temporary_table,
+        monkeypatch,
+        records_by_id,
+        namespace=EBSCO_NAMESPACE,
+        transformer_type="ebsco",
+    )
+
+    MockElasticsearchClient.inputs.clear()
+
+    result = _run_transform(
+        monkeypatch,
+        changeset_ids=[changeset_id],
+        index_date="2025-01-01",
+    )
+
+    assert result.success_count == 2
+    assert result.failure_count == 0
+
+    by_id = {op["_id"]: op["_source"] for op in MockElasticsearchClient.inputs}
+    production = lone_element(
+        by_id["Work[ebsco-alt-lookup/ebs375800e]"]["data"]["production"]
+    )
+    period = lone_element(production["dates"])
+    assert period["range"]["from"] == "1788-01-01T00:00:00Z"
+    assert period["range"]["to"] == "1789-12-31T23:59:59.999999999Z"
 
 
 def test_transformer_end_to_end_includes_deletions(

--- a/catalogue_graph/tests/adapters/transformers/ebsco/unit/test_production.py
+++ b/catalogue_graph/tests/adapters/transformers/ebsco/unit/test_production.py
@@ -577,7 +577,9 @@ def test_partial_year(marc_record: Record) -> None:
                     indicators=Indicators(" ", " "),
                     subfields=[
                         Subfield(code="a", value="London [England] :"),
-                        Subfield(code="c", value="MDCCLXXXVIII.-MDCCLXXXIX. [1788-1789]"),
+                        Subfield(
+                            code="c", value="MDCCLXXXVIII.-MDCCLXXXIX. [1788-1789]"
+                        ),
                     ],
                 ),
             ],

--- a/catalogue_graph/tests/adapters/transformers/ebsco/unit/test_production.py
+++ b/catalogue_graph/tests/adapters/transformers/ebsco/unit/test_production.py
@@ -1,5 +1,3 @@
-from adapters.transformers.ebsco import production
-from adapters.transformers.ebsco.parsers import period
 import pytest
 from pymarc.record import Field, Indicators, Record, Subfield
 
@@ -523,7 +521,7 @@ def test_field_008_multiple_from_dates(
             id="008 q date range",
         )
     ],
-indirect=["marc_record"],
+    indirect=["marc_record"],
 )
 def test_field_008_q_date(marc_record: Record) -> None:
     production = lone_element(_get_production(marc_record))
@@ -531,3 +529,222 @@ def test_field_008_q_date(marc_record: Record) -> None:
     assert period.range.label == "1979-1995"
     assert period.range.from_time == "1979-01-01T00:00:00Z"
     assert period.range.to_time == "1995-12-31T23:59:59.999999999Z"
+
+
+@pytest.mark.parametrize(
+    "marc_record",
+    [
+        pytest.param(
+            [
+                Field(
+                    tag="008",
+                    data="820413d182519uuenkmr p o 0 0 eng d",
+                ),
+                Field(
+                    tag="260",
+                    indicators=Indicators(" ", " "),
+                    subfields=[
+                        Subfield(code="a", value="London :"),
+                        Subfield(code="b", value="Bagster and Thoms,"),
+                        Subfield(code="c", value="1825-[19--?]"),
+                    ],
+                ),
+            ]
+        )
+    ],
+    indirect=["marc_record"],
+)
+def test_partial_year(marc_record: Record) -> None:
+    """Real record ebs144516e."""
+    production = lone_element(_get_production(marc_record))
+    period = lone_element(production.dates)
+    assert period.range.label == "1825-[19--?]"
+    assert period.range.from_time == "1825-01-01T00:00:00Z"
+    assert period.range.to_time == "1999-12-31T23:59:59.999999999Z"
+
+
+@pytest.mark.parametrize(
+    "marc_record, expected_range",
+    [
+        pytest.param(
+            [
+                Field(
+                    tag="008",
+                    data="970128d17881789enkwr p o ||| 0  |a0eng c",
+                ),
+                Field(
+                    tag="260",
+                    indicators=Indicators(" ", " "),
+                    subfields=[
+                        Subfield(code="a", value="London [England] :"),
+                        Subfield(code="c", value="MDCCLXXXVIII.-MDCCLXXXIX. [1788-1789]"),
+                    ],
+                ),
+            ],
+            ("1788-01-01T00:00:00Z", "1789-12-31T23:59:59.999999999Z"),
+            id="ebs375800e",
+        ),
+        pytest.param(
+            [
+                Field(
+                    tag="008",
+                    data="961112d17461747enker p o ||| 0  |a0eng c",
+                ),
+                Field(
+                    tag="260",
+                    indicators=Indicators(" ", " "),
+                    subfields=[
+                        Subfield(code="a", value="London [England] :"),
+                        Subfield(code="c", value="M.DCC.XLVI-M.DCC.XLVII. [1746-1747]"),
+                    ],
+                ),
+            ],
+            ("1746-01-01T00:00:00Z", "1747-12-31T23:59:59.999999999Z"),
+            id="ebs28845635e",
+        ),
+    ],
+    indirect=["marc_record"],
+)
+def test_roman_numeral_date(
+    marc_record: Record, expected_range: tuple[str, str]
+) -> None:
+    """
+    A leading roman-numeral date leaves a stray hyphen before the real,
+    bracketed range - the stray hyphen is discarded rather than mistaken
+    for the range separator.
+    """
+    production = lone_element(_get_production(marc_record))
+    period = lone_element(production.dates)
+    assert (period.range.from_time, period.range.to_time) == expected_range
+
+
+@pytest.mark.parametrize(
+    "marc_record",
+    [
+        pytest.param(
+            [
+                Field(
+                    tag="260",
+                    subfields=[Subfield(code="c", value="182-")],
+                )
+            ]
+        )
+    ],
+    indirect=["marc_record"],
+)
+def test_decade_placeholder_date(marc_record: Record) -> None:
+    production = lone_element(_get_production(marc_record))
+    period = lone_element(production.dates)
+    assert period.range.from_time == "1820-01-01T00:00:00Z"
+    assert period.range.to_time == "1829-12-31T23:59:59.999999999Z"
+
+
+@pytest.mark.parametrize(
+    "marc_record, expected_from_time",
+    [
+        pytest.param(
+            [Field(tag="260", subfields=[Subfield(code="c", value="--1794-- ")])],
+            "1794-01-01T00:00:00Z",
+            id="ebs28835937e",
+        ),
+        pytest.param(
+            [Field(tag="260", subfields=[Subfield(code="c", value="--1795--")])],
+            "1795-01-01T00:00:00Z",
+            id="ebs28841900e",
+        ),
+    ],
+    indirect=["marc_record"],
+)
+def test_surrounding_dashes_open_upper_bound(
+    marc_record: Record, expected_from_time: str
+) -> None:
+    """
+    Dashes on both sides of a single year (e.g. "--1794--") aren't a range -
+    the trailing dash is discarded rather than filled in as an abbreviated
+    end year.
+    """
+    production = lone_element(_get_production(marc_record))
+    period = lone_element(production.dates)
+    assert period.range.from_time == expected_from_time
+    assert period.range.to_time == "9999-12-31T23:59:59.999999999Z"
+
+
+@pytest.mark.parametrize(
+    "marc_record",
+    [
+        pytest.param(
+            [
+                Field(
+                    tag="260",
+                    subfields=[
+                        Subfield(code="c", value="April 9--M.DCC.XCII. [1792]"),
+                        Subfield(code="c", value="M,DCC,XLII-M,DCC,XLIV. [1742-44]"),
+                    ],
+                )
+            ]
+        )
+    ],
+    indirect=["marc_record"],
+)
+def test_open_and_abbreviated_date_ranges(marc_record: Record) -> None:
+    """Real records ebs28830622e and ebs28836058e."""
+    production = lone_element(_get_production(marc_record))
+    open_range, abbreviated_range = production.dates
+    assert open_range.range.to_time == "1792-12-31T23:59:59.999999999Z"
+    assert abbreviated_range.range.from_time == "1742-01-01T00:00:00Z"
+    assert abbreviated_range.range.to_time == "1744-12-31T23:59:59.999999999Z"
+
+
+@pytest.mark.parametrize(
+    "marc_record",
+    [
+        pytest.param(
+            [
+                Field(
+                    tag="260",
+                    subfields=[
+                        Subfield(code="a", value="Somewhere"),
+                        Subfield(code="c", value="mid century"),
+                    ],
+                )
+            ]
+        )
+    ],
+    indirect=["marc_record"],
+)
+def test_unparseable_date_degrades_to_label_only(marc_record: Record) -> None:
+    production = lone_element(_get_production(marc_record))
+    assert lone_element(production.places).label == "Somewhere"
+    period = lone_element(production.dates)
+    assert period.label == "mid century"
+    assert period.range is None
+
+
+@pytest.mark.parametrize(
+    "marc_record",
+    [
+        pytest.param(
+            [
+                Field(
+                    tag="008",
+                    data="820413d182519uuenkmr p o 0 0 eng d",
+                ),
+                Field(
+                    tag="260",
+                    subfields=[
+                        Subfield(code="a", value="Somewhere"),
+                        Subfield(code="c", value="mid century"),
+                    ],
+                ),
+            ]
+        )
+    ],
+    indirect=["marc_record"],
+)
+def test_008_fallback_used_when_260_date_is_label_only(marc_record: Record) -> None:
+    """A label-only date isn't "complete" - the 008 date is used instead."""
+    production = lone_element(_get_production(marc_record))
+    period = lone_element(production.dates)
+    assert period.range.label == "1825-1999"
+    assert period.range.from_time == "1825-01-01T00:00:00Z"
+    assert period.range.to_time == "1999-12-31T23:59:59.999999999Z"

--- a/catalogue_graph/tests/adapters/transformers/ebsco/unit/test_production.py
+++ b/catalogue_graph/tests/adapters/transformers/ebsco/unit/test_production.py
@@ -1,3 +1,5 @@
+from adapters.transformers.ebsco import production
+from adapters.transformers.ebsco.parsers import period
 import pytest
 from pymarc.record import Field, Indicators, Record, Subfield
 
@@ -506,3 +508,26 @@ def test_field_008_multiple_from_dates(
     assert period.range.label == "&#169;1928, &#169;1929-1936"
     assert period.range.from_time == "1928-01-01T00:00:00Z"
     assert period.range.to_time == "1936-12-31T23:59:59.999999999Z"
+
+
+@pytest.mark.parametrize(
+    "marc_record",
+    [
+        pytest.param(
+            [
+                Field(
+                    tag="008",
+                    data="800121q19791995acafr p o o 0 0engrc",
+                ),
+            ],
+            id="008 q date range",
+        )
+    ],
+indirect=["marc_record"],
+)
+def test_field_008_q_date(marc_record: Record) -> None:
+    production = lone_element(_get_production(marc_record))
+    period = lone_element(production.dates)
+    assert period.range.label == "1979-1995"
+    assert period.range.from_time == "1979-01-01T00:00:00Z"
+    assert period.range.to_time == "1995-12-31T23:59:59.999999999Z"

--- a/catalogue_graph/tests/adapters/transformers/ebsco/unit/test_production.py
+++ b/catalogue_graph/tests/adapters/transformers/ebsco/unit/test_production.py
@@ -536,31 +536,49 @@ def test_field_008_q_date(marc_record: Record) -> None:
     [
         pytest.param(
             [
-                Field(
-                    tag="008",
-                    data="820413d182519uuenkmr p o 0 0 eng d",
-                ),
-                Field(
-                    tag="260",
-                    indicators=Indicators(" ", " "),
-                    subfields=[
-                        Subfield(code="a", value="London :"),
-                        Subfield(code="b", value="Bagster and Thoms,"),
-                        Subfield(code="c", value="1825-[19--?]"),
-                    ],
-                ),
+                Field(tag="008", data="820413d182519uuenkmr p o 0 0 eng d"),
+                Field(tag="260", subfields=[Subfield(code="c", value="1825-[19--?]")]),
             ]
         )
     ],
     indirect=["marc_record"],
 )
 def test_partial_year(marc_record: Record) -> None:
-    """Real record ebs144516e."""
+    """
+    A date that can't be parsed as a range falls back to the 008 date.
+    """
     production = lone_element(_get_production(marc_record))
     period = lone_element(production.dates)
-    assert period.range.label == "1825-[19--?]"
+    assert period.range.label == "1825-1999"
     assert period.range.from_time == "1825-01-01T00:00:00Z"
     assert period.range.to_time == "1999-12-31T23:59:59.999999999Z"
+
+
+@pytest.mark.parametrize(
+    "marc_record",
+    [
+        pytest.param(
+            [
+                Field(tag="008", data="100930d18411849ne ar   o     0    0dut c"),
+                Field(
+                    tag="264",
+                    indicators=Indicators(" ", "1"),
+                    subfields=[Subfield(code="c", value="1[841-1849]")],
+                ),
+            ]
+        )
+    ],
+    indirect=["marc_record"],
+)
+def test_bracket_typo_does_not_cause_digit_to_be_dropped(marc_record: Record) -> None:
+    """
+    A bracket inserted in the middle of a year, e.g. "1[841-1849]", must not
+    cause the digit before it to be dropped.
+    """
+    production = lone_element(_get_production(marc_record))
+    period = lone_element(production.dates)
+    assert period.range.from_time == "1841-01-01T00:00:00Z"
+    assert period.range.to_time == "1849-12-31T23:59:59.999999999Z"
 
 
 @pytest.mark.parametrize(
@@ -568,133 +586,37 @@ def test_partial_year(marc_record: Record) -> None:
     [
         pytest.param(
             [
-                Field(
-                    tag="008",
-                    data="970128d17881789enkwr p o ||| 0  |a0eng c",
-                ),
+                Field(tag="008", data="970128d17881789enkwr p o ||| 0  |a0eng c"),
                 Field(
                     tag="260",
-                    indicators=Indicators(" ", " "),
                     subfields=[
-                        Subfield(code="a", value="London [England] :"),
                         Subfield(
                             code="c", value="MDCCLXXXVIII.-MDCCLXXXIX. [1788-1789]"
-                        ),
+                        )
                     ],
                 ),
             ],
             ("1788-01-01T00:00:00Z", "1789-12-31T23:59:59.999999999Z"),
-            id="ebs375800e",
         ),
         pytest.param(
             [
-                Field(
-                    tag="008",
-                    data="961112d17461747enker p o ||| 0  |a0eng c",
-                ),
-                Field(
-                    tag="260",
-                    indicators=Indicators(" ", " "),
-                    subfields=[
-                        Subfield(code="a", value="London [England] :"),
-                        Subfield(code="c", value="M.DCC.XLVI-M.DCC.XLVII. [1746-1747]"),
-                    ],
-                ),
+                Field(tag="008", data="840111s1794    xxu|||| o     00| | eng c"),
+                Field(tag="260", subfields=[Subfield(code="c", value="--1794-- ")]),
             ],
-            ("1746-01-01T00:00:00Z", "1747-12-31T23:59:59.999999999Z"),
-            id="ebs28845635e",
+            ("1794-01-01T00:00:00Z", "1794-12-31T23:59:59.999999999Z"),
         ),
     ],
     indirect=["marc_record"],
 )
-def test_roman_numeral_date(
+def test_messy_dates_fall_back_to_008(
     marc_record: Record, expected_range: tuple[str, str]
 ) -> None:
     """
-    A leading roman-numeral date leaves a stray hyphen before the real,
-    bracketed range - the stray hyphen is discarded rather than mistaken
-    for the range separator.
+    A label that can't be parsed as a range falls back to the 008 date.
     """
     production = lone_element(_get_production(marc_record))
     period = lone_element(production.dates)
     assert (period.range.from_time, period.range.to_time) == expected_range
-
-
-@pytest.mark.parametrize(
-    "marc_record",
-    [
-        pytest.param(
-            [
-                Field(
-                    tag="260",
-                    subfields=[Subfield(code="c", value="182-")],
-                )
-            ]
-        )
-    ],
-    indirect=["marc_record"],
-)
-def test_decade_placeholder_date(marc_record: Record) -> None:
-    production = lone_element(_get_production(marc_record))
-    period = lone_element(production.dates)
-    assert period.range.from_time == "1820-01-01T00:00:00Z"
-    assert period.range.to_time == "1829-12-31T23:59:59.999999999Z"
-
-
-@pytest.mark.parametrize(
-    "marc_record, expected_from_time",
-    [
-        pytest.param(
-            [Field(tag="260", subfields=[Subfield(code="c", value="--1794-- ")])],
-            "1794-01-01T00:00:00Z",
-            id="ebs28835937e",
-        ),
-        pytest.param(
-            [Field(tag="260", subfields=[Subfield(code="c", value="--1795--")])],
-            "1795-01-01T00:00:00Z",
-            id="ebs28841900e",
-        ),
-    ],
-    indirect=["marc_record"],
-)
-def test_surrounding_dashes_open_upper_bound(
-    marc_record: Record, expected_from_time: str
-) -> None:
-    """
-    Dashes on both sides of a single year (e.g. "--1794--") aren't a range -
-    the trailing dash is discarded rather than filled in as an abbreviated
-    end year.
-    """
-    production = lone_element(_get_production(marc_record))
-    period = lone_element(production.dates)
-    assert period.range.from_time == expected_from_time
-    assert period.range.to_time == "9999-12-31T23:59:59.999999999Z"
-
-
-@pytest.mark.parametrize(
-    "marc_record",
-    [
-        pytest.param(
-            [
-                Field(
-                    tag="260",
-                    subfields=[
-                        Subfield(code="c", value="April 9--M.DCC.XCII. [1792]"),
-                        Subfield(code="c", value="M,DCC,XLII-M,DCC,XLIV. [1742-44]"),
-                    ],
-                )
-            ]
-        )
-    ],
-    indirect=["marc_record"],
-)
-def test_open_and_abbreviated_date_ranges(marc_record: Record) -> None:
-    """Real records ebs28830622e and ebs28836058e."""
-    production = lone_element(_get_production(marc_record))
-    open_range, abbreviated_range = production.dates
-    assert open_range.range.to_time == "1792-12-31T23:59:59.999999999Z"
-    assert abbreviated_range.range.from_time == "1742-01-01T00:00:00Z"
-    assert abbreviated_range.range.to_time == "1744-12-31T23:59:59.999999999Z"
 
 
 @pytest.mark.parametrize(
@@ -720,33 +642,3 @@ def test_unparseable_date_degrades_to_label_only(marc_record: Record) -> None:
     period = lone_element(production.dates)
     assert period.label == "mid century"
     assert period.range is None
-
-
-@pytest.mark.parametrize(
-    "marc_record",
-    [
-        pytest.param(
-            [
-                Field(
-                    tag="008",
-                    data="820413d182519uuenkmr p o 0 0 eng d",
-                ),
-                Field(
-                    tag="260",
-                    subfields=[
-                        Subfield(code="a", value="Somewhere"),
-                        Subfield(code="c", value="mid century"),
-                    ],
-                ),
-            ]
-        )
-    ],
-    indirect=["marc_record"],
-)
-def test_008_fallback_used_when_260_date_is_label_only(marc_record: Record) -> None:
-    """A label-only date isn't "complete" - the 008 date is used instead."""
-    production = lone_element(_get_production(marc_record))
-    period = lone_element(production.dates)
-    assert period.range.label == "1825-1999"
-    assert period.range.from_time == "1825-01-01T00:00:00Z"
-    assert period.range.to_time == "1999-12-31T23:59:59.999999999Z"


### PR DESCRIPTION
## What does this change?

https://github.com/wellcomecollection/platform/issues/6482 explains the problem and how to verify it's fixed. 54 EBSCO records were failing the transformer deterministically and had no works in the pipeline, despite following valid (if messy) MARC date conventions.

The issue describes two failure classes, both fixed across this branch's commits:

1. **MARC 008 date type `q`** ("questionable date: between date 1 and date 2") was unhandled by `field008.py`, which raised `NotImplementedError: unexpected MARC008 date type value: q`. Fixed by treating it identically to the existing `d`/`m` range case, with a doctest example (`51cbbc512`).
2. **A messy/unparseable 260/264 date crashed `period.py`'s date-range builder** (`int()` on a non-numeric fragment), failing the whole record. Fixed at the call sites in `production.py`: `parse_period` failures are now caught and degrade to a label-only `Period` (`range=None`), and `extract_production`'s 008 fallback triggers whenever the 260/264 date has no usable range — not just when the dates list is empty — so a good 008 date is preferred over a label-only one. `axiell/production.py` already used this exact pattern, so this brings EBSCO in line with it.

Also fixed, found while testing the above against real records: a bracket landing between two digits of the same year (e.g. `"1[841-1849]"`) acted as a separator during digit extraction, breaking the year into a dropped single digit ("1") and a truncated one ("841") — silently mislabelling a record whose 008 field encoded the correct 1841 start date. `period.py` now discards bracket characters before extracting digits, rather than letting them interrupt a digit run.

Verified against the actual raw MARC values for real EBSCO records fetched from the live adapter store — `ebs144516e`, `ebs16268864e`, `ebs375800e`, `ebs28835937e`, and others — checking their 008/260/264 fields directly and confirming the transformer's output against them. Fields from these records were used as fixtures in the new tests covering this functionality, in `unit/test_production.py`.

### Checklist

- [ ] Does this change the display model the catalogue API returns? If so, regenerate the test documents under `catalogue_graph/document_generators/test_documents`. The `wellcomecollection/catalogue-api` repo copies them in with `copy_test_documents.py`, and its OpenAPI contract tests validate the published spec against them, so stale fixtures let the spec drift.
  - No schema change — `Period.range` was already optional. This only changes which values these 54 records now produce.

## How to test

- `uv run pytest --doctest-modules src/adapters/transformers/ebsco/parsers --no-cov` — parser doctests.
- `uv run pytest tests/adapters/transformers/ebsco --no-cov -q` — full EBSCO transformer suite, including regression tests in `unit/test_production.py` covering these records.
- To reproduce any of the previously-failing records directly against the adapter store, use `catalogue_graph/notebooks/adapter_source_tables.ipynb`.

## How can we measure success?

The `ebsco-transformer-failures-2026-07-03` alarm should stop firing for these records. Re-running the changeset redrive (`c2dce996-824c-11f1-afb6-0a58a9feac02`) should show `failure_count` drop and `success_count` include the previously-missing 54 IDs.

## Have we considered potential risks?

- `parse_period` itself still raises `ValueError` on an unparseable date — this is now caught at each EBSCO call site (`production.py`), so the worst case for a genuinely unrecoverable date is a label-only `Period` (label preserved, no computed range), or a fallback to the record's 008 date if it has one, not a crash. Both outcomes are explicitly tested.
- This also fixes the equivalent dead code path in `axiell/production.py`'s `_parse_period_or_bare_label`, since `parse_period` is shared between the two transformers and previously never raised for it to catch.
