### PR TITLE
Read every language on a TEI textLang instead of rejecting the record

### DIFF
--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiLanguages.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiLanguages.scala
@@ -30,55 +30,51 @@ object TeiLanguages extends Logging {
         case (n, Right((languageList, languageNoteList))) =>
           val label = n.text
 
-          val langId = parseLanguageId(n)
-
-          (langId, label) match {
-            case (Right(Some(id)), label) if label.trim.nonEmpty =>
-              appendLanguageOrNote(languageList, languageNoteList, id, label)
-            case (Right(None), label) if label.trim.nonEmpty =>
-              appendNote(languageList, languageNoteList, label)
-            case (Right(_), _) =>
+          (parseLanguageIds(n), label) match {
+            case (_, label) if label.trim.isEmpty =>
               warn(s"Missing label for language node $n")
               Right((languageList, languageNoteList))
-            case (Left(err), _) => Left(err)
+            case (Nil, label) =>
+              appendNote(languageList, languageNoteList, label)
+            case (ids, label) =>
+              appendLanguagesOrNote(languageList, languageNoteList, ids, label)
           }
 
         case (_, Left(err)) => Left(err)
       }
 
-  private def parseLanguageId(n: Node) = {
-    val mainLangId = (n \@ "mainLang").toLowerCase
-    val otherLangId = (n \@ "otherLangs").toLowerCase
-    (mainLangId, otherLangId) match {
-      case (id1, id2) if id2.isEmpty && id1.nonEmpty => Right(Some(id1))
-      case (id1, id2) if id1.isEmpty && id2.nonEmpty => Right(Some(id2))
-      case (id1, id2) if id2.isEmpty && id1.isEmpty =>
-        Right(None)
-      case _ =>
-        Left(new RuntimeException(s"Multiple language IDs in $n"))
-    }
-  }
+  /** A textLang may name a main language, other languages, or both. Both is how
+    * TEI describes a multi-language manuscript, so read every id rather than
+    * treating the combination as an error.
+    */
+  private def parseLanguageIds(n: Node): List[String] =
+    (Seq(n \@ "mainLang") ++ (n \@ "otherLangs").split("\\s+"))
+      .map(_.toLowerCase.trim)
+      .filter(_.nonEmpty)
+      .distinct
+      .toList
 
-  private def appendLanguageOrNote(
+  private def appendLanguagesOrNote(
     languageList: List[Language],
     languageNoteList: List[Note],
-    id: String,
+    ids: List[String],
     label: String
-  ) =
-    TeiLanguageData(id, label).fold(
-      err => {
-        warn("Could not parse language", err)
-        appendNote(languageList, languageNoteList, label)
-      },
-      appendLanguage(languageList, languageNoteList, _)
-    )
+  ) = {
+    val languages = ids.flatMap {
+      id =>
+        TeiLanguageData(id, label) match {
+          case Right(language) => Some(language)
+          case Left(err) =>
+            warn("Could not parse language", err)
+            None
+        }
+    }
 
-  private def appendLanguage(
-    languageList: List[Language],
-    languageNoteList: List[Note],
-    language: Language
-  ) =
-    Right((language +: languageList, languageNoteList))
+    // The label is shared by every id on the node, so it only becomes a note
+    // when it yielded no language at all.
+    if (languages.isEmpty) appendNote(languageList, languageNoteList, label)
+    else Right((languages ++ languageList, languageNoteList))
+  }
 
   private def appendNote(
     languageList: List[Language],

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiLanguages.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/transformers/TeiLanguages.scala
@@ -6,6 +6,7 @@ import weco.catalogue.internal_model.work.{Note, NoteType}
 import weco.pipeline.transformer.result.Result
 import weco.pipeline.transformer.tei.data.TeiLanguageData
 
+import java.util.Locale
 import scala.xml.{Elem, Node, NodeSeq}
 
 object TeiLanguages extends Logging {
@@ -23,33 +24,37 @@ object TeiLanguages extends Logging {
     * of (id, label) pairs.
     */
   def parseLanguages(value: NodeSeq): Result[(List[Language], List[Note])] =
-    (value \ "textLang")
-      .foldRight(
-        Right((Nil, Nil)): Either[Throwable, (List[Language], List[Note])]
-      ) {
-        case (n, Right((languageList, languageNoteList))) =>
-          val label = n.text
+    Right(
+      (value \ "textLang")
+        .foldRight((List.empty[Language], List.empty[Note])) {
+          case (n, (languageList, languageNoteList)) =>
+            val label = n.text
 
-          (parseLanguageIds(n), label) match {
-            case (_, label) if label.trim.isEmpty =>
-              warn(s"Missing label for language node $n")
-              Right((languageList, languageNoteList))
-            case (Nil, label) =>
-              appendNote(languageList, languageNoteList, label)
-            case (ids, label) =>
-              appendLanguagesOrNote(languageList, languageNoteList, ids, label)
-          }
-
-        case (_, Left(err)) => Left(err)
-      }
+            (parseLanguageIds(n), label) match {
+              case (_, label) if label.trim.isEmpty =>
+                warn(s"Missing label for language node $n")
+                (languageList, languageNoteList)
+              case (Nil, label) =>
+                appendNote(languageList, languageNoteList, label)
+              case (ids, label) =>
+                appendLanguagesOrNote(
+                  languageList,
+                  languageNoteList,
+                  ids,
+                  label
+                )
+            }
+        }
+    )
 
   /** A textLang may name a main language, other languages, or both. Both is how
     * TEI describes a multi-language manuscript, so read every id rather than
-    * treating the combination as an error.
+    * treating the combination as an error. Lowercasing is pinned to Locale.ROOT
+    * so an id cannot stop matching under the JVM's default locale.
     */
   private def parseLanguageIds(n: Node): List[String] =
     (Seq(n \@ "mainLang") ++ (n \@ "otherLangs").split("\\s+"))
-      .map(_.toLowerCase.trim)
+      .map(_.toLowerCase(Locale.ROOT).trim)
       .filter(_.nonEmpty)
       .distinct
       .toList
@@ -59,7 +64,7 @@ object TeiLanguages extends Logging {
     languageNoteList: List[Note],
     ids: List[String],
     label: String
-  ) = {
+  ): (List[Language], List[Note]) = {
     val languages = ids.flatMap {
       id =>
         TeiLanguageData(id, label) match {
@@ -73,15 +78,15 @@ object TeiLanguages extends Logging {
     // The label is shared by every id on the node, so it only becomes a note
     // when it yielded no language at all.
     if (languages.isEmpty) appendNote(languageList, languageNoteList, label)
-    else Right((languages ++ languageList, languageNoteList))
+    else (languages ++ languageList, languageNoteList)
   }
 
   private def appendNote(
     languageList: List[Language],
     languageNoteList: List[Note],
     label: String
-  ) =
-    Right((languageList, languageNoteFrom(label) +: languageNoteList))
+  ): (List[Language], List[Note]) =
+    (languageList, languageNoteFrom(label) +: languageNoteList)
 
   private def languageNoteFrom(label: String) =
     Note(NoteType.LanguageNote, label)

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/transformers/TeiLanguagesTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/transformers/TeiLanguagesTest.scala
@@ -77,18 +77,68 @@ class TeiLanguagesTest
     ))
   }
 
-  it("errors on languages that have more than one lang attribute") {
+  it("reads every language on a node that has both mainLang and otherLangs") {
     val xml =
       teiXml(
         languages = List(
-          <textLang mainLang="id1" otherLangs="id2">Sanskrit</textLang>
+          <textLang mainLang="ar" otherLangs="ota">Arabic</textLang>
+        )
+      )
+
+    TeiLanguages(xml).value shouldBe ((
+      List(Language(id = "ara", label = "Arabic")),
+      Nil
+    ))
+  }
+
+  it("keeps the main language when otherLangs holds several ids") {
+    val xml =
+      teiXml(
+        languages = List(
+          <textLang mainLang="la" otherLangs="grc fr">Latin</textLang>
+        )
+      )
+
+    TeiLanguages(xml).value shouldBe ((
+      List(Language(id = "lat", label = "Latin")),
+      Nil
+    ))
+  }
+
+  it(
+    "puts a multi-language node in a language note when its label names no single language"
+  ) {
+    val xml =
+      teiXml(
+        languages = List(
+          <textLang mainLang="ar" otherLangs="fa">Arabic and Persian</textLang>
         )
       )
 
     val result = TeiLanguages(xml)
 
-    result shouldBe a[Left[_, _]]
-    result.left.get.getMessage should include("language ID")
+    result shouldBe a[Right[_, _]]
+    result.value shouldBe ((
+      Nil,
+      List(Note(NoteType.LanguageNote, "Arabic and Persian"))
+    ))
+  }
+
+  it("does not fail the whole manuscript for a multi-language node") {
+    val xml =
+      teiXml(
+        languages = List(
+          mainLanguage("sa", "Sanskrit"),
+          <textLang mainLang="ar" otherLangs="es">Arabic with interlinear Spanish</textLang>
+        )
+      )
+
+    TeiLanguages(xml).value shouldBe ((
+      List(Language(id = "san", label = "Sanskrit")),
+      List(
+        Note(NoteType.LanguageNote, "Arabic with interlinear Spanish")
+      )
+    ))
   }
 
   it("skips languages without a label") {

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/transformers/TeiLanguagesTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/transformers/TeiLanguagesTest.scala
@@ -81,6 +81,23 @@ class TeiLanguagesTest
     val xml =
       teiXml(
         languages = List(
+          <textLang mainLang="grc" otherLangs="el">Greek</textLang>
+        )
+      )
+
+    TeiLanguages(xml).value shouldBe ((
+      List(
+        Language(id = "grc", label = "Greek, Ancient (to 1453)"),
+        Language(id = "gre", label = "Greek, Modern (1453- )")
+      ),
+      Nil
+    ))
+  }
+
+  it("keeps the language of the id that maps when another id does not") {
+    val xml =
+      teiXml(
+        languages = List(
           <textLang mainLang="ar" otherLangs="ota">Arabic</textLang>
         )
       )


### PR DESCRIPTION
## What does this change?

Closes #3545.

A `textLang` that carries both `mainLang` and `otherLangs` is the standard TEI way to describe a manuscript written in more than one language. `TeiLanguages.parseLanguageId` treated that combination as an error and returned a `Left`, which propagated out of the fold and failed the whole transform, so any bilingual manuscript was unpublishable. Three Arabic manuscripts are absent from the catalogue for this reason, found in the dead-letter set from the wellcomecollection/platform#6445 reindex.

Every id on the node is now read, `mainLang` first and then each space-separated value in `otherLangs`, and offered in turn to `TeiLanguageData` with the node's label. Ids that map contribute a `Language` in document order. If no id maps, the label becomes a language note, which is the existing fallback for a label that cannot be matched.

Splitting a combined label such as "Arabic and Persian" into per-language parts is deliberately not attempted. `TeiLanguageData` matches on id and label together on purpose, to surface source data that needs fixing, and guessing at free text would undermine that.

### Checklist

- [x] Does this change the display model the catalogue API returns? No. It changes which works are published and can add a language note, but the model itself is unchanged.

## How to test

`sbt "transformer_tei/test"`. `TeiLanguagesTest` gains four cases: both attributes with a matchable label keeps the language, a space-separated `otherLangs` still keeps the main language, both attributes with a combined label produce a language note, and a multi-language node no longer discards the languages found on other nodes in the same manuscript. The test that asserted the old error is gone, since that behaviour is what this removes.

Verified against the real files as well. Running the three dead-lettered manuscripts through `TeiXml(...).parse` on this branch returns `Right` for all three, where `main` fails them:

| Manuscript | File | `textLang` |
|---|---|---|
| `manuscript_16417` | `Arabic/MS_Arabic_773.xml` | `mainLang="ar" otherLangs="es"`, "Arabic with interlinear Spanish" |
| `manuscript_16464` | `Arabic/MS_Arabic_820.xml` | `mainLang="ar" otherLangs="ota"`, "Arabic and Turkish" |
| `manuscript_16530` | `Arabic/MS_Arabic_886.xml` | `mainLang="ar" otherLangs="fa"`, "Arabic and Persian" |

`manuscript_16417` comes out with its inner work carrying `Note(LanguageNote, "Arabic with interlinear Spanish")`, which is the intended outcome.

One local test fails on this branch and on `main` alike: `TeiTransformerEndToEndTest` needs localstack on port 4566.

## How can we measure success?

The three manuscripts appear in the catalogue after the next TEI transform, and `Multiple language IDs` stops appearing in the TEI transformer logs.

## Have we considered potential risks?

The change is permissive, so a manuscript that used to fail now publishes. The risk is publishing a work with less language data than a cataloguer intended, since a combined label lands in a language note rather than as structured languages. That is strictly better than the current behaviour of publishing nothing at all, and the `Unable to map TEI language to catalogue language` warning still fires per unmapped id, so the source data is still visible as something to fix.

No alarm is needed. The failure mode this removes was silent by nature: it dead-lettered a record with nothing to tell the person who wrote it, which is being followed up separately.
