### PR TITLE
Pin the inferrer ruff rule set and fix the resulting lint errors

### DIFF
--- a/pipeline/inferrer/aspect_ratio_inferrer/app/main.py
+++ b/pipeline/inferrer/aspect_ratio_inferrer/app/main.py
@@ -1,6 +1,7 @@
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, HTTPException
+
 from common import http
 from common.image import get_image_from_url
 from common.logging import get_logger
@@ -42,7 +43,7 @@ async def main(query_url: str):
     except ValueError as e:
         error_string = str(e)
         logger.error(error_string)
-        raise HTTPException(status_code=404, detail=error_string)
+        raise HTTPException(status_code=404, detail=error_string) from e
 
     aspect_ratio = image.width / image.height
     logger.info(f"extracted aspect ratio from url: {query_url}")

--- a/pipeline/inferrer/aspect_ratio_inferrer/test/test_aspect_ratio_inferrer.py
+++ b/pipeline/inferrer/aspect_ratio_inferrer/test/test_aspect_ratio_inferrer.py
@@ -1,4 +1,5 @@
-from unittest.mock import patch, AsyncMock
+from unittest.mock import AsyncMock, patch
+
 import main
 from fastapi.testclient import TestClient
 

--- a/pipeline/inferrer/common/common/batching.py
+++ b/pipeline/inferrer/common/common/batching.py
@@ -1,5 +1,6 @@
 import asyncio
-from typing import Callable, Dict, Generic, List, TypeVar
+from collections.abc import Callable
+from typing import Generic, TypeVar
 from uuid import UUID, uuid4
 
 from async_timeout import timeout
@@ -37,7 +38,7 @@ class BatchExecutionQueue(Generic[Input, Result]):
 
     def __init__(
         self,
-        sync_batch_processor: Callable[[List[Input]], List[Result]],
+        sync_batch_processor: Callable[[list[Input]], list[Result]],
         batch_size: int,
         timeout: float,
     ):
@@ -45,7 +46,7 @@ class BatchExecutionQueue(Generic[Input, Result]):
         self.batch_size = batch_size
         self.timeout = timeout
         self.queue = asyncio.Queue(batch_size)
-        self.output: Dict[UUID, Result] = {}
+        self.output: dict[UUID, Result] = {}
 
     def __del__(self):
         self.stop_worker()
@@ -133,7 +134,7 @@ class BatchExecutionQueue(Generic[Input, Result]):
         # This implementation is based upon:
         # http://blog.mathieu-leplatre.info/some-python-3-asyncio-snippets.html#consume-queue-in-batches
         while True:
-            batch: List[(UUID, Input)] = []
+            batch: list[(UUID, Input)] = []
             try:
                 with timeout(self.timeout):
                     while len(batch) < self.batch_size:
@@ -149,10 +150,10 @@ class BatchExecutionQueue(Generic[Input, Result]):
 
             if batch:
                 try:
-                    ids, inputs = zip(*batch)
-                    results: List[Result] = self.sync_batch_processor(inputs)
+                    ids, inputs = zip(*batch, strict=True)
+                    results: list[Result] = self.sync_batch_processor(inputs)
                     assert len(results) == len(inputs)
-                    self.output.update(dict(zip(ids, results)))
+                    self.output.update(dict(zip(ids, results, strict=True)))
                 except Exception as e:
                     log.error("Error processing batch", e)
                     raise e from None

--- a/pipeline/inferrer/common/common/batching.py
+++ b/pipeline/inferrer/common/common/batching.py
@@ -134,7 +134,7 @@ class BatchExecutionQueue(Generic[Input, Result]):
         # This implementation is based upon:
         # http://blog.mathieu-leplatre.info/some-python-3-asyncio-snippets.html#consume-queue-in-batches
         while True:
-            batch: list[(UUID, Input)] = []
+            batch: list[tuple[UUID, Input]] = []
             try:
                 with timeout(self.timeout):
                     while len(batch) < self.batch_size:
@@ -151,11 +151,11 @@ class BatchExecutionQueue(Generic[Input, Result]):
             if batch:
                 try:
                     ids, inputs = zip(*batch, strict=True)
-                    results: list[Result] = self.sync_batch_processor(inputs)
+                    results: list[Result] = self.sync_batch_processor(list(inputs))
                     assert len(results) == len(inputs)
                     self.output.update(dict(zip(ids, results, strict=True)))
                 except Exception as e:
-                    log.error("Error processing batch", e)
+                    log.exception("Error processing batch")
                     raise e from None
                 finally:
                     self.__mark_queue_done(len(batch))

--- a/pipeline/inferrer/common/common/http.py
+++ b/pipeline/inferrer/common/common/http.py
@@ -47,8 +47,8 @@ async def fetch_url_json(url, params=None):
         except (
             json.JSONDecodeError,
             aiohttp.client_exceptions.ContentTypeError,
-        ):
-            raise ValueError(f"Couldn't decode json from {url}")
+        ) as e:
+            raise ValueError(f"Couldn't decode json from {url}") from e
 
 
 async def fetch_redirect_url(url, params=None):

--- a/pipeline/inferrer/common/common/image.py
+++ b/pipeline/inferrer/common/common/image.py
@@ -18,7 +18,7 @@ async def get_image_from_url(image_url, size=None):
 
     try:
         image = Image.open(BytesIO(image_pointer))
-    except UnidentifiedImageError:
+    except UnidentifiedImageError as e:
         # If this error gets thrown from inside Pillow, it only has the BytesIO
         # object, and we get the moderately unhelpful error:
         #
@@ -26,7 +26,9 @@ async def get_image_from_url(image_url, size=None):
         #
         # Rethrowing it with the image URL should give us more context if/when
         # this error occurs.
-        raise UnidentifiedImageError("cannot identify image from URL %r" % image_url)
+        raise UnidentifiedImageError(
+            f"cannot identify image from URL {image_url!r}"
+        ) from e
 
     if size:
         image = image.resize((size, size), resample=Image.BILINEAR)
@@ -37,8 +39,8 @@ async def get_local_image(path):
     try:
         async with AIOFile(path, "rb") as afp:
             return await afp.read()
-    except FileNotFoundError:
-        raise ValueError(f"{path} does not exist")
+    except FileNotFoundError as e:
+        raise ValueError(f"{path} does not exist") from e
 
 
 def is_valid_image(response):
@@ -63,8 +65,8 @@ async def get_remote_image(url):
 def get_image_url_from_iiif_url(iiif_url, input_size=224):
     try:
         image = IIIFImageClient.init_from_url(iiif_url)
-    except ParseError:
-        raise ValueError(f"{iiif_url} is not a valid iiif URL")
+    except ParseError as e:
+        raise ValueError(f"{iiif_url} is not a valid iiif URL") from e
 
     if "dlcs" in image.api_endpoint:
         # DLCS provides a thumbnails service which only serves certain sizes of

--- a/pipeline/inferrer/feature_inferrer/app/main.py
+++ b/pipeline/inferrer/feature_inferrer/app/main.py
@@ -1,14 +1,14 @@
-import numpy as np
 import base64
 from contextlib import asynccontextmanager
 
+import numpy as np
 from fastapi import FastAPI, HTTPException
+from src.feature_extraction import extract_features
+
 from common import http
+from common.batching import BatchExecutionQueue
 from common.image import get_image_from_url
 from common.logging import get_logger
-from common.batching import BatchExecutionQueue
-
-from src.feature_extraction import extract_features
 
 logger = get_logger(__name__)
 
@@ -42,7 +42,7 @@ async def main(query_url: str):
     except ValueError as e:
         error_string = str(e)
         logger.error(error_string)
-        raise HTTPException(status_code=404, detail=error_string)
+        raise HTTPException(status_code=404, detail=error_string) from e
 
     features = await batch_inferrer_queue.execute(image)
     normalised_features = features / np.linalg.norm(features, axis=0, keepdims=True)

--- a/pipeline/inferrer/feature_inferrer/fetch_vgg.py
+++ b/pipeline/inferrer/feature_inferrer/fetch_vgg.py
@@ -1,4 +1,5 @@
 import os
+
 from torch.hub import load_state_dict_from_url
 from torchvision.models import VGG16_Weights
 

--- a/pipeline/inferrer/feature_inferrer/test/test_feature_inferrer.py
+++ b/pipeline/inferrer/feature_inferrer/test/test_feature_inferrer.py
@@ -1,7 +1,8 @@
-import numpy as np
 import base64
-from unittest.mock import patch, AsyncMock
+from unittest.mock import AsyncMock, patch
+
 import main
+import numpy as np
 from fastapi.testclient import TestClient
 
 

--- a/pipeline/inferrer/palette_inferrer/app/main.py
+++ b/pipeline/inferrer/palette_inferrer/app/main.py
@@ -2,12 +2,12 @@ import base64
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, HTTPException
+from palette_encoder import PaletteEncoder
+
 from common import http
 from common.batching import BatchExecutionQueue
 from common.image import get_image_from_url
 from common.logging import get_logger
-
-from palette_encoder import PaletteEncoder
 
 logger = get_logger(__name__)
 
@@ -43,7 +43,7 @@ async def main(query_url: str):
     except ValueError as e:
         error_string = str(e)
         logger.error(error_string)
-        raise HTTPException(status_code=404, detail=error_string)
+        raise HTTPException(status_code=404, detail=error_string) from e
 
     palette_result = await batch_inferrer_queue.execute(image)
     logger.info(f"extracted color palette from url: {query_url}")

--- a/pipeline/inferrer/palette_inferrer/app/palette_encoder.py
+++ b/pipeline/inferrer/palette_inferrer/app/palette_encoder.py
@@ -1,6 +1,6 @@
 import numpy as np
-from PIL import Image
 from joblib import Parallel, delayed
+from PIL import Image
 
 
 class PaletteEncoder:
@@ -70,7 +70,7 @@ class PaletteEncoder:
         """
         average = pixel_array.mean(axis=0)
         r, g, b = average.astype(int)
-        hex = "#{:02x}{:02x}{:02x}".format(r, g, b)
+        hex = f"#{r:02x}{g:02x}{b:02x}"
         return hex
 
     def process_image(self, image: Image):

--- a/pipeline/inferrer/palette_inferrer/app/palette_encoder.py
+++ b/pipeline/inferrer/palette_inferrer/app/palette_encoder.py
@@ -55,7 +55,7 @@ class PaletteEncoder:
 
         return histogram.flatten()
 
-    def average_color_hex(self, pixel_array: np.ndarray) -> np.ndarray:
+    def average_color_hex(self, pixel_array: np.ndarray) -> str:
         """
         Extract the average color of the input image and return it as a hex
         string.
@@ -65,13 +65,12 @@ class PaletteEncoder:
                 The flattened array of RGB pixels from the input image
 
         Returns:
-            np.ndarray:
-                The flattened color histogram as a 1D numpy array.
+            str:
+                The average color as a hex string, e.g. "#1a2b3c".
         """
         average = pixel_array.mean(axis=0)
         r, g, b = average.astype(int)
-        hex = f"#{r:02x}{g:02x}{b:02x}"
-        return hex
+        return f"#{r:02x}{g:02x}{b:02x}"
 
     def process_image(self, image: Image):
         rgb_image = image.convert("RGB").resize(

--- a/pipeline/inferrer/palette_inferrer/test/test_palette_inferrer.py
+++ b/pipeline/inferrer/palette_inferrer/test/test_palette_inferrer.py
@@ -1,7 +1,8 @@
-import numpy as np
 import base64
-from unittest.mock import patch, AsyncMock
+from unittest.mock import AsyncMock, patch
+
 import main
+import numpy as np
 from fastapi.testclient import TestClient
 
 

--- a/pipeline/inferrer/ruff.toml
+++ b/pipeline/inferrer/ruff.toml
@@ -1,0 +1,27 @@
+# Pin the rule set so a new ruff release's default selection can't break CI.
+# Mirrors catalogue_graph/pyproject.toml.
+line-length = 88
+# Not inferred from the per-inferrer pyproject.toml files, so state it here.
+target-version = "py310"
+
+[lint]
+select = [
+    # pycodestyle
+    "E",
+    # Pyflakes
+    "F",
+    # pyupgrade
+    "UP",
+    # flake8-bugbear
+    "B",
+    # flake8-simplify
+    "SIM",
+    # isort
+    "I",
+]
+ignore = ["E501"]
+
+[lint.isort]
+# Without this, the `common/` directory makes a bare `common` import look
+# first-party while `common.image` does not, splitting the two apart.
+known-first-party = ["common"]


### PR DESCRIPTION
## What does this change?

The shared `python_check` action runs `uvx ruff check` with no version pin, so CI always takes whatever ruff is newest. Ruff 0.16 widened its default rule selection well beyond `E`/`F`, and nothing under `pipeline/inferrer/` had a ruff config, so all three check jobs started failing on files nobody had touched since #2929. Dependabot PR #3534 is the visible casualty, but any change under `pipeline/inferrer/` hits the same wall, and so does main.

A `ruff.toml` at `pipeline/inferrer/` now states the rule selection explicitly, mirroring `catalogue_graph/pyproject.toml`, so the next change to ruff's defaults can't break the build. Two settings are less obvious:

- `target-version = "py310"`, because a standalone `ruff.toml` doesn't read `requires-python` from the nested per-inferrer projects.
- `known-first-party = ["common"]`, because the `common/` directory otherwise makes a bare `common` import look first-party while `common.image` doesn't resolve, splitting the two into separate blocks.

The code changes are import ordering, `list`/`dict` builtin annotations, f-strings replacing `%` and `.format`, and exception chaining in the handlers that re-wrap into `HTTPException` or `ValueError`.

The two `zip` calls in `batching.py` gain `strict=True`. That is safe rather than behaviour-changing: batch elements are always the 2-tuples pushed at `batching.py:85`, and `len(results) == len(inputs)` is already asserted on the line above the second call.

Formatting is untouched. Two test files are unformatted on main, but the workflow sets `skip-format-check: 'true'`, so that is a separate question.

### Checklist

- [x] Does this change the display model the catalogue API returns? No, this is lint and config only.

## How to test

`uvx ruff check pipeline/inferrer/<project>` for each of `aspect_ratio_inferrer`, `feature_inferrer` and `palette_inferrer` passes on this branch and fails on main. The same three jobs in CI are the real check.

Tests: aspect_ratio_inferrer (4 passed) and palette_inferrer (5 passed) run clean locally. feature_inferrer cannot run on Apple Silicon (`RuntimeError: MKL-DNN build is disabled` at collection); I confirmed that failure is identical on unmodified main, so CI on Linux is the check there.

## How can we measure success?

The inferrer workflow goes green on this branch, and #3534 can be rebased and merged.

## Have we considered potential risks?

The exception-chaining edits change traceback content, not control flow. The `strict=True` additions would raise on a length mismatch that the existing assert already treats as impossible, and `BatchExecutionQueue` internals are not covered by the inferrer tests (they mock `batch_inferrer_queue.execute`), so that is the one edit CI will not exercise.

The broader risk is unfixed: this repo pins nothing about ruff, and the same drift will hit `catalogue_graph` and `scripts/` whenever their configs fall behind a new default. Pinning the ruff version in `wellcomecollection/.github` would fix it for every project at once, but that is a change to a shared repo and out of scope here.


One thing found but deliberately not fixed: `fetch_vgg.py:10` passes `os.getenv("VERBOSE", default=False)` as `progress`. Ruff 0.16 flagged it as `PLW1508` under the wide defaults, but `PL` is not in the selection here. Setting `VERBOSE=false` would enable the progress bar rather than disable it, since any non-empty string is truthy. It only affects a build-time progress bar, and picking the right behaviour is a call for whoever owns the image build, so I have left it alone.
