### PR TITLE
Stop ingesting the systems-transformation TEI folder

### DIFF
--- a/tei_adapter/tei_id_extractor/src/main/scala/weco/catalogue/tei/id_extractor/TeiIdExtractorWorkerService.scala
+++ b/tei_adapter/tei_id_extractor/src/main/scala/weco/catalogue/tei/id_extractor/TeiIdExtractorWorkerService.scala
@@ -111,26 +111,25 @@ class TeiIdExtractorWorkerService[Dest](
       }
       .via(catchErrors)
 
+  private val excludedDirs = Seq(
+    // These are directories used for TEI management, not actual TEI files.
+    "docs/",
+    "Templates/",
+    // These are files we don't want to ingest directly into the platform;
+    // e.g. stuff that's been written for collaboration on external projects.
+    //
+    // See https://github.com/wellcomecollection/catalogue-pipeline/issues/2197#issuecomment-1249665377
+    "Arabic/Fihrist/",
+    // Calm manuscript exports waiting to be edited by hand. They are moved to
+    // "Calm manuscripts" once they are fit to publish, and only then should
+    // they reach the catalogue.
+    "systems-transformation/"
+  )
+
   /** Is this a TEI file we want to process as part of the pipeline? */
   private def isTeiFile(path: String): Boolean = {
     val isXmlFile = path.endsWith(".xml")
-
     val isInRootOfRepo = !path.contains("/")
-
-    val excludedDirs = Seq(
-      // These are directories used for TEI management, not actual TEI files.
-      "docs/",
-      "Templates/",
-      // These are files we don't want to ingest directly into the platform;
-      // e.g. stuff that's been written for collaboration on external projects.
-      //
-      // See https://github.com/wellcomecollection/catalogue-pipeline/issues/2197#issuecomment-1249665377
-      "Arabic/Fihrist/",
-      // Calm manuscript exports waiting to be edited by hand. They are moved to
-      // "Calm manuscripts" once they are fit to publish, and only then should
-      // they reach the catalogue.
-      "systems-transformation/"
-    )
     val isInExcludedDir = excludedDirs.exists(dir => path.startsWith(dir))
 
     isXmlFile && !isInRootOfRepo && !isInExcludedDir

--- a/tei_adapter/tei_id_extractor/src/main/scala/weco/catalogue/tei/id_extractor/TeiIdExtractorWorkerService.scala
+++ b/tei_adapter/tei_id_extractor/src/main/scala/weco/catalogue/tei/id_extractor/TeiIdExtractorWorkerService.scala
@@ -125,7 +125,11 @@ class TeiIdExtractorWorkerService[Dest](
       // e.g. stuff that's been written for collaboration on external projects.
       //
       // See https://github.com/wellcomecollection/catalogue-pipeline/issues/2197#issuecomment-1249665377
-      "Arabic/Fihrist/"
+      "Arabic/Fihrist/",
+      // Calm manuscript exports waiting to be edited by hand. They are moved to
+      // "Calm manuscripts" once they are fit to publish, and only then should
+      // they reach the catalogue.
+      "systems-transformation/"
     )
     val isInExcludedDir = excludedDirs.exists(dir => path.startsWith(dir))
 

--- a/tei_adapter/tei_id_extractor/src/test/scala/weco/catalogue/tei/id_extractor/TeiIdExtractorWorkerServiceTest.scala
+++ b/tei_adapter/tei_id_extractor/src/test/scala/weco/catalogue/tei/id_extractor/TeiIdExtractorWorkerServiceTest.scala
@@ -134,26 +134,28 @@ class TeiIdExtractorWorkerServiceTest
       "docs/example.xml"
     )
 
-    excludedPaths.foreach {
-      path =>
-        withWorkerService(httpClient = neverCallClient) {
-          case (QueuePair(queue, dlq), messageSender, store, _) =>
-            val message =
+    withWorkerService(httpClient = neverCallClient) {
+      case (QueuePair(queue, dlq), messageSender, store, _) =>
+        excludedPaths.foreach {
+          path =>
+            sendNotificationToSQS(
+              queue,
               s"""
         {
           "path": "$path",
           "uri": "$repoUrl/git/blobs/4bfe74311d86293447f173108190a4b4664d68ea",
           "timeModified": "2021-05-27T14:05:00Z"
         }""".stripMargin
+            )
+        }
 
-            sendNotificationToSQS(queue, message)
-
-            eventually {
-              store.entries.keySet shouldBe empty
-              messageSender.messages shouldBe empty
-              assertQueueEmpty(queue)
-              assertQueueEmpty(dlq)
-            }
+        // If any of these stopped being excluded, neverCallClient would fail the
+        // fetch and the message would end up on the DLQ.
+        eventually {
+          store.entries.keySet shouldBe empty
+          messageSender.messages shouldBe empty
+          assertQueueEmpty(queue)
+          assertQueueEmpty(dlq)
         }
     }
   }

--- a/tei_adapter/tei_id_extractor/src/test/scala/weco/catalogue/tei/id_extractor/TeiIdExtractorWorkerServiceTest.scala
+++ b/tei_adapter/tei_id_extractor/src/test/scala/weco/catalogue/tei/id_extractor/TeiIdExtractorWorkerServiceTest.scala
@@ -119,6 +119,45 @@ class TeiIdExtractorWorkerServiceTest
     }
   }
 
+  it("a message for a file in an excluded directory is ignored") {
+    val neverCallClient = new HttpClient {
+      override def singleRequest(request: HttpRequest): Future[HttpResponse] =
+        Future.failed(new Throwable("This should never be called!"))
+    }
+
+    // These files carry a perfectly good xml:id, so nothing but the path stops
+    // them reaching the catalogue.
+    val excludedPaths = Seq(
+      "systems-transformation/MS_94.xml",
+      "Arabic/Fihrist/MS_Arabic_1.xml",
+      "Templates/template.xml",
+      "docs/example.xml"
+    )
+
+    excludedPaths.foreach {
+      path =>
+        withWorkerService(httpClient = neverCallClient) {
+          case (QueuePair(queue, dlq), messageSender, store, _) =>
+            val message =
+              s"""
+        {
+          "path": "$path",
+          "uri": "$repoUrl/git/blobs/4bfe74311d86293447f173108190a4b4664d68ea",
+          "timeModified": "2021-05-27T14:05:00Z"
+        }""".stripMargin
+
+            sendNotificationToSQS(queue, message)
+
+            eventually {
+              store.entries.keySet shouldBe empty
+              messageSender.messages shouldBe empty
+              assertQueueEmpty(queue)
+              assertQueueEmpty(dlq)
+            }
+        }
+    }
+  }
+
   it("an older message for a file changed is ignored") {
     withWorkerService() {
       case (QueuePair(queue, dlq), messageSender, store, bucket) =>


### PR DESCRIPTION
## What does this change?

Adds `systems-transformation/` to the directories the TEI id extractor skips.

That folder holds Calm manuscript exports which are edited by hand and then moved to `Calm manuscripts` once they are fit to publish. The cataloguing team understood it to be excluded from the catalogue. It is not: all 263 files in it are live on wellcomecollection.org.

Nothing was stopping them. `IdExtractor` takes whatever the root `<TEI xml:id="...">` says, with no pattern requirement, and these files carry ids like `MS_94` rather than `manuscript_15651`. All 263 have a root id, are in `tei-adapter-store`, and resolve to a work in the index the API serves.

They also displace existing records rather than sitting beside them. TEI outranks Sierra and Calm in the merger, so `MS_94` is the merge target for the Sierra work `b19689160`, its METS work and the Calm record `049f9a54-…`. All three read "Arzneibuch"; the public page now reads "MS.94".

### Checklist

- [x] Does this change the display model the catalogue API returns? No. It changes which source files are ingested.

## How to test

`sbt "tei_id_extractor/test"`, which needs localstack and so runs in CI. `TeiIdExtractorWorkerServiceTest` gains a case asserting a path in each excluded directory is ignored, with an HTTP client that fails if called.

## What this does not do

It stops further ingest. It does not retract the 263 works already published, and it closes the normal retraction route, because `isTeiFile` gates the deleted path as well as the changed one. Retraction is tracked separately in wellcomecollection/platform#6504.

Moving a file to `Calm manuscripts` still works: the delete for the old path is skipped, the change for the new path is processed and carries the same id.

## Risks

If a file in that folder is ever needed in the catalogue before it is moved, it will now be silently absent, which is the same failure mode as the missing manuscripts in wellcomecollection/platform#6494. Reported by @v.sloyan.
