### PR TITLE
Delete TEI inner works when their parent is deleted

### DIFF
--- a/pipeline/matcher_merger/merger/src/main/scala/weco/pipeline/merger/services/Merger.scala
+++ b/pipeline/matcher_merger/merger/src/main/scala/weco/pipeline/merger/services/Merger.scala
@@ -70,6 +70,14 @@ trait Merger extends MergerLogging {
     }
 
   def merge(works: Seq[Work[Identified]]): MergerOutcome = {
+    val outcome = mergeWorks(works)
+    outcome.copy(
+      resultWorks =
+        outcome.resultWorks ++ deletedInternalWorks(outcome.resultWorks)
+    )
+  }
+
+  private def mergeWorks(works: Seq[Work[Identified]]): MergerOutcome = {
     works match {
       case Seq(target: Work.Visible[Identified]) =>
         logIntentions(target, Nil)
@@ -142,6 +150,37 @@ trait Merger extends MergerLogging {
             )
           )
       }
+  }
+
+  /** Inner works are synthesised from the parent's stubs on every merge, so
+    * deleting a parent has to delete them explicitly.
+    */
+  private def deletedInternalWorks(
+    resultWorks: Seq[Work[Identified]]
+  ): Seq[Work.Deleted[Identified]] = {
+    val alreadyEmitted = resultWorks.map(_.state.canonicalId).toSet
+
+    resultWorks
+      .collect { case w: Work.Deleted[Identified] => w }
+      .flatMap {
+        parent =>
+          parent.state.internalWorkStubs.map {
+            case InternalWork.Identified(sourceIdentifier, canonicalId, _) =>
+              Work.Deleted[Identified](
+                version = parent.version,
+                state = Identified(
+                  sourceIdentifier = sourceIdentifier,
+                  canonicalId = canonicalId,
+                  sourceModifiedTime = parent.state.sourceModifiedTime
+                ),
+                deletedReason = DeletedReason.TeiDeletedInMerger
+              )
+          }
+      }
+      .filterNot {
+        child => alreadyEmitted.contains(child.state.canonicalId)
+      }
+      .distinct
   }
 
   private def redirectSourceToTarget(

--- a/pipeline/matcher_merger/merger/src/main/scala/weco/pipeline/merger/services/MergerManager.scala
+++ b/pipeline/matcher_merger/merger/src/main/scala/weco/pipeline/merger/services/MergerManager.scala
@@ -16,8 +16,9 @@ class MergerManager(val mergerRules: Merger) {
     val works = maybeWorks.flatten
     if (works.size == maybeWorks.size) {
       val result = mergerRules.merge(works)
-      // TEI works can have internal works, which are added to
-      // resultWorks by the Merger, so the number of resulting works can be
+      // TEI works can have internal works, which the Merger adds to
+      // resultWorks (as visible works from a live parent, or as deleted works
+      // from a deleted parent), so the number of resulting works can be
       // greater than modifiedWorks.size
       assert(result.resultWorks.size >= works.size)
       result

--- a/pipeline/matcher_merger/merger/src/test/scala/weco/pipeline/merger/services/PlatformMergerTest.scala
+++ b/pipeline/matcher_merger/merger/src/test/scala/weco/pipeline/merger/services/PlatformMergerTest.scala
@@ -11,6 +11,7 @@ import weco.catalogue.internal_model.work.WorkFsm._
 import weco.catalogue.internal_model.work.WorkState.{Identified, Merged}
 import weco.catalogue.internal_model.work.generators.SourceWorkGenerators
 import weco.catalogue.internal_model.work.{
+  DeletedReason,
   Format,
   InternalWork,
   InvisibilityReason,
@@ -1138,6 +1139,58 @@ class PlatformMergerTest
         _.data.thumbnail shouldBe metsWork.data.thumbnail
       }
     }
+
+    it("deletes the inner works of a deleted TEI work") {
+      val stubs = List(createInternalWorkStub, createInternalWorkStub)
+      val deletedTeiWork = teiIdentifiedWork()
+        .mapState { _.copy(internalWorkStubs = stubs) }
+        .deleted()
+
+      val result = merger.merge(works = Seq(deletedTeiWork))
+
+      result.resultWorks should have size 3
+
+      val deletedWorks = result.resultWorks.collect {
+        case w: Work.Deleted[Identified] => w
+      }
+      deletedWorks.map(_.state.canonicalId) should contain theSameElementsAs
+        deletedTeiWork.state.canonicalId +: stubs.map(_.canonicalId)
+
+      val innerWorks =
+        deletedWorks.filterNot(
+          _.state.canonicalId == deletedTeiWork.state.canonicalId
+        )
+      innerWorks.foreach {
+        w =>
+          w.deletedReason shouldBe DeletedReason.TeiDeletedInMerger
+          w.version shouldBe deletedTeiWork.version
+          w.state.sourceModifiedTime shouldBe deletedTeiWork.state.sourceModifiedTime
+      }
+    }
+
+    it(
+      "deletes the inner works of a deleted TEI work alongside a visible target"
+    ) {
+      val stubs = List(createInternalWorkStub, createInternalWorkStub)
+      val deletedTeiWork = teiIdentifiedWork()
+        .mapState { _.copy(internalWorkStubs = stubs) }
+        .deleted()
+
+      val sierraWork = sierraPhysicalIdentifiedWork()
+
+      val result = merger.merge(works = Seq(sierraWork, deletedTeiWork))
+
+      result.resultWorks should have size 4
+
+      result.resultWorks.collect {
+        case w: Work.Visible[Identified] => w.state.canonicalId
+      } shouldBe Seq(sierraWork.state.canonicalId)
+
+      result.resultWorks.collect {
+        case w: Work.Deleted[Identified] => w.state.canonicalId
+      } should contain theSameElementsAs
+        deletedTeiWork.state.canonicalId +: stubs.map(_.canonicalId)
+    }
   }
 
   it("passes a Folio work through the merger unchanged") {
@@ -1167,4 +1220,13 @@ class PlatformMergerTest
     val mergedWork = mergedWorks.head.asInstanceOf[Work.Visible[Merged]]
     mergedWork.data shouldBe axiellWork.data
   }
+
+  private def createInternalWorkStub: InternalWork.Identified =
+    InternalWork.Identified(
+      sourceIdentifier = createTeiSourceIdentifier,
+      canonicalId = createCanonicalId,
+      workData = WorkData(
+        title = Some(s"tei-inner-${randomAlphanumeric(length = 10)}")
+      )
+    )
 }

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/Transformer.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/Transformer.scala
@@ -19,4 +19,9 @@ trait Transformer[SourceData] {
     newWork: Work[Source],
     storedWork: Work[Source]
   ): Work[Source] = newWork
+
+  /** Whether this work would be wrong without the stored work to reconcile
+    * against. If it would, the transformer fails rather than sending it.
+    */
+  def requiresStoredWork(newWork: Work[Source]): Boolean = false
 }

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/Transformer.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/Transformer.scala
@@ -11,4 +11,12 @@ trait Transformer[SourceData] {
     sourceData: SourceData,
     version: Int
   ): Result[Work[Source]]
+
+  /** Carry over state that the new work cannot derive from the source record,
+    * e.g. TEI internal work stubs on a deletion.
+    */
+  def reconcileWithStored(
+    newWork: Work[Source],
+    storedWork: Work[Source]
+  ): Work[Source] = newWork
 }

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/TransformerWorker.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/TransformerWorker.scala
@@ -33,6 +33,8 @@ case class TransformerError[SourceData, Key](
   sourceData: SourceData,
   key: Key
 ) extends TransformerWorkerError(t.getMessage)
+case class StoredWorkRetrievalError[Key](t: Throwable, key: Key)
+    extends TransformerWorkerError(t.getMessage)
 
 trait SourceDataRetriever[Payload, SourceData] {
   def lookupSourceData(
@@ -104,10 +106,12 @@ trait TransformerEventProcessor[Payload <: SourcePayload, SourceData]
             case err: RetrieverNotFoundException =>
               debug(s"No stored work for $key: $err")
               Right(Some((transformedWork, key)))
-            // A work that needs the stored one is left to fail, so the message
-            // is retried rather than sent in a state we know to be wrong.
+            // A work that needs the stored one fails, so the message is
+            // retried rather than sent in a state we know to be wrong.
             case err: Throwable
-                if !transformer.requiresStoredWork(transformedWork) =>
+                if transformer.requiresStoredWork(transformedWork) =>
+              Left(StoredWorkRetrievalError(err, key))
+            case err: Throwable =>
               warn(
                 s"Unable to retrieve work $key, sending without reconciliation",
                 err
@@ -255,6 +259,11 @@ final class TransformerWorker[Payload <: SourcePayload, SourceData, SenderDest](
               case TransformerError(t, sourceData, key) =>
                 error(
                   s"$transformerName: TransformerError on $sourceData with $key ($t)"
+                )
+              case StoredWorkRetrievalError(t, key) =>
+                error(
+                  s"$transformerName: StoredWorkRetrievalError on $key; this work cannot be sent without the stored work to reconcile against",
+                  t
                 )
             }
 

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/TransformerWorker.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/TransformerWorker.scala
@@ -11,7 +11,11 @@ import weco.catalogue.internal_model.Implicits._
 import weco.json.JsonUtil.fromJson
 import weco.messaging.sns.NotificationMessage
 import weco.pipeline_storage.Indexable._
-import weco.pipeline_storage.{PipelineStorageStream, Retriever}
+import weco.pipeline_storage.{
+  PipelineStorageStream,
+  Retriever,
+  RetrieverNotFoundException
+}
 import weco.storage.{Identified, ReadError, Version}
 import io.circe.optics.JsonPath._
 import weco.typesafe.Runnable
@@ -84,8 +88,10 @@ trait TransformerEventProcessor[Payload <: SourcePayload, SourceData]
           .apply(workIndexable.id(transformedWork))
           .map {
             storedWork =>
-              if (shouldSend(transformedWork, storedWork)) {
-                Right(Some((transformedWork, key)))
+              val reconciledWork =
+                transformer.reconcileWithStored(transformedWork, storedWork)
+              if (shouldSend(reconciledWork, storedWork)) {
+                Right(Some((reconciledWork, key)))
               } else {
                 info(
                   s"$transformerName: from $key transformed work with id ${transformedWork.id}; already in pipeline so not re-sending"
@@ -94,8 +100,14 @@ trait TransformerEventProcessor[Payload <: SourcePayload, SourceData]
               }
           }
           .recover {
+            // Not-found is the normal first sighting of a record, so it stays quiet.
+            case err: RetrieverNotFoundException =>
+              debug(s"No stored work for $key: $err")
+              Right(Some((transformedWork, key)))
             case err: Throwable =>
-              debug(s"Unable to retrieve work $key: $err")
+              warn(
+                s"Unable to retrieve work $key, sending without reconciliation: $err"
+              )
               Right(Some((transformedWork, key)))
           }
 

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/TransformerWorker.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/TransformerWorker.scala
@@ -104,7 +104,10 @@ trait TransformerEventProcessor[Payload <: SourcePayload, SourceData]
             case err: RetrieverNotFoundException =>
               debug(s"No stored work for $key: $err")
               Right(Some((transformedWork, key)))
-            case err: Throwable =>
+            // A work that needs the stored one is left to fail, so the message
+            // is retried rather than sent in a state we know to be wrong.
+            case err: Throwable
+                if !transformer.requiresStoredWork(transformedWork) =>
               warn(
                 s"Unable to retrieve work $key, sending without reconciliation",
                 err

--- a/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/TransformerWorker.scala
+++ b/pipeline/transformer/transformer_common/src/main/scala/weco/pipeline/transformer/TransformerWorker.scala
@@ -106,7 +106,8 @@ trait TransformerEventProcessor[Payload <: SourcePayload, SourceData]
               Right(Some((transformedWork, key)))
             case err: Throwable =>
               warn(
-                s"Unable to retrieve work $key, sending without reconciliation: $err"
+                s"Unable to retrieve work $key, sending without reconciliation",
+                err
               )
               Right(Some((transformedWork, key)))
           }

--- a/pipeline/transformer/transformer_common/src/test/scala/weco/pipeline/transformer/TransformerWorkerTest.scala
+++ b/pipeline/transformer/transformer_common/src/test/scala/weco/pipeline/transformer/TransformerWorkerTest.scala
@@ -227,6 +227,56 @@ class TransformerWorkerTest
     }
 
     it(
+      "indexes the work returned by reconcileWithStored, not the transformed one"
+    ) {
+      // The whole point of reconcileWithStored is that its result is what
+      // leaves the transformer. Computing it and then forwarding the original
+      // would be silent, so assert on what actually gets indexed.
+      val reconcilingTransformer = new ExampleTransformer {
+        override def reconcileWithStored(
+          newWork: Work[Source],
+          storedWork: Work[Source]
+        ): Work[Source] =
+          newWork match {
+            case w: Work.Visible[Source] =>
+              w.copy(
+                data = w.data.copy(
+                  title = w.data.title.map(_ + " [reconciled]")
+                )
+              )
+            case other => other
+          }
+      }
+
+      withWorker(transformer = reconcilingTransformer) {
+        case (_, QueuePair(queue, dlq), workIndexer, _, store) =>
+          implicit val s: MemoryVersionedStore[S3ObjectLocation, ExampleData] =
+            store
+          val payload = createPayloadWith(version = 1)
+
+          // Nothing stored yet, so there is nothing to reconcile against.
+          sendNotificationToSQS(queue, payload)
+          eventually {
+            workIndexer.index should have size 1
+            workIndexer.index.values.head.data.title.get should not include
+              "[reconciled]"
+          }
+
+          // Now a stored work exists, so the reconciled work is what should
+          // be indexed.
+          sendNotificationToSQS(queue, setPayloadVersion(payload, 2))
+          eventually {
+            assertQueueEmpty(dlq)
+            assertQueueEmpty(queue)
+            workIndexer.index.values.head.version shouldBe 2
+            workIndexer.index.values.head.data.title.get should include(
+              "[reconciled]"
+            )
+          }
+      }
+    }
+
+    it(
       "re-sends a Work if the stored Work has the same version and the same data"
     ) {
       withWorker() {

--- a/pipeline/transformer/transformer_common/src/test/scala/weco/pipeline/transformer/TransformerWorkerTest.scala
+++ b/pipeline/transformer/transformer_common/src/test/scala/weco/pipeline/transformer/TransformerWorkerTest.scala
@@ -15,7 +15,7 @@ import weco.messaging.fixtures.SQS.QueuePair
 import weco.messaging.memory.MemoryMessageSender
 import weco.pipeline.transformer.example._
 import weco.pipeline.transformer.result.Result
-import weco.pipeline_storage.RetrieverNotFoundException
+import weco.pipeline_storage.{Retriever, RetrieverNotFoundException}
 import weco.pipeline_storage.fixtures.PipelineStorageStreamFixtures
 import weco.pipeline_storage.memory.{MemoryIndexer, MemoryRetriever}
 import weco.storage.Version
@@ -435,6 +435,60 @@ class TransformerWorkerTest
       }
     }
 
+    it(
+      "if the retriever errors and the transformer needs the stored work"
+    ) {
+      val brokenRetriever =
+        new MemoryRetriever[Work[Source]](index = mutable.Map()) {
+          override def apply(id: String): Future[Work[Source]] =
+            Future.failed(new RuntimeException("BOOM!"))
+        }
+
+      val needsStoredWork = new ExampleTransformer {
+        override def requiresStoredWork(newWork: Work[Source]): Boolean = true
+      }
+
+      withWorker(
+        transformer = needsStoredWork,
+        transformedWorkRetriever = Some(brokenRetriever)
+      ) {
+        case (_, QueuePair(queue, dlq), workIndexer, workKeySender, store) =>
+          sendNotificationToSQS(queue, createPayload(store))
+
+          eventually {
+            assertQueueHasSize(dlq, size = 1)
+            assertQueueEmpty(queue)
+
+            // Indexing it would overwrite the stored work we failed to read.
+            workIndexer.index shouldBe empty
+            workKeySender.messages shouldBe empty
+          }
+      }
+    }
+
+    it(
+      "but sends the work anyway if the transformer doesn't need the stored work"
+    ) {
+      val brokenRetriever =
+        new MemoryRetriever[Work[Source]](index = mutable.Map()) {
+          override def apply(id: String): Future[Work[Source]] =
+            Future.failed(new RuntimeException("BOOM!"))
+        }
+
+      withWorker(transformedWorkRetriever = Some(brokenRetriever)) {
+        case (_, QueuePair(queue, dlq), workIndexer, workKeySender, store) =>
+          sendNotificationToSQS(queue, createPayload(store))
+
+          eventually {
+            assertQueueEmpty(dlq)
+            assertQueueEmpty(queue)
+
+            workIndexer.index should have size 1
+            workKeySender.messages should have size 1
+          }
+      }
+    }
+
     it("if it can't send the key of the indexed work") {
       val brokenSender = new MemoryMessageSender() {
         override def send(body: String): Try[Unit] =
@@ -467,6 +521,7 @@ class TransformerWorkerTest
         initialEntries = Map.empty
       ),
     transformer: Transformer[ExampleData] = new ExampleTransformer,
+    transformedWorkRetriever: Option[Retriever[Work[Source]]] = None,
     visibilityTimeout: FiniteDuration = 1.second
   )(
     testWith: TestWith[
@@ -488,7 +543,7 @@ class TransformerWorkerTest
           sender = workKeySender
         ) {
           pipelineStream =>
-            val retriever =
+            val retriever = transformedWorkRetriever.getOrElse(
               new MemoryRetriever[Work[Source]](index = mutable.Map()) {
                 override def apply(id: String): Future[Work[Source]] =
                   workIndexer.index.get(id) match {
@@ -497,6 +552,7 @@ class TransformerWorkerTest
                       Future.failed(new RetrieverNotFoundException(id))
                   }
               }
+            )
 
             val worker = new TransformerWorker(
               transformer = transformer,

--- a/pipeline/transformer/transformer_common/src/test/scala/weco/pipeline/transformer/TransformerWorkerTest.scala
+++ b/pipeline/transformer/transformer_common/src/test/scala/weco/pipeline/transformer/TransformerWorkerTest.scala
@@ -452,7 +452,17 @@ class TransformerWorkerTest
         transformer = needsStoredWork,
         transformedWorkRetriever = Some(brokenRetriever)
       ) {
-        case (_, QueuePair(queue, dlq), workIndexer, workKeySender, store) =>
+        case (
+              worker,
+              QueuePair(queue, dlq),
+              workIndexer,
+              workKeySender,
+              store
+            ) =>
+          whenReady(worker.processEvent(createPayload(store))) {
+            _.left.value shouldBe a[StoredWorkRetrievalError[_]]
+          }
+
           sendNotificationToSQS(queue, createPayload(store))
 
           eventually {

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiTransformer.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiTransformer.scala
@@ -32,6 +32,24 @@ class TeiTransformer(teiReader: Readable[S3ObjectLocation, String])
         handleTeiDelete(id, version, time)
     }
 
+  /** A deletion has no XML to parse, so the inner works it used to have are
+    * only knowable from the previously stored work. The merger needs them to
+    * delete the children.
+    */
+  override def reconcileWithStored(
+    newWork: Work[Source],
+    storedWork: Work[Source]
+  ): Work[Source] =
+    newWork match {
+      case w: Work.Deleted[Source] if w.state.internalWorkStubs.isEmpty =>
+        w.copy(
+          state = w.state.copy(
+            internalWorkStubs = storedWork.state.internalWorkStubs
+          )
+        )
+      case _ => newWork
+    }
+
   private def handleTeiDelete(id: String, version: Int, time: Instant) =
     Right(
       Work.Deleted[Source](

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiTransformer.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiTransformer.scala
@@ -50,6 +50,15 @@ class TeiTransformer(teiReader: Readable[S3ObjectLocation, String])
       case _ => newWork
     }
 
+  /** Sending a deletion without its stubs loses them for good: it overwrites
+    * the stored work that held them, so a replay has nothing left to read.
+    */
+  override def requiresStoredWork(newWork: Work[Source]): Boolean =
+    newWork match {
+      case w: Work.Deleted[Source] => w.state.internalWorkStubs.isEmpty
+      case _                       => false
+    }
+
   private def handleTeiDelete(id: String, version: Int, time: Instant) =
     Right(
       Work.Deleted[Source](

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiTransformerTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiTransformerTest.scala
@@ -25,6 +25,7 @@ import weco.storage.store.memory.MemoryStore
 
 import java.nio.charset.StandardCharsets
 import java.time.Instant
+import scala.util.Random
 
 class TeiTransformerTest
     extends AnyFunSpec
@@ -308,6 +309,123 @@ class TeiTransformerTest
       )
     )
   }
+
+  describe("reconciling a delete with the stored work") {
+    it("copies the internal work stubs from the stored work") {
+      val stubs = List(createInternalWorkSource, createInternalWorkSource)
+      val reconciled = new TeiTransformer(emptyStore).reconcileWithStored(
+        newWork = deletedWork(),
+        storedWork = visibleWorkWithStubs(stubs)
+      )
+
+      reconciled shouldBe a[Work.Deleted[_]]
+      reconciled.state.internalWorkStubs shouldBe stubs
+    }
+
+    it("leaves the delete alone if the stored work has no stubs") {
+      val delete = deletedWork()
+      new TeiTransformer(emptyStore).reconcileWithStored(
+        newWork = delete,
+        storedWork = visibleWorkWithStubs(stubs = Nil)
+      ) shouldBe delete
+    }
+
+    it("keeps the stubs it already has rather than taking the stored ones") {
+      // The guard that makes this hold is what stops a replay overwriting a
+      // delete that has already been reconciled, which would resend forever.
+      val alreadyReconciled = List(createInternalWorkSource)
+      val different = List(createInternalWorkSource, createInternalWorkSource)
+
+      val reconciled = new TeiTransformer(emptyStore).reconcileWithStored(
+        newWork = deletedWorkWithStubs(alreadyReconciled),
+        storedWork = visibleWorkWithStubs(different)
+      )
+
+      reconciled.state.internalWorkStubs shouldBe alreadyReconciled
+      reconciled.state.internalWorkStubs should not be different
+    }
+
+    it("leaves a work that isn't a delete untouched") {
+      val newWork = visibleWorkWithStubs(stubs = Nil)
+      new TeiTransformer(emptyStore).reconcileWithStored(
+        newWork = newWork,
+        storedWork = visibleWorkWithStubs(List(createInternalWorkSource))
+      ) shouldBe newWork
+    }
+
+    it("is a fixed point on an already-reconciled delete") {
+      // Replays have to be stable: a second delete must produce the same
+      // document as the stored one, or it re-sends forever.
+      val stubs = List(createInternalWorkSource)
+      val transformer = new TeiTransformer(emptyStore)
+      val reconciled = transformer.reconcileWithStored(
+        newWork = deletedWork(),
+        storedWork = visibleWorkWithStubs(stubs)
+      )
+
+      transformer.reconcileWithStored(
+        newWork = deletedWork(),
+        storedWork = reconciled
+      ) shouldBe reconciled
+      transformer.reconcileWithStored(
+        newWork = reconciled,
+        storedWork = reconciled
+      ) shouldBe reconciled
+    }
+  }
+
+  private val deleteId = "manuscript_15651"
+  private val deleteSourceIdentifier = SourceIdentifier(
+    identifierType = IdentifierType.Tei,
+    ontologyType = "Work",
+    value = deleteId
+  )
+  private val deleteTime = instantInLast30Days
+
+  private def emptyStore = new MemoryStore[S3ObjectLocation, String](Map.empty)
+
+  private def deletedWork(): Work[Source] =
+    Work.Deleted[Source](
+      version = 1,
+      state = Source(deleteSourceIdentifier, deleteTime),
+      deletedReason = DeletedReason.DeletedFromSource("Deleted by TEI source")
+    )
+
+  private def deletedWorkWithStubs(
+    stubs: List[InternalWork.Source]
+  ): Work[Source] =
+    Work.Deleted[Source](
+      version = 1,
+      state = Source(
+        sourceIdentifier = deleteSourceIdentifier,
+        sourceModifiedTime = deleteTime,
+        internalWorkStubs = stubs
+      ),
+      deletedReason = DeletedReason.DeletedFromSource("Deleted by TEI source")
+    )
+
+  private def visibleWorkWithStubs(
+    stubs: List[InternalWork.Source]
+  ): Work[Source] =
+    Work.Visible[Source](
+      version = 1,
+      state = Source(
+        sourceIdentifier = deleteSourceIdentifier,
+        sourceModifiedTime = deleteTime,
+        internalWorkStubs = stubs
+      ),
+      data = WorkData[Unidentified](title = Some("A TEI manuscript"))
+    )
+
+  private def createInternalWorkSource: InternalWork.Source =
+    InternalWork.Source(
+      sourceIdentifier = SourceIdentifier(
+        identifierType = IdentifierType.Tei,
+        ontologyType = "Work",
+        value = s"${deleteId}_${Random.alphanumeric.take(6).mkString}"
+      ),
+      workData = WorkData[Unidentified](title = Some("An inner work"))
+    )
 
   private def transformToWork(filename: String)(
     id: String,

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiTransformerTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiTransformerTest.scala
@@ -374,6 +374,26 @@ class TeiTransformerTest
     }
   }
 
+  describe("deciding whether the stored work is required") {
+    it("requires it for a delete that has no stubs of its own") {
+      new TeiTransformer(emptyStore).requiresStoredWork(
+        deletedWork()
+      ) shouldBe true
+    }
+
+    it("does not require it for a delete that already carries its stubs") {
+      new TeiTransformer(emptyStore).requiresStoredWork(
+        deletedWorkWithStubs(List(createInternalWorkSource))
+      ) shouldBe false
+    }
+
+    it("does not require it for a work that isn't a delete") {
+      new TeiTransformer(emptyStore).requiresStoredWork(
+        visibleWorkWithStubs(stubs = Nil)
+      ) shouldBe false
+    }
+  }
+
   private val deleteId = "manuscript_15651"
   private val deleteSourceIdentifier = SourceIdentifier(
     identifierType = IdentifierType.Tei,


### PR DESCRIPTION
## What does this change?

Fixes the parent-deletion half of wellcomecollection/platform#6471. Deliberately not a closing reference: the rename half needs a further change, described under Scope below, so the issue should stay open.

TEI manuscripts produce inner works from `msItem` and `msPart` elements. They are not source records: the merger synthesises them on every merge from the parent's `internalWorkStubs`. Nothing has ever deleted them, so deleting a parent left every child behind, still advertising a `partOf` pointing at a work the API now returns 410 for.

Confirmed live on 2026-08-10 while piloting the retraction in wellcomecollection/platform#6504: deleting `MS_197` took the parent `aknvf9qw` to 410 Gone and left `akpvxvj5` at 200. Retracting that folder would strand 462 such works, several of them phantom duplicates of the record they were meant to describe.

A deletion has no XML to parse, so the stubs are only knowable from the previously stored work. `TransformerWorker` already retrieves that work on every message, to decide whether re-sending would be a no-op, so the change is:

- `Transformer` gains a `reconcileWithStored` hook, concrete and defaulting to a no-op, so no other source is affected and the SAM conversion in the Sierra transformer's `Main` still compiles.
- `TeiTransformer` overrides it to carry the stored stubs onto a deleted work whose own stub list is empty.
- `Merger.merge` wraps the existing body and turns a deleted work's stubs into `Work.Deleted` children, deduplicated against what the merge already emitted.

The `isEmpty` guard on the override is what makes replays stable: once a reconciled delete is stored, reconciling again produces the same document, so `areEquivalent` holds and nothing resends in a loop.

Downstream needs no change. The id minter walks any node carrying a `sourceIdentifier` with no knowledge of `internalWorkStubs`, and minting is lookup-or-create, so deleted children keep the canonical ids they already have. Work nodes reach the graph from a source filtered on `{"match": {"type": "Visible"}}`, and `CatalogueWorkIdentifiersGraphRemover` drops path identifiers once disconnected, so the graph sheds the children on its own.

### Checklist

- [x] Does this change the display model the catalogue API returns? No. It changes which works are deleted.

## How to test

`sbt "transformer_tei/test" "transformer_common/test" "merger/test"`, with `docker compose up` in `pipeline/transformer/transformer_common` and `pipeline/matcher_merger/merger` first. All three suites pass: 165, 58 and 256 tests, the last including `MergerIntegrationTest`.

The new tests were checked against the mutations they exist to catch, rather than assumed to work:

- Changing `Right(Some((reconciledWork, key)))` back to `transformedWork` in `TransformerWorker` makes "indexes the work returned by reconcileWithStored, not the transformed one" fail. Without that test the substitution is silent: every TEI delete would ship with `internalWorkStubs: []` and every other test still passes.
- Removing the `isEmpty` guard from the override makes "keeps the stubs it already has rather than taking the stored ones" fail.

`PlatformMergerTest` keeps its existing "returns both Works unmodified if one of the Works is deleted", which is the guard that a stub-free deleted work still emits nothing extra.

## Scope

Only the parent-deletion case. The rename case in the same issue, where an `msItem` id changes and the old inner work is orphaned alongside the new one, needs somewhere to record the stubs that have gone, which means a new field on `WorkState.Source` and `WorkState.Identified`. That would put every stored `works-source` and `works-identified` document for all five Scala sources behind an assumption about circe `useDefaults` that I have not verified, so it belongs in its own change.

## Risks

`TransformerWorker` is shared by Sierra, Calm, METS, Miro, EBSCO and Axiell. The hook defaults to returning the new work unchanged, so those sources see no behaviour change, which the existing suites cover.

The one behaviour change beyond TEI is in the retriever's `recover` block. A genuine retrieval failure now logs at `warn` with the exception attached, and if the transformer says it needs the stored work, the message fails and dead-letters rather than being sent in a state we know to be wrong. Only TEI says that, and only for a deletion carrying no stubs of its own, so the other sources still send as before. Not-found is unchanged and still sends, since it fires on the first sighting of every record.

That guard exists because the failure was worse than a missed deletion. `batchIndexAndSendFlow` indexes before it sends, and `ElasticIndexer` writes with `ExternalGte` versioning, so a stub-free delete overwrites the stored work that held the stubs. A replay then reconciles against a delete with nothing in it and produces the same document, leaving the record exactly as the bug leaves it today. Dropping the deletion is permanent; dead-lettering the message is one redrive. Raised by @agnesgaroux in review.

