### PR TITLE
Point the incremental works ingest at works-indexed-2026-07-30

### DIFF
--- a/pipeline/terraform/2025-10-02/main.tf
+++ b/pipeline/terraform/2025-10-02/main.tf
@@ -18,7 +18,7 @@ module "pipeline" {
   graph_index_dates = {
     merged    = "2025-10-02"
     augmented = "2026-06-15"
-    works     = "2026-03-03"
+    works     = "2026-07-30"
     concepts  = "2026-03-03"
     images    = "2026-04-29"
   }


### PR DESCRIPTION
## What does this change?

Moves `graph_index_dates.works` on the 2025-10-02 stack from `2026-03-03` to `2026-07-30`, so the 15-minute incremental pipeline maintains the new archive-browsing index instead of the current prod index.

Part of wellcomecollection/platform#6509. This must be merged together with #3521 while the incremental schedule is paused, then applied manually: the #3521 merge auto-retags the pipeline images, and the new ingestor code emits fields (`query.collectionPath.sort` and the archive/collection blocks) that the strict `works-indexed-2026-03-03` mapping rejects, so incremental windows would fail until ingest points at the new index.

From the apply onwards `works-indexed-2026-03-03` is frozen; the API keeps serving it until the ElasticConfig flip in catalogue-api.

## How to test

`terraform plan` on the 2025-10-02 stack should show only the ingest target change plus the #3521 mapping additions applied in place.

## Have we considered potential risks?

The apply rotates the pipeline ES API keys, which the catalogue API is built to tolerate. Prod search data goes stale from the apply until the index flip, so the remaining phases of platform#6509 should follow within days.