### PR TITLE
Match the ECS retry error names Step Functions actually raises

### DIFF
--- a/pipeline/terraform/modules/pipeline/state_machine_image_inferrer.tf
+++ b/pipeline/terraform/modules/pipeline/state_machine_image_inferrer.tf
@@ -97,12 +97,13 @@ locals {
       JitterStrategy  = "FULL"
     },
     {
+      # ErrorEquals is an exact, case-sensitive match, so the prefix is ECS., not Ecs.
       ErrorEquals = [
-        "Ecs.ServerException",
-        "Ecs.ThrottlingException",
-        "Ecs.TaskFailedToStartException",
-        "Ecs.CannotPullContainerErrorException",
-        "Ecs.ContainerRuntimeTimeoutErrorException",
+        "ECS.ServerException",
+        "ECS.ThrottlingException",
+        "ECS.TaskFailedToStartException",
+        "ECS.CannotPullContainerErrorException",
+        "ECS.ContainerRuntimeTimeoutErrorException",
       ]
       IntervalSeconds = 5
       MaxAttempts     = 3

--- a/pipeline/terraform/modules/pipeline_new/state_machine_image_inferrer.tf
+++ b/pipeline/terraform/modules/pipeline_new/state_machine_image_inferrer.tf
@@ -24,12 +24,13 @@ locals {
       JitterStrategy  = "FULL"
     },
     {
+      # ErrorEquals is an exact, case-sensitive match, so the prefix is ECS., not Ecs.
       ErrorEquals = [
-        "Ecs.ServerException",
-        "Ecs.ThrottlingException",
-        "Ecs.TaskFailedToStartException",
-        "Ecs.CannotPullContainerErrorException",
-        "Ecs.ContainerRuntimeTimeoutErrorException",
+        "ECS.ServerException",
+        "ECS.ThrottlingException",
+        "ECS.TaskFailedToStartException",
+        "ECS.CannotPullContainerErrorException",
+        "ECS.ContainerRuntimeTimeoutErrorException",
       ]
       IntervalSeconds = 5
       MaxAttempts     = 3

--- a/pipeline/terraform/modules/pipeline_services/graph/locals.tf
+++ b/pipeline/terraform/modules/pipeline_services/graph/locals.tf
@@ -194,17 +194,18 @@ locals {
 
   state_function_default_retry = [
     {
+      # ErrorEquals is an exact, case-sensitive match, so the prefix is ECS., not Ecs.
       ErrorEquals = [
         "Lambda.ServiceException",
         "Lambda.AWSLambdaException",
         "Lambda.SdkClientException",
         "Lambda.TooManyRequestsException",
-        "Ecs.ServerException",
-        "Ecs.ThrottlingException",
-        "Ecs.TaskFailedToStartException",
-        "Ecs.CannotPullContainerErrorException",
-        "Ecs.ContainerRuntimeTimeoutErrorException",
-        "Ecs.EssentialContainerExited",
+        "ECS.ServerException",
+        "ECS.ThrottlingException",
+        "ECS.TaskFailedToStartException",
+        "ECS.CannotPullContainerErrorException",
+        "ECS.ContainerRuntimeTimeoutErrorException",
+        "ECS.EssentialContainerExited",
         "States.Timeout",
       ]
       IntervalSeconds = 1


### PR DESCRIPTION
## What does this change?

The graph incremental pipeline fails about once a week on a transient `ECS.ServerException` (HTTP 500) from ECS RunTask, firing the `graph-pipeline-incremental-run-failed-2026-07-03` alarm.

A `Retry` block with `MaxAttempts = 3` already exists to absorb this, but it never fires. `ErrorEquals` is an exact, case-sensitive match, and the lists spell the prefix `Ecs.` rather than `ECS.`. The execution history shows `TaskFailed` going straight to `ExecutionFailed` with zero retry attempts. With no `ToleratedFailurePercentage` on the parent Map, one failed extractor then aborts its eight siblings and fails the run.

This corrects the prefix in the three places it appears: `pipeline_services/graph/locals.tf` and the two `state_machine_image_inferrer.tf` files. The neighbouring `ECS.AmazonECSException` in both inferrer files was already correct, which confirms the right prefix.

Only the prefix changes. `ECS.ServerException` is the one suffix I have observed in real failures, so the others are unverified and may still be inert.

### Checklist

- [x] Display model unchanged: this is Step Functions retry config only.

## How to test

Not reproducible on demand, since the error is transient and AWS-side. The evidence:

```
aws stepfunctions get-execution-history --region eu-west-1 \
  --execution-arn arn:aws:states:eu-west-1:760097843905:execution:graph-extractor-2026-07-03:dbd16f66-7007-463c-9f99-6f1ef80c7e6b
```

`TaskFailed` with `ECS.ServerException` goes straight to `ExecutionFailed`, no retries, despite `MaxAttempts = 3` in the deployed definition. After apply, the same error should retry instead of failing the run.

## How can we measure success?

`ExecutionsFailed` on `graph-pipeline-incremental-2026-07-03` drops for this cause. In the 30 days to 2026-08-10: 1682 successes and 29 failures, four of them this pattern (07-25, 08-02, 08-03, 08-08).

## Have we considered potential risks?

Low. It makes an existing retry work rather than adding behaviour, and stays scoped to transient infrastructure errors. Application failures are still not retried.

A run hitting a 500 now takes a few seconds longer instead of failing fast. That is the point: incremental windows are fixed, non-overlapping and have no catch-up, so a failed run currently drops 15 minutes of changes. The window lost on 2026-08-08 has been replayed.
