### PR TITLE
Tei adapter deletion bug fix

### DIFF
--- a/tei_adapter/terraform/locals.tf
+++ b/tei_adapter/terraform/locals.tf
@@ -13,6 +13,17 @@ locals {
   tei_id_extractor_max_connections = 5
   rds_lock_timeout_seconds         = 10 * 60
 
+  # tei_id_extractor and tei_adapter both delay processing of *Deleted*
+  # messages, to avoid mistaking a file rename (delete-of-old + add-of-new)
+  # for a genuine deletion before the corresponding "changed" message has
+  # landed. Each queue's visibility timeout MUST exceed its own delete
+  # delay by a comfortable margin - otherwise SQS redelivers an in-flight
+  # delete message before the delay finishes, causing it to loop
+  # indefinitely and land in the DLQ without ever completing processing.
+  tei_adapter_delete_delay_seconds      = 2 * 60  # 2 minutes
+  tei_id_extractor_delete_delay_seconds = 30 * 60 # 30 minutes
+  visibility_timeout_buffer_seconds     = 10 * 60 # headroom beyond the delay for actual message processing
+
   monitoring_outputs = data.terraform_remote_state.monitoring.outputs
 
   lambda_error_alarm_arn = local.monitoring_outputs["platform_lambda_error_alerts_topic_arn"]

--- a/tei_adapter/terraform/rds_id_extractor.tf
+++ b/tei_adapter/terraform/rds_id_extractor.tf
@@ -56,7 +56,7 @@ module "tei_id_extractor_rds_serverless_cluster" {
   db_security_group_id     = aws_security_group.database_sg.id
   aws_db_subnet_group_name = aws_db_subnet_group.default.name
 
-  engine_version = "8.0.mysql_aurora.3.08.2"
+  engine_version = "8.0.mysql_aurora.3.10.3"
 
   snapshot_identifier = "aurora-mysql-v3-tei-pre-migration-24-15-08"
 }

--- a/tei_adapter/terraform/tei_adapter.tf
+++ b/tei_adapter/terraform/tei_adapter.tf
@@ -7,14 +7,14 @@ module "tei_adapter_w" {
   topic_arns = [module.tei_id_extractor_topic.arn]
 
   queue_name                       = "tei-adapter"
-  queue_visibility_timeout_seconds = 60
+  queue_visibility_timeout_seconds = local.tei_adapter_delete_delay_seconds + local.visibility_timeout_buffer_seconds
   message_retention_seconds        = 4 * 24 * 60 * 60
 
   env_vars = {
     metrics_namespace        = "${local.namespace}_tei_adapter"
     topic_arn                = module.tei_adapter_topic.arn
     parallelism              = 10
-    delete_delay             = "2 minutes"
+    delete_delay             = "${local.tei_adapter_delete_delay_seconds}s"
     tei_adapter_dynamo_table = aws_dynamodb_table.tei_adapter_table.id
   }
 

--- a/tei_adapter/terraform/tei_id_extractor.tf
+++ b/tei_adapter/terraform/tei_id_extractor.tf
@@ -7,7 +7,7 @@ module "tei_id_extractor_w" {
   topic_arns = [module.tei_updater_lambda.topic_arn]
 
   queue_name                       = "tei-id-extractor"
-  queue_visibility_timeout_seconds = local.rds_lock_timeout_seconds + 30
+  queue_visibility_timeout_seconds = local.tei_id_extractor_delete_delay_seconds + local.visibility_timeout_buffer_seconds
 
   env_vars = {
     metrics_namespace = "${local.namespace}_tei_id_extractor"
@@ -15,7 +15,7 @@ module "tei_id_extractor_w" {
     bucket            = aws_s3_bucket.tei_adapter.id
     parallelism       = 10
     max_connections   = local.tei_id_extractor_max_connections
-    delete_delay      = "30 minutes"
+    delete_delay      = "${local.tei_id_extractor_delete_delay_seconds}s"
     database          = "pathid"
     table             = "pathid"
   }

--- a/tei_adapter/terraform/terraform.tf
+++ b/tei_adapter/terraform/terraform.tf
@@ -1,6 +1,8 @@
 terraform {
   backend "s3" {
-    role_arn = "arn:aws:iam::760097843905:role/platform-developer"
+    assume_role = {
+      role_arn = "arn:aws:iam::760097843905:role/platform-developer"
+    }
 
     bucket         = "wellcomecollection-platform-infra"
     key            = "terraform/tei_adapter.tfstate"
@@ -13,7 +15,9 @@ data "terraform_remote_state" "shared_infra" {
   backend = "s3"
 
   config = {
-    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    assume_role = {
+      role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    }
 
     bucket = "wellcomecollection-platform-infra"
     key    = "terraform/platform-infrastructure/shared.tfstate"
@@ -25,7 +29,9 @@ data "terraform_remote_state" "accounts_catalogue" {
   backend = "s3"
 
   config = {
-    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    assume_role = {
+      role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    }
 
     bucket = "wellcomecollection-platform-infra"
     key    = "terraform/aws-account-infrastructure/catalogue.tfstate"
@@ -37,7 +43,9 @@ data "terraform_remote_state" "monitoring" {
   backend = "s3"
 
   config = {
-    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    assume_role = {
+      role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    }
 
     bucket = "wellcomecollection-platform-infra"
     key    = "terraform/monitoring.tfstate"


### PR DESCRIPTION
## What does this change?

See https://github.com/wellcomecollection/platform/issues/6487
Increase tei queues visibility timeout to prevent messages from being redriven before the delete_delay allows the service to process anything, and landing i nthe DLQ after a few tries
Also: align the DRS DB to the engine version already running in the deployed service


### Checklist

- [ ] Does this change the display model the catalogue API returns? If so, regenerate the test documents under `catalogue_graph/document_generators/test_documents`. The `wellcomecollection/catalogue-api` repo copies them in with `copy_test_documents.py`, and its OpenAPI contract tests validate the published spec against them, so stale fixtures let the spec drift.

## How to test

Run `terraform plan` in tei_adapter/terraform
```
Plan: 2 to add, 4 to change, 2 to destroy.
```
Add/destroy: the task defs whose env vars are changing 
module.tei_id_extractor_w.module.scaling_service.module.service.aws_ecs_service.service and module.tei_adapter_w.module.scaling_service.module.service.aws_ecs_service.service depends on task definitions 
service's read from queue policy, assuming linked to update task definition too 

## How can we measure success?

https://wellcomecollection.org/works/bured6mf is not available in the public catalogue

## Have we considered potential risks?
- Slower recovery from a genuinely crashed consumer. If a task dies mid-processing for an unrelated reason (OOM, deploy, crash), the message now sits invisible for up to 12/40 minutes before anything can retry it — versus under a minute before.
- Slower DLQ escalation for truly broken messages. A message that will never succeed now takes far longer to exhaust maxReceiveCount and land in the DLQ (each failed attempt now "costs" up to 12/40 minutes instead of seconds), delaying any DLQ-based alerting.
- Reduced effective throughput under bursty load, since each in-flight message occupies a slot for much longer even when doing essentially no CPU work (just waiting out the delay) — a lower-probability concern given this is a low-volume queue, but worth naming.

~~The main issue that *needs* addressing is the scale down of the services based on number of visible messages: the "queue low → scale down" alarm has ample opportunity to fire and terminate the running task while the message is still mid-delay. Looking into this~~ The scale down adds up all SQS messages states so won't trigger until no message in flight 

