### PR TITLE
Allow the transformer to process records from a list of ids

### DIFF
--- a/catalogue_graph/src/adapters/steps/transformer.py
+++ b/catalogue_graph/src/adapters/steps/transformer.py
@@ -141,20 +141,13 @@ def build_transformer(
 
     snapshot_id = event.snapshot_id or adapter_store.current_snapshot_id()
 
-    if event.ids and event.transformer_type == "axiell":
-        # Not yet wired: AxiellChangesetReader doesn't thread ids through to
-        # its source, so falling through here would silently ignore ids and
-        # read every active record instead.
-        raise ValueError(
-            f"id-mode transforms are not yet supported for {event.transformer_type!r}"
-        )
-
     if event.transformer_type == "axiell":
         reader = AxiellChangesetReader.build(
             AXIELL_CONFIG,
             event.changeset_ids,
             use_rest_api_table=use_rest_api_table,
             snapshot_id=snapshot_id,
+            ids=event.ids,
             adapter_store=adapter_store,
         )
         return AxiellTransformer(reader)

--- a/catalogue_graph/src/adapters/steps/transformer.py
+++ b/catalogue_graph/src/adapters/steps/transformer.py
@@ -141,10 +141,10 @@ def build_transformer(
 
     snapshot_id = event.snapshot_id or adapter_store.current_snapshot_id()
 
-    if event.ids and event.transformer_type in ("axiell", "folio"):
-        # Not yet wired: AxiellChangesetReader and FolioTransformer don't
-        # thread ids through to their sources, so falling through here would
-        # silently ignore ids and read every active record instead.
+    if event.ids and event.transformer_type == "axiell":
+        # Not yet wired: AxiellChangesetReader doesn't thread ids through to
+        # its source, so falling through here would silently ignore ids and
+        # read every active record instead.
         raise ValueError(
             f"id-mode transforms are not yet supported for {event.transformer_type!r}"
         )
@@ -173,7 +173,11 @@ def build_transformer(
             use_rest_api_table=use_rest_api_table, create_if_not_exists=False
         )
         return FolioTransformer(
-            adapter_store, event.changeset_ids, snapshot_id, items_store=items_store
+            adapter_store,
+            event.changeset_ids,
+            snapshot_id,
+            ids=event.ids,
+            items_store=items_store,
         )
     raise ValueError(f"Unknown transformer type: {event.transformer_type}")
 

--- a/catalogue_graph/src/adapters/steps/transformer.py
+++ b/catalogue_graph/src/adapters/steps/transformer.py
@@ -11,7 +11,7 @@ from collections.abc import Callable
 from typing import Any, Literal, Protocol, cast
 
 import structlog
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from adapters.extractors.ebsco import config as ebsco_config
 from adapters.extractors.ebsco import helpers as ebsco_helpers
@@ -37,12 +37,47 @@ logger = structlog.get_logger(__name__)
 
 TransformerType = Literal["axiell", "ebsco", "folio"]
 
+STEP_FUNCTIONS_STATE_LIMIT_BYTES = 262_144
+# Live adapter stores: axiell ids are 17 chars, ebsco 8-13, folio a fixed 81.
+ASSUMED_MAX_ID_LENGTH = 100
+
+MAX_IDS_PER_RUN = int(
+    STEP_FUNCTIONS_STATE_LIMIT_BYTES * 0.9 // (ASSUMED_MAX_ID_LENGTH + 3)
+)
+"""Bounded by the Step Functions state limit above; distinct from the
+OAI-PMH loader's MAX_IDS_PER_RUN (50,000), which bounds run time, not
+payload size."""
+
 
 class TransformerEvent(BaseModel):
     transformer_type: TransformerType
     job_id: str
     changeset_ids: list[str] = Field(default_factory=list)
+    ids: list[str] | None = None
+    """Adapter store record ids to transform. Mutually exclusive with
+    changeset_ids; an explicitly empty list is rejected, not treated as
+    none."""
     snapshot_id: int | None = None
+
+    @model_validator(mode="after")
+    def _check_ids(self) -> "TransformerEvent":
+        if self.ids is None:
+            return self
+        if self.changeset_ids:
+            raise ValueError(
+                "ids and changeset_ids are mutually exclusive; supply one or "
+                "the other, not both"
+            )
+        if not self.ids:
+            raise ValueError(
+                "ids was supplied but is empty; an id run needs at least one record id"
+            )
+        if len(self.ids) > MAX_IDS_PER_RUN:
+            raise ValueError(
+                f"{len(self.ids)} ids exceeds the {MAX_IDS_PER_RUN} per-run "
+                f"ceiling; split the work across several runs"
+            )
+        return self
 
 
 class AdapterConfig(Protocol):

--- a/catalogue_graph/src/adapters/steps/transformer.py
+++ b/catalogue_graph/src/adapters/steps/transformer.py
@@ -141,6 +141,14 @@ def build_transformer(
 
     snapshot_id = event.snapshot_id or adapter_store.current_snapshot_id()
 
+    if event.ids and event.transformer_type in ("axiell", "folio"):
+        # Not yet wired: AxiellChangesetReader and FolioTransformer don't
+        # thread ids through to their sources, so falling through here would
+        # silently ignore ids and read every active record instead.
+        raise ValueError(
+            f"id-mode transforms are not yet supported for {event.transformer_type!r}"
+        )
+
     if event.transformer_type == "axiell":
         reader = AxiellChangesetReader.build(
             AXIELL_CONFIG,
@@ -151,7 +159,9 @@ def build_transformer(
         )
         return AxiellTransformer(reader)
     if event.transformer_type == "ebsco":
-        return EbscoTransformer(adapter_store, event.changeset_ids, snapshot_id)
+        return EbscoTransformer(
+            adapter_store, event.changeset_ids, snapshot_id, ids=event.ids
+        )
     if event.transformer_type == "folio":
         # Join the enriched items store so FOLIO works carry items with stable
         # `folio-item` identifiers.
@@ -209,6 +219,7 @@ def handler(
         success_count=len(transformer.successful_ids),
         failure_count=len(transformer.errors),
         changeset_ids=event.changeset_ids,
+        ids=event.ids,
         snapshot_id=transformer.source.snapshot_id,
     )
 
@@ -218,6 +229,7 @@ def handler(
         successful_ids=transformer.successful_ids,
         errors=transformer.errors,
         changeset_ids=event.changeset_ids,
+        ids=event.ids or [],
         snapshot_id=transformer.source.snapshot_id,
         job_id=event.job_id,
         s3_bucket=config.S3_BUCKET,
@@ -246,6 +258,19 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     ).model_dump(mode="json")
 
 
+def _read_ids(args: argparse.Namespace) -> list[str] | None:
+    """Collect record ids from --id and/or --ids-file. None (not an empty
+    list) if neither was given, so the event's changeset/reindex path is
+    untouched."""
+    if not args.ids and not args.ids_file:
+        return None
+    ids = list(args.ids or [])
+    if args.ids_file:
+        with open(args.ids_file, encoding="utf-8") as f:
+            ids += [line.strip() for line in f if line.strip()]
+    return ids
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Transform adapter data")
     parser.add_argument(
@@ -260,6 +285,21 @@ def main() -> None:
         action="append",
         default=[],
         help="Changeset identifier to transform (repeatable)",
+    )
+    parser.add_argument(
+        "--id",
+        dest="ids",
+        action="append",
+        default=None,
+        help="Record id to transform (repeatable). Mutually exclusive with "
+        "--changeset-id.",
+    )
+    parser.add_argument(
+        "--ids-file",
+        type=str,
+        default=None,
+        help="Path to a file of record ids, one per line. Mutually exclusive "
+        "with --changeset-id.",
     )
     parser.add_argument(
         "--snapshot-id",
@@ -296,6 +336,7 @@ def main() -> None:
     event = TransformerEvent(
         transformer_type=args.transformer_type,
         changeset_ids=args.changeset_ids,
+        ids=_read_ids(args),
         snapshot_id=args.snapshot_id,
         job_id=args.job_id,
     )

--- a/catalogue_graph/src/adapters/transformers/README.md
+++ b/catalogue_graph/src/adapters/transformers/README.md
@@ -128,6 +128,8 @@ AWS_PROFILE=platform-developer uv run python -m adapters.steps.transformer \
 |--------------------------|----------|-------------------------------------------------------------------------------------------------------------------------------------------|
 | `--transformer-type`     | Yes      | Which transformer to run: `axiell`, `ebsco`, or `folio`                                                                                   |
 | `--changeset-id`         | No       | Changeset ID to transform. Can be repeated for multiple changesets. If omitted, transforms all records.                                   |
+| `--id`                   | No       | Record id to transform (repeatable). Mutually exclusive with `--changeset-id`. Combines with `--ids-file` if both are given.              |
+| `--ids-file`             | No       | Path to a file of record ids, one per line. Mutually exclusive with `--changeset-id`. Combines with `--id` if both are given.             |
 | `--job-id`               | No       | Job identifier for manifest tracking. Defaults to `dev`.                                                                                  |
 | `--use-rest-api-table`   | No       | Use the S3 Tables catalog instead of local storage.                                                                                       |
 | `--es-mode`              | No       | Elasticsearch target: `local` (default) or `public`.                                                                                      |
@@ -144,6 +146,19 @@ In production, the transformer runs as a Lambda function. The event structure:
   "changeset_ids": [
     "changeset-001",
     "changeset-002"
+  ]
+}
+```
+
+To re-transform a specific set of already-stored records instead — e.g. after a transformer bug fix, or to recover records missing from the index — supply `ids` instead of `changeset_ids`. The two are mutually exclusive; an explicitly empty `ids` list is rejected rather than falling through to a full reindex:
+
+```json
+{
+  "transformer_type": "ebsco",
+  "job_id": "idload-20250116",
+  "ids": [
+    "ebs00001",
+    "ebs00002"
   ]
 }
 ```
@@ -189,6 +204,14 @@ If indexing a tombstone fails, the error lands in the transformer report and fir
 transformer-failures alarm, but the execution still succeeds. Facts are only read by runs for their original
 changeset ids, so recovery is a manual redrive: re-run the transformer for that pipeline with the failed run's
 changeset ids (idempotent, safe to repeat).
+
+**Id-mode runs never deliver deletion facts.** Facts are recorded and read per-changeset (a fact means "this GUID
+was superseded, as detected during changeset C"), and there is no equivalent per-id query. An id-mode run only
+re-transforms the named records via `iter_records()`; `iter_deletions()` returns nothing when `changeset_ids` is
+empty, whether that's because the run is a full reindex or an id-mode run. This is intentional: id-mode exists to
+re-transform records that are already known to be current (a bad field, a spot fix after a transformer change),
+not to replay historical deletions — those are already delivered by the ordinary changeset-driven run that
+detected them.
 
 ```mermaid
 ---

--- a/catalogue_graph/src/adapters/transformers/axiell_transformer.py
+++ b/catalogue_graph/src/adapters/transformers/axiell_transformer.py
@@ -23,6 +23,7 @@ class AxiellTransformer(MarcXmlTransformer):
         super().__init__(
             adapter_store=reader.adapter_store,
             changeset_ids=reader.changeset_ids,
+            ids=reader.ids,
             snapshot_id=reader.snapshot_id,
         )
 
@@ -33,8 +34,6 @@ class AxiellTransformer(MarcXmlTransformer):
         snapshot_id: int | None,
         ids: list[str] | None = None,
     ) -> RecordSource:
-        # ids is not yet wired for Axiell; build_transformer rejects it before
-        # an AxiellTransformer is ever constructed with one.
         return AxiellStoreSource(self._reader)
 
     @property

--- a/catalogue_graph/src/adapters/transformers/axiell_transformer.py
+++ b/catalogue_graph/src/adapters/transformers/axiell_transformer.py
@@ -31,7 +31,10 @@ class AxiellTransformer(MarcXmlTransformer):
         adapter_store: AdapterStore,
         changeset_ids: list[str],
         snapshot_id: int | None,
+        ids: list[str] | None = None,
     ) -> RecordSource:
+        # ids is not yet wired for Axiell; build_transformer rejects it before
+        # an AxiellTransformer is ever constructed with one.
         return AxiellStoreSource(self._reader)
 
     @property

--- a/catalogue_graph/src/adapters/transformers/ebsco_transformer.py
+++ b/catalogue_graph/src/adapters/transformers/ebsco_transformer.py
@@ -10,9 +10,13 @@ class EbscoTransformer(MarcXmlTransformer):
         adapter_store: AdapterStore,
         changeset_ids: list[str],
         snapshot_id: int | None,
+        ids: list[str] | None = None,
     ) -> None:
         super().__init__(
-            adapter_store, changeset_ids=changeset_ids, snapshot_id=snapshot_id
+            adapter_store,
+            changeset_ids=changeset_ids,
+            snapshot_id=snapshot_id,
+            ids=ids,
         )
 
     @property

--- a/catalogue_graph/src/adapters/transformers/folio_store_source.py
+++ b/catalogue_graph/src/adapters/transformers/folio_store_source.py
@@ -25,9 +25,10 @@ class FolioStoreSource(AdapterStoreSource):
         adapter_store: AdapterStore,
         changeset_ids: list[str],
         snapshot_id: int | None = None,
+        ids: list[str] | None = None,
         items_store: AdapterStore | None = None,
     ):
-        super().__init__(adapter_store, changeset_ids, snapshot_id)
+        super().__init__(adapter_store, changeset_ids, snapshot_id, ids)
         self.items_store = items_store
 
     def _process_rows(self, rows: list[dict[str, Any]]) -> Generator[dict[str, Any]]:

--- a/catalogue_graph/src/adapters/transformers/folio_transformer.py
+++ b/catalogue_graph/src/adapters/transformers/folio_transformer.py
@@ -26,7 +26,10 @@ class FolioTransformer(MarcXmlTransformer):
         adapter_store: AdapterStore,
         changeset_ids: list[str],
         snapshot_id: int | None,
+        ids: list[str] | None = None,
     ) -> AdapterStoreSource:
+        # ids is not yet wired for FOLIO; build_transformer rejects it before
+        # a FolioTransformer is ever constructed with one.
         return FolioStoreSource(
             adapter_store, changeset_ids, snapshot_id, items_store=self._items_store
         )

--- a/catalogue_graph/src/adapters/transformers/folio_transformer.py
+++ b/catalogue_graph/src/adapters/transformers/folio_transformer.py
@@ -11,14 +11,13 @@ class FolioTransformer(MarcXmlTransformer):
         adapter_store: AdapterStore,
         changeset_ids: list[str],
         snapshot_id: int | None,
+        ids: list[str] | None = None,
         items_store: AdapterStore | None = None,
     ) -> None:
         # Stored before super().__init__, which builds the source via _build_source.
         self._items_store = items_store
         super().__init__(
-            adapter_store,
-            changeset_ids=changeset_ids,
-            snapshot_id=snapshot_id,
+            adapter_store, changeset_ids=changeset_ids, snapshot_id=snapshot_id, ids=ids
         )
 
     def _build_source(
@@ -28,10 +27,12 @@ class FolioTransformer(MarcXmlTransformer):
         snapshot_id: int | None,
         ids: list[str] | None = None,
     ) -> AdapterStoreSource:
-        # ids is not yet wired for FOLIO; build_transformer rejects it before
-        # a FolioTransformer is ever constructed with one.
         return FolioStoreSource(
-            adapter_store, changeset_ids, snapshot_id, items_store=self._items_store
+            adapter_store,
+            changeset_ids,
+            snapshot_id,
+            ids=ids,
+            items_store=self._items_store,
         )
 
     @property

--- a/catalogue_graph/src/adapters/transformers/reporting.py
+++ b/catalogue_graph/src/adapters/transformers/reporting.py
@@ -15,6 +15,7 @@ class TransformerReport(PipelineReport):
     pipeline_date: str
     transformer_type: str
     changeset_ids: list[str]
+    ids: list[str]
     job_id: str
     snapshot_id: int | None = None
 
@@ -48,8 +49,8 @@ class TransformerReport(PipelineReport):
 
     @property
     def s3_uri(self) -> str:
-        changeset_label = "_".join(self.changeset_ids) or "reindex"
-        file_name = f"{changeset_label}__{self.job_id}.json"
+        run_label = "idload" if self.ids else "_".join(self.changeset_ids) or "reindex"
+        file_name = f"{run_label}__{self.job_id}.json"
         path = PurePosixPath(
             f"pipeline-{self.pipeline_date}",
             self.transformer_type,

--- a/catalogue_graph/src/adapters/transformers/source_work_transformer.py
+++ b/catalogue_graph/src/adapters/transformers/source_work_transformer.py
@@ -22,10 +22,11 @@ class SourceWorkTransformer(ElasticBaseTransformer[SourceWork], ABC):
         adapter_store: AdapterStore,
         changeset_ids: list[str],
         snapshot_id: int | None = None,
+        ids: list[str] | None = None,
     ) -> None:
         super().__init__()
         self.source: RecordSource = self._build_source(
-            adapter_store, changeset_ids, snapshot_id
+            adapter_store, changeset_ids, snapshot_id, ids
         )
 
     def _build_source(
@@ -33,10 +34,11 @@ class SourceWorkTransformer(ElasticBaseTransformer[SourceWork], ABC):
         adapter_store: AdapterStore,
         changeset_ids: list[str],
         snapshot_id: int | None,
+        ids: list[str] | None = None,
     ) -> RecordSource:
         """Build the record source. Subclasses override this to supply a
         source-specific subclass (e.g. `FolioStoreSource`)."""
-        return AdapterStoreSource(adapter_store, changeset_ids, snapshot_id)
+        return AdapterStoreSource(adapter_store, changeset_ids, snapshot_id, ids)
 
     @property
     @abstractmethod

--- a/catalogue_graph/src/adapters/utils/adapter_store_source.py
+++ b/catalogue_graph/src/adapters/utils/adapter_store_source.py
@@ -2,6 +2,7 @@ from collections.abc import Generator
 from typing import Any
 
 import structlog
+from pyiceberg.expressions import In
 
 from adapters.utils.adapter_store import AdapterStore
 from core.source import BaseSource
@@ -21,10 +22,17 @@ class AdapterStoreSource(RecordSource):
         adapter_store: AdapterStore,
         changeset_ids: list[str],
         snapshot_id: int | None = None,
+        ids: list[str] | None = None,
     ):
+        if changeset_ids and ids:
+            raise ValueError(
+                "changeset_ids and ids are mutually exclusive; supply one or "
+                "the other, not both"
+            )
         self.adapter_store = adapter_store
         self.changeset_ids = changeset_ids
         self.snapshot_id = snapshot_id
+        self.ids = ids
 
     def stream_raw(self) -> Generator[dict[str, Any]]:
         if self.changeset_ids:
@@ -33,6 +41,16 @@ class AdapterStoreSource(RecordSource):
             # whole (possibly multi-changeset) table alongside the Arrow copy.
             table = self.adapter_store.get_records_by_changesets(
                 self.changeset_ids, self.snapshot_id
+            )
+            for batch in table.to_batches():
+                yield from self._process_rows(batch.to_pylist())
+        elif self.ids:
+            # Includes soft-deleted rows, for the same reason as the changeset
+            # path: tombstones must overwrite live documents downstream. The
+            # store is sorted on id, so this filter prunes row groups rather
+            # than scanning the whole namespace.
+            table = self.adapter_store.get_namespace_records(
+                In("id", self.ids), self.snapshot_id
             )
             for batch in table.to_batches():
                 yield from self._process_rows(batch.to_pylist())

--- a/catalogue_graph/src/adapters/utils/axiell_changeset_reader.py
+++ b/catalogue_graph/src/adapters/utils/axiell_changeset_reader.py
@@ -75,6 +75,7 @@ class AxiellChangesetReader:
         adapter_store: AdapterStore,
         changeset_ids: list[str],
         snapshot_id: int | None = None,
+        ids: list[str] | None = None,
         facts_store: DeletionFactsStore | None = None,
         reconciler_store: ReconcilerStore | None = None,
     ) -> None:
@@ -86,6 +87,7 @@ class AxiellChangesetReader:
         self.adapter_store = adapter_store
         self.changeset_ids = changeset_ids
         self.snapshot_id = snapshot_id
+        self.ids = ids
         self.facts_store = facts_store
         self.reconciler_store = reconciler_store
 
@@ -97,6 +99,7 @@ class AxiellChangesetReader:
         *,
         use_rest_api_table: bool,
         snapshot_id: int | None = None,
+        ids: list[str] | None = None,
         adapter_store: AdapterStore | None = None,
         with_deletion_facts: bool = True,
     ) -> "AxiellChangesetReader":
@@ -133,7 +136,8 @@ class AxiellChangesetReader:
         return cls(
             adapter_store,
             changeset_ids,
-            snapshot_id,
+            snapshot_id=snapshot_id,
+            ids=ids,
             facts_store=facts_store,
             reconciler_store=reconciler_store,
         )
@@ -148,7 +152,10 @@ class AxiellChangesetReader:
         reindex mode) — consumers that only want a sample must break early.
         """
         source = AdapterStoreSource(
-            self.adapter_store, self.changeset_ids, self.snapshot_id
+            self.adapter_store,
+            self.changeset_ids,
+            snapshot_id=self.snapshot_id,
+            ids=self.ids,
         )
         yield from source.stream_raw()
 

--- a/catalogue_graph/tests/adapters/transformers/axiell/test_transformer.py
+++ b/catalogue_graph/tests/adapters/transformers/axiell/test_transformer.py
@@ -19,6 +19,8 @@ def _run_transform(
     monkeypatch: pytest.MonkeyPatch,
     *,
     changeset_ids: list[str] | None = None,
+    ids: list[str] | None = None,
+    job_id: str = "20250101T1200",
     index_date: str | None = None,
     pipeline_date: str = "dev",
     facts_table: IcebergTable | None = None,
@@ -39,8 +41,9 @@ def _run_transform(
 
     event = TransformerEvent(
         transformer_type="axiell",
-        job_id="20250101T1200",
+        job_id=job_id,
         changeset_ids=changeset_ids or [],
+        ids=ids,
     )
 
     return handler(
@@ -143,3 +146,107 @@ def test_transformer_end_to_end_includes_deletions(
     assert deleted["type"] == "Deleted"
     assert deleted["deletedReason"]["type"] == "DeletedFromSource"
     assert deleted["deletedReason"]["info"] == "Marked as deleted from source"
+
+
+def test_transformer_id_run_transforms_only_named_ids(
+    temporary_table: IcebergTable, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    not_requested = "<record><leader>00000nam a2200000   4500</leader><controlfield tag='005'>20251225123045.0</controlfield><controlfield tag='001'>ax00003</controlfield><datafield tag='245' ind1='0' ind2='0'><subfield code='a'>Not requested</subfield></datafield><datafield tag='035'><subfield code='a'>(Calm RefNo)A/B/D</subfield></datafield><datafield tag='351'><subfield code='c'>item</subfield></datafield><datafield tag='583' ind1='0'><subfield code='l'>catalogued</subfield></datafield></record>"
+    records_by_id = {
+        "ax00001": TEST_RECORD_ONE,
+        "ax00002": TEST_RECORD_TWO,
+        "ax00003": not_requested,
+    }
+    # The changeset id is irrelevant to an id run; only seed the store.
+    prepare_changeset(
+        temporary_table,
+        monkeypatch,
+        records_by_id,
+        namespace=AXIELL_NAMESPACE,
+        transformer_type="axiell",
+    )
+
+    MockElasticsearchClient.inputs.clear()
+
+    result = _run_transform(
+        monkeypatch,
+        ids=["ax00001", "ax00002"],
+        index_date="2025-01-01",
+    )
+
+    assert result.success_count == 2
+    assert result.failure_count == 0
+    assert result.changeset_ids == []
+    assert result.ids == ["ax00001", "ax00002"]
+
+    indexed_ids = {op["_id"] for op in MockElasticsearchClient.inputs}
+    assert indexed_ids == {
+        "Work[axiell-guid/ax00001]",
+        "Work[axiell-guid/ax00002]",
+    }
+
+
+def test_transformer_id_run_includes_deleted_rows_as_tombstones(
+    temporary_table: IcebergTable, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    records_by_id: dict[str, tuple[str, bool] | str] = {
+        "ax00001": TEST_RECORD_ONE,
+        "ax00003": (
+            "<record><leader>00000nam a2200000   4500</leader><controlfield tag='005'>20251225123045.0</controlfield><controlfield tag='001'>ax00003</controlfield><datafield tag='245' ind1='0' ind2='0'><subfield code='a'>Deleted Axiell Work</subfield></datafield></record>",
+            True,
+        ),
+    }
+    prepare_changeset(
+        temporary_table,
+        monkeypatch,
+        records_by_id,
+        namespace=AXIELL_NAMESPACE,
+        transformer_type="axiell",
+    )
+
+    MockElasticsearchClient.inputs.clear()
+
+    result = _run_transform(
+        monkeypatch,
+        ids=["ax00001", "ax00003"],
+        index_date="2025-01-01",
+    )
+
+    assert result.success_count == 2
+    assert result.failure_count == 0
+
+    by_id = {op["_id"]: op for op in MockElasticsearchClient.inputs}
+    deleted = by_id["Work[axiell-guid/ax00003]"]["_source"]
+    assert deleted["type"] == "Deleted"
+    assert deleted["deletedReason"]["type"] == "DeletedFromSource"
+
+
+def test_transformer_id_run_report_key_is_not_reindex(
+    temporary_table: IcebergTable, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    records_by_id = {
+        "ax00001": TEST_RECORD_ONE,
+    }
+    prepare_changeset(
+        temporary_table,
+        monkeypatch,
+        records_by_id,
+        namespace=AXIELL_NAMESPACE,
+        transformer_type="axiell",
+    )
+
+    result = _run_transform(
+        monkeypatch,
+        ids=["ax00001"],
+        index_date="2025-01-01",
+        job_id="idload-20250101T1200",
+    )
+
+    assert (
+        result.report_s3_uri
+        == "s3://wellcomecollection-platform-axiell-adapter/pipeline-dev/axiell/dev/idload__idload-20250101T1200.json"
+    )
+
+    report = read_transformer_report(result)
+    assert report["ids"] == ["ax00001"]
+    assert report["changeset_ids"] == []

--- a/catalogue_graph/tests/adapters/transformers/ebsco/test_transformer.py
+++ b/catalogue_graph/tests/adapters/transformers/ebsco/test_transformer.py
@@ -18,16 +18,19 @@ def _run_transform(
     monkeypatch: pytest.MonkeyPatch,
     *,
     changeset_ids: list[str] | None = None,
+    ids: list[str] | None = None,
     index_date: str | None = None,
     pipeline_date: str = "dev",
+    job_id: str = "20250101T1200",
 ) -> TransformerResult:
     monkeypatch.setattr(adapter_config, "PIPELINE_DATE", pipeline_date)
     monkeypatch.setattr(adapter_config, "INDEX_DATE", index_date)
 
     event = TransformerEvent(
         transformer_type="ebsco",
-        job_id="20250101T1200",
+        job_id=job_id,
         changeset_ids=changeset_ids or [],
+        ids=ids,
     )
 
     return handler(
@@ -257,3 +260,106 @@ def test_build_transformer_uses_latest_snapshot_when_event_has_no_snapshot_id(
     assert len(rows) == 1
     assert "Initial Snapshot Title" in rows[0]["content"]
     assert "Later Snapshot Title" not in rows[0]["content"]
+
+
+def test_transformer_id_run_transforms_only_named_ids(
+    temporary_table: IcebergTable, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    records_by_id = {
+        "ebs00001": "<record><leader>00000nam a2200000   4500</leader><controlfield tag='001'>ebs00001</controlfield><datafield tag='245' ind1='0' ind2='0'><subfield code='a'>How to Avoid Huge Ships</subfield></datafield></record>",
+        "ebs00002": "<record><leader>00000nam a2200000   4500</leader><controlfield tag='001'>ebs00002</controlfield><datafield tag='245' ind1='0' ind2='0'><subfield code='a'>Parasites, hosts and diseases</subfield></datafield></record>",
+        "ebs00003": "<record><leader>00000nam a2200000   4500</leader><controlfield tag='001'>ebs00003</controlfield><datafield tag='245' ind1='0' ind2='0'><subfield code='a'>Not requested</subfield></datafield></record>",
+    }
+    # The changeset id is irrelevant to an id run; only seed the store.
+    prepare_changeset(
+        temporary_table,
+        monkeypatch,
+        records_by_id,
+        namespace=EBSCO_NAMESPACE,
+        transformer_type="ebsco",
+    )
+
+    MockElasticsearchClient.inputs.clear()
+
+    result = _run_transform(
+        monkeypatch,
+        ids=["ebs00001", "ebs00002"],
+        index_date="2025-01-01",
+    )
+
+    assert result.success_count == 2
+    assert result.failure_count == 0
+    assert result.changeset_ids == []
+    assert result.ids == ["ebs00001", "ebs00002"]
+
+    indexed_ids = {op["_id"] for op in MockElasticsearchClient.inputs}
+    assert indexed_ids == {
+        "Work[ebsco-alt-lookup/ebs00001]",
+        "Work[ebsco-alt-lookup/ebs00002]",
+    }
+
+
+def test_transformer_id_run_includes_deleted_rows_as_tombstones(
+    temporary_table: IcebergTable, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    records_by_id: dict[str, tuple[str, bool] | str] = {
+        "ebs00001": "<record><leader>00000nam a2200000   4500</leader><controlfield tag='001'>ebs00001</controlfield><datafield tag='245' ind1='0' ind2='0'><subfield code='a'>How to Avoid Huge Ships</subfield></datafield></record>",
+        "ebs00003": (
+            "<record><leader>00000nam a2200000   4500</leader><controlfield tag='001'>ebs00003</controlfield><datafield tag='245' ind1='0' ind2='0'><subfield code='a'>Deleted Work</subfield></datafield></record>",
+            True,
+        ),
+    }
+    prepare_changeset(
+        temporary_table,
+        monkeypatch,
+        records_by_id,
+        namespace=EBSCO_NAMESPACE,
+        transformer_type="ebsco",
+    )
+
+    MockElasticsearchClient.inputs.clear()
+
+    result = _run_transform(
+        monkeypatch,
+        ids=["ebs00001", "ebs00003"],
+        index_date="2025-01-01",
+    )
+
+    assert result.success_count == 2
+    assert result.failure_count == 0
+
+    by_id = {op["_id"]: op for op in MockElasticsearchClient.inputs}
+    deleted = by_id["Work[ebsco-alt-lookup/ebs00003]"]["_source"]
+    assert deleted["type"] == "Deleted"
+    assert deleted["deletedReason"]["type"] == "DeletedFromSource"
+
+
+def test_transformer_id_run_report_key_is_not_reindex(
+    temporary_table: IcebergTable, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    records_by_id = {
+        "ebs00001": "<record><leader>00000nam a2200000   4500</leader><controlfield tag='001'>ebs00001</controlfield><datafield tag='245' ind1='0' ind2='0'><subfield code='a'>How to Avoid Huge Ships</subfield></datafield></record>",
+    }
+    prepare_changeset(
+        temporary_table,
+        monkeypatch,
+        records_by_id,
+        namespace=EBSCO_NAMESPACE,
+        transformer_type="ebsco",
+    )
+
+    result = _run_transform(
+        monkeypatch,
+        ids=["ebs00001"],
+        index_date="2025-01-01",
+        job_id="idload-20250101T1200",
+    )
+
+    assert (
+        result.report_s3_uri
+        == "s3://wellcomecollection-platform-ebsco-adapter/pipeline-dev/ebsco/dev/idload__idload-20250101T1200.json"
+    )
+
+    report = read_transformer_report(result)
+    assert report["ids"] == ["ebs00001"]
+    assert report["changeset_ids"] == []

--- a/catalogue_graph/tests/adapters/transformers/folio/test_transformer.py
+++ b/catalogue_graph/tests/adapters/transformers/folio/test_transformer.py
@@ -16,6 +16,8 @@ def _run_transform(
     monkeypatch: pytest.MonkeyPatch,
     *,
     changeset_ids: list[str] | None = None,
+    ids: list[str] | None = None,
+    job_id: str = "20260101T1200",
     index_date: str | None = None,
     pipeline_date: str = "dev",
 ) -> TransformerResult:
@@ -32,8 +34,9 @@ def _run_transform(
 
     event = TransformerEvent(
         transformer_type="folio",
-        job_id="20260101T1200",
+        job_id=job_id,
         changeset_ids=changeset_ids or [],
+        ids=ids,
     )
 
     return handler(
@@ -197,3 +200,106 @@ def test_transformer_includes_predecessor_identifier(
         "ontologyType": "Work",
         "value": "b12345679",
     }
+
+
+def test_transformer_id_run_transforms_only_named_ids(
+    temporary_table: IcebergTable, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    records_by_id = {
+        "fo00001": "<record><leader>00000nam a2200000   4500</leader><controlfield tag='005'>20261225123045.0</controlfield><controlfield tag='001'>fo00001</controlfield><datafield tag='245' ind1='0' ind2='0'><subfield code='a'>Folio Title One</subfield></datafield></record>",
+        "fo00002": "<record><leader>00000nam a2200000   4500</leader><controlfield tag='005'>20261225123045.0</controlfield><controlfield tag='001'>fo00002</controlfield><datafield tag='245' ind1='0' ind2='0'><subfield code='a'>Folio Title Two</subfield></datafield></record>",
+        "fo00003": "<record><leader>00000nam a2200000   4500</leader><controlfield tag='005'>20261225123045.0</controlfield><controlfield tag='001'>fo00003</controlfield><datafield tag='245' ind1='0' ind2='0'><subfield code='a'>Not requested</subfield></datafield></record>",
+    }
+    # The changeset id is irrelevant to an id run; only seed the store.
+    prepare_changeset(
+        temporary_table,
+        monkeypatch,
+        records_by_id,
+        namespace=FOLIO_NAMESPACE,
+        transformer_type="folio",
+    )
+
+    MockElasticsearchClient.inputs.clear()
+
+    result = _run_transform(
+        monkeypatch,
+        ids=["fo00001", "fo00002"],
+        index_date="2026-01-01",
+    )
+
+    assert result.success_count == 2
+    assert result.failure_count == 0
+    assert result.changeset_ids == []
+    assert result.ids == ["fo00001", "fo00002"]
+
+    indexed_ids = {op["_id"] for op in MockElasticsearchClient.inputs}
+    assert indexed_ids == {
+        "Work[folio-instance/fo00001]",
+        "Work[folio-instance/fo00002]",
+    }
+
+
+def test_transformer_id_run_includes_deleted_rows_as_tombstones(
+    temporary_table: IcebergTable, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    records_by_id: dict[str, tuple[str, bool] | str] = {
+        "fo00001": "<record><leader>00000nam a2200000   4500</leader><controlfield tag='005'>20261225123045.0</controlfield><controlfield tag='001'>fo00001</controlfield><datafield tag='245' ind1='0' ind2='0'><subfield code='a'>Folio Title One</subfield></datafield></record>",
+        "fo00003": (
+            "<record><leader>00000nam a2200000   4500</leader><controlfield tag='005'>20261225123045.0</controlfield><controlfield tag='001'>fo00003</controlfield><datafield tag='245' ind1='0' ind2='0'><subfield code='a'>Deleted Folio Work</subfield></datafield></record>",
+            True,
+        ),
+    }
+    prepare_changeset(
+        temporary_table,
+        monkeypatch,
+        records_by_id,
+        namespace=FOLIO_NAMESPACE,
+        transformer_type="folio",
+    )
+
+    MockElasticsearchClient.inputs.clear()
+
+    result = _run_transform(
+        monkeypatch,
+        ids=["fo00001", "fo00003"],
+        index_date="2026-01-01",
+    )
+
+    assert result.success_count == 2
+    assert result.failure_count == 0
+
+    by_id = {op["_id"]: op for op in MockElasticsearchClient.inputs}
+    deleted = by_id["Work[folio-instance/fo00003]"]["_source"]
+    assert deleted["type"] == "Deleted"
+    assert deleted["deletedReason"]["type"] == "DeletedFromSource"
+
+
+def test_transformer_id_run_report_key_is_not_reindex(
+    temporary_table: IcebergTable, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    records_by_id = {
+        "fo00001": "<record><leader>00000nam a2200000   4500</leader><controlfield tag='005'>20261225123045.0</controlfield><controlfield tag='001'>fo00001</controlfield><datafield tag='245' ind1='0' ind2='0'><subfield code='a'>Folio Title One</subfield></datafield></record>",
+    }
+    prepare_changeset(
+        temporary_table,
+        monkeypatch,
+        records_by_id,
+        namespace=FOLIO_NAMESPACE,
+        transformer_type="folio",
+    )
+
+    result = _run_transform(
+        monkeypatch,
+        ids=["fo00001"],
+        index_date="2026-01-01",
+        job_id="idload-20260101T1200",
+    )
+
+    assert (
+        result.report_s3_uri
+        == "s3://wellcomecollection-platform-folio-adapter/pipeline-dev/folio/dev/idload__idload-20260101T1200.json"
+    )
+
+    report = read_transformer_report(result)
+    assert report["ids"] == ["fo00001"]
+    assert report["changeset_ids"] == []

--- a/catalogue_graph/tests/adapters/transformers/test_transformer_event.py
+++ b/catalogue_graph/tests/adapters/transformers/test_transformer_event.py
@@ -1,0 +1,54 @@
+"""Tests for TransformerEvent's ids/changeset_ids validation."""
+
+import pytest
+
+from adapters.steps.transformer import MAX_IDS_PER_RUN, TransformerEvent
+
+
+def _event(**overrides: object) -> TransformerEvent:
+    payload: dict[str, object] = {
+        "transformer_type": "ebsco",
+        "job_id": "job-1",
+    }
+    payload.update(overrides)
+    return TransformerEvent.model_validate(payload)
+
+
+def test_no_ids_or_changesets_is_a_valid_reindex_event() -> None:
+    event = _event()
+    assert event.ids is None
+    assert event.changeset_ids == []
+
+
+def test_changeset_ids_alone_is_valid() -> None:
+    event = _event(changeset_ids=["cs1"])
+    assert event.ids is None
+    assert event.changeset_ids == ["cs1"]
+
+
+def test_ids_alone_is_valid() -> None:
+    event = _event(ids=["rec1", "rec2"])
+    assert event.ids == ["rec1", "rec2"]
+    assert event.changeset_ids == []
+
+
+def test_rejects_ids_combined_with_changeset_ids() -> None:
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        _event(ids=["rec1"], changeset_ids=["cs1"])
+
+
+def test_rejects_an_explicitly_empty_id_list() -> None:
+    """An id query that came back empty must fail, not silently fall through
+    to a full reindex."""
+    with pytest.raises(ValueError, match="at least one record id"):
+        _event(ids=[])
+
+
+def test_rejects_a_run_over_the_id_ceiling() -> None:
+    with pytest.raises(ValueError, match="exceeds"):
+        _event(ids=[f"rec{i}" for i in range(MAX_IDS_PER_RUN + 1)])
+
+
+def test_allows_a_run_at_the_id_ceiling() -> None:
+    event = _event(ids=[f"rec{i}" for i in range(MAX_IDS_PER_RUN)])
+    assert len(event.ids or []) == MAX_IDS_PER_RUN

--- a/catalogue_graph/tests/adapters/utils/test_adapter_store_source.py
+++ b/catalogue_graph/tests/adapters/utils/test_adapter_store_source.py
@@ -4,6 +4,7 @@ from collections.abc import Generator
 from typing import cast
 
 import pyarrow as pa
+import pytest
 
 from adapters.utils.adapter_store import AdapterStore
 from adapters.utils.adapter_store_source import AdapterStoreSource
@@ -83,6 +84,70 @@ def test_stream_raw_empty_changeset_yields_nothing(
     source = AdapterStoreSource(store, changeset_ids=["nonexistent"])
 
     assert list(source.stream_raw()) == []
+
+
+def test_stream_raw_id_path_yields_only_requested_ids(
+    adapter_store_with_records: AdapterStoreFactory,
+) -> None:
+    """With ids and no changeset ids, stream_raw yields only the named rows."""
+    store = adapter_store_with_records(
+        [
+            {"id": "rec001", "content": "first"},
+            {"id": "rec002", "content": "second"},
+            {"id": "rec003", "content": "third"},
+        ]
+    )
+    source = AdapterStoreSource(store, changeset_ids=[], ids=["rec001", "rec003"])
+
+    rows = list(source.stream_raw())
+
+    assert sorted(row["id"] for row in rows) == ["rec001", "rec003"]
+
+
+def test_stream_raw_id_path_includes_deleted_rows_with_content(
+    adapter_store_with_records: AdapterStoreFactory,
+) -> None:
+    """A soft-deleted row matching a requested id is streamed with its
+    preserved content, so it can overwrite a live document downstream."""
+    store = adapter_store_with_records(
+        [
+            {"id": "rec001", "content": "active"},
+            {
+                "id": "rec002",
+                "content": "deleted with content preserved",
+                "deleted": True,
+            },
+        ]
+    )
+    source = AdapterStoreSource(store, changeset_ids=[], ids=["rec001", "rec002"])
+
+    rows = {row["id"]: row for row in source.stream_raw()}
+
+    assert sorted(rows) == ["rec001", "rec002"]
+    assert rows["rec002"]["deleted"] is True
+    assert rows["rec002"]["content"] == "deleted with content preserved"
+
+
+def test_stream_raw_id_path_no_matching_ids_yields_nothing(
+    adapter_store_with_records: AdapterStoreFactory,
+) -> None:
+    """Ids that match no row yield an empty stream, not a fallback reindex."""
+    store = adapter_store_with_records([{"id": "rec001", "content": "first"}])
+    source = AdapterStoreSource(store, changeset_ids=[], ids=["nonexistent"])
+
+    assert list(source.stream_raw()) == []
+
+
+def test_rejects_changeset_ids_combined_with_ids(
+    adapter_store_with_records: AdapterStoreFactory,
+) -> None:
+    """Both being set is rejected outright, not silently resolved by picking
+    one, so a caller that passes both by mistake gets a clear error instead
+    of a confusing partial result."""
+    store = adapter_store_with_records([{"id": "rec001", "content": "first"}])
+
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        AdapterStoreSource(store, changeset_ids=["changeset-1"], ids=["rec001"])
 
 
 class _ClosableBatchStream:

--- a/catalogue_graph/tests/adapters/utils/test_axiell_changeset_reader.py
+++ b/catalogue_graph/tests/adapters/utils/test_axiell_changeset_reader.py
@@ -32,12 +32,14 @@ MARCXML = (
 def _reader(
     adapter_table: IcebergTable,
     changeset_ids: list[str],
+    ids: list[str] | None = None,
     facts_table: IcebergTable | None = None,
     reconciler_table: IcebergTable | None = None,
 ) -> AxiellChangesetReader:
     return AxiellChangesetReader(
         AdapterStore(adapter_table, namespace=NAMESPACE),
         changeset_ids,
+        ids=ids,
         facts_store=(
             DeletionFactsStore(facts_table, namespace=NAMESPACE)
             if facts_table is not None
@@ -73,6 +75,31 @@ def test_records_pass_through_unchanged_including_tombstones(
 
     rows = {
         row["id"]: row for row in _reader(temporary_table, changeset_ids).iter_records()
+    }
+
+    assert set(rows) == {"collect-1", "collect-2"}
+    assert rows["collect-2"]["deleted"] is True
+    assert rows["collect-2"]["content"] == MARCXML
+
+
+def test_records_by_id_yields_only_named_records_including_tombstones(
+    temporary_table: IcebergTable,
+) -> None:
+    # The changeset id is irrelevant to an id run; only seed the store.
+    _seed_adapter_rows(
+        temporary_table,
+        [
+            {"id": "collect-1", "content": MARCXML},
+            {"id": "collect-2", "content": MARCXML, "deleted": True},
+            {"id": "collect-3", "content": MARCXML},
+        ],
+    )
+
+    rows = {
+        row["id"]: row
+        for row in _reader(
+            temporary_table, [], ids=["collect-1", "collect-2"]
+        ).iter_records()
     }
 
     assert set(rows) == {"collect-1", "collect-2"}
@@ -156,6 +183,30 @@ def test_no_changesets_yields_no_deletions_and_reads_no_facts(
     assert list(reader.iter_deletions()) == []
 
 
+def test_ids_mode_yields_no_deletions_and_reads_no_facts(
+    temporary_table: IcebergTable,
+    deletion_facts_temporary_table: IcebergTable,
+    reconciler_temporary_table: IcebergTable,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An id-mode run only re-transforms named records; it does not replay
+    superseded-guid deletion facts, which are keyed by changeset, not id."""
+    reader = _reader(
+        temporary_table,
+        [],
+        ids=["collect-1"],
+        facts_table=deletion_facts_temporary_table,
+        reconciler_table=reconciler_temporary_table,
+    )
+    assert reader.facts_store is not None
+
+    def fail_read(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("facts must not be read during an id-mode run")
+
+    monkeypatch.setattr(reader.facts_store, "get_records_by_changesets", fail_read)
+    assert list(reader.iter_deletions()) == []
+
+
 def test_facts_store_requires_reconciler_store(
     temporary_table: IcebergTable,
     deletion_facts_temporary_table: IcebergTable,
@@ -214,3 +265,15 @@ def test_build_reuses_injected_adapter_store(temporary_table: IcebergTable) -> N
     )
     assert reader.adapter_store is adapter_store
     assert config.adapter_builds == 0
+
+
+def test_build_threads_ids_onto_reader(temporary_table: IcebergTable) -> None:
+    config = _CountingConfig(temporary_table)
+    reader = AxiellChangesetReader.build(
+        config,
+        [],
+        use_rest_api_table=False,
+        ids=["collect-1", "collect-2"],
+    )
+    assert reader.ids == ["collect-1", "collect-2"]
+    assert reader.changeset_ids == []


### PR DESCRIPTION
## What does this change?

Closes wellcomecollection/platform#6498, which lays out the problem, the necessary changes, and the desired behaviour in detail.

In short: the transformer state machine could previously only be told what to transform by changeset id. That's a problem when a specific, known set of records needs re-processing: a set of works with a bad field, a handful of documents missing from the source index, or a spot fix after a transformer parsing change. This PR gives the transformer an `ids` field, mirroring the id mode the OAI-PMH loader already has one stage earlier (`adapters.steps.oai_pmh.loader`), so a known set of records can be redriven directly by adapter store record id — without needing to refresh from source or reindex everything.

**Identifiers**: `ids` means the adapter store record id. For Axiell and FOLIO, that's the OAI-PMH header identifier — the same value the OAI-PMH loader's own id mode (`adapters.steps.oai_pmh.loader`) already operates on, so a recovery there can hand ids straight from one step to the next without translation. For EBSCO, it's the record's MARC 001, falling back to a cleaned MARC 035 `$a` if 001 is blank.

**What changed, by area**:

- `TransformerEvent` (`adapters/steps/transformer.py`) gains `ids: list[str] | None`. Mutually exclusive with `changeset_ids` — supplying both raises `ValueError`. An explicitly empty list is also rejected, so an id query that came back empty fails loudly instead of silently falling through to a full reindex. New `MAX_IDS_PER_RUN` constant, derived from the Step Functions 256 KiB state payload limit — not the loader's separate, much larger constant of the same name, which would exceed what an execution input can carry.
- `AdapterStoreSource.stream_raw` (`adapters/utils/adapter_store_source.py`) gains a third branch: with `ids` set, it reads `get_namespace_records(In("id", ids), snapshot_id)` — the same namespace-scoped read the changeset path uses, so soft-deleted rows are included and can overwrite live documents downstream. The adapter store is sorted on `id`, so this prunes Parquet row groups rather than scanning the table.
- `build_transformer` threads `ids` through to all three concrete transformers. `EbscoTransformer` and `FolioTransformer` pass it straight into `AdapterStoreSource`/`FolioStoreSource`; FOLIO's item-enrichment join needed no changes, since it was already keyed by id per batch. `AxiellTransformer` goes through `AxiellChangesetReader` instead — both `build()` and `iter_records()` now accept and thread `ids`.
- `TransformerReport` records the `ids` list, and the S3 manifest key now uses an `idload__<job_id>` prefix for id runs — distinct from a changeset run's joined-changeset-id key and a full reindex's `reindex__<job_id>` key.
- `catalogue_graph/src/adapters/transformers/README.md` documents the new event shape, the CLI flags, and the deletion-facts caveat below.

**Deliberately out of scope, per the issue**: Axiell's deletion-fact delivery (superseded-GUID tombstones, via `AxiellChangesetReader.iter_deletions()`) does not extend to id-mode. Facts are recorded and read per-changeset; there's no equivalent per-id query, and id-mode's use cases (a bad field, a spot fix after a transformer change) don't need historical-deletion replay — those are already delivered by the changeset-driven run that originally detected them.

### Checklist

- [x] Does this change the display model the catalogue API returns? No.

## How to test

From `catalogue_graph/`: `uv run pytest tests/adapters` (1049 passing), plus `mypy .` and `ruff check`/`ruff format`, all clean.

## How can we measure success?

Checked directly against the issue's "done when" list:

- **An id run transforms exactly the named records, including soft-deleted rows as tombstones** — covered end-to-end for all three transformer types (`test_transformer_id_run_transforms_only_named_ids`, `test_transformer_id_run_includes_deleted_rows_as_tombstones` in each of `tests/adapters/transformers/{axiell,ebsco,folio}/test_transformer.py`).
- **Ids and changesets cannot be combined, and an empty id list is an error** — `tests/adapters/transformers/test_transformer_event.py` (7 tests), plus `AdapterStoreSource`'s own independent check.
- **Reports for id runs are distinguishable from reindex runs in S3** — the `idload__<job_id>` manifest key, tested per adapter (`test_transformer_id_run_report_key_is_not_reindex`).
- **Tests cover the three-way source branch and the event validation** — `tests/adapters/utils/test_adapter_store_source.py` (11 tests) and `test_transformer_event.py`.
- **README documents the event shape, CLI flags, and the deletion-facts caveat** — done in `catalogue_graph/src/adapters/transformers/README.md`.

Operationally, an operator recovering a known set of bad/missing records can now invoke the transformer directly with `ids` instead of hunting down the changesets those records arrived in or running a full reindex:

- CLI: `uv run python -m adapters.steps.transformer --transformer-type <type> --id <id> [--id <id> ...]`, or `--ids-file <path>` for a file of ids, one per line. The two combine with each other if both are given, but both are mutually exclusive with `--changeset-id`.
- Lambda / state machine: pass `ids` instead of `changeset_ids` in the input. No Terraform change is needed — the state machine already passes `$.detail` through to the Lambda unaltered, so an id run is started the same way as a changeset redrive:

  ```bash
  aws stepfunctions start-execution \
    --state-machine-arn <transformer-YYYY-MM-DD> \
    --input '{"detail": {"transformer_type": "axiell", "job_id": "idload-...", "ids": ["..."]}}'
  ```

## Have we considered potential risks?

From the issue's constraints:

> The per-adapter `failure_count` alarm fires on transform failures regardless of how the run was started, so a hand-driven id run with bad records will page. Acceptable, but worth a note in the runbook.

The runbook update itself isn't part of this PR.
