### PR TITLE
Delete inner works whose stub has gone from the record

### DIFF
--- a/catalogue_graph/src/models/pipeline/source/work.py
+++ b/catalogue_graph/src/models/pipeline/source/work.py
@@ -9,6 +9,7 @@ class SourceWorkState(WorkState):
     # We don't need the internal_work_stubs in python, but to allow
     # deserialisation in the scala pipeline, we include them here.
     internal_work_stubs: list[str] = Field(default_factory=list)
+    removed_internal_work_stubs: list[str] = Field(default_factory=list)
     merge_candidates: list[MergeCandidate] = Field(default_factory=list)
     modified_time: str
 

--- a/catalogue_graph/tests/fixtures/work/visible_source_maximal.json
+++ b/catalogue_graph/tests/fixtures/work/visible_source_maximal.json
@@ -242,6 +242,7 @@
     "modifiedTime": "2025-10-24T01:00:00Z",
     "relations": null,
     "internalWorkStubs": [],
+    "removedInternalWorkStubs": [],
     "mergeCandidates": []
   }
 }

--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Work.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/work/Work.scala
@@ -182,7 +182,10 @@ object WorkState {
     sourceModifiedTime: Instant,
     mergeCandidates: List[MergeCandidate[IdState.Identifiable]] = Nil,
     internalWorkStubs: List[InternalWork.Source] = Nil,
-    relations: Relations = Relations.none
+    relations: Relations = Relations.none,
+    // Stubs this work used to have. The merger synthesises inner works from
+    // internalWorkStubs, so dropping one silently orphans its work.
+    removedInternalWorkStubs: List[InternalWork.Source] = Nil
   ) extends WorkState {
 
     type WorkDataState = DataState.Unidentified
@@ -199,7 +202,8 @@ object WorkState {
     sourceModifiedTime: Instant,
     mergeCandidates: List[MergeCandidate[IdState.Identified]] = Nil,
     internalWorkStubs: List[InternalWork.Identified] = Nil,
-    relations: Relations = Relations.none
+    relations: Relations = Relations.none,
+    removedInternalWorkStubs: List[InternalWork.Identified] = Nil
   ) extends WorkState {
 
     type WorkDataState = DataState.Identified

--- a/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/WorkTest.scala
+++ b/common/internal_model/src/test/scala/weco/catalogue/internal_model/work/WorkTest.scala
@@ -66,6 +66,26 @@ class WorkTest extends AnyFunSpec with Matchers with WorkGenerators {
     )
   }
 
+  it("parses a stored Work that predates removedInternalWorkStubs") {
+    // Every work already in works-source and works-identified was written
+    // without this field, and the transformer reads them back to reconcile.
+    val stored: Work[WorkState.Identified] = identifiedWork()
+    val encoded = io.circe.parser.parse(toJson(stored).get).right.get
+    val state = encoded.hcursor.downField("state")
+
+    // Fails if the field moves and the removal below stops doing anything.
+    state.keys.get should contain("removedInternalWorkStubs")
+
+    val withoutField = state
+      .withFocus(_.mapObject(_.remove("removedInternalWorkStubs")))
+      .top
+      .get
+
+    fromJson[Work[WorkState.Identified]](
+      withoutField.noSpaces
+    ).get.state.removedInternalWorkStubs shouldBe empty
+  }
+
   it("preserves redirect sources when transitioning Work.Visible") {
     val redirectSources = (1 to 3).map {
       _ =>

--- a/pipeline/matcher_merger/merger/src/main/scala/weco/pipeline/merger/services/Merger.scala
+++ b/pipeline/matcher_merger/merger/src/main/scala/weco/pipeline/merger/services/Merger.scala
@@ -73,7 +73,7 @@ trait Merger extends MergerLogging {
     val outcome = mergeWorks(works)
     outcome.copy(
       resultWorks =
-        outcome.resultWorks ++ deletedInternalWorks(outcome.resultWorks)
+        outcome.resultWorks ++ deletedInternalWorks(works, outcome.resultWorks)
     )
   }
 
@@ -152,36 +152,50 @@ trait Merger extends MergerLogging {
       }
   }
 
-  /** Inner works are synthesised from the parent's stubs on every merge, so
-    * deleting a parent has to delete them explicitly.
+  /** Inner works are synthesised from the parent's stubs on every merge, so an
+    * inner work only stops being made when its stub goes. Both ways that
+    * happens, the whole parent being deleted and a single stub being removed
+    * from it, leave a work behind that has to be deleted explicitly.
+    *
+    * Removals are read from the works going in rather than the ones coming out,
+    * because a TEI work that loses the merge is redirected and its stubs are
+    * dropped on the way.
     */
   private def deletedInternalWorks(
+    works: Seq[Work[Identified]],
     resultWorks: Seq[Work[Identified]]
   ): Seq[Work.Deleted[Identified]] = {
     val alreadyEmitted = resultWorks.map(_.state.canonicalId).toSet
 
-    resultWorks
+    val deletedParents = resultWorks
       .collect { case w: Work.Deleted[Identified] => w }
-      .flatMap {
+      .flatMap(
+        parent => parent.state.internalWorkStubs.map(deleteChildOf(parent))
+      )
+
+    val removedStubs = works
+      .flatMap(
         parent =>
-          parent.state.internalWorkStubs.map {
-            case InternalWork.Identified(sourceIdentifier, canonicalId, _) =>
-              Work.Deleted[Identified](
-                version = parent.version,
-                state = Identified(
-                  sourceIdentifier = sourceIdentifier,
-                  canonicalId = canonicalId,
-                  sourceModifiedTime = parent.state.sourceModifiedTime
-                ),
-                deletedReason = DeletedReason.TeiDeletedInMerger
-              )
-          }
-      }
-      .filterNot {
-        child => alreadyEmitted.contains(child.state.canonicalId)
-      }
-      .distinct
+          parent.state.removedInternalWorkStubs.map(deleteChildOf(parent))
+      )
+
+    (deletedParents ++ removedStubs).filterNot {
+      child => alreadyEmitted.contains(child.state.canonicalId)
+    }.distinct
   }
+
+  private def deleteChildOf(
+    parent: Work[Identified]
+  )(stub: InternalWork.Identified): Work.Deleted[Identified] =
+    Work.Deleted[Identified](
+      version = parent.version,
+      state = Identified(
+        sourceIdentifier = stub.sourceIdentifier,
+        canonicalId = stub.canonicalId,
+        sourceModifiedTime = parent.state.sourceModifiedTime
+      ),
+      deletedReason = DeletedReason.TeiDeletedInMerger
+    )
 
   private def redirectSourceToTarget(
     target: Work.Visible[Identified]

--- a/pipeline/matcher_merger/merger/src/main/scala/weco/pipeline/merger/services/Merger.scala
+++ b/pipeline/matcher_merger/merger/src/main/scala/weco/pipeline/merger/services/Merger.scala
@@ -160,6 +160,17 @@ trait Merger extends MergerLogging {
     * Removals are read from the works going in rather than the ones coming out,
     * because a TEI work that loses the merge is redirected and its stubs are
     * dropped on the way.
+    *
+    * WARNING: removals are never pruned, so a parent re-emits a delete for
+    * every stub it has ever lost, on every merge. That is harmless for an id
+    * that was renamed and never seen again, but wrong for one that MOVED to
+    * another manuscript under the same id: this parent deletes it on every
+    * update, while the new parent only revives it when the new parent itself
+    * changes, so the work flips between deleted and visible depending on which
+    * was touched last. Fixing it properly needs state this stage does not have,
+    * either a record of which removals have already been actioned or a lookup
+    * of who currently claims the id. Worth designing in when the merger is
+    * rewritten in Python rather than bolting onto this one.
     */
   private def deletedInternalWorks(
     works: Seq[Work[Identified]],

--- a/pipeline/matcher_merger/merger/src/test/scala/weco/pipeline/merger/services/PlatformMergerTest.scala
+++ b/pipeline/matcher_merger/merger/src/test/scala/weco/pipeline/merger/services/PlatformMergerTest.scala
@@ -1191,6 +1191,70 @@ class PlatformMergerTest
       } should contain theSameElementsAs
         deletedTeiWork.state.canonicalId +: stubs.map(_.canonicalId)
     }
+
+    it("deletes an inner work whose stub has been removed from the record") {
+      val kept = createInternalWorkStub
+      val removed = createInternalWorkStub
+      val teiWork = teiIdentifiedWork().mapState {
+        _.copy(
+          internalWorkStubs = List(kept),
+          removedInternalWorkStubs = List(removed)
+        )
+      }
+
+      val result = merger.merge(works = Seq(teiWork))
+
+      result.resultWorks.collect {
+        case w: Work.Visible[Identified] => w.state.canonicalId
+      } should contain theSameElementsAs Seq(
+        teiWork.state.canonicalId,
+        kept.canonicalId
+      )
+
+      val deleted = result.resultWorks.collect {
+        case w: Work.Deleted[Identified] => w
+      }
+      deleted.map(_.state.canonicalId) shouldBe Seq(removed.canonicalId)
+      deleted.head.deletedReason shouldBe DeletedReason.TeiDeletedInMerger
+    }
+
+    it("deletes removed inner works of a TEI work that loses the merge") {
+      // An EBSCO work outranks TEI, so the TEI work is redirected and its
+      // stubs are dropped from the result. The removals still have to happen.
+      val removed = createInternalWorkStub
+      val teiWork = teiIdentifiedWork().mapState {
+        _.copy(removedInternalWorkStubs = List(removed))
+      }
+      val ebscoWork = ebscoIdentifiedWork()
+
+      val result = merger.merge(works = Seq(ebscoWork, teiWork))
+
+      result.resultWorks.collect {
+        case w: Work.Deleted[Identified] => w.state.canonicalId
+      } shouldBe Seq(removed.canonicalId)
+    }
+
+    it("never deletes an inner work it has just emitted") {
+      // The transformer drops a stub from the removed list when the record
+      // takes it back, so the two lists should not overlap. If they ever do,
+      // the live work has to win over the delete.
+      val contested = createInternalWorkStub
+      val teiWork = teiIdentifiedWork().mapState {
+        _.copy(
+          internalWorkStubs = List(contested),
+          removedInternalWorkStubs = List(contested)
+        )
+      }
+
+      val result = merger.merge(works = Seq(teiWork))
+
+      result.resultWorks.collect {
+        case w: Work.Deleted[Identified] => w.state.canonicalId
+      } shouldBe empty
+      result.resultWorks.collect {
+        case w: Work.Visible[Identified] => w.state.canonicalId
+      } should contain(contested.canonicalId)
+    }
   }
 
   it("passes a Folio work through the merger unchanged") {

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiTransformer.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiTransformer.scala
@@ -9,6 +9,7 @@ import weco.catalogue.internal_model.work.{
   DeletedReason,
   InternalWork,
   Work,
+  WorkData,
   WorkState
 }
 import weco.catalogue.source_model.tei.{
@@ -77,6 +78,9 @@ class TeiTransformer(teiReader: Readable[S3ObjectLocation, String])
 
     (storedState.internalWorkStubs ++ storedState.removedInternalWorkStubs)
       .filterNot(stub => present.contains(stub.sourceIdentifier))
+      // The merger only needs the ids to delete the work, and this list is
+      // never pruned, so keeping the data would grow the record forever.
+      .map(_.copy(workData = WorkData()))
       .distinct
   }
 

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiTransformer.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiTransformer.scala
@@ -5,7 +5,12 @@ import weco.catalogue.internal_model.identifiers.{
   SourceIdentifier
 }
 import weco.catalogue.internal_model.work.WorkState.Source
-import weco.catalogue.internal_model.work.{DeletedReason, Work, WorkState}
+import weco.catalogue.internal_model.work.{
+  DeletedReason,
+  InternalWork,
+  Work,
+  WorkState
+}
 import weco.catalogue.source_model.tei.{
   TeiChangedMetadata,
   TeiDeletedMetadata,
@@ -44,18 +49,46 @@ class TeiTransformer(teiReader: Readable[S3ObjectLocation, String])
       case w: Work.Deleted[Source] if w.state.internalWorkStubs.isEmpty =>
         w.copy(
           state = w.state.copy(
-            internalWorkStubs = storedWork.state.internalWorkStubs
+            internalWorkStubs = storedWork.state.internalWorkStubs,
+            // A removal the merger has not acted on yet would otherwise be
+            // dropped by the deletion that follows it.
+            removedInternalWorkStubs = storedWork.state.removedInternalWorkStubs
+          )
+        )
+      case w: Work.Visible[Source] =>
+        w.copy(state =
+          w.state.copy(
+            removedInternalWorkStubs = removedStubs(w.state, storedWork.state)
           )
         )
       case _ => newWork
     }
 
-  /** Sending a deletion without its stubs loses them for good: it overwrites
-    * the stored work that held them, so a replay has nothing left to read.
+  /** A stub that has gone from the XML leaves an inner work behind, and the
+    * next version of the record is the only place that is visible. Carrying the
+    * stored list forward keeps ids that earlier versions dropped, since a
+    * removal is only ever seen once.
+    */
+  private def removedStubs(
+    newState: Source,
+    storedState: Source
+  ): List[InternalWork.Source] = {
+    val present = newState.internalWorkStubs.map(_.sourceIdentifier).toSet
+
+    (storedState.internalWorkStubs ++ storedState.removedInternalWorkStubs)
+      .filterNot(stub => present.contains(stub.sourceIdentifier))
+      .distinct
+  }
+
+  /** Sending either kind of work unreconciled loses the stubs for good: it
+    * overwrites the stored work that held them, so a replay has nothing left to
+    * read. A missing work is different, and still sends: see the not-found
+    * branch in TransformerWorker.
     */
   override def requiresStoredWork(newWork: Work[Source]): Boolean =
     newWork match {
       case w: Work.Deleted[Source] => w.state.internalWorkStubs.isEmpty
+      case _: Work.Visible[Source] => true
       case _                       => false
     }
 

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiTransformerTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiTransformerTest.scala
@@ -322,6 +322,23 @@ class TeiTransformerTest
       reconciled.state.internalWorkStubs shouldBe stubs
     }
 
+    it("carries forward a removal the merger has not acted on yet") {
+      // The transformer indexes before it sends, so a removal can be stored
+      // while its delete is still unsent. A deletion arriving in that window
+      // must not drop it, or the inner work is orphaned for good.
+      val kept = createInternalWorkSource
+      val removed = createInternalWorkSource
+
+      val reconciled = new TeiTransformer(emptyStore).reconcileWithStored(
+        newWork = deletedWork(),
+        storedWork =
+          visibleWorkWith(stubs = List(kept), removed = List(removed))
+      )
+
+      reconciled.state.internalWorkStubs shouldBe List(kept)
+      reconciled.state.removedInternalWorkStubs shouldBe List(removed)
+    }
+
     it("leaves the delete alone if the stored work has no stubs") {
       val delete = deletedWork()
       new TeiTransformer(emptyStore).reconcileWithStored(
@@ -345,14 +362,6 @@ class TeiTransformerTest
       reconciled.state.internalWorkStubs should not be different
     }
 
-    it("leaves a work that isn't a delete untouched") {
-      val newWork = visibleWorkWithStubs(stubs = Nil)
-      new TeiTransformer(emptyStore).reconcileWithStored(
-        newWork = newWork,
-        storedWork = visibleWorkWithStubs(List(createInternalWorkSource))
-      ) shouldBe newWork
-    }
-
     it("is a fixed point on an already-reconciled delete") {
       // Replays have to be stable: a second delete must produce the same
       // document as the stored one, or it re-sends forever.
@@ -374,6 +383,108 @@ class TeiTransformerTest
     }
   }
 
+  describe("reconciling a changed record with the stored work") {
+    it("records a stub the record no longer has") {
+      val kept = createInternalWorkSource
+      val removed = createInternalWorkSource
+
+      val reconciled = new TeiTransformer(emptyStore).reconcileWithStored(
+        newWork = visibleWorkWithStubs(List(kept)),
+        storedWork = visibleWorkWithStubs(List(kept, removed))
+      )
+
+      reconciled.state.internalWorkStubs shouldBe List(kept)
+      reconciled.state.removedInternalWorkStubs shouldBe List(removed)
+    }
+
+    it("records nothing when the record still has every stub") {
+      val newWork = visibleWorkWithStubs(List(createInternalWorkSource))
+      new TeiTransformer(emptyStore).reconcileWithStored(
+        newWork = newWork,
+        storedWork = newWork
+      ) shouldBe newWork
+    }
+
+    it("keeps removals the stored work already carried") {
+      // A stub is only seen to go once, on the version that drops it, so the
+      // list has to accumulate rather than be recomputed each time.
+      val kept = createInternalWorkSource
+      val removedEarlier = createInternalWorkSource
+      val removedNow = createInternalWorkSource
+
+      val reconciled = new TeiTransformer(emptyStore).reconcileWithStored(
+        newWork = visibleWorkWithStubs(List(kept)),
+        storedWork = visibleWorkWith(
+          stubs = List(kept, removedNow),
+          removed = List(removedEarlier)
+        )
+      )
+
+      reconciled.state.removedInternalWorkStubs should contain theSameElementsAs List(
+        removedEarlier,
+        removedNow
+      )
+    }
+
+    it("drops a removal when the stub comes back") {
+      // Deleting a work that the record has readopted would take a live inner
+      // work out of the catalogue.
+      val restored = createInternalWorkSource
+
+      val reconciled = new TeiTransformer(emptyStore).reconcileWithStored(
+        newWork = visibleWorkWithStubs(List(restored)),
+        storedWork = visibleWorkWith(stubs = Nil, removed = List(restored))
+      )
+
+      reconciled.state.removedInternalWorkStubs shouldBe empty
+    }
+
+    it("brings a stub back cleanly when the record is revived") {
+      // Removed then readded: the merger has to stop deleting it and start
+      // making it again, so the removal must not survive the revival.
+      val revived = createInternalWorkSource
+      val transformer = new TeiTransformer(emptyStore)
+
+      val present = visibleWorkWithStubs(List(revived))
+      val removed =
+        transformer.reconcileWithStored(
+          newWork = visibleWorkWithStubs(Nil),
+          storedWork = present
+        )
+      removed.state.removedInternalWorkStubs shouldBe List(revived)
+
+      val restored =
+        transformer.reconcileWithStored(newWork = present, storedWork = removed)
+      restored.state.internalWorkStubs shouldBe List(revived)
+      restored.state.removedInternalWorkStubs shouldBe empty
+
+      // And a second removal is still caught after the revival.
+      transformer
+        .reconcileWithStored(
+          newWork = visibleWorkWithStubs(Nil),
+          storedWork = restored
+        )
+        .state
+        .removedInternalWorkStubs shouldBe List(revived)
+    }
+
+    it("is a fixed point on an already-reconciled record") {
+      val kept = createInternalWorkSource
+      val removed = createInternalWorkSource
+      val transformer = new TeiTransformer(emptyStore)
+
+      val reconciled = transformer.reconcileWithStored(
+        newWork = visibleWorkWithStubs(List(kept)),
+        storedWork = visibleWorkWithStubs(List(kept, removed))
+      )
+
+      transformer.reconcileWithStored(
+        newWork = visibleWorkWithStubs(List(kept)),
+        storedWork = reconciled
+      ) shouldBe reconciled
+    }
+  }
+
   describe("deciding whether the stored work is required") {
     it("requires it for a delete that has no stubs of its own") {
       new TeiTransformer(emptyStore).requiresStoredWork(
@@ -387,10 +498,11 @@ class TeiTransformerTest
       ) shouldBe false
     }
 
-    it("does not require it for a work that isn't a delete") {
+    it("requires it for a changed record, where removals are only visible") {
+      // Nothing in the XML says which stubs used to be there.
       new TeiTransformer(emptyStore).requiresStoredWork(
         visibleWorkWithStubs(stubs = Nil)
-      ) shouldBe false
+      ) shouldBe true
     }
   }
 
@@ -426,13 +538,19 @@ class TeiTransformerTest
 
   private def visibleWorkWithStubs(
     stubs: List[InternalWork.Source]
+  ): Work[Source] = visibleWorkWith(stubs = stubs, removed = Nil)
+
+  private def visibleWorkWith(
+    stubs: List[InternalWork.Source],
+    removed: List[InternalWork.Source]
   ): Work[Source] =
     Work.Visible[Source](
       version = 1,
       state = Source(
         sourceIdentifier = deleteSourceIdentifier,
         sourceModifiedTime = deleteTime,
-        internalWorkStubs = stubs
+        internalWorkStubs = stubs,
+        removedInternalWorkStubs = removed
       ),
       data = WorkData[Unidentified](title = Some("A TEI manuscript"))
     )

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiTransformerTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiTransformerTest.scala
@@ -394,7 +394,23 @@ class TeiTransformerTest
       )
 
       reconciled.state.internalWorkStubs shouldBe List(kept)
-      reconciled.state.removedInternalWorkStubs shouldBe List(removed)
+      idsOf(reconciled.state.removedInternalWorkStubs) shouldBe
+        List(removed.sourceIdentifier)
+    }
+
+    it("drops the data from a removed stub, keeping only its identity") {
+      // The list is never pruned, so keeping the data would grow the record
+      // forever. The merger only needs the ids to delete the work.
+      val removed = createInternalWorkSource
+      removed.workData.title should not be empty
+
+      val reconciled = new TeiTransformer(emptyStore).reconcileWithStored(
+        newWork = visibleWorkWithStubs(Nil),
+        storedWork = visibleWorkWithStubs(List(removed))
+      )
+
+      reconciled.state.removedInternalWorkStubs.head.workData shouldBe
+        WorkData[Unidentified]()
     }
 
     it("records nothing when the record still has every stub") {
@@ -420,10 +436,11 @@ class TeiTransformerTest
         )
       )
 
-      reconciled.state.removedInternalWorkStubs should contain theSameElementsAs List(
-        removedEarlier,
-        removedNow
-      )
+      idsOf(reconciled.state.removedInternalWorkStubs) should
+        contain theSameElementsAs List(
+          removedEarlier.sourceIdentifier,
+          removedNow.sourceIdentifier
+        )
     }
 
     it("drops a removal when the stub comes back") {
@@ -451,7 +468,8 @@ class TeiTransformerTest
           newWork = visibleWorkWithStubs(Nil),
           storedWork = present
         )
-      removed.state.removedInternalWorkStubs shouldBe List(revived)
+      idsOf(removed.state.removedInternalWorkStubs) shouldBe
+        List(revived.sourceIdentifier)
 
       val restored =
         transformer.reconcileWithStored(newWork = present, storedWork = removed)
@@ -465,7 +483,8 @@ class TeiTransformerTest
           storedWork = restored
         )
         .state
-        .removedInternalWorkStubs shouldBe List(revived)
+        .removedInternalWorkStubs
+        .map(_.sourceIdentifier) shouldBe List(revived.sourceIdentifier)
     }
 
     it("is a fixed point on an already-reconciled record") {
@@ -554,6 +573,9 @@ class TeiTransformerTest
       ),
       data = WorkData[Unidentified](title = Some("A TEI manuscript"))
     )
+
+  private def idsOf(stubs: List[InternalWork.Source]): List[SourceIdentifier] =
+    stubs.map(_.sourceIdentifier)
 
   private def createInternalWorkSource: InternalWork.Source =
     InternalWork.Source(


### PR DESCRIPTION
## What does this change?

Stacked on #3557, which handles the other half of wellcomecollection/platform#6471. Review that one first: this branch contains its commits and the diff here will shrink once it merges.

wellcomecollection/platform#6471 describes a cataloguer renaming an `msItem`'s `xml:id`, `Amer_8_1` to `MS_Amer_8_1` in `Spanish/MS_Amer_8.xml`. The transformer rebuilds `internalWorkStubs` from scratch on every reprocess, so the old id simply stops appearing and nothing downstream is ever told it has gone. The merger synthesises inner works from those stubs on every merge, so the work the old stub produced is stranded. Across the TEI repository's history, 83 ids have been removed from 15 manuscripts that still exist. How many of those left a live orphan is not established: a removal only strands a work if the id was live long enough for one to be minted and indexed, and MS_Arabic_870, the one manuscript I checked against the index, turned out to have none.

```
                 version n              version n+1
  the record     msItem Amer_8_1   →    msItem MS_Amer_8_1

  before         stubs [Amer_8_1]       stubs [MS_Amer_8_1]
                 merger makes           merger makes
                 └─ Amer_8_1            └─ MS_Amer_8_1
                                        Amer_8_1 stays in the index,
                                        partOf a parent that has dropped it

  after          stubs   [MS_Amer_8_1]  (new parse)
                 removed [Amer_8_1]     (diffed against the stored work)
                 merger makes MS_Amer_8_1 and deletes Amer_8_1
```

This is the transform-time reconciliation the issue asks for, done against the previously stored work rather than a new table. `WorkState` now carries `removedInternalWorkStubs` beside the current stubs. The TEI transformer fills it in `reconcileWithStored`, and the merger deletes from it the same way #3557 deletes the children of a deleted parent.

Three things worth a look:

- The list accumulates rather than being recomputed. A removal is only ever seen on the one version that drops it, so recomputing would lose it on the next update. An id that comes back is taken out again, so a readopted stub is not deleted out from under the catalogue.
- The merger reads removals from the works going into the merge, not the ones coming out. A TEI work that loses a merge is redirected, and `redirectSourceToTarget` drops its stubs on the way, so reading the output would silently skip those records.
- `requiresStoredWork` now returns true for visible TEI works as well as stub-less deletes. The transformer indexes before it sends, so sending unreconciled overwrites the work that held the evidence and the removal is lost for good. The cost is that a genuine retrieval error now dead-letters any TEI change rather than passing it through. Not-found is a separate branch and still sends, so a reindex into a fresh pipeline is unaffected. I think this is the judgement call most worth a second opinion.

The display model is unchanged, so the test documents do not need regenerating: the new field is on `WorkState.Source` and `WorkState.Identified`, and the API reads `WorkState.Merged`.

## How to test

`merger/test`, `transformer_tei/test`, `internal_model/test`. The behavioural tests are "records a stub the record no longer has", "keeps removals the stored work already carried", "drops a removal when the stub comes back", "deletes an inner work whose stub has been removed from the record" and "deletes removed inner works of a TEI work that loses the merge". I mutation-tested each of them: breaking either half of the implementation fails them.

`WorkTest` asserts a stored work written before this field still decodes, and asserts the field is present before stripping it so it cannot pass vacuously. The Python id-minter needs no change because it walks raw documents for anything carrying a `sourceIdentifier`, so the removed stubs are minted alongside the current ones.

## How can we measure success?

A rename flowed through the 2026-07-03 pipeline should produce a `Deleted` work for the old id, and the API should return 410 for it rather than a work whose `partOf` disowns it.

This does not clear the existing orphans. For a rename that has already been transformed, `works-source` was overwritten at the moment it happened, so there is no stored evidence left to diff against. Those need a separate discovery route, most likely the identifiers table or the TEI git history, tracked on wellcomecollection/platform#6471.

## Have we considered potential risks?

The widened `requiresStoredWork` is the main one, described above: rare retrieval errors now dead-letter TEI changes. A dead-lettered message is one redrive, where a lost removal is permanent, which is why it is set that way.

A stub genuinely moving from one manuscript to another is a race this cannot settle. The two manuscripts are separate matcher graphs, so the delete from the old parent and the live work from the new one are separate merges with no ordering between them, and whichever lands last wins. The same race already exists for parent deletion. Within a single merge the live work wins, and there is a test for that.

