### PR TITLE
Extract a shared find_work state machine module from the image inferrer

### DIFF
--- a/catalogue_graph/src/core/find_work.py
+++ b/catalogue_graph/src/core/find_work.py
@@ -1,0 +1,42 @@
+"""Shared input handling for find_work steps."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Any
+
+# Window end lags the scheduled time so recently written documents have indexed.
+SCHEDULE_INDEXING_LAG = timedelta(minutes=5)
+
+
+def normalise_lambda_input(event: dict, defaults: dict[str, Any]) -> dict:
+    """Normalise a find-work Lambda payload into FindWorkEvent fields.
+
+    Scheduled runs send scheduled_time, which becomes the window end minus an
+    indexing lag; replays pass ids (source_identifiers is accepted as an alias)
+    or an explicit window. With no scope at all, full: true is required so a
+    malformed invoke fails loudly instead of scanning the whole index.
+    Deployment-identity defaults (pipeline_date etc.) fill only absent fields.
+    """
+    data = {k: v for k, v in event.items() if v is not None}
+    scheduled_time = data.pop("scheduled_time", None)
+    full = data.pop("full", None)
+
+    if data.get("ids") is None:
+        alias = data.pop("source_identifiers", None)
+        if alias is not None:
+            data["ids"] = alias
+
+    if data.get("ids") is None and data.get("window") is None:
+        if scheduled_time is not None:
+            end_time = datetime.fromisoformat(scheduled_time) - SCHEDULE_INDEXING_LAG
+            data["window"] = {"end_time": end_time}
+        elif full is not True:
+            raise ValueError(
+                "No ids, window or scheduled_time given; "
+                "pass 'full': true to scan the whole index."
+            )
+
+    for key, value in defaults.items():
+        data.setdefault(key, value)
+    return data

--- a/catalogue_graph/src/inferrer/steps/find_work.py
+++ b/catalogue_graph/src/inferrer/steps/find_work.py
@@ -9,6 +9,7 @@ one per downstream inference task (fanned out by the state machine's Map state).
 
 from __future__ import annotations
 
+import os
 import typing
 from argparse import ArgumentParser
 from concurrent.futures import ThreadPoolExecutor
@@ -16,6 +17,7 @@ from itertools import batched
 
 import structlog
 
+from core.find_work import normalise_lambda_input
 from inferrer.models import (
     DEFAULT_PARTITION_SIZE,
     FindWorkEvent,
@@ -99,7 +101,21 @@ def write_partitions_to_s3(
 
 
 def lambda_handler(event: dict, context: typing.Any) -> dict[str, typing.Any]:
-    parsed_event = FindWorkEvent(**event)
+    # Scope comes from the invocation (scheduled_time or replay input); the
+    # deployment-identity fields come from the environment.
+    parsed_event = FindWorkEvent(
+        **normalise_lambda_input(
+            event,
+            defaults={
+                "pipeline_date": os.environ.get("PIPELINE_DATE"),
+                "graph_date": os.environ.get("GRAPH_DATE"),
+                "index_dates": {
+                    "initial": os.environ.get("INDEX_DATE_INITIAL"),
+                    "augmented": os.environ.get("INDEX_DATE_AUGMENTED"),
+                },
+            },
+        )
+    )
     execution_context = ExecutionContext(
         trace_id=get_trace_id(context),
         pipeline_step="inference_find_work",

--- a/catalogue_graph/tests/core/test_find_work.py
+++ b/catalogue_graph/tests/core/test_find_work.py
@@ -1,0 +1,58 @@
+"""Tests for the shared find_work Lambda input normalisation."""
+
+from __future__ import annotations
+
+import pytest
+
+from core.find_work import normalise_lambda_input
+
+DEFAULTS = {"pipeline_date": "dev", "graph_date": "dev"}
+
+
+def test_scheduled_time_becomes_window_end_minus_lag() -> None:
+    data = normalise_lambda_input({"scheduled_time": "2026-08-04T14:20:45Z"}, DEFAULTS)
+    assert data["window"]["end_time"].isoformat() == "2026-08-04T14:15:45+00:00"
+    assert data["pipeline_date"] == "dev"
+    assert "scheduled_time" not in data
+
+
+def test_explicit_window_wins_over_scheduled_time() -> None:
+    window = {"start_time": "2026-08-01T00:00:00Z", "end_time": "2026-08-01T01:00:00Z"}
+    data = normalise_lambda_input(
+        {"scheduled_time": "2026-08-04T14:20:45Z", "window": window}, DEFAULTS
+    )
+    assert data["window"] == window
+
+
+def test_source_identifiers_is_an_alias_for_ids() -> None:
+    data = normalise_lambda_input({"source_identifiers": ["a", "b"]}, DEFAULTS)
+    assert data["ids"] == ["a", "b"]
+    assert "source_identifiers" not in data
+
+
+def test_ids_win_over_the_alias() -> None:
+    data = normalise_lambda_input({"ids": ["a"], "source_identifiers": ["b"]}, DEFAULTS)
+    assert data["ids"] == ["a"]
+
+
+def test_no_scope_requires_explicit_full() -> None:
+    with pytest.raises(ValueError, match="full"):
+        normalise_lambda_input({"job_id": "x"}, DEFAULTS)
+
+
+def test_null_window_does_not_become_full_scan() -> None:
+    with pytest.raises(ValueError, match="full"):
+        normalise_lambda_input({"window": None}, DEFAULTS)
+
+
+def test_full_flag_allows_unscoped() -> None:
+    data = normalise_lambda_input({"full": True}, DEFAULTS)
+    assert "window" not in data and "ids" not in data and "full" not in data
+
+
+def test_input_identity_wins_over_defaults() -> None:
+    data = normalise_lambda_input(
+        {"ids": ["a"], "pipeline_date": "2026-07-03"}, DEFAULTS
+    )
+    assert data["pipeline_date"] == "2026-07-03"
+    assert data["graph_date"] == "dev"

--- a/catalogue_graph/tests/inferrer/test_find_work.py
+++ b/catalogue_graph/tests/inferrer/test_find_work.py
@@ -1,3 +1,5 @@
+import pytest
+
 from inferrer.models import FindWorkEvent, InferenceManagerEvent
 from inferrer.steps import find_work
 from models.events import PipelineIndexDates
@@ -88,6 +90,22 @@ def test_lambda_handler_writes_partitions_to_s3_and_returns_refs() -> None:
         assert partition.pipeline_date == PIPELINE_DATE
         resolved_ids += partition.ids or []
     assert sorted(resolved_ids) == ["a", "b", "c"]
+
+
+def test_lambda_handler_accepts_scheduled_time(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PIPELINE_DATE", PIPELINE_DATE)
+    monkeypatch.setenv("GRAPH_DATE", PIPELINE_DATE)
+    mock_es_secrets("inferrer", PIPELINE_DATE)
+    _seed_initial_images(["a"])
+
+    # scheduled_time - 5min lag = window end 12:05; start defaults to 11:50,
+    # covering the seeded modifiedTime of 12:00.
+    result = find_work.lambda_handler(
+        {"scheduled_time": "2026-06-10T12:10:00Z"}, _LambdaContext()
+    )
+    assert len(result["partitions"]) == 1
 
 
 def test_handler_builds_window_query_on_modified_time() -> None:

--- a/pipeline/terraform/modules/find_work_state_machine/README.md
+++ b/pipeline/terraform/modules/find_work_state_machine/README.md
@@ -20,7 +20,9 @@ image inferrer, a Lambda for the id-minter), one bounded partition at a time.
 `max_concurrency` is the work-in-progress ceiling. Pin it to the worker's real
 capacity rather than picking a number here: the inferrer pins it to the ASG's
 `max_instances`, and the id-minter (moving onto this module in
-wellcomecollection/platform#6486) to its RDS connection budget.
+wellcomecollection/platform#6486) to its RDS connection budget. It cannot
+exceed 40, the most concurrent iterations an INLINE Map will run; a validation
+rejects higher values that Step Functions would otherwise silently cap.
 
 ## Failure semantics
 
@@ -41,6 +43,31 @@ What happens next depends on `tolerate_partition_failures`:
   means a replay only needs to cover the failed partitions, not the whole
   window.
 
+## Retry and alerting
+
+Retries happen at the worker state only, through the caller-injected `Retry`
+policies. They should cover transient infrastructure (plus `Lambda.Unknown` for
+Lambda workers, so a function timeout gets a re-run); re-running a whole
+partition is safe because consumers process idempotently. Once those retries
+exhaust, the partition is recorded and not retried again within the execution.
+Application failures such as a poisoned document would loop forever if retried
+blindly, and the ASL layer cannot tell them apart from stubborn transients, so
+recovery from recorded failures is a deliberate, human-started replay.
+
+Do not redrive a failed execution. The Map state itself never fails (the catch
+records partition failures), so a redrive restarts from `FailPartitions`,
+re-evaluates the same aggregate and fails again. Replay with a fresh
+`StartExecution` as described below.
+
+Alerting rides on the module's state machine alarms (`ExecutionsFailed`,
+`ExecutionsAborted`, `ExecutionsTimedOut`, threshold 0, wired to the chatbot
+topic). With `tolerate_partition_failures = false`, a lost partition fails the
+execution and therefore alerts. With `true`, tolerated failures do not alarm;
+the aggregate counts sit in the execution output but nothing consumes them
+automatically, so consumers in that mode need their own signal for failure
+classes that matter (the inferrer alarms on its `download_failure_count`
+metric).
+
 ## Replaying
 
 Scheduled runs process the window `[scheduled_time - 20min, scheduled_time - 5min]`.
@@ -60,19 +87,26 @@ slip fails validation in the Lambda rather than scanning the full index):
   minutes). Windows slice to arbitrary timestamps, so a dense range can be
   replayed as several smaller executions.
 - `ids`, a JSON array of ids to process instead of a window.
-- `job_id`, recommended whenever consumers write per-run reports; generated ids
-  are minute-granular, so concurrent replays started in the same minute collide.
+- `job_id`, honoured by consumers that stamp per-run reports (the id-minter,
+  whose generated ids are minute-granular, so concurrent replays started in the
+  same minute collide without one). The inferrer's find-work event has no
+  `job_id` field and silently ignores it.
 - `partition_size`, to override the consumer's default ids-per-partition.
 
 Replays are safe to repeat because both consumers process idempotently, and the
 partition files are keyed by scope (window, ids or full), so re-running the
-same input overwrites the previous run's files rather than accumulating.
+same input overwrites the previous run's files rather than accumulating. The
+flip side is that two concurrent replays of the same scope share the same
+partition files and will trample each other; run same-scope replays one at a
+time.
 
 ## Replaying only the failed partitions
 
-The `results` array in the Map output preserves partition order, so the indices
-of entries with `partition_failed: true` identify which partition files failed.
-The files live under the consumer's scope-keyed prefix, for example:
+Each failure record in the Map output's `results` array carries the failed
+partition's `s3_uri` and a truncated `error`, so the execution output alone
+identifies what failed and why. (The array also preserves partition order, so
+positional index works as a fallback.) The files live under the consumer's
+scope-keyed prefix, for example:
 
 ```
 s3://wellcomecollection-catalogue-graph/graph-<graph_date>/pipeline-<date>/<service>/find_work/windows/<start>-<end>/partition-<i>.json

--- a/pipeline/terraform/modules/find_work_state_machine/README.md
+++ b/pipeline/terraform/modules/find_work_state_machine/README.md
@@ -20,9 +20,8 @@ image inferrer, a Lambda for the id-minter), one bounded partition at a time.
 `max_concurrency` is the work-in-progress ceiling. Pin it to the worker's real
 capacity rather than picking a number here: the inferrer pins it to the ASG's
 `max_instances`, and the id-minter (moving onto this module in
-wellcomecollection/platform#6486) to its RDS connection budget. It cannot
-exceed 40, the most concurrent iterations an INLINE Map will run; a validation
-rejects higher values that Step Functions would otherwise silently cap.
+wellcomecollection/platform#6486) to its RDS connection budget. An INLINE Map
+runs at most 40 concurrent iterations, whatever the setting.
 
 ## Failure semantics
 

--- a/pipeline/terraform/modules/find_work_state_machine/README.md
+++ b/pipeline/terraform/modules/find_work_state_machine/README.md
@@ -4,11 +4,17 @@ A scheduled scan-and-fan-out state machine for pipeline steps whose work volume
 per window is unbounded:
 
 ```
-ConstructEvent (build the window from the schedule, or pass through replay input)
-  -> FindWork (Lambda: ids in scope, partitioned into files on S3)
-    -> ProcessPartitions (Map: one worker per partition ref, bounded concurrency)
-      -> CheckPartitionFailures (fail loudly, or tolerate and succeed)
+FindWork (Lambda: normalise the input, find the ids in scope, partition to S3)
+  -> ProcessPartitions (Map: one worker per partition ref, bounded concurrency)
+    -> CheckPartitionFailures (fail loudly, or tolerate and succeed)
 ```
+
+The state machine passes its raw invocation payload straight to the find-work
+Lambda, which owns all input handling (`core/find_work.normalise_lambda_input`):
+a scheduled run's `scheduled_time` becomes the window end minus an indexing
+lag, replay input passes through, and deployment identity (pipeline date, graph
+date, index dates) comes from the Lambda's environment. Keeping this in Python
+makes the guards unit-testable instead of living as JSONata in the definition.
 
 The find-work Lambda only discovers ids and slices them, so its runtime does not
 depend on how much work the window matched. Each partition file on S3 holds the
@@ -94,6 +100,8 @@ slip fails validation in the Lambda rather than scanning the full index):
   same minute collide without one). The inferrer's find-work event has no
   `job_id` field and silently ignores it.
 - `partition_size`, to override the consumer's default ids-per-partition.
+- `full: true`, required to run with no ids and no window; without it an
+  unscoped invoke fails rather than scanning the whole index.
 
 Replays are safe to repeat because both consumers process idempotently, and the
 partition files are keyed by scope (window, ids or full), so re-running the

--- a/pipeline/terraform/modules/find_work_state_machine/README.md
+++ b/pipeline/terraform/modules/find_work_state_machine/README.md
@@ -1,0 +1,82 @@
+# find_work state machine
+
+A scheduled scan-and-fan-out state machine for pipeline steps whose work volume
+per window is unbounded:
+
+```
+ConstructEvent (build the window from the schedule, or pass through replay input)
+  -> FindWork (Lambda: ids in scope, partitioned into files on S3)
+    -> ProcessPartitions (Map: one worker per partition ref, bounded concurrency)
+      -> CheckPartitionFailures (fail loudly, or tolerate and succeed)
+```
+
+The find-work Lambda only discovers ids and slices them, so its runtime does not
+depend on how much work the window matched. Each partition file on S3 holds the
+full event for one worker; the Map iterates small `{s3_uri, count}` refs so its
+payload stays under the Step Functions 256 KB state limit. The long-running
+processing happens in the caller-injected worker state (an ECS task for the
+image inferrer, a Lambda for the id-minter), one bounded partition at a time.
+
+`max_concurrency` is the work-in-progress ceiling. Pin it to the worker's real
+capacity rather than picking a number here: the inferrer pins it to the ASG's
+`max_instances`, and the id-minter (moving onto this module in
+wellcomecollection/platform#6486) to its RDS connection budget.
+
+## Failure semantics
+
+A partition that fails after the worker's own retries is caught and recorded,
+so every other partition still runs. The Map output carries the aggregate:
+
+```json
+{"partition_count": 34, "failed_partition_count": 2, "results": [...]}
+```
+
+What happens next depends on `tolerate_partition_failures`:
+
+- `true` (image inferrer): the execution succeeds. This is only safe when a
+  later scheduled window re-covers the same records idempotently.
+- `false` (the id-minter, once adopted): once every partition has finished, the
+  execution fails with `PartitionsFailed`. Nothing re-covers a missed window for
+  these consumers, so a silent skip would be data loss; failing after the Map
+  means a replay only needs to cover the failed partitions, not the whole
+  window.
+
+## Replaying
+
+Scheduled runs process the window `[scheduled_time - 20min, scheduled_time - 5min]`.
+To replay a lost or failed range, start an execution with explicit input instead:
+
+```sh
+aws stepfunctions start-execution \
+  --state-machine-arn arn:aws:states:eu-west-1:760097843905:stateMachine:pipeline-<date>_<name> \
+  --name <replay-name> \
+  --input '{"job_id": "replay-s01", "window": {"start_time": "2026-07-30T16:32:00Z", "end_time": "2026-07-30T16:34:00Z"}}'
+```
+
+Accepted input fields, all guarded against malformed shapes (a `window: null`
+slip fails validation in the Lambda rather than scanning the full index):
+
+- `window`, with `start_time` optional (defaults to `end_time` minus 15
+  minutes). Windows slice to arbitrary timestamps, so a dense range can be
+  replayed as several smaller executions.
+- `ids`, a JSON array of ids to process instead of a window.
+- `job_id`, recommended whenever consumers write per-run reports; generated ids
+  are minute-granular, so concurrent replays started in the same minute collide.
+- `partition_size`, to override the consumer's default ids-per-partition.
+
+Replays are safe to repeat because both consumers process idempotently, and the
+partition files are keyed by scope (window, ids or full), so re-running the
+same input overwrites the previous run's files rather than accumulating.
+
+## Replaying only the failed partitions
+
+The `results` array in the Map output preserves partition order, so the indices
+of entries with `partition_failed: true` identify which partition files failed.
+The files live under the consumer's scope-keyed prefix, for example:
+
+```
+s3://wellcomecollection-catalogue-graph/graph-<graph_date>/pipeline-<date>/<service>/find_work/windows/<start>-<end>/partition-<i>.json
+```
+
+Each file contains the ids for that partition, so a targeted replay is an
+`ids`-mode execution built from the failed files' contents.

--- a/pipeline/terraform/modules/find_work_state_machine/README.md
+++ b/pipeline/terraform/modules/find_work_state_machine/README.md
@@ -35,12 +35,15 @@ so every other partition still runs. The Map output carries the aggregate:
 What happens next depends on `tolerate_partition_failures`:
 
 - `true` (image inferrer): the execution succeeds. This is only safe when a
-  later scheduled window re-covers the same records idempotently.
+  missed record stays recoverable, because replaying the same window later
+  re-covers it idempotently (scheduled windows tile with no overlap, so the
+  next one does not). The execution succeeding means nothing alarms, so the
+  consumer also needs its own failure signal (see Retry and alerting).
 - `false` (the id-minter, once adopted): once every partition has finished, the
-  execution fails with `PartitionsFailed`. Nothing re-covers a missed window for
-  these consumers, so a silent skip would be data loss; failing after the Map
-  means a replay only needs to cover the failed partitions, not the whole
-  window.
+  execution fails with `PartitionsFailed`. A tolerated skip would leave the
+  missed records unprocessed with nothing to notice them, so the execution
+  fails loudly instead; failing after the Map means a replay only needs to
+  cover the failed partitions, not the whole window.
 
 ## Retry and alerting
 

--- a/pipeline/terraform/modules/find_work_state_machine/main.tf
+++ b/pipeline/terraform/modules/find_work_state_machine/main.tf
@@ -22,6 +22,8 @@ module "find_work_lambda" {
   memory_size = var.find_work_lambda.memory_size
   timeout     = var.find_work_lambda.timeout
 
+  environment_variables = var.find_work_lambda.environment_variables
+
   vpc_config = var.vpc_config
 }
 

--- a/pipeline/terraform/modules/find_work_state_machine/main.tf
+++ b/pipeline/terraform/modules/find_work_state_machine/main.tf
@@ -1,0 +1,48 @@
+# A scheduled scan-and-fan-out state machine:
+#   ConstructEvent (build the window from the schedule, or pass through replay input)
+#     -> FindWork (Lambda: ids in scope, partitioned to S3)
+#       -> ProcessPartitions (Map: one worker per partition ref, bounded by max_concurrency)
+#
+# The find-work Lambda only discovers and slices, so its runtime never depends
+# on how much work the window matched; the long-running processing happens in
+# the injected worker state, one bounded partition at a time.
+
+module "find_work_lambda" {
+  source = "../pipeline_lambda"
+
+  service_name = var.find_work_lambda.service_name
+  description  = var.find_work_lambda.description
+
+  pipeline_date       = var.pipeline_date
+  ecr_repository_name = var.ecr_repository_name
+
+  image_config = {
+    command = var.find_work_lambda.command
+  }
+
+  memory_size = var.find_work_lambda.memory_size
+  timeout     = var.find_work_lambda.timeout
+
+  vpc_config = var.vpc_config
+}
+
+# The Lambda reads ES credentials from Secrets Manager at runtime.
+resource "aws_iam_role_policy" "find_work_secret_read" {
+  role   = module.find_work_lambda.lambda_role_name
+  policy = var.find_work_secret_read_policy_json
+}
+
+# find_work writes each partition's ids to S3 (pass-by-reference) so the state
+# machine Map payload stays small; each worker reads its partition back.
+data "aws_iam_policy_document" "find_work_s3_write" {
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:PutObject"]
+    resources = var.partition_s3_arns
+  }
+}
+
+resource "aws_iam_role_policy" "find_work_s3_write" {
+  role   = module.find_work_lambda.lambda_role_name
+  policy = data.aws_iam_policy_document.find_work_s3_write.json
+}

--- a/pipeline/terraform/modules/find_work_state_machine/main.tf
+++ b/pipeline/terraform/modules/find_work_state_machine/main.tf
@@ -3,9 +3,8 @@
 #     -> FindWork (Lambda: ids in scope, partitioned to S3)
 #       -> ProcessPartitions (Map: one worker per partition ref, bounded by max_concurrency)
 #
-# The find-work Lambda only discovers and slices, so its runtime never depends
-# on how much work the window matched; the long-running processing happens in
-# the injected worker state, one bounded partition at a time.
+# The find-work Lambda only discovers and slices; the injected worker state
+# does the long-running processing, one bounded partition at a time.
 
 module "find_work_lambda" {
   source = "../pipeline_lambda"

--- a/pipeline/terraform/modules/find_work_state_machine/outputs.tf
+++ b/pipeline/terraform/modules/find_work_state_machine/outputs.tf
@@ -1,0 +1,11 @@
+output "state_machine_arn" {
+  value = module.state_machine.state_machine_arn
+}
+
+output "find_work_lambda_arn" {
+  value = module.find_work_lambda.lambda_arn
+}
+
+output "find_work_lambda_role_name" {
+  value = module.find_work_lambda.lambda_role_name
+}

--- a/pipeline/terraform/modules/find_work_state_machine/schedule.tf
+++ b/pipeline/terraform/modules/find_work_state_machine/schedule.tf
@@ -1,0 +1,51 @@
+resource "aws_scheduler_schedule" "schedule" {
+  name                = "${local.slug}-schedule-${var.pipeline_date}"
+  schedule_expression = var.schedule.cron
+
+  flexible_time_window {
+    mode = "OFF"
+  }
+
+  target {
+    arn      = module.state_machine.state_machine_arn
+    role_arn = aws_iam_role.run_state_machine.arn
+
+    input = <<JSON
+    {
+      "scheduled_time": "<aws.scheduler.scheduled-time>"
+    }
+    JSON
+  }
+
+  state = var.schedule.enabled ? "ENABLED" : "DISABLED"
+}
+
+resource "aws_iam_role" "run_state_machine" {
+  name = "run-${local.slug}-role-${var.pipeline_date}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = { Service = "scheduler.amazonaws.com" }
+        Action    = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "run_state_machine" {
+  role = aws_iam_role.run_state_machine.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "states:StartExecution"
+        Resource = module.state_machine.state_machine_arn
+      }
+    ]
+  })
+}

--- a/pipeline/terraform/modules/find_work_state_machine/state_machine.tf
+++ b/pipeline/terraform/modules/find_work_state_machine/state_machine.tf
@@ -16,13 +16,10 @@ locals {
   ]
 
   # Scheduled runs derive the window end from scheduled_time - 5min (indexing
-  # lag); the find-work step defaults the start to end - 15min. Replays may
-  # instead pass explicit ids or a window, plus a job_id and partition_size.
-  # Shape guards keep malformed input (e.g. window: null, for which $exists is
-  # true) from reaching the Lambda as "no window", which would scan the full
-  # index. A window that is an object but invalid (e.g. start_time only) is
-  # passed through so the Lambda's validation rejects it loudly, rather than
-  # being silently replaced by the schedule-derived window.
+  # lag); replays may instead pass ids or an explicit window, plus a job_id
+  # and partition_size. The shape guards stop window:null becoming "no window"
+  # (a full-index scan); an object-shaped but invalid window is passed through
+  # so the Lambda rejects it loudly.
   construct_event_output = trimspace(<<-EOT
     {% $merge([
       ${jsonencode(merge({ pipeline_date = var.pipeline_date }, var.static_event_fields))},
@@ -46,16 +43,9 @@ locals {
       StartAt         = var.worker_state_name
       States = {
         (var.worker_state_name) = merge(var.worker_state, {
-          # A partition that still fails after the worker's own retries is
-          # recorded rather than aborting the whole Map, so every other
-          # partition still runs; CheckPartitionFailures decides afterwards
-          # what that means for the execution. The Catch's Output carries the
-          # partition's S3 ref ($states.input here is the state's original
-          # input, the partition ref) and a truncated error into the Map
-          # results, so a failed execution's output identifies what failed and
-          # why without walking per-iteration history. JSONata drops object
-          # keys whose value is undefined, so an unexpected shape degrades to
-          # a bare {partition_failed: true} rather than an error.
+          # Record a partition that still fails after the worker's own retries,
+          # so the rest of the Map runs; the Output keeps the partition ref and
+          # a truncated error visible in the Map results for triage.
           Catch = [
             {
               ErrorEquals = ["States.ALL"]

--- a/pipeline/terraform/modules/find_work_state_machine/state_machine.tf
+++ b/pipeline/terraform/modules/find_work_state_machine/state_machine.tf
@@ -1,0 +1,146 @@
+locals {
+  slug = replace(var.name, "_", "-")
+
+  lambda_retry = [
+    {
+      ErrorEquals = [
+        "Lambda.ServiceException",
+        "Lambda.AWSLambdaException",
+        "Lambda.SdkClientException",
+        "Lambda.TooManyRequestsException",
+      ]
+      IntervalSeconds = 2
+      MaxAttempts     = 3
+      BackoffRate     = 2.0
+    }
+  ]
+
+  # Scheduled runs derive the window end from scheduled_time - 5min (indexing
+  # lag); the find-work step defaults the start to end - 15min. Replays may
+  # instead pass explicit ids or a window, plus a job_id and partition_size.
+  # Shape guards keep malformed input (e.g. window: null) from reaching the
+  # Lambda as "no window", which would scan the full index.
+  construct_event_output = trimspace(<<-EOT
+    {% $merge([
+      ${jsonencode(merge({ pipeline_date = var.pipeline_date }, var.static_event_fields))},
+      $type($states.input.ids) = 'array'
+        ? {'ids': $states.input.ids}
+        : {'window': $exists($states.input.window.end_time)
+            ? $states.input.window
+            : {'end_time': $fromMillis($toMillis($states.input.scheduled_time) - 300000)}},
+      $type($states.input.job_id) = 'string' ? {'job_id': $states.input.job_id} : {},
+      $type($states.input.partition_size) = 'number' ? {'partition_size': $states.input.partition_size} : {}
+    ]) %}
+  EOT
+  )
+
+  process_partitions = {
+    Type           = "Map"
+    Items          = "{% $states.input.partitions %}"
+    MaxConcurrency = var.max_concurrency
+    ItemProcessor = {
+      ProcessorConfig = { Mode = "INLINE" }
+      StartAt         = var.worker_state_name
+      States = {
+        (var.worker_state_name) = merge(var.worker_state, {
+          # A partition that still fails after the worker's own retries is
+          # recorded rather than aborting the whole Map, so every other
+          # partition still runs; CheckPartitionFailures decides afterwards
+          # what that means for the execution.
+          Catch = [
+            {
+              ErrorEquals = ["States.ALL"]
+              Next        = "RecordPartitionFailure"
+            }
+          ]
+          End = true
+        })
+        RecordPartitionFailure = {
+          Type = "Pass"
+          Output = {
+            "partition_failed" : true
+          }
+          End = true
+        }
+      }
+    }
+    Output = "{% {'partition_count': $count($states.result), 'failed_partition_count': $count($states.result[partition_failed = true]), 'results': $states.result} %}"
+    Next   = "CheckPartitionFailures"
+  }
+
+  # Failing only after every partition has run means a replay needs to cover
+  # just the failed partitions, not the whole window. When failures are
+  # tolerated the check is a constant-false Choice, so the states stay
+  # structurally identical either way.
+  failure_check_states = {
+    CheckPartitionFailures = {
+      Type = "Choice"
+      Choices = [
+        {
+          Condition = var.tolerate_partition_failures ? "{% false %}" : "{% $states.input.failed_partition_count > 0 %}"
+          Next      = "FailPartitions"
+        }
+      ]
+      Default = "Succeeded"
+    }
+    FailPartitions = {
+      Type  = "Fail"
+      Error = "PartitionsFailed"
+      Cause = "{% $string($states.input.failed_partition_count) & ' of ' & $string($states.input.partition_count) & ' partitions failed; see the Map results for detail' %}"
+    }
+    Succeeded = {
+      Type = "Succeed"
+    }
+  }
+
+  state_machine_definition = jsonencode({
+    QueryLanguage = "JSONata"
+    Comment       = var.comment
+    StartAt       = "ConstructEvent"
+    States = merge(
+      {
+        ConstructEvent = {
+          Type   = "Pass"
+          Output = local.construct_event_output
+          Next   = "FindWork"
+        }
+        FindWork = {
+          Type     = "Task"
+          Resource = "arn:aws:states:::lambda:invoke"
+          Arguments = {
+            FunctionName = module.find_work_lambda.lambda_arn
+            Payload      = "{% $states.input %}"
+          }
+          Output = "{% $states.result.Payload %}"
+          Retry  = local.lambda_retry
+          Next   = "ProcessPartitions"
+        }
+        ProcessPartitions = local.process_partitions
+      },
+      local.failure_check_states
+    )
+  })
+}
+
+module "state_machine" {
+  source = "../state_machine"
+
+  name                     = "pipeline-${var.pipeline_date}_${var.name}"
+  state_machine_definition = local.state_machine_definition
+
+  invokable_lambda_arns = concat([module.find_work_lambda.lambda_arn], var.worker_lambda_arns)
+
+  policies_to_attach = var.state_machine_policies
+}
+
+module "state_machine_alarms" {
+  source = "../state_machine_alarms"
+
+  state_machine_arn = module.state_machine.state_machine_arn
+  alarm_name_prefix = var.alarm_name_prefix
+  alarm_name_suffix = "-${var.pipeline_date}"
+
+  default_alarm_configuration = {
+    alarm_actions = [var.alarm_topic_arn]
+  }
+}

--- a/pipeline/terraform/modules/find_work_state_machine/state_machine.tf
+++ b/pipeline/terraform/modules/find_work_state_machine/state_machine.tf
@@ -18,14 +18,17 @@ locals {
   # Scheduled runs derive the window end from scheduled_time - 5min (indexing
   # lag); the find-work step defaults the start to end - 15min. Replays may
   # instead pass explicit ids or a window, plus a job_id and partition_size.
-  # Shape guards keep malformed input (e.g. window: null) from reaching the
-  # Lambda as "no window", which would scan the full index.
+  # Shape guards keep malformed input (e.g. window: null, for which $exists is
+  # true) from reaching the Lambda as "no window", which would scan the full
+  # index. A window that is an object but invalid (e.g. start_time only) is
+  # passed through so the Lambda's validation rejects it loudly, rather than
+  # being silently replaced by the schedule-derived window.
   construct_event_output = trimspace(<<-EOT
     {% $merge([
       ${jsonencode(merge({ pipeline_date = var.pipeline_date }, var.static_event_fields))},
       $type($states.input.ids) = 'array'
         ? {'ids': $states.input.ids}
-        : {'window': $exists($states.input.window.end_time)
+        : {'window': $type($states.input.window) = 'object'
             ? $states.input.window
             : {'end_time': $fromMillis($toMillis($states.input.scheduled_time) - 300000)}},
       $type($states.input.job_id) = 'string' ? {'job_id': $states.input.job_id} : {},
@@ -46,10 +49,17 @@ locals {
           # A partition that still fails after the worker's own retries is
           # recorded rather than aborting the whole Map, so every other
           # partition still runs; CheckPartitionFailures decides afterwards
-          # what that means for the execution.
+          # what that means for the execution. The Catch's Output carries the
+          # partition's S3 ref ($states.input here is the state's original
+          # input, the partition ref) and a truncated error into the Map
+          # results, so a failed execution's output identifies what failed and
+          # why without walking per-iteration history. JSONata drops object
+          # keys whose value is undefined, so an unexpected shape degrades to
+          # a bare {partition_failed: true} rather than an error.
           Catch = [
             {
               ErrorEquals = ["States.ALL"]
+              Output      = "{% {'partition_failed': true, 's3_uri': $states.input.s3_uri, 'error': $substring($string($states.errorOutput), 0, 1000)} %}"
               Next        = "RecordPartitionFailure"
             }
           ]
@@ -57,10 +67,7 @@ locals {
         })
         RecordPartitionFailure = {
           Type = "Pass"
-          Output = {
-            "partition_failed" : true
-          }
-          End = true
+          End  = true
         }
       }
     }
@@ -137,7 +144,7 @@ module "state_machine_alarms" {
   source = "../state_machine_alarms"
 
   state_machine_arn = module.state_machine.state_machine_arn
-  alarm_name_prefix = var.alarm_name_prefix
+  alarm_name_prefix = coalesce(var.alarm_name_prefix, local.slug)
   alarm_name_suffix = "-${var.pipeline_date}"
 
   default_alarm_configuration = {

--- a/pipeline/terraform/modules/find_work_state_machine/state_machine.tf
+++ b/pipeline/terraform/modules/find_work_state_machine/state_machine.tf
@@ -15,11 +15,9 @@ locals {
     }
   ]
 
-  # Scheduled runs derive the window end from scheduled_time - 5min (indexing
-  # lag); replays may instead pass ids or an explicit window, plus a job_id
-  # and partition_size. The shape guards stop window:null becoming "no window"
-  # (a full-index scan); an object-shaped but invalid window is passed through
-  # so the Lambda rejects it loudly.
+  # Window end = scheduled_time - 5min (indexing lag); replays may pass ids,
+  # an explicit window, job_id or partition_size. The guards stop window:null
+  # becoming a full-index scan; an invalid window object fails loudly in the Lambda.
   construct_event_output = trimspace(<<-EOT
     {% $merge([
       ${jsonencode(merge({ pipeline_date = var.pipeline_date }, var.static_event_fields))},
@@ -43,9 +41,7 @@ locals {
       StartAt         = var.worker_state_name
       States = {
         (var.worker_state_name) = merge(var.worker_state, {
-          # Record a partition that still fails after the worker's own retries,
-          # so the rest of the Map runs; the Output keeps the partition ref and
-          # a truncated error visible in the Map results for triage.
+          # Record a failed partition (ref + truncated error) and keep the Map running.
           Catch = [
             {
               ErrorEquals = ["States.ALL"]
@@ -65,10 +61,8 @@ locals {
     Next   = "CheckPartitionFailures"
   }
 
-  # Failing only after every partition has run means a replay needs to cover
-  # just the failed partitions, not the whole window. When failures are
-  # tolerated the check is a constant-false Choice, so the states stay
-  # structurally identical either way.
+  # Fail only after every partition has run, so a replay covers just the failed
+  # partitions. When tolerated, the Choice is constant-false so the shape stays identical.
   failure_check_states = {
     CheckPartitionFailures = {
       Type = "Choice"

--- a/pipeline/terraform/modules/find_work_state_machine/state_machine.tf
+++ b/pipeline/terraform/modules/find_work_state_machine/state_machine.tf
@@ -15,23 +15,6 @@ locals {
     }
   ]
 
-  # Window end = scheduled_time - 5min (indexing lag); replays may pass ids,
-  # an explicit window, job_id or partition_size. The guards stop window:null
-  # becoming a full-index scan; an invalid window object fails loudly in the Lambda.
-  construct_event_output = trimspace(<<-EOT
-    {% $merge([
-      ${jsonencode(merge(var.static_event_fields, { pipeline_date = var.pipeline_date }))},
-      $type($states.input.ids) = 'array'
-        ? {'ids': $states.input.ids}
-        : {'window': $type($states.input.window) = 'object'
-            ? $states.input.window
-            : {'end_time': $fromMillis($toMillis($states.input.scheduled_time) - 300000)}},
-      $type($states.input.job_id) = 'string' ? {'job_id': $states.input.job_id} : {},
-      $type($states.input.partition_size) = 'number' ? {'partition_size': $states.input.partition_size} : {}
-    ]) %}
-  EOT
-  )
-
   process_partitions = {
     Type           = "Map"
     Items          = "{% $states.input.partitions %}"
@@ -84,17 +67,14 @@ locals {
     }
   }
 
+  # The raw invocation payload (scheduled_time, or replay input) goes straight
+  # to the find-work Lambda, which owns all input normalisation and guards.
   state_machine_definition = jsonencode({
     QueryLanguage = "JSONata"
     Comment       = var.comment
-    StartAt       = "ConstructEvent"
+    StartAt       = "FindWork"
     States = merge(
       {
-        ConstructEvent = {
-          Type   = "Pass"
-          Output = local.construct_event_output
-          Next   = "FindWork"
-        }
         FindWork = {
           Type     = "Task"
           Resource = "arn:aws:states:::lambda:invoke"

--- a/pipeline/terraform/modules/find_work_state_machine/state_machine.tf
+++ b/pipeline/terraform/modules/find_work_state_machine/state_machine.tf
@@ -20,7 +20,7 @@ locals {
   # becoming a full-index scan; an invalid window object fails loudly in the Lambda.
   construct_event_output = trimspace(<<-EOT
     {% $merge([
-      ${jsonencode(merge({ pipeline_date = var.pipeline_date }, var.static_event_fields))},
+      ${jsonencode(merge(var.static_event_fields, { pipeline_date = var.pipeline_date }))},
       $type($states.input.ids) = 'array'
         ? {'ids': $states.input.ids}
         : {'window': $type($states.input.window) = 'object'

--- a/pipeline/terraform/modules/find_work_state_machine/variables.tf
+++ b/pipeline/terraform/modules/find_work_state_machine/variables.tf
@@ -42,7 +42,7 @@ variable "find_work_secret_read_policy_json" {
 
 variable "partition_s3_arns" {
   type        = list(string)
-  description = "S3 object ARNs the find-work Lambda writes partition files to (pass-by-reference so the Map payload stays under the Step Functions 256 KB limit)."
+  description = "S3 object ARNs the find-work Lambda writes partition files to."
 }
 
 variable "static_event_fields" {
@@ -53,32 +53,17 @@ variable "static_event_fields" {
 
 variable "max_concurrency" {
   type        = number
-  description = "Map MaxConcurrency: the work-in-progress ceiling. Pin to the worker's real capacity (ASG instances, DB connection budget) rather than picking a number here."
-
-  validation {
-    condition     = var.max_concurrency > 0 && var.max_concurrency <= 40
-    error_message = "An INLINE Map never runs more than 40 concurrent iterations, so a max_concurrency above 40 silently caps there; keep it within the platform ceiling."
-  }
+  description = "Map MaxConcurrency: the work-in-progress ceiling. Pin to the worker's real capacity (ASG instances, DB connection budget)."
 }
 
 variable "worker_state_name" {
   type        = string
-  description = "Name of the injected worker state, caller-defined so execution histories read meaningfully."
-
-  validation {
-    condition     = var.worker_state_name != "RecordPartitionFailure"
-    error_message = "RecordPartitionFailure is reserved by the module for the partition-failure catch state."
-  }
+  description = "Name of the injected worker state."
 }
 
 variable "worker_state" {
   type        = any
-  description = "ASL Task state that processes one partition ref. Passed without Catch, Next or End; the module appends Catch and End."
-
-  validation {
-    condition     = length(setintersection(keys(var.worker_state), ["Catch", "Next", "End"])) == 0
-    error_message = "worker_state must not define Catch, Next or End: the module appends its own Catch and End, and would otherwise silently clobber the caller's error routing or render invalid ASL."
-  }
+  description = "ASL Task state that processes one partition ref, passed without Catch or End (the module appends both)."
 }
 
 variable "worker_lambda_arns" {
@@ -95,7 +80,7 @@ variable "state_machine_policies" {
 
 variable "tolerate_partition_failures" {
   type        = bool
-  description = "Whether a failed partition is tolerated. Only safe when a later scheduled window re-covers the same records idempotently; otherwise the execution fails once every other partition has finished."
+  description = "Tolerate failed partitions. Only safe when a later window re-covers the same records; otherwise the execution fails once every partition has finished."
 }
 
 variable "schedule" {

--- a/pipeline/terraform/modules/find_work_state_machine/variables.tf
+++ b/pipeline/terraform/modules/find_work_state_machine/variables.tf
@@ -19,11 +19,12 @@ variable "ecr_repository_name" {
 
 variable "find_work_lambda" {
   type = object({
-    service_name = string
-    description  = string
-    command      = list(string)
-    memory_size  = optional(number, 1024)
-    timeout      = optional(number, 300)
+    service_name          = string
+    description           = string
+    command               = list(string)
+    memory_size           = optional(number, 1024)
+    timeout               = optional(number, 300)
+    environment_variables = optional(map(string), {})
   })
   description = "The work-discovery Lambda: an entrypoint in the unified pipeline image that scans for ids in scope and partitions them to S3."
 }
@@ -43,12 +44,6 @@ variable "find_work_secret_read_policy_json" {
 variable "partition_s3_arns" {
   type        = list(string)
   description = "S3 object ARNs the find-work Lambda writes partition files to."
-}
-
-variable "static_event_fields" {
-  type        = any
-  default     = {}
-  description = "Extra fields merged into every constructed event alongside pipeline_date (e.g. index_dates, graph_date)."
 }
 
 variable "max_concurrency" {

--- a/pipeline/terraform/modules/find_work_state_machine/variables.tf
+++ b/pipeline/terraform/modules/find_work_state_machine/variables.tf
@@ -1,0 +1,99 @@
+variable "name" {
+  type        = string
+  description = "Underscored service name, e.g. `image_inferrer`. Names the state machine (`pipeline-<date>_<name>`); the hyphenated form names the schedule and scheduler role."
+}
+
+variable "pipeline_date" {
+  type = string
+}
+
+variable "comment" {
+  type        = string
+  description = "Comment on the rendered state machine definition."
+}
+
+variable "ecr_repository_name" {
+  type        = string
+  description = "ECR repository holding the unified pipeline Lambda image the find-work Lambda runs from."
+}
+
+variable "find_work_lambda" {
+  type = object({
+    service_name = string
+    description  = string
+    command      = list(string)
+    memory_size  = optional(number, 1024)
+    timeout      = optional(number, 300)
+  })
+  description = "The work-discovery Lambda: an entrypoint in the unified pipeline image that scans for ids in scope and partitions them to S3."
+}
+
+variable "vpc_config" {
+  type = object({
+    subnet_ids         = list(string)
+    security_group_ids = list(string)
+  })
+}
+
+variable "find_work_secret_read_policy_json" {
+  type        = string
+  description = "IAM policy granting the find-work Lambda read access to its ES credentials."
+}
+
+variable "partition_s3_arns" {
+  type        = list(string)
+  description = "S3 object ARNs the find-work Lambda writes partition files to (pass-by-reference so the Map payload stays under the Step Functions 256 KB limit)."
+}
+
+variable "static_event_fields" {
+  type        = any
+  default     = {}
+  description = "Extra fields merged into every constructed event alongside pipeline_date (e.g. index_dates, graph_date)."
+}
+
+variable "max_concurrency" {
+  type        = number
+  description = "Map MaxConcurrency: the work-in-progress ceiling. Pin to the worker's real capacity (ASG instances, DB connection budget) rather than picking a number here."
+}
+
+variable "worker_state_name" {
+  type        = string
+  description = "Name of the injected worker state, caller-defined so execution histories read meaningfully."
+}
+
+variable "worker_state" {
+  type        = any
+  description = "ASL Task state that processes one partition ref. Passed without Catch or End; the module appends both."
+}
+
+variable "worker_lambda_arns" {
+  type        = list(string)
+  default     = []
+  description = "Lambda ARNs the state machine invokes as workers (empty for ECS-based workers)."
+}
+
+variable "state_machine_policies" {
+  type        = map(string)
+  default     = {}
+  description = "Extra IAM policy documents to attach to the state machine role (e.g. runTask on the worker's ECS task)."
+}
+
+variable "tolerate_partition_failures" {
+  type        = bool
+  description = "Whether a failed partition is tolerated. Only safe when a later scheduled window re-covers the same records idempotently; otherwise the execution fails once every other partition has finished."
+}
+
+variable "schedule" {
+  type = object({
+    cron    = string
+    enabled = bool
+  })
+}
+
+variable "alarm_name_prefix" {
+  type = string
+}
+
+variable "alarm_topic_arn" {
+  type = string
+}

--- a/pipeline/terraform/modules/find_work_state_machine/variables.tf
+++ b/pipeline/terraform/modules/find_work_state_machine/variables.tf
@@ -54,16 +54,31 @@ variable "static_event_fields" {
 variable "max_concurrency" {
   type        = number
   description = "Map MaxConcurrency: the work-in-progress ceiling. Pin to the worker's real capacity (ASG instances, DB connection budget) rather than picking a number here."
+
+  validation {
+    condition     = var.max_concurrency > 0 && var.max_concurrency <= 40
+    error_message = "An INLINE Map never runs more than 40 concurrent iterations, so a max_concurrency above 40 silently caps there; keep it within the platform ceiling."
+  }
 }
 
 variable "worker_state_name" {
   type        = string
   description = "Name of the injected worker state, caller-defined so execution histories read meaningfully."
+
+  validation {
+    condition     = var.worker_state_name != "RecordPartitionFailure"
+    error_message = "RecordPartitionFailure is reserved by the module for the partition-failure catch state."
+  }
 }
 
 variable "worker_state" {
   type        = any
-  description = "ASL Task state that processes one partition ref. Passed without Catch or End; the module appends both."
+  description = "ASL Task state that processes one partition ref. Passed without Catch, Next or End; the module appends Catch and End."
+
+  validation {
+    condition     = length(setintersection(keys(var.worker_state), ["Catch", "Next", "End"])) == 0
+    error_message = "worker_state must not define Catch, Next or End: the module appends its own Catch and End, and would otherwise silently clobber the caller's error routing or render invalid ASL."
+  }
 }
 
 variable "worker_lambda_arns" {
@@ -91,7 +106,9 @@ variable "schedule" {
 }
 
 variable "alarm_name_prefix" {
-  type = string
+  type        = string
+  default     = null
+  description = "Defaults to the hyphenated service name; set only when the alarm naming must differ from it."
 }
 
 variable "alarm_topic_arn" {

--- a/pipeline/terraform/modules/pipeline_new/ecs_task_inference_manager.tf
+++ b/pipeline/terraform/modules/pipeline_new/ecs_task_inference_manager.tf
@@ -139,7 +139,7 @@ data "aws_iam_policy_document" "inference_manager_task_token" {
     effect  = "Allow"
     actions = ["states:SendTaskSuccess", "states:SendTaskFailure", "states:SendTaskHeartbeat"]
     resources = [
-      module.image_inferrer_state_machine.state_machine_arn,
+      module.image_inferrer.state_machine_arn,
     ]
   }
 }

--- a/pipeline/terraform/modules/pipeline_new/state_machine_image_inferrer.tf
+++ b/pipeline/terraform/modules/pipeline_new/state_machine_image_inferrer.tf
@@ -54,6 +54,12 @@ module "image_inferrer" {
     command      = ["inferrer.steps.find_work.lambda_handler"]
     memory_size  = 1024
     timeout      = 300 # 5 minutes
+    environment_variables = {
+      PIPELINE_DATE        = var.pipeline_date
+      GRAPH_DATE           = var.graph_date
+      INDEX_DATE_INITIAL   = var.index_dates.initial
+      INDEX_DATE_AUGMENTED = var.index_dates.augmented
+    }
   }
 
   vpc_config = {
@@ -69,14 +75,6 @@ module "image_inferrer" {
   partition_s3_arns = [
     "arn:aws:s3:::wellcomecollection-catalogue-graph/graph-*/*/inferrer/*"
   ]
-
-  static_event_fields = {
-    graph_date = var.graph_date
-    index_dates = {
-      initial   = var.index_dates.initial
-      augmented = var.index_dates.augmented
-    }
-  }
 
   # Matches the inferrer ASG max_instances (local.inference_max_concurrency)
   # so the Map never fans out more tasks than the capacity provider can place.

--- a/pipeline/terraform/modules/pipeline_new/state_machine_image_inferrer.tf
+++ b/pipeline/terraform/modules/pipeline_new/state_machine_image_inferrer.tf
@@ -1,82 +1,17 @@
-# Work-discovery Lambda for the image-inferrer state machine: queries
-# images-initial for images modified within the scheduled window and partitions
-# their ids for the Map fan-out.
-# (The unified_pipeline_lambda ECR data source is declared in locals.tf.)
-
-module "inference_find_work_lambda" {
-  source = "../pipeline_lambda"
-
-  service_name = "image-inference-find-work"
-  description  = "Finds images needing inference within a time window and partitions them for the image-inferrer state machine."
-
-  pipeline_date       = var.pipeline_date
-  ecr_repository_name = data.aws_ecr_repository.unified_pipeline_lambda.name
-
-  image_config = {
-    command = ["inferrer.steps.find_work.lambda_handler"]
-  }
-
-  memory_size = 1024
-  timeout     = 300 # 5 minutes
-
-  vpc_config = {
-    subnet_ids = local.network_config.subnets
-    security_group_ids = [
-      local.network_config.ec_privatelink_security_group_id,
-      aws_security_group.egress.id,
-    ]
-  }
-}
-
-# The Lambda reads ES credentials from Secrets Manager at runtime.
-resource "aws_iam_role_policy" "inference_find_work_secret_read" {
-  role   = module.inference_find_work_lambda.lambda_role_name
-  policy = data.aws_iam_policy_document.inference_manager_pipeline_storage_secret_read.json
-}
-
-# find_work writes each partition's ids to S3 (pass-by-reference) so the state
-# machine Map payload stays small; the inference task reads them back.
-data "aws_iam_policy_document" "inference_find_work_s3_write" {
-  statement {
-    effect  = "Allow"
-    actions = ["s3:PutObject"]
-    resources = [
-      "arn:aws:s3:::wellcomecollection-catalogue-graph/graph-*/*/inferrer/*"
-    ]
-  }
-}
-
-resource "aws_iam_role_policy" "inference_find_work_s3_write" {
-  role   = module.inference_find_work_lambda.lambda_role_name
-  policy = data.aws_iam_policy_document.inference_find_work_s3_write.json
-}
-
-# Scheduled image-inference state machine:
-#   ConstructEvent (build the time window from the schedule)
-#     -> FindWork (Lambda: ids of images modified in the window, partitioned)
-#       -> InferImages (Map: one EC2 inference task per partition, runTask.waitForTaskToken)
+# Scheduled image-inference state machine, built on the shared
+# find_work_state_machine module:
+#   ConstructEvent (build the time window from the schedule, or pass through replay input)
+#     -> FindWork (Lambda: ids of images modified in the window, partitioned to S3)
+#       -> ProcessPartitions (Map: one EC2 inference task per partition, runTask.waitForTaskToken)
 #
 # This is the sole image inferrer; it replaced the always-on SQS-driven image_inferrer
 # Scala service, which has been retired. The schedule is gated on
 # var.enable_image_inferrer_schedule.
+# (The unified_pipeline_lambda ECR data source is declared in locals.tf.)
 
 locals {
   # Generous timeout so EC2 capacity-provider warm-up does not trip the task token.
   inference_task_token_timeout_seconds = 3 * 60 * 60 # 3 hours
-
-  inference_lambda_retry = [
-    {
-      ErrorEquals = [
-        "Lambda.ServiceException",
-        "Lambda.AWSLambdaException",
-        "Lambda.SdkClientException",
-        "Lambda.TooManyRequestsException",
-      ]
-      IntervalSeconds = 2
-      MaxAttempts     = 3
-      BackoffRate     = 2.0
-    }
-  ]
 
   # Retry transient ECS infrastructure errors only. Application failures (e.g. a
   # poisoned-doc error) are intentionally NOT retried so they surface promptly.
@@ -110,193 +45,148 @@ locals {
       JitterStrategy  = "FULL"
     }
   ]
-
-  image_inferrer_state_machine_definition = jsonencode({
-    QueryLanguage = "JSONata"
-    Comment       = "Find images modified within the window and augment them with inferred data."
-    StartAt       = "ConstructEvent"
-    States = {
-      ConstructEvent = {
-        Type = "Pass"
-        Output = {
-          "pipeline_date" : var.pipeline_date,
-          "graph_date" : var.graph_date,
-          "index_dates" : {
-            "initial" : var.index_dates.initial,
-            "augmented" : var.index_dates.augmented
-          },
-          # Window end is 5 minutes before the scheduled time (indexing lag);
-          # the find-work step defaults the window start to end - 15 minutes.
-          "window" : {
-            "end_time" : "{% $fromMillis($toMillis($states.input.scheduled_time) - 300000) %}"
-          }
-        }
-        Next = "FindWork"
-      }
-
-      FindWork = {
-        Type     = "Task"
-        Resource = "arn:aws:states:::lambda:invoke"
-        Arguments = {
-          FunctionName = module.inference_find_work_lambda.lambda_arn
-          Payload      = "{% $states.input %}"
-        }
-        Output = "{% $states.result.Payload %}"
-        Retry  = local.inference_lambda_retry
-        Next   = "InferImages"
-      }
-
-      InferImages = {
-        Type  = "Map"
-        Items = "{% $states.input.partitions %}"
-        # Matches the inferrer ASG max_instances (local.inference_max_concurrency)
-        # so the Map never fans out more tasks than the capacity provider can place.
-        MaxConcurrency = local.inference_max_concurrency
-        ItemProcessor = {
-          ProcessorConfig = { Mode = "INLINE" }
-          StartAt         = "RunInferenceTask"
-          States = {
-            RunInferenceTask = {
-              Type           = "Task"
-              Resource       = "arn:aws:states:::ecs:runTask.waitForTaskToken"
-              TimeoutSeconds = local.inference_task_token_timeout_seconds
-              Retry          = local.inference_ecs_retry
-              Arguments = {
-                Cluster        = aws_ecs_cluster.cluster.arn
-                TaskDefinition = module.inference_manager_ecs_task.task_definition_arn
-                CapacityProviderStrategy = [
-                  {
-                    CapacityProvider = module.inference_capacity_provider.name
-                    Weight           = 1
-                  }
-                ]
-                NetworkConfiguration = {
-                  AwsvpcConfiguration = {
-                    AssignPublicIp = "DISABLED"
-                    Subnets        = local.network_config.subnets
-                    SecurityGroups = [
-                      local.network_config.ec_privatelink_security_group_id,
-                      aws_security_group.egress.id,
-                    ]
-                  }
-                }
-                Overrides = {
-                  ContainerOverrides = [
-                    {
-                      Name = local.inference_manager_container_name
-                      Command = [
-                        "/app/src/inferrer/steps/inference_manager.py",
-                        "--event", "{% $string($states.input) %}",
-                        "--task-token", "{% $states.context.Task.Token %}",
-                      ]
-                    }
-                  ]
-                }
-              }
-              # A partition that still fails after task-level retries (an
-              # exhausted capacity retry, a permanently-missing image, or an ES
-              # error) is recorded and tolerated rather than aborting the whole
-              # Map. Its images are left un-augmented and picked up by a later
-              # window (writes are idempotent external_gte). Without this, one bad
-              # partition fails-fast the entire run.
-              Catch = [
-                {
-                  ErrorEquals = ["States.ALL"]
-                  Next        = "RecordPartitionFailure"
-                }
-              ]
-              End = true
-            }
-            RecordPartitionFailure = {
-              Type = "Pass"
-              Output = {
-                "partition_failed" : true
-              }
-              End = true
-            }
-          }
-        }
-        End = true
-      }
-    }
-  })
 }
 
-module "image_inferrer_state_machine" {
-  source = "../state_machine"
+module "image_inferrer" {
+  source = "../find_work_state_machine"
 
-  name                     = "pipeline-${var.pipeline_date}_image_inferrer"
-  state_machine_definition = local.image_inferrer_state_machine_definition
+  name          = "image_inferrer"
+  pipeline_date = var.pipeline_date
+  comment       = "Find images modified within the window and augment them with inferred data."
 
-  invokable_lambda_arns = [module.inference_find_work_lambda.lambda_arn]
+  ecr_repository_name = data.aws_ecr_repository.unified_pipeline_lambda.name
 
-  policies_to_attach = {
+  find_work_lambda = {
+    service_name = "image-inference-find-work"
+    description  = "Finds images needing inference within a time window and partitions them for the image-inferrer state machine."
+    command      = ["inferrer.steps.find_work.lambda_handler"]
+    memory_size  = 1024
+    timeout      = 300 # 5 minutes
+  }
+
+  vpc_config = {
+    subnet_ids = local.network_config.subnets
+    security_group_ids = [
+      local.network_config.ec_privatelink_security_group_id,
+      aws_security_group.egress.id,
+    ]
+  }
+
+  find_work_secret_read_policy_json = data.aws_iam_policy_document.inference_manager_pipeline_storage_secret_read.json
+
+  partition_s3_arns = [
+    "arn:aws:s3:::wellcomecollection-catalogue-graph/graph-*/*/inferrer/*"
+  ]
+
+  static_event_fields = {
+    graph_date = var.graph_date
+    index_dates = {
+      initial   = var.index_dates.initial
+      augmented = var.index_dates.augmented
+    }
+  }
+
+  # Matches the inferrer ASG max_instances (local.inference_max_concurrency)
+  # so the Map never fans out more tasks than the capacity provider can place.
+  max_concurrency = local.inference_max_concurrency
+
+  # A failed partition's images are left un-augmented and picked up by a later
+  # window (writes are idempotent external_gte), so it should not fail the run.
+  tolerate_partition_failures = true
+
+  worker_state_name = "RunInferenceTask"
+  worker_state = {
+    Type           = "Task"
+    Resource       = "arn:aws:states:::ecs:runTask.waitForTaskToken"
+    TimeoutSeconds = local.inference_task_token_timeout_seconds
+    Retry          = local.inference_ecs_retry
+    Arguments = {
+      Cluster        = aws_ecs_cluster.cluster.arn
+      TaskDefinition = module.inference_manager_ecs_task.task_definition_arn
+      CapacityProviderStrategy = [
+        {
+          CapacityProvider = module.inference_capacity_provider.name
+          Weight           = 1
+        }
+      ]
+      NetworkConfiguration = {
+        AwsvpcConfiguration = {
+          AssignPublicIp = "DISABLED"
+          Subnets        = local.network_config.subnets
+          SecurityGroups = [
+            local.network_config.ec_privatelink_security_group_id,
+            aws_security_group.egress.id,
+          ]
+        }
+      }
+      Overrides = {
+        ContainerOverrides = [
+          {
+            Name = local.inference_manager_container_name
+            Command = [
+              "/app/src/inferrer/steps/inference_manager.py",
+              "--event", "{% $string($states.input) %}",
+              "--task-token", "{% $states.context.Task.Token %}",
+            ]
+          }
+        ]
+      }
+    }
+  }
+
+  state_machine_policies = {
     "inference_manager_ecs_task_invoke_policy" = module.inference_manager_ecs_task.invoke_policy_document
   }
-}
 
-module "image_inferrer_state_machine_alarms" {
-  source = "../state_machine_alarms"
+  schedule = {
+    cron    = "cron(0,15,30,45 * * * ? *)"
+    enabled = var.enable_image_inferrer_schedule
+  }
 
-  state_machine_arn = module.image_inferrer_state_machine.state_machine_arn
   alarm_name_prefix = "image-inferrer"
-  alarm_name_suffix = "-${var.pipeline_date}"
-
-  default_alarm_configuration = {
-    alarm_actions = [local.monitoring_infra["chatbot_topic_arn"]]
-  }
+  alarm_topic_arn   = local.monitoring_infra["chatbot_topic_arn"]
 }
 
-# --- EventBridge schedule -------------------------------------------------- #
+# These resources predate the find_work_state_machine module; the moves keep
+# terraform updating them in place. Removable once every stack using this
+# module has applied.
 
-resource "aws_scheduler_schedule" "image_inferrer_schedule" {
-  name                = "image-inferrer-schedule-${var.pipeline_date}"
-  schedule_expression = "cron(0,15,30,45 * * * ? *)"
-
-  flexible_time_window {
-    mode = "OFF"
-  }
-
-  target {
-    arn      = module.image_inferrer_state_machine.state_machine_arn
-    role_arn = aws_iam_role.run_image_inferrer_role.arn
-
-    input = <<JSON
-    {
-      "scheduled_time": "<aws.scheduler.scheduled-time>"
-    }
-    JSON
-  }
-
-  state = var.enable_image_inferrer_schedule ? "ENABLED" : "DISABLED"
+moved {
+  from = module.inference_find_work_lambda
+  to   = module.image_inferrer.module.find_work_lambda
 }
 
-resource "aws_iam_role" "run_image_inferrer_role" {
-  name = "run-image-inferrer-role-${var.pipeline_date}"
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect    = "Allow"
-        Principal = { Service = "scheduler.amazonaws.com" }
-        Action    = "sts:AssumeRole"
-      }
-    ]
-  })
+moved {
+  from = aws_iam_role_policy.inference_find_work_secret_read
+  to   = module.image_inferrer.aws_iam_role_policy.find_work_secret_read
 }
 
-resource "aws_iam_role_policy" "run_image_inferrer_policy" {
-  role = aws_iam_role.run_image_inferrer_role.id
+moved {
+  from = aws_iam_role_policy.inference_find_work_s3_write
+  to   = module.image_inferrer.aws_iam_role_policy.find_work_s3_write
+}
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect   = "Allow"
-        Action   = "states:StartExecution"
-        Resource = module.image_inferrer_state_machine.state_machine_arn
-      }
-    ]
-  })
+moved {
+  from = module.image_inferrer_state_machine
+  to   = module.image_inferrer.module.state_machine
+}
+
+moved {
+  from = module.image_inferrer_state_machine_alarms
+  to   = module.image_inferrer.module.state_machine_alarms
+}
+
+moved {
+  from = aws_scheduler_schedule.image_inferrer_schedule
+  to   = module.image_inferrer.aws_scheduler_schedule.schedule
+}
+
+moved {
+  from = aws_iam_role.run_image_inferrer_role
+  to   = module.image_inferrer.aws_iam_role.run_state_machine
+}
+
+moved {
+  from = aws_iam_role_policy.run_image_inferrer_policy
+  to   = module.image_inferrer.aws_iam_role_policy.run_state_machine
 }

--- a/pipeline/terraform/modules/pipeline_new/state_machine_image_inferrer.tf
+++ b/pipeline/terraform/modules/pipeline_new/state_machine_image_inferrer.tf
@@ -143,8 +143,7 @@ module "image_inferrer" {
     enabled = var.enable_image_inferrer_schedule
   }
 
-  alarm_name_prefix = "image-inferrer"
-  alarm_topic_arn   = local.monitoring_infra["chatbot_topic_arn"]
+  alarm_topic_arn = local.monitoring_infra["chatbot_topic_arn"]
 }
 
 # These resources predate the find_work_state_machine module; the moves keep

--- a/pipeline/terraform/modules/pipeline_new/state_machine_image_inferrer.tf
+++ b/pipeline/terraform/modules/pipeline_new/state_machine_image_inferrer.tf
@@ -1,13 +1,9 @@
-# Scheduled image-inference state machine, built on the shared
-# find_work_state_machine module:
-#   ConstructEvent (build the time window from the schedule, or pass through replay input)
-#     -> FindWork (Lambda: ids of images modified in the window, partitioned to S3)
-#       -> ProcessPartitions (Map: one EC2 inference task per partition, runTask.waitForTaskToken)
+# Scheduled image inference on the shared find_work_state_machine module:
+# FindWork partitions the images modified in the window, and each partition
+# runs as an EC2 inference task (runTask.waitForTaskToken).
 #
-# This is the sole image inferrer; it replaced the always-on SQS-driven image_inferrer
-# Scala service, which has been retired. The schedule is gated on
-# var.enable_image_inferrer_schedule.
-# (The unified_pipeline_lambda ECR data source is declared in locals.tf.)
+# This is the sole image inferrer; it replaced the retired SQS-driven Scala
+# service. (The unified_pipeline_lambda ECR data source is declared in locals.tf.)
 
 locals {
   # Generous timeout so EC2 capacity-provider warm-up does not trip the task token.
@@ -16,13 +12,9 @@ locals {
   # Retry transient ECS infrastructure errors only. Application failures (e.g. a
   # poisoned-doc error) are intentionally NOT retried so they surface promptly.
   inference_ecs_retry = [
-    # Capacity/placement contention. When the Map fans out runTask calls
-    # concurrently, ECS can momentarily fail placement with
-    # `ECS.AmazonECSException: Insufficient CPU available` if two tasks race for
-    # the same instance, or while the EC2 capacity provider is still scaling up.
-    # This is transient and clears once a slot frees / the reservation registers,
-    # so retry it generously (long enough to outlast an in-flight task) rather
-    # than letting one placement race abort the whole run.
+    # Placement contention: concurrent runTask calls race for instances
+    # (`Insufficient CPU available`) or hit an ASG still scaling up, so retry
+    # generously (long enough to outlast an in-flight task) rather than abort.
     {
       ErrorEquals     = ["ECS.AmazonECSException"]
       IntervalSeconds = 15
@@ -146,9 +138,8 @@ module "image_inferrer" {
   alarm_topic_arn = local.monitoring_infra["chatbot_topic_arn"]
 }
 
-# These resources predate the find_work_state_machine module; the moves keep
-# terraform updating them in place. Removable once every stack using this
-# module has applied.
+# Keep pre-module resources updating in place; removable once every stack
+# using this module has applied.
 
 moved {
   from = module.inference_find_work_lambda

--- a/pipeline/terraform/modules/pipeline_new/state_machine_image_inferrer.tf
+++ b/pipeline/terraform/modules/pipeline_new/state_machine_image_inferrer.tf
@@ -82,8 +82,9 @@ module "image_inferrer" {
   # so the Map never fans out more tasks than the capacity provider can place.
   max_concurrency = local.inference_max_concurrency
 
-  # A failed partition's images are left un-augmented and picked up by a later
-  # window (writes are idempotent external_gte), so it should not fail the run.
+  # A failed partition's images stay un-augmented until the same window is
+  # replayed (writes are idempotent external_gte), so it should not fail the
+  # run; the download_failure_count alarm covers the class that matters.
   tolerate_partition_failures = true
 
   worker_state_name = "RunInferenceTask"


### PR DESCRIPTION
## What does this change?

Phase 1 of wellcomecollection/platform#6486. The image inferrer's scan, partition and fan out state machine becomes a reusable terraform module at `pipeline/terraform/modules/find_work_state_machine`, so the id-minter can adopt the same shape in phase 2. The worker state stays caller-injected, because the ECS `runTask.waitForTaskToken` variant and the Lambda one the id-minter needs share almost nothing beyond the fan-out around them. Only the caller in `modules/pipeline_new` moves onto the module, and eight `moved` blocks keep every resource updating in place; the old `pipeline` module (the 2025-10-02 production stack) is untouched.

Three deliberate behaviour changes for the inferrer, all confined to the state machine definition:

- Event construction moves out of the state machine into the find-work Lambda as tested Python (`core/find_work.normalise_lambda_input`): a scheduled run's raw `scheduled_time` becomes the window, replays pass explicit `ids` or a `window` (no more synthetic `scheduled_time`), a malformed window fails loudly, and an unscoped invoke needs `full: true` instead of degrading into a whole-index scan. Deployment identity comes from Lambda env vars, so the definition carries no behaviour.
- A failed partition is recorded with its `s3_uri` and a truncated error, and the Map output aggregates `partition_count` and `failed_partition_count`. The CheckPartitionFailures choice that follows is constant-false for the inferrer, preserving today's tolerate semantics (a missed image stays recoverable by replaying the same window idempotently). The id-minter has no signal of its own for a skipped partition, so in phase 2 it will set `tolerate_partition_failures = false` and a lost partition will fail the execution and alarm, where the equivalent loss in wellcomecollection/platform#6445 was silent.
- The Map state is renamed from InferImages to ProcessPartitions.

The module README documents the pattern, the retry and alerting semantics, and the replay procedure, including why a redrive cannot recover a failed run (the Map never fails, so a redrive restarts at FailPartitions and immediately re-fails; recovery is a fresh StartExecution, optionally over only the failed partitions).

### Checklist

- [ ] Does this change the display model the catalogue API returns? No. It changes pipeline orchestration only.

## How to test

`terraform validate` passes on `pipeline/terraform/2026-07-03`, and the rendered definitions of both variants (tolerate true and false) pass `aws stepfunctions validate-state-machine-definition`.

## How can we measure success?

There is nothing to measure on the inferrer, whose behaviour is unchanged apart from the three items above. Success is phase 2 wiring the id-minter to this module rather than copying the pattern again.

## Have we considered potential risks?

This needs a manual `terraform apply` of `pipeline/terraform/2026-07-03` after merge, and the risk sits in the eight `moved` blocks: get one wrong and the plan replaces the find-work Lambda, its role or the schedule instead of moving it.

<details><summary>Plan gate before applying</summary>

- the eight moves show as moves, with no creates or destroys
- the only change is the state machine definition
- schedule, IAM roles, alarms and the find-work Lambda are untouched

</details>



