### PR TITLE
Add --wipe-only to rebuild_adapter.py so the clear can run ahead of the rebuild

### DIFF
--- a/catalogue_graph/scripts/README.md
+++ b/catalogue_graph/scripts/README.md
@@ -79,6 +79,19 @@ recovers with a plain re-run. Two things to watch:
   reset but the stores were not rebuilt, leaving the gap between disabling the
   trigger and the synthetic cursor uncovered. Re-cover it with the reloader.
 
+### Wipe only
+
+`--wipe-only` wipes the same stores the rebuild would (adapter store, plus
+reconciler and deletion facts for Axiell, plus items for FOLIO) and stops:
+no download, reload, reconcile or events. Use it when the clear and the
+rebuild have to happen at different times, for example clearing ahead of a
+bulk load in the source system and rebuilding once the load has landed.
+
+It leaves the window store and harvest cursor alone, so disable the harvest
+schedule first and keep it disabled until the rebuild: an incremental harvest
+against a wiped store repopulates it with whatever the source serves. The
+pre-wipe Iceberg snapshot ids are logged for time-travel rollback.
+
 ### Usage
 
 ```bash
@@ -94,6 +107,12 @@ uv run python scripts/rebuild_adapter.py \
   --use-rest-api-table \
   --snapshot-path /tmp/folio.parquet \
   --folio-items-snapshot-path /tmp/folio_items.parquet
+
+# Wipe without rebuilding
+uv run python scripts/rebuild_adapter.py \
+  --adapter-type axiell \
+  --use-rest-api-table \
+  --wipe-only
 ```
 
 Pass `--skip-publish-event` to load the stores without triggering downstream

--- a/catalogue_graph/scripts/rebuild_adapter.py
+++ b/catalogue_graph/scripts/rebuild_adapter.py
@@ -571,12 +571,13 @@ def main() -> None:
         description="Rebuild an OAI-PMH adapter store from a full snapshot"
     )
     add_adapter_event_args(parser)
-    parser.add_argument(
+    target = parser.add_mutually_exclusive_group(required=True)
+    target.add_argument(
         "--snapshot-path",
         metavar="PATH",
-        help="Path to the bib records snapshot file. If the file already exists, the download is skipped and the existing snapshot is used. Required unless --wipe-only.",
+        help="Path to the bib records snapshot file. If the file already exists, the download is skipped and the existing snapshot is used.",
     )
-    parser.add_argument(
+    target.add_argument(
         "--wipe-only",
         action="store_true",
         help="Wipe the adapter's stores and stop: no download, reload, reconcile or events. Leaves the window store and harvest cursor alone, so disable the harvest schedule first.",

--- a/catalogue_graph/scripts/rebuild_adapter.py
+++ b/catalogue_graph/scripts/rebuild_adapter.py
@@ -13,9 +13,15 @@ and the existing snapshot is reused. Similarly for --folio-items-snapshot-path.
 Snapshot files are only ever moved into place after a complete, successful
 write, so an existing file is always safe to resume from.
 
+With --wipe-only the stores are wiped and left empty, for a clear that runs
+ahead of a later rebuild. The window store and harvest cursor are untouched,
+so disable the harvest schedule first or incremental harvests will repopulate
+the store.
+
 Usage:
     uv run python scripts/rebuild_adapter.py --adapter-type axiell --use-rest-api-table --snapshot-path /tmp/axiell.parquet
     uv run python scripts/rebuild_adapter.py --adapter-type folio --use-rest-api-table --snapshot-path /tmp/folio.parquet --folio-items-snapshot-path /tmp/folio_items.parquet
+    uv run python scripts/rebuild_adapter.py --adapter-type axiell --use-rest-api-table --wipe-only
 """
 
 from __future__ import annotations
@@ -363,6 +369,16 @@ def _confirm_rebuild(adapter_type: AdapterType) -> None:
         raise SystemExit("Aborted.")
 
 
+def _confirm_wipe_only(adapter_type: AdapterType) -> None:
+    """Confirmation gate before the stores are wiped and left empty."""
+    confirm = input(
+        f"WARNING: about to wipe all stores for '{adapter_type}' and leave "
+        "them empty (no rebuild). Type CONFIRM to proceed: "
+    ).strip()
+    if confirm != "CONFIRM":
+        raise SystemExit("Aborted.")
+
+
 def _confirm_publish(adapter_type: AdapterType, changeset_count: int) -> None:
     """Confirm before publishing EventBridge events for each changeset."""
     confirm = input(
@@ -432,12 +448,13 @@ def rebuild_adapter(
     adapter_type: AdapterType,
     *,
     use_rest_api_table: bool = False,
-    snapshot_path: str,
+    snapshot_path: str | None = None,
     folio_items_snapshot_path: str | None = None,
     skip_publish_event: bool = False,
     publish_interval_seconds: float = 0.0,
+    wipe_only: bool = False,
 ) -> None:
-    if not use_rest_api_table and not skip_publish_event:
+    if not wipe_only and not use_rest_api_table and not skip_publish_event:
         raise ValueError(
             "--skip-publish-event is required without --use-rest-api-table: "
             "a local-table rebuild would still publish real adapter.completed "
@@ -445,7 +462,42 @@ def rebuild_adapter(
             "ids that only exist locally."
         )
 
+    if wipe_only and (
+        snapshot_path is not None or folio_items_snapshot_path is not None
+    ):
+        raise ValueError(
+            "--wipe-only takes no snapshots: it wipes the stores and stops "
+            "(for FOLIO, both the bib and items stores)"
+        )
+
     config = get_config(adapter_type)
+
+    if wipe_only:
+        _confirm_wipe_only(adapter_type)
+        _wipe_store(
+            config.build_adapter_store(use_rest_api_table=use_rest_api_table),
+            store_name="adapter store",
+        )
+        if adapter_type == "folio":
+            _wipe_store(
+                build_items_store(use_rest_api_table=use_rest_api_table),
+                store_name="items store",
+            )
+        if adapter_type == "axiell":
+            reconcile_runtime = build_reconcile_runtime(
+                adapter_type, use_rest_api_table=use_rest_api_table
+            )
+            _wipe_store(
+                reconcile_runtime.reconciler_store, store_name="reconciler store"
+            )
+            _wipe_store(
+                reconcile_runtime.facts_store, store_name="deletion facts store"
+            )
+        return
+
+    if snapshot_path is None:
+        raise ValueError("--snapshot-path is required to rebuild")
+
     job_id = create_job_id()
 
     _confirm_rebuild(adapter_type)
@@ -522,8 +574,12 @@ def main() -> None:
     parser.add_argument(
         "--snapshot-path",
         metavar="PATH",
-        required=True,
-        help="Path to the bib records snapshot file. If the file already exists, the download is skipped and the existing snapshot is used.",
+        help="Path to the bib records snapshot file. If the file already exists, the download is skipped and the existing snapshot is used. Required unless --wipe-only.",
+    )
+    parser.add_argument(
+        "--wipe-only",
+        action="store_true",
+        help="Wipe the adapter's stores and stop: no download, reload, reconcile or events. Leaves the window store and harvest cursor alone, so disable the harvest schedule first.",
     )
     parser.add_argument(
         "--folio-items-snapshot-path",
@@ -560,6 +616,7 @@ def main() -> None:
         folio_items_snapshot_path=args.folio_items_snapshot_path,
         skip_publish_event=args.skip_publish_event,
         publish_interval_seconds=args.publish_interval_seconds,
+        wipe_only=args.wipe_only,
     )
 
 

--- a/catalogue_graph/tests/adapters/conftest.py
+++ b/catalogue_graph/tests/adapters/conftest.py
@@ -156,6 +156,21 @@ def temporary_table() -> Generator[IcebergTable, None, None]:
 
 
 @pytest.fixture
+def items_temporary_table() -> Generator[IcebergTable, None, None]:
+    """A second adapter-schema table, for tests needing bib and items stores."""
+    config = LocalIcebergTableConfig(
+        table_name=str(uuid1()),
+        namespace="test",
+        db_name="test_catalog",
+    )
+    table = get_local_table(config)
+    try:
+        yield table
+    finally:
+        table.catalog.drop_table(f"test.{config.table_name}")
+
+
+@pytest.fixture
 def temporary_window_status_table() -> Generator[IcebergTable, None, None]:
     config = LocalIcebergTableConfig(
         table_name=str(uuid1()),

--- a/catalogue_graph/tests/adapters/utils/test_rebuild_adapter.py
+++ b/catalogue_graph/tests/adapters/utils/test_rebuild_adapter.py
@@ -25,6 +25,7 @@ from adapters.utils.window_summary import WindowSummary
 from tests.adapters.conftest import (
     adapter_records_to_table,
     deletion_facts_records_to_table,
+    reconciler_records_to_table,
 )
 
 
@@ -359,6 +360,64 @@ def test_rebuild_adapter_orchestration_axiell(
 
     assert len(reconciled) == 1
     assert published == [[changeset_id] for changeset_id in reconciled[0]]
+
+
+def test_wipe_only_axiell_empties_the_stores_and_stops(
+    temporary_table: IcebergTable,
+    reconciler_temporary_table: IcebergTable,
+    deletion_facts_temporary_table: IcebergTable,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--wipe-only empties the adapter, reconciler and facts stores and does
+    nothing else: the config stub has no window store and no download client,
+    so touching either fails the test, and no events are published. Runs on
+    local tables without skip_publish_event, since the local-table publish
+    guard must not apply to a wipe."""
+    adapter_store = AdapterStore(temporary_table, "test_namespace")
+    temporary_table.append(
+        adapter_records_to_table([{"id": "rec001", "content": "stale"}])
+    )
+    reconciler_store = ReconcilerStore(reconciler_temporary_table, "test_namespace")
+    reconciler_temporary_table.append(
+        reconciler_records_to_table([{"id": "rec001", "guid": "guid-1"}])
+    )
+    facts_store = DeletionFactsStore(deletion_facts_temporary_table, "test_namespace")
+    facts_store.append_facts(
+        deletion_facts_records_to_table(
+            [{"record_id": "rec001", "guid": "guid-1", "changeset": "c1"}]
+        )
+    )
+    reconcile_runtime = ReconcileRuntime(
+        adapter_store=adapter_store,
+        reconciler_store=reconciler_store,
+        facts_store=facts_store,
+        adapter_name="axiell",
+        namespace="test_namespace",
+    )
+    config_stub = SimpleNamespace(build_adapter_store=lambda **kwargs: adapter_store)
+    monkeypatch.setattr(rebuild_adapter, "get_config", lambda adapter_type: config_stub)
+    monkeypatch.setattr(
+        rebuild_adapter, "build_reconcile_runtime", lambda *a, **k: reconcile_runtime
+    )
+    monkeypatch.setattr("builtins.input", lambda *args: "CONFIRM")
+    published: list[object] = []
+    monkeypatch.setattr(
+        rebuild_adapter, "_publish_adapter_event", lambda *a: published.append(a)
+    )
+
+    rebuild_adapter.rebuild_adapter("axiell", wipe_only=True)
+
+    assert adapter_store.get_all_records().num_rows == 0
+    assert reconciler_store.get_all_records().num_rows == 0
+    assert facts_store.get_all_records().num_rows == 0
+    assert published == []
+
+
+def test_wipe_only_refuses_snapshot_paths() -> None:
+    with pytest.raises(ValueError, match="wipe-only takes no snapshots"):
+        rebuild_adapter.rebuild_adapter(
+            "axiell", wipe_only=True, snapshot_path="/tmp/leftover.parquet"
+        )
 
 
 def test_reconcile_runtime_sees_the_loaded_records(

--- a/catalogue_graph/tests/adapters/utils/test_rebuild_adapter.py
+++ b/catalogue_graph/tests/adapters/utils/test_rebuild_adapter.py
@@ -413,6 +413,42 @@ def test_wipe_only_axiell_empties_the_stores_and_stops(
     assert published == []
 
 
+def test_wipe_only_folio_empties_bib_and_items_stores_and_stops(
+    temporary_table: IcebergTable,
+    items_temporary_table: IcebergTable,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--wipe-only on FOLIO empties both the bib and items stores and does
+    nothing else: the config stub has no window store and no download client,
+    so touching either fails the test, and no events are published."""
+    adapter_store = AdapterStore(temporary_table, "test_namespace")
+    temporary_table.append(
+        adapter_records_to_table([{"id": "rec001", "content": "stale bib"}])
+    )
+    items_store = AdapterStore(items_temporary_table, "items_namespace")
+    items_temporary_table.append(
+        adapter_records_to_table(
+            [{"id": "item001", "content": "stale item"}], namespace="items_namespace"
+        )
+    )
+    config_stub = SimpleNamespace(build_adapter_store=lambda **kwargs: adapter_store)
+    monkeypatch.setattr(rebuild_adapter, "get_config", lambda adapter_type: config_stub)
+    monkeypatch.setattr(
+        rebuild_adapter, "build_items_store", lambda **kwargs: items_store
+    )
+    monkeypatch.setattr("builtins.input", lambda *args: "CONFIRM")
+    published: list[object] = []
+    monkeypatch.setattr(
+        rebuild_adapter, "_publish_adapter_event", lambda *a: published.append(a)
+    )
+
+    rebuild_adapter.rebuild_adapter("folio", wipe_only=True)
+
+    assert adapter_store.get_all_records().num_rows == 0
+    assert items_store.get_all_records().num_rows == 0
+    assert published == []
+
+
 def test_wipe_only_refuses_snapshot_paths() -> None:
     with pytest.raises(ValueError, match="wipe-only takes no snapshots"):
         rebuild_adapter.rebuild_adapter(


### PR DESCRIPTION
## What does this change?

wellcomecollection/platform#6503 splits the round 2 Axiell adapter store work into a clear that runs ahead of the next data load (phase 6a) and a rebuild that is gated on the load landing (phase 6b). `rebuild_adapter.py` had no way to do the first half on its own, because the store wipes were inline in the rebuild flow.

`--wipe-only` wipes the same stores the rebuild would (the adapter store, plus the reconciler and deletion facts stores for Axiell, plus the items store for FOLIO) behind the existing CONFIRM gate and then stops: no download, reload, reconcile or published events. Pre-wipe Iceberg snapshot ids are still logged, so a wipe can be rolled back by time travel.

It deliberately leaves the window store and harvest cursor alone, so the operator has to disable the harvest schedule first, otherwise an incremental harvest repopulates the store from whatever the source is serving. The module docstring, `--help` and the scripts README all say so. Companion change wellcomecollection/catalogue-pipeline#3563 makes that pause for round 2.

Relates to wellcomecollection/platform#6503.

### Checklist

- [ ] Does this change the display model the catalogue API returns? No. It only adds an operator-run mode to a maintenance script.

## How to test

`cd catalogue_graph && uv run --group dev pytest tests/adapters/utils/test_rebuild_adapter.py` (11 passed). Two new tests cover the wipe path (stores emptied, window store untouched, nothing published) and the rejection of snapshot arguments. `ruff check`, `ruff format` and `mypy .` are clean.

## How can we measure success?

The round 2 clear can be run without holding the rebuild open across the data load. Nothing to measure beyond the wipe completing and the stores reading back empty.

## Have we considered potential risks?

The wipe is destructive and now easier to reach on its own, so it stays behind the CONFIRM prompt and refuses snapshot paths, which would suggest the caller meant to rebuild. It is exempt from the local-table `--skip-publish-event` guard, which is safe because a wipe publishes nothing. The residual risk is operator sequencing: wiping with the harvest schedule still enabled silently refills the store, which is why the flag is documented as requiring the pause and why the pre-wipe snapshot ids are logged.
