### PR TITLE
Suppress Axiell works marked publish_to_web: no

### DIFF
--- a/catalogue_graph/src/adapters/transformers/axiell/publish_to_web.py
+++ b/catalogue_graph/src/adapters/transformers/axiell/publish_to_web.py
@@ -1,0 +1,30 @@
+"""
+Extract the publish-to-web marker from local field
+981 - Local field, emitted by the OAI stylesheet
+    $a - 'yes' or 'no', from the Axiell publish_to_web checkbox
+"""
+
+from typing import Literal
+
+from pymarc.record import Record
+
+from adapters.transformers.marc.common import non_empty_subfields
+
+PublishToWeb = Literal["yes", "no"]
+
+
+def extract_publish_to_web(record: Record) -> PublishToWeb | None:
+    """Extract the explicit publish-to-web marker from 981 $a.
+
+    Returns None when the marker is absent (records harvested before the
+    stylesheet emitted it) or carries an unexpected value; callers must treat
+    None as publishable so pre-marker harvests keep their current visibility.
+    """
+    values = non_empty_subfields("981", "a", record)
+    if not values:
+        return None
+
+    value = values[0].strip().lower()
+    if value in ("yes", "no"):
+        return value  # type: ignore[return-value]
+    return None

--- a/catalogue_graph/src/adapters/transformers/axiell/publish_to_web.py
+++ b/catalogue_graph/src/adapters/transformers/axiell/publish_to_web.py
@@ -25,6 +25,8 @@ def extract_publish_to_web(record: Record) -> PublishToWeb | None:
         return None
 
     value = values[0].strip().lower()
-    if value in ("yes", "no"):
-        return value  # type: ignore[return-value]
+    if value == "yes":
+        return "yes"
+    if value == "no":
+        return "no"
     return None

--- a/catalogue_graph/src/adapters/transformers/builders/axiell_work_builder.py
+++ b/catalogue_graph/src/adapters/transformers/builders/axiell_work_builder.py
@@ -78,8 +78,8 @@ class AxiellWorkBuilder(MarcXmlWorkBuilder):
 
         # The publish_to_web checkbox decides whether a finished record may go
         # online, separately from its cataloguing status. Only an explicit 'no'
-        # suppresses: records harvested before the stylesheet emitted the
-        # marker carry none and must keep their current visibility.
+        # suppresses: the marker is absent on records harvested before the
+        # stylesheet change, and those must keep their current visibility.
         if extract_publish_to_web(self.record) == "no":
             return True
 

--- a/catalogue_graph/src/adapters/transformers/builders/axiell_work_builder.py
+++ b/catalogue_graph/src/adapters/transformers/builders/axiell_work_builder.py
@@ -19,6 +19,7 @@ from adapters.transformers.axiell.physical_description import (
 from adapters.transformers.axiell.production import (
     extract_production,
 )
+from adapters.transformers.axiell.publish_to_web import extract_publish_to_web
 from adapters.transformers.axiell.subjects import extract_subjects
 from adapters.transformers.builders.marc_xml_work_builder import MarcXmlWorkBuilder
 from adapters.transformers.marc.last_transaction_time import (
@@ -73,6 +74,13 @@ class AxiellWorkBuilder(MarcXmlWorkBuilder):
         # suppressing them must not require one.
         catalogue_status = extract_catalogue_status(self.record)
         if catalogue_status not in NON_SUPPRESSED_STATUSES:
+            return True
+
+        # The publish_to_web checkbox decides whether a finished record may go
+        # online, separately from its cataloguing status. Only an explicit 'no'
+        # suppresses: records harvested before the stylesheet emitted the
+        # marker carry none and must keep their current visibility.
+        if extract_publish_to_web(self.record) == "no":
             return True
 
         # Records prefixed with AMSG (Archives and Manuscripts Resource Guides) are not

--- a/catalogue_graph/tests/adapters/transformers/axiell/conftest.py
+++ b/catalogue_graph/tests/adapters/transformers/axiell/conftest.py
@@ -7,6 +7,7 @@ def make_axiell_record(
     identifier: str = "test001",
     catalogue_status: str | None = "catalogued",
     ref_no: str | None = "TestRefNo",
+    publish_to_web: str | None = None,
 ) -> Record:
     """Minimal valid Axiell MARC record with all required fields."""
     record = Record()
@@ -29,6 +30,13 @@ def make_axiell_record(
                 tag="583",
                 indicators=Indicators("0", " "),
                 subfields=[Subfield(code="l", value=catalogue_status)],
+            )
+        )
+    if publish_to_web is not None:
+        record.add_field(
+            Field(
+                tag="981",
+                subfields=[Subfield(code="a", value=publish_to_web)],
             )
         )
     return record

--- a/catalogue_graph/tests/adapters/transformers/axiell/test_suppression.py
+++ b/catalogue_graph/tests/adapters/transformers/axiell/test_suppression.py
@@ -46,11 +46,11 @@ def test_publish_to_web_no_yields_deleted_work() -> None:
 
 
 @pytest.mark.parametrize("marker", ["yes", None, "unexpected"])
-def test_publish_to_web_yes_or_absent_yields_visible_work(
+def test_publish_to_web_without_explicit_no_yields_visible_work(
     marker: str | None,
 ) -> None:
-    """Records harvested before the stylesheet emitted the marker carry none
-    and must keep their current visibility."""
+    """Only an explicit 'no' suppresses: absent markers (pre-stylesheet
+    harvests) and unexpected values must keep their current visibility."""
     record = make_axiell_record(publish_to_web=marker)
     assert isinstance(_transform(record), VisibleSourceWork)
 

--- a/catalogue_graph/tests/adapters/transformers/axiell/test_suppression.py
+++ b/catalogue_graph/tests/adapters/transformers/axiell/test_suppression.py
@@ -40,6 +40,26 @@ def test_suppressed_statuses_yield_deleted_work(status: str) -> None:
     assert isinstance(_transform(record), DeletedSourceWork)
 
 
+def test_publish_to_web_no_yields_deleted_work() -> None:
+    record = make_axiell_record(publish_to_web="no")
+    assert isinstance(_transform(record), DeletedSourceWork)
+
+
+@pytest.mark.parametrize("marker", ["yes", None, "unexpected"])
+def test_publish_to_web_yes_or_absent_yields_visible_work(
+    marker: str | None,
+) -> None:
+    """Records harvested before the stylesheet emitted the marker carry none
+    and must keep their current visibility."""
+    record = make_axiell_record(publish_to_web=marker)
+    assert isinstance(_transform(record), VisibleSourceWork)
+
+
+def test_publish_to_web_no_without_ref_no_yields_deleted_work() -> None:
+    record = make_axiell_record(publish_to_web="no", ref_no=None)
+    assert isinstance(_transform(record), DeletedSourceWork)
+
+
 def test_missing_status_yields_deleted_work() -> None:
     assert isinstance(
         _transform(make_axiell_record(catalogue_status=None)), DeletedSourceWork


### PR DESCRIPTION
## Do not merge yet

This has to land in a specific order, or it will suppress most of the Axiell collection:

1. Axiell populate `publish_to_web` per the approved migration mapping (Catalogued and Partially catalogued get yes).
2. The stylesheet marker is uploaded to the hosted server (wellcomecollection/axiell-collections-xslt#21).
3. Then merge this, deploy, and run a full re-harvest.

Today `publish_to_web` is set on 4 records in the whole collect database, so almost every record would harvest as an explicit "no". Merging before the data is populated would progressively suppress every record touched by an incremental harvest.

## What does this change?

Axiell works whose `publish_to_web` marker says "no" are now suppressed by the transformer.

`publish_to_web` records whether a finished description may appear online, separately from `record_progress` ("is it finished?"). Collections information have confirmed that records marked "Closed description" in Calm must not be public, and this is the gate that keeps them off the site.

Only an explicit "no" suppresses. A missing or unrecognised marker means visible, so records harvested before the stylesheet change keep the visibility they have now and there is no cliff edge between the two harvest generations.

### Checklist

- [ ] Does this change the display model the catalogue API returns? No. It changes which Axiell records become `DeletedSourceWork` rather than anything about the documents we produce.

## How to test

From `catalogue_graph/`: `uv run --group dev pytest` (195 passing), plus `mypy .` and `ruff check .`, both clean.

## How can we measure success?

After the re-harvest, no work whose source record is marked "Closed description" is visible in the catalogue, and the count of suppressed Axiell works matches the count of records left unticked by the migration.

## Have we considered potential risks?

The suppression decision is only as good as the data behind it, which is why the sequencing above matters. If the migration marks records wrongly, works disappear from the site; that is recoverable by fixing the Axiell data and re-harvesting, but worth a spot check of the suppressed count before and after.

Closes wellcomecollection/platform#6477 (the stylesheet PR wellcomecollection/axiell-collections-xslt#21 merges first in the activation order; this PR merges last, so the issue closes when both are in)

