### PR TITLE
Map the Axiell CLOSED access status to Closed

### DIFF
--- a/catalogue_graph/src/adapters/transformers/axiell/access_status.py
+++ b/catalogue_graph/src/adapters/transformers/axiell/access_status.py
@@ -32,7 +32,6 @@ logger = structlog.get_logger(__name__)
 #  * PRIVATE: No CALM equivalent. At the moment, only one record has this status (collect:100003386)
 
 # CALM has a few more statuses which currently don't exist in Axiell:
-#  * Closed: Mapped to Closed
 #  * Donor Permission: Mapped to PermissionRequired
 #  * Cannot Be Produced: Mapped to Unavailable
 #  * Temporarily Unavailable: Mapped to TemporarilyUnavailable
@@ -47,6 +46,7 @@ ACCESS_STATUS_MAPPING = {
     "MISSING": Unavailable,
     "SAFEGUARDED": Safeguarded,
     "BYAPPOINTMENT": ByAppointment,
+    "CLOSED": Closed,
 }
 
 
@@ -65,9 +65,10 @@ def extract_access_status(record: Record) -> AccessStatus | None:
     if status in ACCESS_STATUS_MAPPING:
         return ACCESS_STATUS_MAPPING[status]
 
-    # Unlike CALM, Axiell does not currently have a CLOSED status value. To determine if an item is closed,
-    # we use the 'closed until' date instead. If this date is in the future, the item is closed.
-    # This approach produces a ~98% match with the CALM transformer.
+    # Most closed material does not (yet) carry a CLOSED status value: the Calm-to-Axiell
+    # migration delivered Calm's 'Closed' as 'Certain restrictions apply' until the next
+    # data load restores the full status vocabulary. For records without a usable status,
+    # a 'closed until' date in the future marks the item as closed.
     closed_until = extract_closed_until_date(record)
     if closed_until and closed_until >= date.today():
         return Closed

--- a/catalogue_graph/tests/adapters/transformers/axiell/test_access_status.py
+++ b/catalogue_graph/tests/adapters/transformers/axiell/test_access_status.py
@@ -1,4 +1,4 @@
-from pymarc.record import Field, Subfield
+from pymarc.record import Field, Record, Subfield
 
 from adapters.transformers.axiell.access_status import extract_access_status
 from models.pipeline.access_status import Closed, Open, Restricted
@@ -7,17 +7,11 @@ from tests.adapters.transformers.axiell.conftest import make_axiell_record
 # mypy: allow-untyped-calls
 
 
-def add_506(record, code: str, value: str) -> None:
+def add_506(record: Record, code: str, value: str) -> None:
     record.add_field(Field(tag="506", subfields=[Subfield(code=code, value=value)]))
 
 
-def test_closed_status_maps_to_closed() -> None:
-    record = make_axiell_record()
-    add_506(record, "f", "CLOSED")
-    assert extract_access_status(record) == Closed
-
-
-def test_closed_status_needs_no_closed_until_date() -> None:
+def test_closed_status_maps_to_closed_without_closed_until_date() -> None:
     # Permanently closed material carries CLOSED with no 506 $g at all.
     record = make_axiell_record()
     add_506(record, "f", "CLOSED")

--- a/catalogue_graph/tests/adapters/transformers/axiell/test_access_status.py
+++ b/catalogue_graph/tests/adapters/transformers/axiell/test_access_status.py
@@ -1,0 +1,56 @@
+from pymarc.record import Field, Subfield
+
+from adapters.transformers.axiell.access_status import extract_access_status
+from models.pipeline.access_status import Closed, Open, Restricted
+from tests.adapters.transformers.axiell.conftest import make_axiell_record
+
+# mypy: allow-untyped-calls
+
+
+def add_506(record, code: str, value: str) -> None:
+    record.add_field(Field(tag="506", subfields=[Subfield(code=code, value=value)]))
+
+
+def test_closed_status_maps_to_closed() -> None:
+    record = make_axiell_record()
+    add_506(record, "f", "CLOSED")
+    assert extract_access_status(record) == Closed
+
+
+def test_closed_status_needs_no_closed_until_date() -> None:
+    # Permanently closed material carries CLOSED with no 506 $g at all.
+    record = make_axiell_record()
+    add_506(record, "f", "CLOSED")
+    assert extract_access_status(record) == Closed
+
+
+def test_mapped_status_wins_over_closed_until_date() -> None:
+    record = make_axiell_record()
+    add_506(record, "f", "OPEN")
+    add_506(record, "g", "2999-01-01")
+    assert extract_access_status(record) == Open
+
+
+def test_restrictionsapply_maps_to_restricted() -> None:
+    record = make_axiell_record()
+    add_506(record, "f", "RESTRICTIONSAPPLY")
+    assert extract_access_status(record) == Restricted
+
+
+def test_no_status_with_future_closed_until_is_closed() -> None:
+    record = make_axiell_record()
+    add_506(record, "g", "2999-01-01")
+    assert extract_access_status(record) == Closed
+
+
+def test_no_status_with_past_closed_until_is_none() -> None:
+    record = make_axiell_record()
+    add_506(record, "g", "2001-01-01")
+    assert extract_access_status(record) is None
+
+
+def test_unrecognised_status_with_future_closed_until_is_closed() -> None:
+    record = make_axiell_record()
+    add_506(record, "f", "PRIVATE")
+    add_506(record, "g", "2999-01-01")
+    assert extract_access_status(record) == Closed


### PR DESCRIPTION
## What does this change?

Axiell records with a `CLOSED` access status value now map to the `Closed` access status. Relates to wellcomecollection/platform#6476.

The Calm-to-Axiell migration delivered Calm's 'Closed' status as 'Certain restrictions apply', so formerly closed material currently displays as Restricted (9,414 records carry that value together with a future closed-until date). The next Axiell data load restores the full Calm status vocabulary, and 18 records already carry `CLOSED` today. Without this mapping, restored `CLOSED` values would be unrecognised: a record with a future closed-until date would still come out Closed via the date-based fallback, but a permanent closure with no date would end up with no access status at all and a warning logged per record.

The comment claiming Axiell has no `CLOSED` value was stale, so it now explains why the closed-until fallback is still doing the work in the meantime.

### Checklist

- [ ] Does this change the display model the catalogue API returns? No. `Closed` is an existing access status, so only which records receive it changes, and none of the generated test documents are affected.

## How to test

From `catalogue_graph/`, `uv run --group dev pytest tests/adapters/transformers/axiell/` (197 passed). The new test file covers the `CLOSED` mapping with and without a closed-until date, a mapped status taking precedence over a future closed-until date, and the existing fallback paths for records with no usable status.

## How can we measure success?

After the next Axiell data load, records carrying `CLOSED` come through with the Closed access status and stop appearing in the transformer's "Unrecognised Axiell access status value" warnings.

## Have we considered potential risks?

Low. Until the data load lands the mapping only affects the 18 records that already carry `CLOSED`, which move from having no access status to Closed. The closed-until fallback is untouched, so nothing currently marked Closed changes.
