### PR TITLE
Add query.source.collectionPath.sort to the images mapping

### DIFF
--- a/index_config/mappings.images_indexed.2024-11-14.json
+++ b/index_config/mappings.images_indexed.2024-11-14.json
@@ -289,6 +289,9 @@
                       "search_analyzer": "whitespace"
                     }
                   }
+                },
+                "sort": {
+                  "type": "keyword"
                 }
               }
             },

--- a/pipeline/terraform/2026-07-03/elastic.tf
+++ b/pipeline/terraform/2026-07-03/elastic.tf
@@ -28,7 +28,7 @@ locals {
         // matcher_merger - graph/ingestor/indexer
         denormalised = "works_denormalised.2025-08-14"
         // graph/ingestor/indexer - API
-        indexed = "works_indexed.2024-11-14"
+        indexed = "works_indexed.2026-07-30"
       }
       images = {
         // matcher_merger - images_inferrer


### PR DESCRIPTION
## What does this change?

Fixes incremental window failures that started 2026-08-10 14:05 on both pipeline stacks, after #3521 deployed.

`QueryImage` embeds the full `QueryWork` as `source`, so the new `collectionPath.sort` field now appears in image documents whose source work has a collection path. The strict `images_indexed.2024-11-14` mapping rejects it (`strict_dynamic_mapping_exception`), failing the images ingestor and aborting the whole window fan-out. Adds `sort` as a keyword under `query.source.collectionPath`, matching the works mapping.

Also moves the 2026-07-03 stack's works index onto the `works_indexed.2026-07-30` mappings: its ingest runs the same new code, so its works index needs the archive fields too (this was already planned ahead of the wellcomecollection/platform#6505 reindex). The frozen prod works index (`works-indexed-2026-03-03`) keeps the untouched 2024-11-14 works mappings.

Part of wellcomecollection/platform#6509.

## How to test

`terraform plan` on each stack should show in-place mapping updates only: `images-indexed-2026-04-29` (2025-10-02 stack) and `images-indexed-2026-07-03` plus `works-indexed-2026-07-03` (2026-07-03 stack).

## Have we considered potential risks?

Purely additive mapping changes. After applying, the failed windows need replaying with fresh StartExecutions.