### PR TITLE
Fan out the id-minter over partitions via the shared find_work module

### DIFF
--- a/.github/workflows/catalogue-graph-deploy.yml
+++ b/.github/workflows/catalogue-graph-deploy.yml
@@ -120,8 +120,9 @@ jobs:
           - graph-bulk-loader
           - graph-remover-incremental
           - graph-ingestor-deletions
-          # Image inferrer (work-discovery lambda for the scheduled state machine).
+          # Work-discovery lambdas for the scheduled state machines.
           - image-inference-find-work
+          - id-minter-find-work
 
 
     steps:

--- a/catalogue_graph/src/config.py
+++ b/catalogue_graph/src/config.py
@@ -25,6 +25,12 @@ INGESTOR_S3_PREFIX = os.environ.get("INGESTOR_S3_PREFIX", INGESTOR_S3_PREFIX_DEF
 INFERRER_S3_PREFIX_DEFAULT = "inferrer"
 INFERRER_S3_PREFIX = os.environ.get("INFERRER_S3_PREFIX", INFERRER_S3_PREFIX_DEFAULT)
 
+# Names find_work partition files in the catalogue-graph bucket, per the
+# *_S3_PREFIX convention; PIPELINE_STEP separately names the id-minter's
+# metric dimension and report path, and namespaced deployments vary it.
+ID_MINTER_S3_PREFIX_DEFAULT = "id_minter"
+ID_MINTER_S3_PREFIX = os.environ.get("ID_MINTER_S3_PREFIX", ID_MINTER_S3_PREFIX_DEFAULT)
+
 BULK_LOADER_S3_PREFIX_DEFAULT = "graph_bulk_loader"
 BULK_LOADER_S3_PREFIX = os.environ.get(
     "BULK_LOADER_S3_PREFIX", BULK_LOADER_S3_PREFIX_DEFAULT

--- a/catalogue_graph/src/core/find_work.py
+++ b/catalogue_graph/src/core/find_work.py
@@ -1,9 +1,22 @@
-"""Shared input handling for find_work steps."""
+"""Shared input handling and partition hand-off for find_work steps."""
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
 from typing import Any
+
+import structlog
+from pydantic import BaseModel
+
+from models.find_work import FindWorkEvent, PartitionRef
+from utils.aws import pydantic_to_s3_json
+
+logger = structlog.get_logger(__name__)
+
+# Concurrency for writing partition files to S3 (one small object per partition).
+S3_WRITE_PARALLELISM = 16
 
 # Window end lags the scheduled time so recently written documents have indexed.
 SCHEDULE_INDEXING_LAG = timedelta(minutes=5)
@@ -40,3 +53,28 @@ def normalise_lambda_input(event: dict, defaults: dict[str, Any]) -> dict:
     for key, value in defaults.items():
         data.setdefault(key, value)
     return data
+
+
+def write_partitions_to_s3(
+    partitions: Sequence[BaseModel],
+    counts: Sequence[int],
+    event: FindWorkEvent,
+) -> list[PartitionRef]:
+    """Write each partition to S3 under the event's scope-keyed prefix and
+    return small refs for the state machine's Map to iterate."""
+
+    def write_one(indexed: tuple[int, BaseModel]) -> PartitionRef:
+        index, partition = indexed
+        s3_uri = event.partition_s3_uri(index)
+        pydantic_to_s3_json(partition, s3_uri)
+        return PartitionRef(s3_uri=s3_uri, count=counts[index])
+
+    with ThreadPoolExecutor(max_workers=S3_WRITE_PARALLELISM) as pool:
+        refs = list(pool.map(write_one, enumerate(partitions)))
+
+    logger.info(
+        "Wrote partitions to S3",
+        partition_count=len(refs),
+        s3_prefix="/".join(event.s3_prefix_parts),
+    )
+    return refs

--- a/catalogue_graph/src/core/source.py
+++ b/catalogue_graph/src/core/source.py
@@ -193,3 +193,17 @@ class ElasticSource(BaseSource):
                 raise item.exception
             else:
                 yield item
+
+
+class ElasticIdsSource(ElasticSource):
+    """An ElasticSource streaming only document _ids (construct with fields=[])."""
+
+    def worker_target(self, slice_index: int, queue: Queue) -> None:
+        search_after = None
+        while hits := self.search(slice_index, search_after):
+            for hit in hits:
+                queue.put(hit["_id"])
+
+            search_after = hits[-1]["sort"]
+
+        queue.put(None)

--- a/catalogue_graph/src/id_minter/README.md
+++ b/catalogue_graph/src/id_minter/README.md
@@ -174,7 +174,18 @@ docker compose -f mysql.docker-compose.yml down -v
 ## Lambda handlers
 
 ### id_minter
-The Lambda entry point is `id_minter.steps.id_minter.lambda_handler`. It expects a `StepFunctionMintingRequest` payload in one of three modes:
+The Lambda entry point is `id_minter.steps.id_minter.lambda_handler`. It expects either a partition ref from the find-work step, or an inline `StepFunctionMintingRequest` payload in one of three modes:
+
+**Partition ref** (scheduled runs, fanned out by the state machine's Map):
+
+```json
+{
+  "s3_uri": "s3://wellcomecollection-catalogue-graph/graph-prod/pipeline-2026-07-03/id_minter/find_work/windows/20260730T1632-20260730T1634/partition-0.json",
+  "count": 10000
+}
+```
+
+The ref resolves from S3 to a full `StepFunctionMintingRequest` (work ids plus a per-partition `jobId`).
 
 **Window mode** (scheduled runs):
 
@@ -196,15 +207,21 @@ An optional `startTime` can be provided; if omitted it defaults to `endTime - 15
 }
 ```
 
-**Full reprocess mode** (process entire index):
+**Full reprocess mode** (process entire index; requires an explicit opt-in so a
+mistyped invoke cannot fall through to a full-index mint):
 
 ```json
 {
+  "full": true,
   "jobId": "full-reprocess-20260210"
 }
 ```
 
 Supplying both `sourceIdentifiers` and a time window is invalid.
+
+### id_minter find_work
+
+The Lambda entry point is `id_minter.steps.find_work.lambda_handler`. It runs at the start of each state machine execution: it scans `works-source` for the ids indexed within the window (or ids/full scope), partitions them into `StepFunctionMintingRequest`s of `partition_size` work ids (default 10,000), writes each partition to S3 and returns small refs for the Map to fan out. An optional `job_id` in the input becomes the base for per-partition job ids (`-p000`, `-p001`, ...).
 
 ### id_generator
 

--- a/catalogue_graph/src/id_minter/id_minting_source.py
+++ b/catalogue_graph/src/id_minter/id_minting_source.py
@@ -1,6 +1,7 @@
 from elasticsearch import Elasticsearch
 
-from core.source import ElasticSource
+import config
+from core.source import ElasticIdsSource, ElasticSource
 from models.source_scope import SourceScope
 
 
@@ -19,4 +20,23 @@ class IdMintingSource(ElasticSource):
             index_name=index_name,
             query=query,
             slice_count=source_scope.slice_count,
+        )
+
+
+class MintingWorkIdsSource(ElasticIdsSource):
+    """Streams only the _ids of works-source docs in scope (for find_work)."""
+
+    def __init__(
+        self, source_scope: SourceScope, es_client: Elasticsearch, index_name: str
+    ):
+        super().__init__(
+            es_client=es_client,
+            index_name=index_name,
+            query=source_scope.to_elasticsearch_query(
+                range_filter_field_name="indexed_at"
+            ),
+            fields=[],
+            batch_size=config.ES_SOURCE_BATCH_SIZE,
+            slice_count=source_scope.slice_count,
+            parallelism=config.ES_SOURCE_PARALLELISM,
         )

--- a/catalogue_graph/src/id_minter/models/step_events.py
+++ b/catalogue_graph/src/id_minter/models/step_events.py
@@ -3,9 +3,15 @@ from __future__ import annotations
 from pydantic import BaseModel, ConfigDict
 from pydantic.alias_generators import to_camel
 
+import config
+from models.find_work import FindWorkEvent
 from models.incremental_window import IncrementalWindow
 from models.source_scope import SourceScope
 from utils.types import NonEmptyString
+
+# Sized so worst-case identifier density (~105 ids/work in dense archives)
+# stays well inside the minting Lambda's 900s timeout.
+DEFAULT_MINT_PARTITION_SIZE = 10_000
 
 
 class StepFunctionMintingRequest(BaseModel):
@@ -24,6 +30,21 @@ class StepFunctionMintingRequest(BaseModel):
     @property
     def source_scope(self) -> SourceScope:
         return SourceScope(ids=self.source_identifiers, window=self.window)
+
+
+class MintingFindWorkEvent(FindWorkEvent):
+    """Input for the id-minter work-discovery step."""
+
+    partition_size: int = DEFAULT_MINT_PARTITION_SIZE
+    job_id: str | None = None
+
+    @property
+    def s3_service_prefix_parts(self) -> list[str]:
+        return [config.ID_MINTER_S3_PREFIX, "find_work"]
+
+
+class MintingFindWorkResult(BaseModel):
+    partitions: list[StepFunctionMintingRequest]
 
 
 class StepFunctionMintingFailure(BaseModel):

--- a/catalogue_graph/src/id_minter/steps/find_work.py
+++ b/catalogue_graph/src/id_minter/steps/find_work.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python
+"""Work-discovery step for the id-minter state machine.
+
+Queries `works-source` for the ids indexed within the scheduled window and
+partitions them into `StepFunctionMintingRequest`s, one per minting Lambda
+invocation fanned out by the state machine's Map. The event's pipeline_date
+selects the ES secrets and the default index date; the `ES_SOURCE_INDEX_*` env
+vars can override the index name, matching the minter itself.
+"""
+
+from __future__ import annotations
+
+import os
+import typing
+from argparse import ArgumentParser
+from itertools import batched
+
+import structlog
+
+from core.find_work import normalise_lambda_input, write_partitions_to_s3
+from id_minter.config import IdMinterConfig
+from id_minter.id_minting_source import MintingWorkIdsSource
+from id_minter.models.step_events import (
+    DEFAULT_MINT_PARTITION_SIZE,
+    MintingFindWorkEvent,
+    MintingFindWorkResult,
+    StepFunctionMintingRequest,
+)
+from models.find_work import FindWorkRefsResult
+from utils.argparse import add_pipeline_event_args
+from utils.elasticsearch import ElasticsearchMode, get_client
+from utils.logger import ExecutionContext, get_trace_id, setup_logging
+from utils.steps import create_job_id
+
+logger = structlog.get_logger(__name__)
+
+
+def handler(
+    event: MintingFindWorkEvent,
+    execution_context: ExecutionContext | None = None,
+    es_mode: ElasticsearchMode = "private",
+) -> MintingFindWorkResult:
+    setup_logging(execution_context)
+
+    # The event's pipeline_date wins over the PIPELINE_DATE env default, so a
+    # local --pipeline-date run reads the right secrets and index.
+    cfg = IdMinterConfig(pipeline_date=event.pipeline_date)
+    es_client = get_client(
+        api_key_name="id_minter",
+        pipeline_date=cfg.pipeline_date,
+        es_mode=es_mode,
+    )
+
+    ids = list(
+        MintingWorkIdsSource(event, es_client, cfg.source_index_name).stream_raw()
+    )
+
+    # Distinct per-partition job ids: concurrent partitions would otherwise
+    # collide on their S3 report names (generated ids are minute-granular).
+    base_job_id = event.job_id or create_job_id()
+    partitions = [
+        StepFunctionMintingRequest(
+            source_identifiers=list(chunk),
+            job_id=f"{base_job_id}-p{index:03d}",
+        )
+        for index, chunk in enumerate(batched(ids, event.partition_size))
+    ]
+
+    logger.info(
+        "Found work",
+        mode=event.mode_label,
+        work_count=len(ids),
+        partition_count=len(partitions),
+        partition_size=event.partition_size,
+        job_id=base_job_id,
+    )
+    return MintingFindWorkResult(partitions=partitions)
+
+
+def lambda_handler(event: dict, context: typing.Any) -> dict[str, typing.Any]:
+    # Scope comes from the invocation (scheduled_time or replay input); the
+    # deployment-identity fields come from the environment.
+    parsed_event = MintingFindWorkEvent(
+        **normalise_lambda_input(
+            event,
+            defaults={
+                "pipeline_date": os.environ.get("PIPELINE_DATE"),
+                "graph_date": os.environ.get("GRAPH_DATE"),
+            },
+        )
+    )
+    execution_context = ExecutionContext(
+        trace_id=get_trace_id(context),
+        pipeline_step="id_minter_find_work",
+    )
+    result = handler(parsed_event, execution_context)
+
+    refs = write_partitions_to_s3(
+        result.partitions,
+        [len(p.source_identifiers or []) for p in result.partitions],
+        parsed_event,
+    )
+    return FindWorkRefsResult(partitions=refs).model_dump(mode="json")
+
+
+def local_handler(parser: ArgumentParser) -> None:
+    add_pipeline_event_args(
+        parser,
+        {
+            "pipeline_date",
+            "window",
+            "ids",
+            "graph_date",
+            "es_mode",
+        },
+    )
+    parser.add_argument(
+        "--partition-size",
+        type=int,
+        default=DEFAULT_MINT_PARTITION_SIZE,
+        help="Number of work ids per minting Lambda invocation.",
+    )
+    parser.add_argument(
+        "--job-id",
+        type=str,
+        required=False,
+        help="Base job id; each partition gets a -pNNN suffix.",
+    )
+    args = parser.parse_args()
+    event = MintingFindWorkEvent.from_argparser(args)
+    result = handler(event, es_mode=args.es_mode)
+    print(result.model_dump_json())
+
+
+if __name__ == "__main__":
+    main_parser: ArgumentParser = ArgumentParser()
+    local_handler(main_parser)

--- a/catalogue_graph/src/id_minter/steps/id_minter.py
+++ b/catalogue_graph/src/id_minter/steps/id_minter.py
@@ -26,6 +26,7 @@ from id_minter.resolvers.data_api_resolver import DataApiIdResolver
 from id_minter.resolvers.minting_resolver import MintingResolver
 from id_minter.sns import publish_ids_to_sns
 from models.incremental_window import IncrementalWindow
+from utils.aws import pydantic_from_s3_json
 from utils.elasticsearch import ElasticsearchMode, get_client
 from utils.logger import ExecutionContext, get_trace_id, setup_logging
 from utils.steps import create_job_id
@@ -42,7 +43,12 @@ class IdMinterRuntime(BaseModel):
     target_es_mode: ElasticsearchMode = "private"
 
 
-class IdMinterResult(StepFunctionMintingRequest):
+class IdMinterResult(BaseModel):
+    """Run summary. Deliberately does not echo source_identifiers: a full
+    partition's id list would blow the Step Functions 256 KB task-output limit."""
+
+    job_id: str
+    window: IncrementalWindow | None = None
     success_count: int
     failure_count: int
     report_s3_uri: str
@@ -190,9 +196,25 @@ def lambda_handler(event: dict, context: Any) -> dict[str, Any]:
         trace_id=get_trace_id(context),
         pipeline_step="id_minter",
     )
-    if "job_id" not in event:
-        event["job_id"] = create_job_id()
-    request = StepFunctionMintingRequest.model_validate(event)
+    if "s3_uri" in event:
+        # A partition ref from the find-work step; resolve the full request
+        # (ids + per-partition job_id) from S3.
+        request = pydantic_from_s3_json(StepFunctionMintingRequest, event["s3_uri"])
+    else:
+        if "job_id" not in event:
+            event["job_id"] = create_job_id()
+        request = StepFunctionMintingRequest.model_validate(event)
+        # Neither ids nor window means a full-index mint; require an explicit
+        # opt-in so a mistyped invoke (e.g. "s3Uri") fails loudly instead.
+        if (
+            request.source_identifiers is None
+            and request.window is None
+            and event.get("full") is not True
+        ):
+            raise ValueError(
+                "Neither source_identifiers nor window given; "
+                "pass 'full': true to mint the entire index."
+            )
     runtime = build_runtime()
     response = handler(
         request,

--- a/catalogue_graph/src/inferrer/models.py
+++ b/catalogue_graph/src/inferrer/models.py
@@ -13,8 +13,6 @@ rather than maintaining a parallel write model here.
 
 from __future__ import annotations
 
-from pathlib import PurePosixPath
-
 from pydantic import BaseModel
 
 import config
@@ -24,6 +22,7 @@ from ingestor.models.augmented.image import (
     ParentWork,
 )
 from models.events import BasePipelineEvent
+from models.find_work import FindWorkEvent as BaseFindWorkEvent
 from models.pipeline.image_state import ImageState
 from models.pipeline.location import DigitalLocation
 from models.pipeline.serialisable import SerialisableModel
@@ -54,7 +53,7 @@ class InferenceManagerEvent(BasePipelineEvent):
     """
 
 
-class FindWorkEvent(BasePipelineEvent):
+class FindWorkEvent(BaseFindWorkEvent):
     """Input for the work-discovery step: a time window (or ids/full)."""
 
     partition_size: int = DEFAULT_PARTITION_SIZE
@@ -62,10 +61,6 @@ class FindWorkEvent(BasePipelineEvent):
     @property
     def s3_service_prefix_parts(self) -> list[str]:
         return [config.INFERRER_S3_PREFIX, "find_work"]
-
-    def partition_s3_uri(self, index: int) -> str:
-        bucket = config.CATALOGUE_GRAPH_S3_BUCKET
-        return f"s3://{bucket}/{PurePosixPath(*self.s3_prefix_parts)}/partition-{index}.json"
 
 
 # --- Step results ---------------------------------------------------------- #
@@ -81,21 +76,3 @@ class InferenceManagerResult(BaseModel):
 
 class FindWorkResult(BaseModel):
     partitions: list[InferenceManagerEvent]
-
-
-class PartitionRef(BaseModel):
-    """A pointer to a partition's `InferenceManagerEvent` stored in S3.
-
-    The work-discovery step writes each partition (its image ids + metadata) to S3
-    and returns these small refs instead of the partitions inline, so the state
-    machine's Map payload stays well under the Step Functions 256 KB state limit
-    even for large windows. Each inference task resolves its ref back to the full
-    event (see `inference_manager.event_validator`).
-    """
-
-    s3_uri: str
-    image_count: int
-
-
-class FindWorkRefsResult(BaseModel):
-    partitions: list[PartitionRef]

--- a/catalogue_graph/src/inferrer/source.py
+++ b/catalogue_graph/src/inferrer/source.py
@@ -1,20 +1,13 @@
-from queue import Queue
-
 from elasticsearch import Elasticsearch
 
 import config
-from core.source import ElasticSource
+from core.source import ElasticIdsSource
 from models.events import BasePipelineEvent
 from utils.elasticsearch import get_images_initial_index_name
 
 
-class ImagesInitialSource(ElasticSource):
-    """Streams the _ids of images-initial docs matching the event's time window.
-
-    Uses the shared ElasticSource (PIT + search_after, retries, slice
-    parallelism); we only need _id, so _source is disabled and worker_target
-    yields the document id.
-    """
+class ImagesInitialSource(ElasticIdsSource):
+    """Streams the _ids of images-initial docs matching the event's time window."""
 
     def __init__(self, event: BasePipelineEvent, es_client: Elasticsearch):
         super().__init__(
@@ -26,11 +19,3 @@ class ImagesInitialSource(ElasticSource):
             slice_count=config.ES_SOURCE_SLICE_COUNT,
             parallelism=config.ES_SOURCE_PARALLELISM,
         )
-
-    def worker_target(self, slice_index: int, queue: Queue) -> None:
-        search_after = None
-        while hits := self.search(slice_index, search_after):
-            for hit in hits:
-                queue.put(hit["_id"])
-            search_after = hits[-1]["sort"]
-        queue.put(None)

--- a/catalogue_graph/src/inferrer/steps/find_work.py
+++ b/catalogue_graph/src/inferrer/steps/find_work.py
@@ -12,23 +12,20 @@ from __future__ import annotations
 import os
 import typing
 from argparse import ArgumentParser
-from concurrent.futures import ThreadPoolExecutor
 from itertools import batched
 
 import structlog
 
-from core.find_work import normalise_lambda_input
+from core.find_work import normalise_lambda_input, write_partitions_to_s3
 from inferrer.models import (
     DEFAULT_PARTITION_SIZE,
     FindWorkEvent,
-    FindWorkRefsResult,
     FindWorkResult,
     InferenceManagerEvent,
-    PartitionRef,
 )
 from inferrer.source import ImagesInitialSource
+from models.find_work import FindWorkRefsResult
 from utils.argparse import add_pipeline_event_args
-from utils.aws import pydantic_to_s3_json
 from utils.elasticsearch import (
     ElasticsearchMode,
     get_client,
@@ -36,9 +33,6 @@ from utils.elasticsearch import (
 from utils.logger import ExecutionContext, get_trace_id, setup_logging
 
 logger = structlog.get_logger(__name__)
-
-# Concurrency for writing partition files to S3 (one small object per partition).
-S3_WRITE_PARALLELISM = 16
 
 
 def handler(
@@ -71,35 +65,6 @@ def handler(
     return FindWorkResult(partitions=partitions)
 
 
-def write_partitions_to_s3(
-    partitions: list[InferenceManagerEvent], event: FindWorkEvent
-) -> list[PartitionRef]:
-    """Write each partition to S3 and return small refs.
-
-    The state machine's Map then iterates these refs (a few hundred bytes each)
-    rather than the full partitions, keeping the find-work result well under the
-    Step Functions 256 KB state limit. Each inference task resolves its ref back
-    to the full `InferenceManagerEvent` from S3. The partitions are written under
-    a scope-keyed prefix for the run.
-    """
-
-    def write_one(indexed: tuple[int, InferenceManagerEvent]) -> PartitionRef:
-        index, partition = indexed
-        s3_uri = event.partition_s3_uri(index)
-        pydantic_to_s3_json(partition, s3_uri)
-        return PartitionRef(s3_uri=s3_uri, image_count=len(partition.ids or []))
-
-    with ThreadPoolExecutor(max_workers=S3_WRITE_PARALLELISM) as pool:
-        refs = list(pool.map(write_one, enumerate(partitions)))
-
-    logger.info(
-        "Wrote partitions to S3",
-        partition_count=len(refs),
-        s3_prefix="/".join(event.s3_prefix_parts),
-    )
-    return refs
-
-
 def lambda_handler(event: dict, context: typing.Any) -> dict[str, typing.Any]:
     # Scope comes from the invocation (scheduled_time or replay input); the
     # deployment-identity fields come from the environment.
@@ -124,7 +89,11 @@ def lambda_handler(event: dict, context: typing.Any) -> dict[str, typing.Any]:
 
     # Hand the partitions off via S3 (pass-by-reference) so the Map's inline
     # payload stays small regardless of how many images the window matched.
-    refs = write_partitions_to_s3(result.partitions, parsed_event)
+    refs = write_partitions_to_s3(
+        result.partitions,
+        [len(p.ids or []) for p in result.partitions],
+        parsed_event,
+    )
     return FindWorkRefsResult(partitions=refs).model_dump(mode="json")
 
 

--- a/catalogue_graph/src/inferrer/steps/inference_manager.py
+++ b/catalogue_graph/src/inferrer/steps/inference_manager.py
@@ -234,10 +234,7 @@ def event_validator(raw_input: str) -> InferenceManagerEvent:
     # find_work; resolve it to the full partition event. Fall back to an inline
     # event for local/CLI use.
     if isinstance(data, dict) and "s3_uri" in data:
-        event = pydantic_from_s3_json(InferenceManagerEvent, data["s3_uri"])
-        if event is None:
-            raise ValueError(f"Partition not found in S3: {data['s3_uri']}")
-        return event
+        return pydantic_from_s3_json(InferenceManagerEvent, data["s3_uri"])
     return InferenceManagerEvent.model_validate(data)
 
 

--- a/catalogue_graph/src/models/find_work.py
+++ b/catalogue_graph/src/models/find_work.py
@@ -1,0 +1,36 @@
+"""Shared models for find_work work-discovery steps.
+
+A find_work step scans an index for the ids in scope, partitions them, writes
+each partition to S3 and returns small refs, so the state machine's Map payload
+stays under the Step Functions 256 KB state limit regardless of window density.
+"""
+
+from __future__ import annotations
+
+from pathlib import PurePosixPath
+
+from pydantic import BaseModel
+
+import config
+from models.events import BasePipelineEvent
+
+
+class FindWorkEvent(BasePipelineEvent):
+    """Input for a work-discovery step: a time window (or ids/full)."""
+
+    partition_size: int
+
+    def partition_s3_uri(self, index: int) -> str:
+        bucket = config.CATALOGUE_GRAPH_S3_BUCKET
+        return f"s3://{bucket}/{PurePosixPath(*self.s3_prefix_parts)}/partition-{index}.json"
+
+
+class PartitionRef(BaseModel):
+    """A pointer to a partition event stored in S3; workers resolve it back."""
+
+    s3_uri: str
+    count: int
+
+
+class FindWorkRefsResult(BaseModel):
+    partitions: list[PartitionRef]

--- a/catalogue_graph/src/utils/aws.py
+++ b/catalogue_graph/src/utils/aws.py
@@ -2,7 +2,7 @@ import csv
 import json
 from collections.abc import Generator
 from functools import lru_cache
-from typing import Any
+from typing import Any, Literal, overload
 
 import boto3
 import polars as pl
@@ -114,10 +114,25 @@ def pydantic_to_s3_json(model: BaseModel, s3_uri: str) -> None:
         f.write(model.model_dump_json())
 
 
+@overload
+def pydantic_from_s3_json[T: BaseModel](
+    model_type: type[T], s3_uri: str, ignore_missing: Literal[False] = ...
+) -> T: ...
+
+
+@overload
+def pydantic_from_s3_json[T: BaseModel](
+    model_type: type[T], s3_uri: str, ignore_missing: Literal[True]
+) -> T | None: ...
+
+
 def pydantic_from_s3_json[T: BaseModel](
     model_type: type[T], s3_uri: str, ignore_missing: bool = False
 ) -> T | None:
-    """Create a Pydantic model of type `model_type` from a JSON file stored in S3."""
+    """Create a Pydantic model of type `model_type` from a JSON file stored in S3.
+
+    Without ignore_missing a missing file raises FileNotFoundError, so the
+    return is only Optional when ignore_missing is True."""
     try:
         with smart_open.open(s3_uri, "r") as f:
             return model_type.model_validate_json(f.read())

--- a/catalogue_graph/tests/id_minter/test_find_work.py
+++ b/catalogue_graph/tests/id_minter/test_find_work.py
@@ -1,0 +1,125 @@
+"""Tests for the id-minter work-discovery step."""
+
+from __future__ import annotations
+
+import pytest
+
+from id_minter.config import ID_MINTER_CONFIG
+from id_minter.models.step_events import (
+    MintingFindWorkEvent,
+    StepFunctionMintingRequest,
+)
+from id_minter.steps import find_work
+from tests.mocks import MockElasticsearchClient, mock_es_secrets
+from utils.aws import pydantic_from_s3_json
+
+
+class _LambdaContext:
+    aws_request_id = "req-abc123"
+
+
+PIPELINE_DATE = ID_MINTER_CONFIG.pipeline_date  # "dev" unless env overrides
+
+
+def _seed_source_works(ids: list[str]) -> None:
+    for work_id in ids:
+        MockElasticsearchClient.index(
+            index=ID_MINTER_CONFIG.source_index_name,
+            id=work_id,
+            document={"indexed_at": "2026-07-30T16:33:00Z"},
+        )
+
+
+def test_handler_partitions_with_per_partition_job_ids() -> None:
+    mock_es_secrets("id_minter", PIPELINE_DATE)
+    _seed_source_works(["a", "b", "c"])
+
+    event = MintingFindWorkEvent(
+        pipeline_date=PIPELINE_DATE,
+        graph_date=PIPELINE_DATE,
+        partition_size=2,
+        job_id="replay-s01",
+    )
+    result = find_work.handler(event, es_mode="private")
+
+    assert len(result.partitions) == 2
+    assert [p.job_id for p in result.partitions] == [
+        "replay-s01-p000",
+        "replay-s01-p001",
+    ]
+    all_ids = [i for p in result.partitions for i in (p.source_identifiers or [])]
+    assert sorted(all_ids) == ["a", "b", "c"]
+
+
+def test_lambda_handler_writes_partitions_to_s3_and_returns_refs() -> None:
+    mock_es_secrets("id_minter", PIPELINE_DATE)
+    _seed_source_works(["a", "b", "c"])
+
+    event = {
+        "pipeline_date": PIPELINE_DATE,
+        "graph_date": PIPELINE_DATE,
+        "partition_size": 2,
+        "window": {
+            "start_time": "2026-07-30T16:32:00Z",
+            "end_time": "2026-07-30T16:34:00Z",
+        },
+    }
+    result = find_work.lambda_handler(event, _LambdaContext())
+
+    refs = result["partitions"]
+    assert len(refs) == 2
+    assert sum(r["count"] for r in refs) == 3
+    # Scope-keyed under the id_minter service prefix, so a rerun of the same
+    # window overwrites rather than accumulates.
+    assert all(
+        "/id_minter/find_work/windows/20260730T1632-20260730T1634/" in r["s3_uri"]
+        for r in refs
+    )
+
+    # The refs resolve back to full minting requests with distinct job ids.
+    resolved = [
+        pydantic_from_s3_json(StepFunctionMintingRequest, r["s3_uri"]) for r in refs
+    ]
+    resolved_ids = [i for p in resolved if p for i in (p.source_identifiers or [])]
+    assert sorted(resolved_ids) == ["a", "b", "c"]
+    job_ids = [p.job_id for p in resolved if p]
+    assert len(set(job_ids)) == 2
+
+
+def test_lambda_handler_accepts_scheduled_time(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PIPELINE_DATE", PIPELINE_DATE)
+    monkeypatch.setenv("GRAPH_DATE", PIPELINE_DATE)
+    mock_es_secrets("id_minter", PIPELINE_DATE)
+    _seed_source_works(["a"])
+
+    # scheduled_time - 5min lag = window end 16:35; start defaults to 16:20,
+    # covering the seeded indexed_at of 16:33.
+    result = find_work.lambda_handler(
+        {"scheduled_time": "2026-07-30T16:40:00Z"}, _LambdaContext()
+    )
+    assert len(result["partitions"]) == 1
+
+
+def test_handler_builds_window_query_on_indexed_at() -> None:
+    mock_es_secrets("id_minter", PIPELINE_DATE)
+    _seed_source_works(["a"])
+
+    event = MintingFindWorkEvent.model_validate(
+        {
+            "pipeline_date": PIPELINE_DATE,
+            "graph_date": PIPELINE_DATE,
+            "window": {"end_time": "2026-07-30T16:34:00Z"},
+        }
+    )
+    find_work.handler(event, es_mode="private")
+
+    assert MockElasticsearchClient.queries[-1] == {
+        "range": {
+            "indexed_at": {
+                "gte": "2026-07-30T16:19:00+00:00",
+                "lte": "2026-07-30T16:34:00+00:00",
+            }
+        }
+    }

--- a/catalogue_graph/tests/id_minter/test_id_minter.py
+++ b/catalogue_graph/tests/id_minter/test_id_minter.py
@@ -51,6 +51,7 @@ from tests.mocks import (
     MockSmartOpen,
     MockSNSClient,
 )
+from utils.aws import pydantic_to_s3_json
 
 pytestmark = pytest.mark.database
 
@@ -690,3 +691,68 @@ class TestBuildMintingSource:
 
         assert source.query == {"match_all": {}}
         assert source.index_name == "works-source-dev"
+
+
+# ---------------------------------------------------------------------------
+# Tests: lambda_handler input dispatch (partition refs and the full-mint guard)
+# ---------------------------------------------------------------------------
+
+
+class TestLambdaHandlerInputDispatch:
+    def test_ref_input_resolves_partition_from_s3(self) -> None:
+        partition = StepFunctionMintingRequest(
+            source_identifiers=["Work[sierra-system-number/b1000001]"],
+            job_id="replay-s01-p000",
+        )
+        s3_uri = "s3://test-bucket/id_minter/find_work/partition-0.json"
+        pydantic_to_s3_json(partition, s3_uri)
+
+        captured: dict = {}
+
+        def fake_handler(event, runtime, execution_context=None):  # type: ignore[no-untyped-def]
+            captured["request"] = event
+            return IdMinterResult(
+                job_id=event.job_id,
+                success_count=1,
+                failure_count=0,
+                report_s3_uri="s3://bucket/report.json",
+            )
+
+        with (
+            patch("id_minter.steps.id_minter.build_runtime", return_value=MagicMock()),
+            patch("id_minter.steps.id_minter.handler", side_effect=fake_handler),
+        ):
+            result = lambda_handler({"s3_uri": s3_uri, "count": 1}, context=None)
+
+        assert captured["request"].source_identifiers == [
+            "Work[sierra-system-number/b1000001]"
+        ]
+        assert captured["request"].job_id == "replay-s01-p000"
+        # The response must not echo the partition's ids: a full partition
+        # would blow the Step Functions 256 KB task-output limit.
+        assert "source_identifiers" not in result
+
+    def test_full_mint_requires_explicit_flag(self) -> None:
+        with pytest.raises(ValueError, match="full"):
+            lambda_handler({"job_id": "accidental-full"}, context=None)
+
+    def test_full_mint_allowed_with_explicit_flag(self) -> None:
+        captured: dict = {}
+
+        def fake_handler(event, runtime, execution_context=None):  # type: ignore[no-untyped-def]
+            captured["request"] = event
+            return IdMinterResult(
+                job_id=event.job_id,
+                success_count=0,
+                failure_count=0,
+                report_s3_uri="s3://bucket/report.json",
+            )
+
+        with (
+            patch("id_minter.steps.id_minter.build_runtime", return_value=MagicMock()),
+            patch("id_minter.steps.id_minter.handler", side_effect=fake_handler),
+        ):
+            lambda_handler({"full": True, "job_id": "deliberate-full"}, context=None)
+
+        assert captured["request"].source_identifiers is None
+        assert captured["request"].window is None

--- a/catalogue_graph/tests/inferrer/test_find_work.py
+++ b/catalogue_graph/tests/inferrer/test_find_work.py
@@ -79,7 +79,7 @@ def test_lambda_handler_writes_partitions_to_s3_and_returns_refs() -> None:
     assert all(
         "/find_work/windows/20260601T0000-20260630T0000/" in r["s3_uri"] for r in refs
     )
-    assert sum(r["image_count"] for r in refs) == 3
+    assert sum(r["count"] for r in refs) == 3
     assert all("ids" not in r for r in refs)
 
     # The refs resolve back to the full partition events in S3.

--- a/catalogue_graph/tests/inferrer/test_inference_manager.py
+++ b/catalogue_graph/tests/inferrer/test_inference_manager.py
@@ -175,7 +175,7 @@ def test_event_validator_resolves_s3_ref() -> None:
     )
     pydantic_to_s3_json(partition, s3_uri)
 
-    resolved = event_validator(json.dumps({"s3_uri": s3_uri, "image_count": 2}))
+    resolved = event_validator(json.dumps({"s3_uri": s3_uri, "count": 2}))
 
     assert resolved.ids == ["x", "y"]
     assert resolved.pipeline_date == PIPELINE_DATE

--- a/pipeline/terraform/modules/find_work_state_machine/README.md
+++ b/pipeline/terraform/modules/find_work_state_machine/README.md
@@ -25,31 +25,36 @@ image inferrer, a Lambda for the id-minter), one bounded partition at a time.
 
 `max_concurrency` is the work-in-progress ceiling. Pin it to the worker's real
 capacity rather than picking a number here: the inferrer pins it to the ASG's
-`max_instances`, and the id-minter (moving onto this module in
-wellcomecollection/platform#6486) to its RDS connection budget. An INLINE Map
+`max_instances`, and the id-minter to its RDS connection budget. An INLINE Map
 runs at most 40 concurrent iterations, whatever the setting.
 
 ## Failure semantics
 
 A partition that fails after the worker's own retries is caught and recorded,
-so every other partition still runs. The Map output carries the aggregate:
+so every other partition still runs. The Map output carries the aggregate
+counts and the failure records only (successful outputs are dropped, so the
+output cannot grow with partition count towards the 256 KB state limit):
 
 ```json
-{"partition_count": 34, "failed_partition_count": 2, "results": [...]}
+{"partition_count": 34, "failed_partition_count": 1, "failed_partitions": [{"partition_failed": true, "s3_uri": "...", "error": "..."}]}
 ```
 
 What happens next depends on `tolerate_partition_failures`:
 
-- `true` (image inferrer): the execution succeeds. This is only safe when a
-  missed record stays recoverable, because replaying the same window later
-  re-covers it idempotently (scheduled windows tile with no overlap, so the
-  next one does not). The execution succeeding means nothing alarms, so the
+- `true`, used by the image inferrer: the execution succeeds. This is only safe
+  when a missed record stays recoverable, because replaying the same window
+  later re-covers it idempotently (scheduled windows tile with no overlap, so
+  the next one does not). The execution succeeding means nothing alarms, so the
   consumer also needs its own failure signal (see Retry and alerting).
-- `false` (the id-minter, once adopted): once every partition has finished, the
+- `false`, used by the id-minter: once every partition has finished, the
   execution fails with `PartitionsFailed`. A tolerated skip would leave the
   missed records unprocessed with nothing to notice them, so the execution
   fails loudly instead; failing after the Map means a replay only needs to
   cover the failed partitions, not the whole window.
+
+Workers must keep their own outputs small too: the 256 KB limit applies to each
+task result before any projection, so a worker that echoes its input ids back
+would fail on dense partitions after doing all its work.
 
 ## Retry and alerting
 
@@ -94,11 +99,12 @@ slip fails validation in the Lambda rather than scanning the full index):
 - `window`, with `start_time` optional (defaults to `end_time` minus 15
   minutes). Windows slice to arbitrary timestamps, so a dense range can be
   replayed as several smaller executions.
-- `ids`, a JSON array of ids to process instead of a window.
-- `job_id`, honoured by consumers that stamp per-run reports (the id-minter,
-  whose generated ids are minute-granular, so concurrent replays started in the
-  same minute collide without one). The inferrer's find-work event has no
-  `job_id` field and silently ignores it.
+- `ids`, a JSON array of ids to process instead of a window; `source_identifiers`
+  is accepted as an alias, matching the id-minter's older replay shape.
+- `job_id`, honoured by consumers that stamp per-run reports: the id-minter
+  derives per-partition job ids from it (`<job_id>-p000`, `-p001`, ...), which
+  keys its S3 reports. The inferrer's find-work event has no `job_id` field and
+  silently ignores it.
 - `partition_size`, to override the consumer's default ids-per-partition.
 - `full: true`, required to run with no ids and no window; without it an
   unscoped invoke fails rather than scanning the whole index.
@@ -112,10 +118,9 @@ time.
 
 ## Replaying only the failed partitions
 
-Each failure record in the Map output's `results` array carries the failed
+Each record in the Map output's `failed_partitions` array carries the failed
 partition's `s3_uri` and a truncated `error`, so the execution output alone
-identifies what failed and why. (The array also preserves partition order, so
-positional index works as a fallback.) The files live under the consumer's
+identifies what failed and why. The files live under the consumer's
 scope-keyed prefix, for example:
 
 ```

--- a/pipeline/terraform/modules/find_work_state_machine/state_machine.tf
+++ b/pipeline/terraform/modules/find_work_state_machine/state_machine.tf
@@ -40,7 +40,10 @@ locals {
         }
       }
     }
-    Output = "{% {'partition_count': $count($states.result), 'failed_partition_count': $count($states.result[partition_failed = true]), 'results': $states.result} %}"
+    # Aggregate counts plus the failure records only: keeping every success
+    # output would let the Map output grow with partition count towards the
+    # 256 KB state limit.
+    Output = "{% {'partition_count': $count($states.result), 'failed_partition_count': $count($states.result[partition_failed = true]), 'failed_partitions': [$states.result[partition_failed = true]]} %}"
     Next   = "CheckPartitionFailures"
   }
 
@@ -60,7 +63,7 @@ locals {
     FailPartitions = {
       Type  = "Fail"
       Error = "PartitionsFailed"
-      Cause = "{% $string($states.input.failed_partition_count) & ' of ' & $string($states.input.partition_count) & ' partitions failed; see the Map results for detail' %}"
+      Cause = "{% $string($states.input.failed_partition_count) & ' of ' & $string($states.input.partition_count) & ' partitions failed; failed_partitions in the Map output has each ref and error' %}"
     }
     Succeeded = {
       Type = "Succeed"

--- a/pipeline/terraform/modules/pipeline_new/state_machine_id_minter.tf
+++ b/pipeline/terraform/modules/pipeline_new/state_machine_id_minter.tf
@@ -1,122 +1,151 @@
+# Scheduled id-minter on the shared find_work_state_machine module: FindWork
+# partitions the works indexed in the window, and each partition mints in its
+# own Lambda invocation, so execution time no longer depends on window density
+# (the platform#6445 losses were three dense windows blowing the 900s timeout).
+# tolerate_partition_failures is false because nothing re-covers a missed
+# indexed_at range: a lost partition must fail the execution, not skip silently.
+
 locals {
-  id_minter_state_machine_definition = jsonencode({
-    QueryLanguage = "JSONata"
-    Comment       = "Invoke the id_minter Lambda"
-    StartAt       = "ConstructEvent"
-    States = {
-      ConstructEvent = {
-        Type = "Pass",
-        # Replays may pass source_identifiers or an explicit window, plus a
-        # job_id; scheduled runs derive the window end from scheduled_time -
-        # 5min. Shape guards keep malformed input (e.g. window: null) from
-        # reaching the Lambda as "no window", which would mint the full index.
-        Output = trimspace(<<-EOT
-          {% $merge([
-            {'pipeline_date': '${var.pipeline_date}'},
-            $type($states.input.source_identifiers) = 'array'
-              ? {'source_identifiers': $states.input.source_identifiers}
-              : {'window': $exists($states.input.window.end_time)
-                  ? $states.input.window
-                  : {'end_time': $fromMillis($toMillis($states.input.scheduled_time) - 300000)}},
-            $type($states.input.job_id) = 'string' ? {'job_id': $states.input.job_id} : {}
-          ]) %}
-        EOT
-        ),
-        Next = "InvokeIdMinter"
-      }
-      InvokeIdMinter = {
-        Type     = "Task"
-        Resource = "arn:aws:states:::lambda:invoke"
-        Arguments = {
-          FunctionName = module.id_minter_lambda.id_minter_lambda_arn
-          Payload      = "{% $states.input %}"
-        }
-        Output = "{% $states.result.Payload %}"
-        Retry = [
-          {
-            ErrorEquals     = ["Lambda.ServiceException", "Lambda.AWSLambdaException", "Lambda.SdkClientException"]
-            IntervalSeconds = 2
-            MaxAttempts     = 3
-            BackoffRate     = 2.0
-          }
-        ]
-        End = true
-      }
-    }
-  })
-}
+  # Concurrency measured during the platform#6445 recovery: 6-way was the sweet
+  # spot against the RDS ACU ceiling; 8 gave no gain and more timeouts.
+  id_minter_max_concurrency = 6
 
-module "id_minter_state_machine" {
-  source = "../state_machine"
-
-  name                     = "pipeline-${var.pipeline_date}_id_minter"
-  state_machine_definition = local.id_minter_state_machine_definition
-  invokable_lambda_arns    = [module.id_minter_lambda.id_minter_lambda_arn]
-}
-
-module "id_minter_state_machine_alarms" {
-  source = "../state_machine_alarms"
-
-  state_machine_arn = module.id_minter_state_machine.state_machine_arn
-  alarm_name_prefix = "id-minter"
-  alarm_name_suffix = "-${var.pipeline_date}"
-
-  default_alarm_configuration = {
-    alarm_actions = [local.monitoring_infra["chatbot_topic_arn"]]
-  }
-}
-
-# EventBridge Scheduler
-resource "aws_scheduler_schedule" "id_minter_schedule" {
-  name                = "id-minter-schedule-${var.pipeline_date}"
-  schedule_expression = "cron(5,20,35,50 * * * ? *)"
-
-  flexible_time_window {
-    mode = "OFF"
-  }
-
-  target {
-    arn      = module.id_minter_state_machine.state_machine_arn
-    role_arn = aws_iam_role.run_id_minter_role.arn
-
-    input = <<JSON
+  id_minter_worker_retry = [
     {
-      "scheduled_time": "<aws.scheduler.scheduled-time>"
+      ErrorEquals = [
+        "Lambda.ServiceException",
+        "Lambda.AWSLambdaException",
+        "Lambda.SdkClientException",
+        "Lambda.TooManyRequestsException",
+      ]
+      IntervalSeconds = 2
+      MaxAttempts     = 3
+      BackoffRate     = 2.0
+    },
+    # Lambda.Unknown covers function timeouts/OOM/crashes, not application
+    # errors; minting is idempotent so a wholesale partition re-run is safe.
+    {
+      ErrorEquals     = ["Lambda.Unknown"]
+      IntervalSeconds = 5
+      MaxAttempts     = 2
+      BackoffRate     = 2.0
     }
-    JSON
+  ]
+}
+
+module "id_minter" {
+  source = "../find_work_state_machine"
+
+  name          = "id_minter"
+  pipeline_date = var.pipeline_date
+  comment       = "Find works indexed within the window and mint canonical ids for them."
+
+  ecr_repository_name = data.aws_ecr_repository.unified_pipeline_lambda.name
+
+  find_work_lambda = {
+    service_name = "id-minter-find-work"
+    description  = "Finds works needing id minting within a time window and partitions them for the id-minter state machine."
+    command      = ["id_minter.steps.find_work.lambda_handler"]
+    # Sized for full-scope replays, which materialise every matching id.
+    memory_size = 2048
+    timeout     = 600
+    # Index name and ES secrets are env-derived, matching the minter itself.
+    environment_variables = {
+      PIPELINE_DATE               = var.pipeline_date
+      GRAPH_DATE                  = var.graph_date
+      ES_SOURCE_INDEX_DATE_SUFFIX = var.index_dates.source
+    }
   }
 
-  state = var.enable_id_minter_schedule ? "ENABLED" : "DISABLED"
+  vpc_config = {
+    subnet_ids = local.network_config.subnets
+    security_group_ids = [
+      local.network_config.ec_privatelink_security_group_id,
+      aws_security_group.egress.id,
+    ]
+  }
+
+  find_work_secret_read_policy_json = data.aws_iam_policy_document.id_minter_find_work_secret_read.json
+
+  partition_s3_arns = [
+    "arn:aws:s3:::wellcomecollection-catalogue-graph/graph-*/*/id_minter/*"
+  ]
+
+  max_concurrency             = local.id_minter_max_concurrency
+  tolerate_partition_failures = false
+
+  worker_state_name = "MintPartition"
+  worker_state = {
+    Type     = "Task"
+    Resource = "arn:aws:states:::lambda:invoke"
+    Arguments = {
+      FunctionName = module.id_minter_lambda.id_minter_lambda_arn
+      Payload      = "{% $states.input %}"
+    }
+    Output = "{% $states.result.Payload %}"
+    Retry  = local.id_minter_worker_retry
+  }
+  worker_lambda_arns = [module.id_minter_lambda.id_minter_lambda_arn]
+
+  schedule = {
+    cron    = "cron(5,20,35,50 * * * ? *)"
+    enabled = var.enable_id_minter_schedule
+  }
+
+  alarm_topic_arn = local.monitoring_infra["chatbot_topic_arn"]
 }
 
-resource "aws_iam_role" "run_id_minter_role" {
-  name = "run-id-minter-role-${var.pipeline_date}"
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Principal = {
-          Service = "scheduler.amazonaws.com"
-        }
-        Action = "sts:AssumeRole"
-      }
+data "aws_iam_policy_document" "id_minter_find_work_secret_read" {
+  statement {
+    effect  = "Allow"
+    actions = ["secretsmanager:GetSecretValue"]
+    resources = [
+      "${local.secrets_manager_prefix}:elasticsearch/pipeline_storage_${var.pipeline_date}/*",
     ]
-  })
+  }
 }
 
-resource "aws_iam_role_policy" "run_id_minter_policy" {
-  role = aws_iam_role.run_id_minter_role.id
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect   = "Allow"
-        Action   = "states:StartExecution"
-        Resource = module.id_minter_state_machine.state_machine_arn
-      }
+# The minting Lambda resolves its partition ref (work ids written by find_work)
+# from S3.
+data "aws_iam_policy_document" "id_minter_partition_read" {
+  statement {
+    effect  = "Allow"
+    actions = ["s3:GetObject"]
+    resources = [
+      "arn:aws:s3:::wellcomecollection-catalogue-graph/graph-*/*/id_minter/*"
     ]
-  })
+  }
+}
+
+resource "aws_iam_role_policy" "id_minter_partition_read" {
+  role   = module.id_minter_lambda.id_minter_lambda_role_name
+  policy = data.aws_iam_policy_document.id_minter_partition_read.json
+}
+
+# Keep pre-module resources updating in place; removable once every stack
+# using this module has applied.
+
+moved {
+  from = module.id_minter_state_machine
+  to   = module.id_minter.module.state_machine
+}
+
+moved {
+  from = module.id_minter_state_machine_alarms
+  to   = module.id_minter.module.state_machine_alarms
+}
+
+moved {
+  from = aws_scheduler_schedule.id_minter_schedule
+  to   = module.id_minter.aws_scheduler_schedule.schedule
+}
+
+moved {
+  from = aws_iam_role.run_id_minter_role
+  to   = module.id_minter.aws_iam_role.run_state_machine
+}
+
+moved {
+  from = aws_iam_role_policy.run_id_minter_policy
+  to   = module.id_minter.aws_iam_role_policy.run_state_machine
 }


### PR DESCRIPTION
Stacked on #3536, so it merges after that PR and should be retargeted to `main` once #3536 lands. The diff here is against `worktree-6486-find-work-module`.

## What does this change?

Phase 2 of wellcomecollection/platform#6486. The id-minter runs as one Lambda invocation per window, so in wellcomecollection/platform#6445 three dense 15 minute windows ran past the 900s timeout and were skipped with nothing to show for it. This moves the id-minter onto the shared find_work state machine from #3536: a find-work Lambda scans `works-source` on `indexed_at`, writes partitions of 10,000 works to S3, and the state machine fans those out to the minting Lambda. 10,000 is sized so that worst case archive identifier density, around 105 ids per work, still finishes well inside the 900s timeout at post-#3527 throughput.

Concurrency is pinned at 6, the RDS sweet spot measured during the #6445 recovery (8 gave no gain and more timeouts). `tolerate_partition_failures` is false, because nothing re-covers a missed `indexed_at` range, so a lost partition fails the execution and alarms where the #6445 losses were silent. Partitions carry per-partition job ids (`<base>-p000`), which also fixes the minute granular collision on S3 report names.

Operators' replay input standardises on `ids`, though `source_identifiers` is still accepted as an alias, and the minting Lambda's response no longer echoes the request's ids, since a full partition would blow the Step Functions 256 KB task output limit. A full index mint now needs an explicit `"full": true`, so a mistyped invoke fails loudly instead of minting the whole index.

Event construction lives in the find-work Lambda rather than the state machine definition, introduced in #3536; this PR extends the same `normalise_lambda_input` path to the id-minter, including the `source_identifiers` alias so the pre-module replay shape keeps working.

### Checklist

- [ ] Does this change the display model the catalogue API returns? No. It changes pipeline orchestration and how the id-minter is invoked, not what is produced.

## How to test

186 id_minter and inferrer tests pass, with new ones covering the partitioning, per-partition job ids, the S3 round trip, the `indexed_at` window query, ref resolution in the minting Lambda and the full-mint guard. mypy and ruff are clean, `terraform validate` passes on `pipeline/terraform/2026-07-03`, and the rendered definitions of both module variants pass `aws stepfunctions validate-state-machine-definition`.

This branch was also exercised pre-merge on the live 2026-07-03 pipeline (dev-tagged Lambdas, schedule disabled, then rolled back to the current state machine while review happens):

| Test | Result |
|---|---|
| Full-mint guard, direct invoke with no scope | Refused with the explicit error |
| Window smoke (15 min of live ingest) | 1 partition of 4 works, scope-keyed partition file, per-partition report |
| Legacy `source_identifiers` replay shape | Accepted via the alias |
| Empty window | 0 partitions, clean success |
| Dense slice, 1 minute of the #6445 reindex burst | 68,822 works, 7 partitions, 0 failures, 2m13s at 6-wide |
| Catch-up window over the paused-schedule gap | Clean success |

The dense slice is the case that killed the old design: the same range previously needed manual slicing to survive the 900s Lambda timeout.

After merge this needs a manual `terraform apply` of `pipeline/terraform/2026-07-03`.

<details><summary>Apply gate</summary>

The pre-merge tests already applied this configuration (moves executed, find-work Lambda and IAM created, Lambda env vars set) and then reverted both state machine definitions to ConstructEvent-bearing shapes while review happens, keeping ticks safe if CI redeploys the Lambdas with main's code. The post-merge plan should therefore show both state machine definition updates as drift being restored, and no creates, destroys or moves. Deploy order matters: let CI put the merged code on the Lambdas before applying, because the old minter code misreads a partition ref as a full-index mint.

</details>

## How can we measure success?

Dense windows stop timing out, and a partition that does fail shows up as a failed execution with `PartitionsFailed` rather than as a window nobody notices was skipped.

## Have we considered potential risks?

Too high a concurrency would overload the id-minter RDS, so 6 is measured rather than guessed and stays a variable that can be lowered without a code change. The `Lambda.Unknown` retry gives a timed out invocation one idempotent re-run. `id-minter-find-work` joins the dated lambda deploy matrix, and the deploy action warn-skips functions absent from a pipeline, so stacks that have not applied are unaffected (2025-10-02 never gets this Lambda).


