### PR TITLE
Report ids that match no row in an id-mode transformer run

### DIFF
--- a/catalogue_graph/src/adapters/steps/transformer.py
+++ b/catalogue_graph/src/adapters/steps/transformer.py
@@ -92,6 +92,7 @@ class AdapterConfig(Protocol):
 class TransformerResult(TransformerEvent):
     success_count: int
     failure_count: int
+    unmatched_count: int
     report_s3_uri: str
 
 
@@ -217,6 +218,7 @@ def handler(
         failure_count=len(transformer.errors),
         changeset_ids=event.changeset_ids,
         ids=event.ids,
+        unmatched_count=len(transformer.source.unmatched_ids),
         snapshot_id=transformer.source.snapshot_id,
     )
 
@@ -225,6 +227,7 @@ def handler(
         transformer_type=event.transformer_type,
         successful_ids=transformer.successful_ids,
         errors=transformer.errors,
+        unmatched_ids=transformer.source.unmatched_ids,
         changeset_ids=event.changeset_ids,
         ids=event.ids or [],
         snapshot_id=transformer.source.snapshot_id,
@@ -239,6 +242,7 @@ def handler(
             **event.model_dump(),
             "success_count": len(transformer.successful_ids),
             "failure_count": len(transformer.errors),
+            "unmatched_count": len(transformer.source.unmatched_ids),
             "report_s3_uri": report.s3_uri,
         },
     )

--- a/catalogue_graph/src/adapters/transformers/axiell_store_source.py
+++ b/catalogue_graph/src/adapters/transformers/axiell_store_source.py
@@ -19,6 +19,7 @@ class AxiellStoreSource(RecordSource):
     def __init__(self, reader: AxiellChangesetReader):
         self.reader = reader
         self.snapshot_id = reader.snapshot_id
+        self.unmatched_ids: list[str] = []
 
     def stream_raw(self) -> Generator[dict[str, Any]]:
         for row in self.reader.iter_records():
@@ -31,6 +32,7 @@ class AxiellStoreSource(RecordSource):
                     "deletion facts in this stream"
                 )
             yield row
+        self.unmatched_ids = self.reader.unmatched_ids
         for deletion in self.reader.iter_deletions():
             yield {
                 "id": deletion.fact_id,

--- a/catalogue_graph/src/adapters/transformers/reporting.py
+++ b/catalogue_graph/src/adapters/transformers/reporting.py
@@ -21,6 +21,7 @@ class TransformerReport(PipelineReport):
 
     successful_ids: list[str]
     errors: list[TransformationError]
+    unmatched_ids: list[str]
 
     s3_bucket: str = Field(exclude=True)
     s3_prefix: str = Field(exclude=True)

--- a/catalogue_graph/src/adapters/utils/adapter_store_source.py
+++ b/catalogue_graph/src/adapters/utils/adapter_store_source.py
@@ -15,6 +15,10 @@ class RecordSource(BaseSource):
 
     snapshot_id: int | None
 
+    unmatched_ids: list[str]
+    """Requested ids (id-mode only) that matched no row in the store. Only
+    meaningful once `stream_raw` has been fully consumed; empty otherwise."""
+
 
 class AdapterStoreSource(RecordSource):
     def __init__(
@@ -33,6 +37,7 @@ class AdapterStoreSource(RecordSource):
         self.changeset_ids = changeset_ids
         self.snapshot_id = snapshot_id
         self.ids = ids
+        self.unmatched_ids = []
 
     def stream_raw(self) -> Generator[dict[str, Any]]:
         if self.changeset_ids:
@@ -49,11 +54,25 @@ class AdapterStoreSource(RecordSource):
             # path: tombstones must overwrite live documents downstream. The
             # store is sorted on id, so this filter prunes row groups rather
             # than scanning the whole namespace.
+            # Deduped so a requested id given twice isn't double-counted in
+            # unmatched_ids below.
+            unique_ids = list(dict.fromkeys(self.ids))
             table = self.adapter_store.get_namespace_records(
-                In("id", self.ids), self.snapshot_id
+                In("id", unique_ids), self.snapshot_id
             )
+            seen_ids: set[str] = set()
             for batch in table.to_batches():
-                yield from self._process_rows(batch.to_pylist())
+                rows = batch.to_pylist()
+                seen_ids.update(row["id"] for row in rows)
+                yield from self._process_rows(rows)
+
+            self.unmatched_ids = [id_ for id_ in unique_ids if id_ not in seen_ids]
+            if self.unmatched_ids:
+                logger.warning(
+                    "Requested ids matched no row in the store",
+                    unmatched_ids=self.unmatched_ids,
+                    unmatched_count=len(self.unmatched_ids),
+                )
         else:
             logger.info("No changeset_id provided; performing full reindex of records.")
 

--- a/catalogue_graph/src/adapters/utils/axiell_changeset_reader.py
+++ b/catalogue_graph/src/adapters/utils/axiell_changeset_reader.py
@@ -90,6 +90,7 @@ class AxiellChangesetReader:
         self.ids = ids
         self.facts_store = facts_store
         self.reconciler_store = reconciler_store
+        self.unmatched_ids: list[str] = []
 
     @classmethod
     def build(
@@ -158,6 +159,7 @@ class AxiellChangesetReader:
             ids=self.ids,
         )
         yield from source.stream_raw()
+        self.unmatched_ids = source.unmatched_ids
 
     def iter_deletions(self) -> Generator[SupersededGuid]:
         """Yield the changesets' deletion facts that are still deliverable.

--- a/catalogue_graph/tests/adapters/transformers/ebsco/test_transformer.py
+++ b/catalogue_graph/tests/adapters/transformers/ebsco/test_transformer.py
@@ -334,6 +334,36 @@ def test_transformer_id_run_includes_deleted_rows_as_tombstones(
     assert deleted["deletedReason"]["type"] == "DeletedFromSource"
 
 
+def test_transformer_id_run_reports_unmatched_ids(
+    temporary_table: IcebergTable, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    records_by_id = {
+        "ebs00001": "<record><leader>00000nam a2200000   4500</leader><controlfield tag='001'>ebs00001</controlfield><datafield tag='245' ind1='0' ind2='0'><subfield code='a'>How to Avoid Huge Ships</subfield></datafield></record>",
+    }
+    prepare_changeset(
+        temporary_table,
+        monkeypatch,
+        records_by_id,
+        namespace=EBSCO_NAMESPACE,
+        transformer_type="ebsco",
+    )
+
+    MockElasticsearchClient.inputs.clear()
+
+    result = _run_transform(
+        monkeypatch,
+        ids=["ebs00001", "ebs-does-not-exist"],
+        index_date="2025-01-01",
+    )
+
+    assert result.success_count == 1
+    assert result.failure_count == 0
+    assert result.unmatched_count == 1
+
+    report = read_transformer_report(result)
+    assert report["unmatched_ids"] == ["ebs-does-not-exist"]
+
+
 def test_transformer_id_run_report_key_is_not_reindex(
     temporary_table: IcebergTable, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/catalogue_graph/tests/adapters/utils/test_adapter_store_source.py
+++ b/catalogue_graph/tests/adapters/utils/test_adapter_store_source.py
@@ -136,6 +136,44 @@ def test_stream_raw_id_path_no_matching_ids_yields_nothing(
     source = AdapterStoreSource(store, changeset_ids=[], ids=["nonexistent"])
 
     assert list(source.stream_raw()) == []
+    assert source.unmatched_ids == ["nonexistent"]
+
+
+def test_stream_raw_id_path_tracks_unmatched_ids_alongside_matches(
+    adapter_store_with_records: AdapterStoreFactory,
+) -> None:
+    """Ids that match a row are excluded from unmatched_ids; ids that don't
+    are recorded, so an operator can tell exactly which of theirs were missed."""
+    store = adapter_store_with_records(
+        [
+            {"id": "rec001", "content": "first"},
+            {"id": "rec002", "content": "second"},
+        ]
+    )
+    source = AdapterStoreSource(
+        store, changeset_ids=[], ids=["rec001", "rec002", "missing-1", "missing-2"]
+    )
+
+    rows = list(source.stream_raw())
+
+    assert sorted(row["id"] for row in rows) == ["rec001", "rec002"]
+    assert sorted(source.unmatched_ids) == ["missing-1", "missing-2"]
+
+
+def test_stream_raw_id_path_dedupes_unmatched_ids(
+    adapter_store_with_records: AdapterStoreFactory,
+) -> None:
+    """A requested id repeated in the input is only reported once when it
+    matches nothing, so duplicates in an operator's list don't inflate the
+    unmatched count."""
+    store = adapter_store_with_records([{"id": "rec001", "content": "first"}])
+    source = AdapterStoreSource(
+        store, changeset_ids=[], ids=["nonexistent", "nonexistent"]
+    )
+
+    list(source.stream_raw())
+
+    assert source.unmatched_ids == ["nonexistent"]
 
 
 def test_rejects_changeset_ids_combined_with_ids(

--- a/catalogue_graph/tests/adapters/utils/test_axiell_changeset_reader.py
+++ b/catalogue_graph/tests/adapters/utils/test_axiell_changeset_reader.py
@@ -107,6 +107,18 @@ def test_records_by_id_yields_only_named_records_including_tombstones(
     assert rows["collect-2"]["content"] == MARCXML
 
 
+def test_records_by_id_tracks_unmatched_ids(temporary_table: IcebergTable) -> None:
+    """An id that matches no store row is surfaced on the reader once
+    iter_records has been fully consumed, so a recovery run can report it."""
+    _seed_adapter_rows(temporary_table, [{"id": "collect-1", "content": MARCXML}])
+
+    reader = _reader(temporary_table, [], ids=["collect-1", "collect-missing"])
+    rows = {row["id"]: row for row in reader.iter_records()}
+
+    assert set(rows) == {"collect-1"}
+    assert reader.unmatched_ids == ["collect-missing"]
+
+
 def test_deletions_are_typed_and_liveness_filtered(
     temporary_table: IcebergTable,
     deletion_facts_temporary_table: IcebergTable,


### PR DESCRIPTION
## What does this change?

A review comment on #3553, which added id-mode support for wellcomecollection/platform#6498, pointed out that an id passed to the transformer which doesn't match any row in the adapter store vanishes without a trace. The run still succeeds, and `successful_ids` only records ids for documents that were actually transformed, so an operator recovering a known list of ids has no record of which ones didn't match anything in the store.

This mirrors the OAI-PMH loader's id-mode outcome reporting. `AdapterStoreSource` now dedupes the requested ids and tracks which ones matched a row while streaming, then logs and records the rest as `unmatched_ids`. Axiell needed separate wiring (`AxiellChangesetReader` and `AxiellStoreSource`) because it builds its own internal `AdapterStoreSource` instead of exposing the transformer's source directly. `unmatched_ids` is logged in full, added to the published `TransformerReport`, and surfaced as `unmatched_count` on `TransformerResult`, alongside the existing `success_count` and `failure_count`.

### Checklist

- [x] Does this change the display model the catalogue API returns? No, this only adds reporting to the transformer's id-mode run.

## How to test

`cd catalogue_graph && uv run --group dev pytest tests/adapters/utils/test_adapter_store_source.py tests/adapters/utils/test_axiell_changeset_reader.py tests/adapters/transformers/ebsco/test_transformer.py tests/adapters/transformers/axiell/test_transformer.py tests/adapters/transformers/folio/test_transformer.py tests/adapters/transformers/test_reporting.py` (55 passed). `ruff check`, `ruff format --check`, and `mypy` are clean.

## How can we measure success?

An id-mode recovery run with a typo'd or genuinely absent id now shows `unmatched_count` in the step's own output and the full `unmatched_ids` list in the published report. Nothing changes for a normal changeset or reindex run, since `unmatched_ids` stays empty when `ids` isn't set.

## Have we considered potential risks?

This change is low risk. The new fields on `TransformerResult` and `TransformerReport` are additive. Deduping requested ids doesn't change which rows get streamed, since the store query already returns distinct rows.