### PR TITLE
Add a fixture covering rarely-populated display fields

### DIFF
--- a/catalogue_graph/document_generators/create_test_work_documents.py
+++ b/catalogue_graph/document_generators/create_test_work_documents.py
@@ -33,7 +33,7 @@ from models.pipeline.access_condition import (
 from models.pipeline.access_method import AccessMethod
 from models.pipeline.access_status import AccessStatus, AccessStatusRelationship
 from models.pipeline.collection_path import CollectionPath
-from models.pipeline.concept import Concept, Genre, Period, Subject
+from models.pipeline.concept import Concept, Contributor, Genre, Period, Subject
 from models.pipeline.format import (
     FORMAT_LABEL_MAPPING,
     Audio,
@@ -42,7 +42,7 @@ from models.pipeline.format import (
     Journals,
     Pictures,
 )
-from models.pipeline.id_label import Id, Language
+from models.pipeline.id_label import Id, Label, Language
 from models.pipeline.identifier import Identified, SourceIdentifier
 from models.pipeline.production import ProductionEvent
 
@@ -1009,6 +1009,75 @@ def create_works_with_digital_location_dates() -> None:
     )
 
 
+def create_work_with_rarely_populated_fields() -> None:
+    """A deliberately maximal work covering display fields no other fixture populates.
+
+    Every field documented in the catalogue API's OpenAPI spec should appear in at
+    least one of these fixtures (see wellcomecollection/platform#6514).
+    """
+    access_condition = AccessCondition(
+        method=AccessMethod(type="ManualRequest"),
+        status=AccessStatus(type="Restricted"),
+        terms="Permission must be obtained from the depositor",
+        note="This file is closed for data protection reasons",
+    )
+    item = create_item(
+        title="Copy 1, with manuscript annotations",
+        note="In poor condition; handle with care",
+        locations=[
+            create_physical_location(
+                location_type_id="closed-stores",
+                access_conditions=[access_condition],
+            )
+        ],
+    )
+
+    # The production concepts are identified, although the display transformer
+    # currently only surfaces their labels.
+    production = ProductionEvent(
+        label="London : Printed for the author, 1897",
+        places=[
+            create_concept(
+                label="London", concept_type="Place", identifier_ontology_type="Place"
+            )
+        ],
+        agents=[
+            create_concept(
+                label="Printed for the author",
+                concept_type="Agent",
+                identifier_ontology_type="Agent",
+            )
+        ],
+        dates=[create_period_for_year("1897")],
+        function=Concept(label="Printing"),
+    )
+
+    # An identified agent, so its identifiers appear in the display document.
+    contributor = Contributor(
+        agent=create_concept(
+            label="Wellcome, Henry Solomon, Sir",
+            concept_type="Person",
+            identifier_ontology_type="Person",
+        ),
+        roles=[Label(label="author")],
+    )
+
+    save_work(
+        work=create_visible_merged_work(
+            title="A work with every rarely-populated display field",
+            physical_description="1 volume ; 23 cm",
+            reference_number="WA/HMM/BU/1",
+            created_date=create_period_for_year("1897"),
+            current_frequency="Quarterly, 1897-1902",
+            contributors=[contributor],
+            production=[production],
+            items=[item],
+        ),
+        description="a work with every rarely-populated display field",
+        doc_id="work.visible.rare-fields",
+    )
+
+
 def generate_all() -> None:
     reset()
 
@@ -1037,6 +1106,7 @@ def generate_all() -> None:
     create_works_with_digital_location_dates()
     create_archive_works()
     create_works_with_sortable_collection_paths()
+    create_work_with_rarely_populated_fields()
 
     print(f"Test documents written to {TEST_DOCUMENTS_DIR}")
 

--- a/catalogue_graph/document_generators/generators/items.py
+++ b/catalogue_graph/document_generators/generators/items.py
@@ -13,11 +13,13 @@ from .locations import create_digital_location, create_physical_location
 def create_item(
     locations: list | None = None,
     other_identifiers: list[SourceIdentifier] | None = None,
+    title: str | None = None,
+    note: str | None = None,
 ) -> Item:
     if locations is None:
         locations = [create_digital_location(location_type_id="iiif-image")]
     item_id = create_identified(other_identifiers=other_identifiers)
-    return Item(id=item_id, locations=locations)
+    return Item(id=item_id, title=title, note=note, locations=locations)
 
 
 def create_unidentifiable_item(locations: list | None = None) -> Item:

--- a/catalogue_graph/document_generators/generators/works.py
+++ b/catalogue_graph/document_generators/generators/works.py
@@ -17,7 +17,7 @@ from ingestor.models.shared.deleted_reason import DeletedReason
 from ingestor.models.shared.invisible_reason import InvisibleReason
 from models.graph_node import Work
 from models.pipeline.collection_path import CollectionPath
-from models.pipeline.concept import Contributor, Genre, Subject
+from models.pipeline.concept import Concept, Contributor, Genre, Subject
 from models.pipeline.format import Format
 from models.pipeline.holdings import Holdings
 from models.pipeline.id_label import Id, Language
@@ -38,6 +38,10 @@ from .random import random_alphanumeric, random_canonical_id, rng
 def create_work_data(
     title: str | None = None,
     description: str | None = None,
+    physical_description: str | None = None,
+    reference_number: str | None = None,
+    created_date: Concept | None = None,
+    current_frequency: str | None = None,
     contributors: list[Contributor] | None = None,
     genres: list[Genre] | None = None,
     subjects: list[Subject] | None = None,
@@ -61,6 +65,10 @@ def create_work_data(
     return WorkData(
         title=title or random_alphanumeric(15),
         description=description,
+        physical_description=physical_description,
+        reference_number=reference_number,
+        created_date=created_date,
+        current_frequency=current_frequency,
         contributors=contributors or [],
         genres=genres or [],
         subjects=subjects or [],
@@ -100,6 +108,10 @@ def create_merged_work_state(
 def create_visible_merged_work(
     title: str | None = None,
     description: str | None = None,
+    physical_description: str | None = None,
+    reference_number: str | None = None,
+    created_date: Concept | None = None,
+    current_frequency: str | None = None,
     contributors: list[Contributor] | None = None,
     genres: list[Genre] | None = None,
     subjects: list[Subject] | None = None,
@@ -126,6 +138,10 @@ def create_visible_merged_work(
         data=create_work_data(
             title=title,
             description=description,
+            physical_description=physical_description,
+            reference_number=reference_number,
+            created_date=created_date,
+            current_frequency=current_frequency,
             contributors=contributors,
             genres=genres,
             subjects=subjects,

--- a/catalogue_graph/document_generators/test_documents/work.visible.rare-fields.json
+++ b/catalogue_graph/document_generators/test_documents/work.visible.rare-fields.json
@@ -1,0 +1,277 @@
+{
+  "description": "a work with every rarely-populated display field",
+  "id": "4cbgoe8p",
+  "document": {
+    "type": "Visible",
+    "debug": {
+      "source": {
+        "id": "4cbgoe8p",
+        "identifier": {
+          "identifierType": {
+            "id": "sierra-system-number"
+          },
+          "ontologyType": "Work",
+          "value": "3QF59FdNQJ"
+        },
+        "version": 1,
+        "modifiedTime": "2025-01-01T00:00:00Z"
+      },
+      "mergedTime": "2025-01-01T00:00:00Z",
+      "indexedTime": "2001-01-01T01:01:01Z",
+      "mergeCandidates": [],
+      "redirectSources": []
+    },
+    "query": {
+      "id": "4cbgoe8p",
+      "title": "A work with every rarely-populated display field",
+      "referenceNumber": "WA/HMM/BU/1",
+      "physicalDescription": "1 volume ; 23 cm",
+      "alternativeTitles": [],
+      "languages.label": [],
+      "sourceIdentifier.value": "3QF59FdNQJ",
+      "identifiers.value": [
+        "4cbgoe8p",
+        "3QF59FdNQJ"
+      ],
+      "images.id": [],
+      "images.identifiers.value": [],
+      "items.identifiers.value": [
+        "Y14y2h0Rzl"
+      ],
+      "items.id": [
+        "l5mem3bu"
+      ],
+      "items.shelfmark.value": [
+        "Shelfmark: NaTDHzrYbX"
+      ],
+      "notes.contents": [],
+      "partOf.title": [],
+      "production.label": [
+        "London",
+        "Printed for the author",
+        "1897"
+      ],
+      "subjects.concepts.label": [],
+      "contributors.agent.label": [
+        "Wellcome, Henry Solomon, Sir"
+      ],
+      "genres.concepts.label": []
+    },
+    "display": {
+      "id": "4cbgoe8p",
+      "title": "A work with every rarely-populated display field",
+      "alternativeTitles": [],
+      "referenceNumber": "WA/HMM/BU/1",
+      "physicalDescription": "1 volume ; 23 cm",
+      "createdDate": {
+        "label": "1897",
+        "type": "Period"
+      },
+      "contributors": [
+        {
+          "agent": {
+            "id": "xoptq11r",
+            "label": "Wellcome, Henry Solomon, Sir",
+            "identifiers": [
+              {
+                "value": "sibpiNFnJJ",
+                "type": "Identifier",
+                "identifierType": {
+                  "id": "sierra-system-number",
+                  "type": "IdentifierType",
+                  "label": "Sierra system number"
+                }
+              }
+            ],
+            "type": "Person"
+          },
+          "roles": [
+            {
+              "label": "author",
+              "type": "ContributionRole"
+            }
+          ],
+          "primary": true,
+          "type": "Contributor"
+        }
+      ],
+      "identifiers": [
+        {
+          "value": "3QF59FdNQJ",
+          "type": "Identifier",
+          "identifierType": {
+            "id": "sierra-system-number",
+            "type": "IdentifierType",
+            "label": "Sierra system number"
+          }
+        }
+      ],
+      "subjects": [],
+      "genres": [],
+      "items": [
+        {
+          "id": "l5mem3bu",
+          "identifiers": [
+            {
+              "value": "Y14y2h0Rzl",
+              "type": "Identifier",
+              "identifierType": {
+                "id": "sierra-system-number",
+                "type": "IdentifierType",
+                "label": "Sierra system number"
+              }
+            }
+          ],
+          "title": "Copy 1, with manuscript annotations",
+          "note": "In poor condition; handle with care",
+          "locations": [
+            {
+              "locationType": {
+                "id": "closed-stores",
+                "type": "LocationType",
+                "label": "Closed stores"
+              },
+              "license": {
+                "id": "pdm",
+                "type": "License",
+                "label": "Public Domain Mark",
+                "url": "https://creativecommons.org/share-your-work/public-domain/pdm/"
+              },
+              "accessConditions": [
+                {
+                  "method": {
+                    "id": "manual-request",
+                    "type": "AccessMethod",
+                    "label": "Manual request"
+                  },
+                  "status": {
+                    "id": "restricted",
+                    "type": "AccessStatus",
+                    "label": "Restricted"
+                  },
+                  "terms": "Permission must be obtained from the depositor",
+                  "note": "This file is closed for data protection reasons",
+                  "type": "AccessCondition"
+                }
+              ],
+              "label": "locationLabel",
+              "shelfmark": "Shelfmark: NaTDHzrYbX",
+              "type": "PhysicalLocation"
+            }
+          ],
+          "type": "Item"
+        }
+      ],
+      "holdings": [],
+      "availabilities": [],
+      "production": [
+        {
+          "label": "London : Printed for the author, 1897",
+          "places": [
+            {
+              "label": "London",
+              "type": "Place"
+            }
+          ],
+          "agents": [
+            {
+              "label": "Printed for the author",
+              "type": "Agent"
+            }
+          ],
+          "dates": [
+            {
+              "label": "1897",
+              "type": "Period"
+            }
+          ],
+          "function": {
+            "label": "Printing",
+            "type": "Concept"
+          },
+          "type": "ProductionEvent"
+        }
+      ],
+      "languages": [],
+      "notes": [],
+      "currentFrequency": "Quarterly, 1897-1902",
+      "formerFrequency": [],
+      "designation": [],
+      "images": [],
+      "parts": [],
+      "partOf": [],
+      "type": "Work"
+    },
+    "aggregatableValues": {
+      "workType": [],
+      "genres": [],
+      "subjects": [],
+      "languages": [],
+      "production.dates": [
+        {
+          "id": "1897",
+          "label": "1897"
+        }
+      ],
+      "contributors.agent": [
+        {
+          "id": "xoptq11r",
+          "label": "Wellcome, Henry Solomon, Sir"
+        }
+      ],
+      "items.locations.license": [
+        {
+          "id": "pdm",
+          "label": "Public Domain Mark"
+        }
+      ],
+      "availabilities": []
+    },
+    "filterableValues": {
+      "workType": "Standard",
+      "production.dates.range.from": [
+        -2303596800000
+      ],
+      "languages.id": [],
+      "genres.label": [],
+      "genres.concepts.id": [],
+      "genres.concepts.sourceIdentifier": [],
+      "subjects.label": [],
+      "subjects.concepts.id": [],
+      "subjects.concepts.sourceIdentifier": [],
+      "contributors.agent.label": [
+        "Wellcome, Henry Solomon, Sir"
+      ],
+      "contributors.agent.id": [
+        "xoptq11r"
+      ],
+      "contributors.agent.sourceIdentifier": [
+        "sibpiNFnJJ"
+      ],
+      "identifiers.value": [
+        "4cbgoe8p",
+        "3QF59FdNQJ"
+      ],
+      "items.locations.license.id": [
+        "pdm"
+      ],
+      "items.locations.accessConditions.status.id": [
+        "restricted"
+      ],
+      "items.id": [
+        "l5mem3bu"
+      ],
+      "items.identifiers.value": [
+        "Y14y2h0Rzl"
+      ],
+      "items.locations.locationType.id": [
+        "closed-stores"
+      ],
+      "items.locations.createdDate": [],
+      "partOf.id": [],
+      "partOf.title": [],
+      "availabilities.id": []
+    }
+  },
+  "createdAt": "2026-08-12T10:26:31.357044+00:00"
+}


### PR DESCRIPTION
## What does this change?

catalogue-api is adding a test that asserts every field documented in its OpenAPI spec appears in at least one of the pipeline-generated test documents (part of wellcomecollection/platform#6514). Fourteen documented field paths are never populated by the deterministic generators, so they sit on a named allowlist there. This PR teaches the generators to populate ten of them, so the allowlist can shrink:

- `Work.physicalDescription`, `Work.referenceNumber`, `Work.createdDate`, `Work.currentFrequency`
- `Item.title`, `Item.note`
- `AccessCondition.terms`, `AccessCondition.note`
- `ProductionEvent.function`
- `Agent.identifiers` (via an identified contributor agent)

Rather than sprinkling fields across many fixtures, it adds one deliberately maximal work, `work.visible.rare-fields.json`, generated by a new `create_work_with_rarely_populated_fields` step. The generators gain pass-through parameters (`physical_description`, `reference_number`, `created_date`, `current_frequency` on works; `title` and `note` on items) with defaults of `None`, and the new step runs last, so the seeded RNG sequence is untouched and no existing fixture changes.

This changes fixture content only, not the display model itself.

The remaining four allowlisted paths, `Period.id`, `Period.identifiers`, `Place.id` and `Place.identifiers`, cannot be exercised from the generators today. The spec only documents Period and Place as components of production events and `createdDate`, and `DisplayWorkTransformer` builds label-only concepts in both places, dropping ids and identifiers even for identified concepts. Surfacing them would be an ingestor behaviour change, out of scope here; the new fixture already carries identified production places, agents and dates, so if the transformer ever passes ids through, the fields will start appearing without further generator work. Once the sync workflow (#3565) is live, this merge will propagate the new fixture to catalogue-api automatically.

### Checklist

- [x] Does this change the display model the catalogue API returns? If so, regenerate the test documents under `catalogue_graph/document_generators/test_documents`. The `wellcomecollection/catalogue-api` repo copies them in with `copy_test_documents.py`, and its OpenAPI contract tests validate the published spec against them, so stale fixtures let the spec drift.

No display model change, but the fixture set gains one document, regenerated with both `create_test_work_documents` and `create_test_image_documents`.

## How to test

From `catalogue_graph/`, run `uv run python -m document_generators.create_test_work_documents` and `uv run python -m document_generators.create_test_image_documents` and check `git status` is clean, which is what CI does. Then inspect `document.display` in `test_documents/work.visible.rare-fields.json` and confirm each of the ten fields above is present (display keys are camelCase). `uv run pytest tests/ingestor`, ruff and mypy all pass.

## How can we measure success?

catalogue-api's fixture coverage test can drop the ten fields from its `allowedUnexercised` list after the next fixture copy, leaving only the four transformer-limited Period and Place paths (plus the fields the API splices in or no longer emits).

## Have we considered potential risks?

Low risk: no pipeline runtime code changes, only test document generators and one new fixture. Existing fixtures are byte-for-byte unchanged, so no downstream test in either repo should move.
