### PR TITLE
Match METS access statuses case-insensitively

### DIFF
--- a/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformers/MetsAccessStatus.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformers/MetsAccessStatus.scala
@@ -2,11 +2,14 @@ package weco.pipeline.transformer.mets.transformers
 
 import weco.catalogue.internal_model.locations.AccessStatus
 
+import java.util.Locale
+
 object MetsAccessStatus {
 
   /** Access statuses are hand-entered in the source METS, so capitalisation
     * varies and carries no meaning. Match on the lowercased value, as
-    * MetsLicence already does for licences.
+    * MetsLicence already does for licences. Lowercasing is pinned to
+    * Locale.ROOT so the match cannot depend on the JVM's default locale.
     */
   def apply(
     accessConditionStatus: Option[String]
@@ -14,7 +17,7 @@ object MetsAccessStatus {
     accessConditionStatus match {
       case None => Right(None)
       case Some(status) =>
-        status.toLowerCase match {
+        status.toLowerCase(Locale.ROOT) match {
           // e.g. b21718969
           case "open" => Right(Some(AccessStatus.Open))
 

--- a/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformers/MetsAccessStatus.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformers/MetsAccessStatus.scala
@@ -3,27 +3,34 @@ package weco.pipeline.transformer.mets.transformers
 import weco.catalogue.internal_model.locations.AccessStatus
 
 object MetsAccessStatus {
+
+  /** Access statuses are hand-entered in the source METS, so capitalisation
+    * varies and carries no meaning. Match on the lowercased value, as
+    * MetsLicence already does for licences.
+    */
   def apply(
     accessConditionStatus: Option[String]
   ): Either[Throwable, Option[AccessStatus]] =
     accessConditionStatus match {
-      // e.g. b21718969
-      case Some(s) if s == "Open" => Right(Some(AccessStatus.Open))
-
-      // e.g. b30468115 / b19912730
-      case Some(s)
-          if s == "Open with advisory" || s == "Requires registration" =>
-        Right(Some(AccessStatus.OpenWithAdvisory))
-
-      // e.g. b16469434 / b21072061
-      case Some(s) if s == "Restricted files" || s == "Clinical images" =>
-        Right(Some(AccessStatus.Restricted))
-
-      // e.g. b16751875
-      case Some(s) if s == "Closed" => Right(Some(AccessStatus.Closed))
-
       case None => Right(None)
-      case Some(s) =>
-        Left(new Throwable(s"Couldn't match $s to an access status"))
+      case Some(status) =>
+        status.toLowerCase match {
+          // e.g. b21718969
+          case "open" => Right(Some(AccessStatus.Open))
+
+          // e.g. b30468115 / b19912730
+          case "open with advisory" | "requires registration" =>
+            Right(Some(AccessStatus.OpenWithAdvisory))
+
+          // e.g. b16469434 / b21072061
+          case "restricted files" | "clinical images" =>
+            Right(Some(AccessStatus.Restricted))
+
+          // e.g. b16751875
+          case "closed" => Right(Some(AccessStatus.Closed))
+
+          case _ =>
+            Left(new Throwable(s"Couldn't match $status to an access status"))
+        }
     }
 }

--- a/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformers/MetsAccessStatus.scala
+++ b/pipeline/transformer/transformer_mets/src/main/scala/weco/pipeline/transformer/mets/transformers/MetsAccessStatus.scala
@@ -1,39 +1,45 @@
 package weco.pipeline.transformer.mets.transformers
 
+import org.apache.commons.lang3.StringUtils.equalsIgnoreCase
 import weco.catalogue.internal_model.locations.AccessStatus
-
-import java.util.Locale
 
 object MetsAccessStatus {
 
   /** Access statuses are hand-entered in the source METS, so capitalisation
-    * varies and carries no meaning. Match on the lowercased value, as
-    * MetsLicence already does for licences. Lowercasing is pinned to
-    * Locale.ROOT so the match cannot depend on the JVM's default locale.
+    * varies and carries no meaning. Compare with equalsIgnoreCase, as
+    * MetsLicence already does for licences: it is locale-independent, unlike
+    * lowercasing against the JVM's default locale.
     */
   def apply(
     accessConditionStatus: Option[String]
   ): Either[Throwable, Option[AccessStatus]] =
     accessConditionStatus match {
+      // e.g. b21718969
+      case Some(s) if equalsIgnoreCase(s, "Open") =>
+        Right(Some(AccessStatus.Open))
+
+      // e.g. b30468115 / b19912730
+      case Some(s)
+          if equalsIgnoreCase(s, "Open with advisory") || equalsIgnoreCase(
+            s,
+            "Requires registration"
+          ) =>
+        Right(Some(AccessStatus.OpenWithAdvisory))
+
+      // e.g. b16469434 / b21072061
+      case Some(s)
+          if equalsIgnoreCase(s, "Restricted files") || equalsIgnoreCase(
+            s,
+            "Clinical images"
+          ) =>
+        Right(Some(AccessStatus.Restricted))
+
+      // e.g. b16751875
+      case Some(s) if equalsIgnoreCase(s, "Closed") =>
+        Right(Some(AccessStatus.Closed))
+
       case None => Right(None)
-      case Some(status) =>
-        status.toLowerCase(Locale.ROOT) match {
-          // e.g. b21718969
-          case "open" => Right(Some(AccessStatus.Open))
-
-          // e.g. b30468115 / b19912730
-          case "open with advisory" | "requires registration" =>
-            Right(Some(AccessStatus.OpenWithAdvisory))
-
-          // e.g. b16469434 / b21072061
-          case "restricted files" | "clinical images" =>
-            Right(Some(AccessStatus.Restricted))
-
-          // e.g. b16751875
-          case "closed" => Right(Some(AccessStatus.Closed))
-
-          case _ =>
-            Left(new Throwable(s"Couldn't match $status to an access status"))
-        }
+      case Some(s) =>
+        Left(new Throwable(s"Couldn't match $s to an access status"))
     }
 }

--- a/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformers/MetsAccessStatusTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformers/MetsAccessStatusTest.scala
@@ -19,6 +19,15 @@ class MetsAccessStatusTest
     ("Closed", AccessStatus.Closed)
   )
 
+  // Capitalisation as found in real Archivematica and Goobi packages.
+  val differentlyCasedTestCases = Table(
+    ("accessConditionStatus", "expectedStatus"),
+    ("Restricted Files", AccessStatus.Restricted),
+    ("closed", AccessStatus.Closed),
+    ("OPEN", AccessStatus.Open),
+    ("open with advisory", AccessStatus.OpenWithAdvisory)
+  )
+
   it("creates an access status") {
     forAll(testCases) {
       case (accessConditionStatus, expectedStatus) =>
@@ -26,6 +35,25 @@ class MetsAccessStatusTest
           Some(expectedStatus)
         )
     }
+  }
+
+  it("ignores the capitalisation of the access status") {
+    forAll(differentlyCasedTestCases) {
+      case (accessConditionStatus, expectedStatus) =>
+        MetsAccessStatus(Some(accessConditionStatus)) shouldBe Right(
+          Some(expectedStatus)
+        )
+    }
+  }
+
+  it("still rejects a status that differs by more than capitalisation") {
+    MetsAccessStatus(Some("Restricted")) shouldBe a[Left[_, _]]
+  }
+
+  it("reports the status as written when it cannot be matched") {
+    MetsAccessStatus(Some("Restricted")).left.get.getMessage should include(
+      "Restricted"
+    )
   }
 
   it("returns None if there are no access conditions") {

--- a/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformers/MetsAccessStatusTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformers/MetsAccessStatusTest.scala
@@ -5,8 +5,6 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
 import weco.catalogue.internal_model.locations.AccessStatus
 
-import java.util.Locale
-
 class MetsAccessStatusTest
     extends AnyFunSpec
     with Matchers
@@ -46,18 +44,6 @@ class MetsAccessStatusTest
           Some(expectedStatus)
         )
     }
-  }
-
-  it("ignores capitalisation regardless of the default locale") {
-    val defaultLocale = Locale.getDefault()
-    try {
-      // Turkish lowercases "I" to a dotless "ı", which would break a
-      // locale-sensitive match on "Clinical images".
-      Locale.setDefault(new Locale("tr", "TR"))
-      MetsAccessStatus(Some("CLINICAL IMAGES")) shouldBe Right(
-        Some(AccessStatus.Restricted)
-      )
-    } finally Locale.setDefault(defaultLocale)
   }
 
   it("still rejects a status that differs by more than capitalisation") {

--- a/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformers/MetsAccessStatusTest.scala
+++ b/pipeline/transformer/transformer_mets/src/test/scala/weco/pipeline/transformer/mets/transformers/MetsAccessStatusTest.scala
@@ -5,6 +5,8 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
 import weco.catalogue.internal_model.locations.AccessStatus
 
+import java.util.Locale
+
 class MetsAccessStatusTest
     extends AnyFunSpec
     with Matchers
@@ -44,6 +46,18 @@ class MetsAccessStatusTest
           Some(expectedStatus)
         )
     }
+  }
+
+  it("ignores capitalisation regardless of the default locale") {
+    val defaultLocale = Locale.getDefault()
+    try {
+      // Turkish lowercases "I" to a dotless "ı", which would break a
+      // locale-sensitive match on "Clinical images".
+      Locale.setDefault(new Locale("tr", "TR"))
+      MetsAccessStatus(Some("CLINICAL IMAGES")) shouldBe Right(
+        Some(AccessStatus.Restricted)
+      )
+    } finally Locale.setDefault(defaultLocale)
   }
 
   it("still rejects a status that differs by more than capitalisation") {


### PR DESCRIPTION
## What does this change?

Part of wellcomecollection/platform#6493.

`MetsAccessStatus` matched the access status from the source METS as an exact, case-sensitive string, and returned a `Left` for anything else, which fails the whole record. Access statuses are hand-entered, so capitalisation varies without carrying any meaning. Two born-digital packages are absent from the catalogue purely because of it:

| Package | Access status in the METS |
|---|---|
| `PPCNE/D/3/19` | `Restricted Files` |
| `PPJLE/A/30/3` | `closed` |

The match is now on the lowercased value. `MetsLicence` already does this for licences, so this brings the two into line. The unmatched-status error still reports the status as written, so a genuine mismatch is still legible in the logs.

This is the outcome of a conversation with digital production about the packages in wellcomecollection/platform#6493. Wording differences are being fixed at source by re-ingesting, because the METS should be the source of truth for access statuses. Capitalisation is the part worth absorbing here, since the statuses are already correct.

### Checklist

- [x] Does this change the display model the catalogue API returns? No. It changes which records transform successfully; the model is unchanged.

## How to test

`sbt "transformer_mets/test"`. `MetsAccessStatusTest` gains a table of real capitalisation variants (`Restricted Files`, `closed`, `OPEN`, `open with advisory`), a case asserting that a status differing by more than capitalisation is still rejected, and one asserting the error still quotes the status as written.

Verified against the real packages as the METS adapter holds them, running `MetsXml(...).accessConditions` over the eight that fail on an access status:

| Package | Status in METS | Before | After |
|---|---|---|---|
| `PPCNE/D/3/19` | `Restricted Files` | fails | `MetsAccessConditions(Some(Restricted), Some(CCBY), None)` |
| `PPJLE/A/30/3` | `closed` | fails | `MetsAccessConditions(Some(Closed), Some(InCopyright), None)` |
| `SAIPA/A/8/8a` | `Restricted` | fails | fails |
| `b33508082`, `b33511196`, `b33670912`, `b33671564`, `b33672520` | `Restricted` | fail | fail |

So this recovers two packages. The six that say `Restricted` are unaffected on purpose: that is a wording difference rather than a capitalisation one, and it is being corrected at source.

One local test fails on this branch and on `main` alike: `MetsTransformerEndToEndTest` needs localstack on port 4566.

`transformer_mets/Test/scalafmtCheck` reports `MetsDataTest.scala` and `ArchivematicaMetsXMLTest.scala` as unformatted. Both are untouched here and are unformatted on `main` too, so I have left them alone rather than add unrelated churn.

## How can we measure success?

`PPCNE/D/3/19` and `PPJLE/A/30/3` appear in the catalogue after the next METS transform, and `Couldn't match Restricted Files to an access status` stops appearing in the METS transformer logs.

## Have we considered potential risks?

The change is permissive: a record that used to fail now transforms. The risk is accepting a status whose capitalisation was meant to signal something, and there is no such convention. Nothing else is loosened, so a status that differs in wording is still rejected and still surfaces as a record to fix.
