### PR TITLE
Quiesce the 2026-07-03 pipeline and pause the Axiell harvest for the round 2 clear

### DIFF
--- a/catalogue_graph/infra/adapters/main.tf
+++ b/catalogue_graph/infra/adapters/main.tf
@@ -16,11 +16,14 @@ module "ebsco" {
 }
 
 module "axiell" {
-  source                = "./modules/adapter"
-  namespace             = "axiell"
-  steps_namespace       = "oai_pmh"
-  s3_bucket_name        = "wellcomecollection-platform-axiell-adapter"
-  schedule_expression   = "rate(15 minutes)"
+  source              = "./modules/adapter"
+  namespace           = "axiell"
+  steps_namespace     = "oai_pmh"
+  s3_bucket_name      = "wellcomecollection-platform-axiell-adapter"
+  schedule_expression = "rate(15 minutes)"
+  # Paused for the round 2 clear (platform#6503): keeps the adapter store empty
+  # between the phase 6a wipe and the post-load rebuild.
+  schedule_enabled      = false
   repository_url        = data.aws_ecr_repository.unified_pipeline_lambda.repository_url
   event_bus_name        = aws_cloudwatch_event_bus.event_bus.name
   ecs_cluster_arn       = aws_ecs_cluster.adapters.arn

--- a/pipeline/terraform/2026-07-03/main.tf
+++ b/pipeline/terraform/2026-07-03/main.tf
@@ -1,8 +1,11 @@
 module "pipeline" {
   source = "../modules/pipeline_new"
 
+  # Quiesced while the pipeline's stateful parts are cleared for round 2
+  # (platform#6503), so nothing writes into the state being wiped. Back on for
+  # the reindex, along with the enable_* flags below.
   reindexing_state = {
-    listen_to_reindexer = true
+    listen_to_reindexer = false
     scale_up_tasks      = false
     scale_up_matcher_db = false
   }
@@ -21,11 +24,11 @@ module "pipeline" {
   # Base AMI for ECS instances
   ami_id = "resolve:ssm:arn:aws:ssm:eu-west-1:760097843905:parameter/imagebuilder/weco-al2023-ecs-optimised-x86_64/latest"
 
-  enable_adapter_transformer_trigger           = true
+  enable_adapter_transformer_trigger           = false
   disable_calm_transformer_topic_subscriptions = true
-  enable_id_minter_schedule                    = true
-  enable_graph_pipeline_schedule               = true
-  enable_image_inferrer_schedule               = true
+  enable_id_minter_schedule                    = false
+  enable_graph_pipeline_schedule               = false
+  enable_image_inferrer_schedule               = false
 
   pipeline_date = local.pipeline_date // namespaces services
   graph_date    = "2026-07-03"        // namespaces graph database


### PR DESCRIPTION
## What does this change?

Quiesces the 2026-07-03 pipeline and pauses the Axiell harvest ahead of the round 2 clear in wellcomecollection/platform#6503, so the stateful parts of the pipeline can be wiped and rebuilt against the next Axiell data load without anything writing into them mid-flight. This is phase 1 plus the first step of phase 6a of that issue.

- `pipeline/terraform/2026-07-03`: turns off the adapter transformer trigger, the id-minter, graph and image-inferrer schedules, and `reindexing_state.listen_to_reindexer`. Same set of flags as round 1's quiesce, #3513.
- `catalogue_graph/infra/adapters`: sets `schedule_enabled = false` on the Axiell adapter, stopping `axiell_adapter_run` so the adapter store stays empty between the phase 6a wipe and the post-load rebuild. The rebuild tooling has no guard against a harvest running concurrently, so the pause is what keeps the rebuild consistent.

Merging applies nothing. Both terraform roots are applied by hand, and both changes are reverted together at the hand-over to the round 2 reindex.

## How to test

`terraform plan` in each root and check the plan only disables the schedules and the reindexer subscription. After the applies, confirm the EventBridge rules for the pipeline schedules and `axiell_adapter_run` are disabled, and that no new changesets appear in the Axiell adapter store.

## How can we measure success?

The 2026-07-03 pipeline and the Axiell adapter store stay static for the duration of the clear, so the phase 6a wipe and rebuild start from a known state.

## Have we considered potential risks?

While the harvest is paused the Axiell to FOLIO sync gets no adapter events, so changes made in Axiell during the clear are not propagated. They are picked up once the harvest resumes.

Leaving either change applied past the clear would silently keep the pipeline idle, which is why the revert is part of the reindex hand-over rather than a follow-up.

Relates to wellcomecollection/platform#6503.
