### PR TITLE
Align mappings.works_indexed.2026-07-30 with deployed index

### DIFF
--- a/index_config/analysis.works_indexed.2026-07-03.json
+++ b/index_config/analysis.works_indexed.2026-07-03.json
@@ -1,0 +1,385 @@
+{
+  "filter": {
+    "pattern_replace_g_j": {
+      "pattern": "g",
+      "type": "pattern_replace",
+      "replacement": "j"
+    },
+    "pattern_replace_j_i": {
+      "pattern": "j",
+      "type": "pattern_replace",
+      "replacement": "i"
+    },
+    "french_elision": {
+      "type": "elision",
+      "articles": [
+        "l",
+        "m",
+        "t",
+        "qu",
+        "n",
+        "s",
+        "j",
+        "d",
+        "c",
+        "jusqu",
+        "quoiqu",
+        "lorsqu",
+        "puisqu"
+      ],
+      "articles_case": "true"
+    },
+    "pattern_replace_uu_w": {
+      "pattern": "uu",
+      "type": "pattern_replace",
+      "replacement": "w"
+    },
+    "pattern_replace_vv_w": {
+      "pattern": "vv",
+      "type": "pattern_replace",
+      "replacement": "w"
+    },
+    "hindi_stemmer": {
+      "type": "stemmer",
+      "language": "hindi"
+    },
+    "pattern_replace_v_u": {
+      "pattern": "v",
+      "type": "pattern_replace",
+      "replacement": "u"
+    },
+    "german_stemmer": {
+      "type": "stemmer",
+      "language": "light_german"
+    },
+    "english_stemmer": {
+      "type": "stemmer",
+      "language": "english"
+    },
+    "italian_elision": {
+      "type": "elision",
+      "articles": [
+        "c",
+        "l",
+        "all",
+        "dall",
+        "dell",
+        "nell",
+        "sull",
+        "coll",
+        "pell",
+        "gl",
+        "agl",
+        "dagl",
+        "degl",
+        "negl",
+        "sugl",
+        "un",
+        "m",
+        "t",
+        "s",
+        "v",
+        "d"
+      ],
+      "articles_case": "true"
+    },
+    "asciifolding": {
+      "type": "asciifolding"
+    },
+    "possessive_english": {
+      "type": "stemmer",
+      "language": "possessive_english"
+    },
+    "spanish_stemmer": {
+      "type": "stemmer",
+      "language": "light_spanish"
+    },
+    "arabic_stemmer": {
+      "type": "stemmer",
+      "language": "arabic"
+    },
+    "french_stemmer": {
+      "type": "stemmer",
+      "language": "light_french"
+    },
+    "italian_stemmer": {
+      "type": "stemmer",
+      "language": "light_italian"
+    },
+    "word_delimiter": {
+      "type": "word_delimiter_graph",
+      "preserve_original": "true"
+    },
+    "bengali_stemmer": {
+      "type": "stemmer",
+      "language": "bengali"
+    },
+    "long_query_token_limiter": {
+      "type": "limit",
+      "max_token_count": 75
+    }
+  },
+  "tokenizer": {
+    "dot_hierarchy": {
+      "type": "path_hierarchy",
+      "delimiter": "."
+    }
+  },
+  "analyzer": {
+    "german": {
+      "filter": [
+        "word_delimiter",
+        "long_query_token_limiter",
+        "lowercase",
+        "german_normalization",
+        "german_stemmer"
+      ],
+      "char_filter": [
+        "slash_remover"
+      ],
+      "tokenizer": "whitespace"
+    },
+    "spanish": {
+      "filter": [
+        "word_delimiter",
+        "long_query_token_limiter",
+        "lowercase",
+        "spanish_stemmer"
+      ],
+      "char_filter": [
+        "slash_remover"
+      ],
+      "tokenizer": "whitespace"
+    },
+    "swappable_characters": {
+      "filter": [
+        "word_delimiter",
+        "long_query_token_limiter",
+        "asciifolding",
+        "lowercase",
+        "pattern_replace_vv_w",
+        "pattern_replace_uu_w",
+        "pattern_replace_v_u",
+        "pattern_replace_j_i",
+        "pattern_replace_g_j"
+      ],
+      "char_filter": [
+        "slash_remover"
+      ],
+      "type": "custom",
+      "tokenizer": "whitespace"
+    },
+    "lowercase": {
+      "filter": [
+        "asciifolding",
+        "word_delimiter",
+        "lowercase"
+      ],
+      "char_filter": [
+        "slash_remover"
+      ],
+      "type": "custom",
+      "tokenizer": "whitespace"
+    },
+    "lowercase_token_limited": {
+      "filter": [
+        "asciifolding",
+        "word_delimiter",
+        "long_query_token_limiter",
+        "lowercase"
+      ],
+      "char_filter": [
+        "slash_remover"
+      ],
+      "type": "custom",
+      "tokenizer": "whitespace"
+    },
+    "italian": {
+      "filter": [
+        "italian_elision",
+        "word_delimiter",
+        "long_query_token_limiter",
+        "lowercase",
+        "italian_stemmer"
+      ],
+      "char_filter": [
+        "slash_remover"
+      ],
+      "tokenizer": "whitespace"
+    },
+    "lowercase_whitespace_tokens": {
+      "filter": [
+        "lowercase"
+      ],
+      "type": "custom",
+      "tokenizer": "whitespace"
+    },
+    "path_analyzer": {
+      "filter": [
+        "asciifolding",
+        "lowercase"
+      ],
+      "type": "custom",
+      "tokenizer": "path_hierarchy"
+    },
+    "dot_path_analyzer": {
+      "filter": [
+        "asciifolding",
+        "lowercase"
+      ],
+      "type": "custom",
+      "tokenizer": "dot_hierarchy"
+    },
+    "persian": {
+      "filter": [
+        "word_delimiter",
+        "long_query_token_limiter",
+        "lowercase",
+        "decimal_digit",
+        "arabic_normalization",
+        "persian_normalization"
+      ],
+      "char_filter": [
+        "zero_width_spaces",
+        "slash_remover"
+      ],
+      "tokenizer": "whitespace"
+    },
+    "cased": {
+      "filter": [
+        "asciifolding",
+        "word_delimiter",
+        "long_query_token_limiter"
+      ],
+      "char_filter": [
+        "slash_remover"
+      ],
+      "type": "custom",
+      "tokenizer": "whitespace"
+    },
+    "arabic": {
+      "filter": [
+        "word_delimiter",
+        "long_query_token_limiter",
+        "lowercase",
+        "decimal_digit",
+        "arabic_normalization",
+        "arabic_stemmer"
+      ],
+      "char_filter": [
+        "slash_remover"
+      ],
+      "tokenizer": "whitespace"
+    },
+    "bengali": {
+      "filter": [
+        "word_delimiter",
+        "long_query_token_limiter",
+        "lowercase",
+        "decimal_digit",
+        "indic_normalization",
+        "bengali_normalization",
+        "bengali_stemmer"
+      ],
+      "char_filter": [
+        "slash_remover"
+      ],
+      "tokenizer": "whitespace"
+    },
+    "english": {
+      "filter": [
+        "possessive_english",
+        "asciifolding",
+        "word_delimiter",
+        "lowercase",
+        "english_stemmer"
+      ],
+      "char_filter": [
+        "slash_remover"
+      ],
+      "tokenizer": "whitespace"
+    },
+    "english_token_limited": {
+      "filter": [
+        "possessive_english",
+        "asciifolding",
+        "word_delimiter",
+        "long_query_token_limiter",
+        "lowercase",
+        "english_stemmer"
+      ],
+      "char_filter": [
+        "slash_remover"
+      ],
+      "tokenizer": "whitespace"
+    },
+    "hindi": {
+      "filter": [
+        "word_delimiter",
+        "long_query_token_limiter",
+        "lowercase",
+        "decimal_digit",
+        "indic_normalization",
+        "hindi_normalization",
+        "hindi_stemmer"
+      ],
+      "char_filter": [
+        "slash_remover"
+      ],
+      "tokenizer": "whitespace"
+    },
+    "french": {
+      "filter": [
+        "french_elision",
+        "word_delimiter",
+        "long_query_token_limiter",
+        "lowercase",
+        "french_stemmer"
+      ],
+      "char_filter": [
+        "slash_remover"
+      ],
+      "tokenizer": "whitespace"
+    },
+    "base": {
+      "filter": [
+        "word_delimiter",
+        "long_query_token_limiter"
+      ],
+      "char_filter": [
+        "slash_remover"
+      ],
+      "type": "custom",
+      "tokenizer": "whitespace"
+    },
+    "normalized_whole_phrase": {
+      "filter": [
+        "asciifolding",
+        "lowercase"
+      ],
+      "char_filter": [
+        "remove_punctuation"
+      ],
+      "tokenizer": "keyword"
+    }
+  },
+  "char_filter": {
+    "slash_remover": {
+      "pattern": "/",
+      "type": "pattern_replace",
+      "replacement": ""
+    },
+    "remove_punctuation": {
+      "pattern": "[^\\p{L}\\p{Nd}\\s]",
+      "_name": "Removes non-letter, non-numeric, and non-whitespace characters. Respects other character sets.",
+      "type": "pattern_replace",
+      "replacement": ""
+    },
+    "zero_width_spaces": {
+      "type": "mapping",
+      "mappings": [
+        "\\u200C=>\\u0020"
+      ]
+    }
+  }
+}

--- a/index_config/mappings.works_indexed.2026-07-03.json
+++ b/index_config/mappings.works_indexed.2026-07-03.json
@@ -1,0 +1,959 @@
+{
+  "dynamic": "strict",
+  "properties": {
+    "aggregatableValues": {
+      "properties": {
+        "availabilities": {
+          "type": "nested",
+          "properties": {
+            "id": {
+              "type": "keyword",
+              "eager_global_ordinals": true
+            },
+            "label": {
+              "type": "keyword",
+              "eager_global_ordinals": true
+            }
+          }
+        },
+        "contributors": {
+          "properties": {
+            "agent": {
+              "type": "nested",
+              "properties": {
+                "id": {
+                  "type": "keyword",
+                  "eager_global_ordinals": true
+                },
+                "label": {
+                  "type": "keyword",
+                  "eager_global_ordinals": true
+                }
+              }
+            }
+          }
+        },
+        "genres": {
+          "type": "nested",
+          "properties": {
+            "id": {
+              "type": "keyword",
+              "eager_global_ordinals": true
+            },
+            "label": {
+              "type": "keyword",
+              "eager_global_ordinals": true
+            }
+          }
+        },
+        "items": {
+          "properties": {
+            "locations": {
+              "properties": {
+                "license": {
+                  "type": "nested",
+                  "properties": {
+                    "id": {
+                      "type": "keyword",
+                      "eager_global_ordinals": true
+                    },
+                    "label": {
+                      "type": "keyword",
+                      "eager_global_ordinals": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "languages": {
+          "type": "nested",
+          "properties": {
+            "id": {
+              "type": "keyword",
+              "eager_global_ordinals": true
+            },
+            "label": {
+              "type": "keyword",
+              "eager_global_ordinals": true
+            }
+          }
+        },
+        "production": {
+          "properties": {
+            "dates": {
+              "type": "nested",
+              "properties": {
+                "id": {
+                  "type": "keyword",
+                  "eager_global_ordinals": true
+                },
+                "label": {
+                  "type": "keyword",
+                  "eager_global_ordinals": true
+                }
+              }
+            }
+          }
+        },
+        "subjects": {
+          "type": "nested",
+          "properties": {
+            "id": {
+              "type": "keyword",
+              "eager_global_ordinals": true
+            },
+            "label": {
+              "type": "keyword",
+              "eager_global_ordinals": true
+            }
+          }
+        },
+        "workType": {
+          "type": "nested",
+          "properties": {
+            "id": {
+              "type": "keyword",
+              "eager_global_ordinals": true
+            },
+            "label": {
+              "type": "keyword",
+              "eager_global_ordinals": true
+            }
+          }
+        },
+        "archive": {
+          "properties": {
+            "category": {
+              "type": "nested",
+              "properties": {
+                "id": {
+                  "type": "keyword",
+                  "eager_global_ordinals": true
+                },
+                "label": {
+                  "type": "keyword",
+                  "eager_global_ordinals": true
+                }
+              }
+            }
+          }
+        },
+        "collection": {
+          "properties": {
+            "root": {
+              "type": "nested",
+              "properties": {
+                "id": {
+                  "type": "keyword",
+                  "eager_global_ordinals": true
+                },
+                "label": {
+                  "type": "keyword",
+                  "eager_global_ordinals": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "debug": {
+      "dynamic": false,
+      "properties": {
+        "indexedTime": {
+          "type": "date"
+        },
+        "mergeCandidates": {
+          "properties": {
+            "id": {
+              "properties": {
+                "canonicalId": {
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "display": {
+      "type": "object",
+      "enabled": false
+    },
+    "filterableValues": {
+      "properties": {
+        "availabilities": {
+          "properties": {
+            "id": {
+              "type": "keyword"
+            }
+          }
+        },
+        "contributors": {
+          "properties": {
+            "agent": {
+              "properties": {
+                "label": {
+                  "type": "keyword"
+                },
+                "id": {
+                  "type": "keyword"
+                },
+                "sourceIdentifier": {
+                  "type": "keyword",
+                  "normalizer": "lowercase"
+                }
+              }
+            }
+          }
+        },
+        "format": {
+          "properties": {
+            "id": {
+              "type": "keyword"
+            }
+          }
+        },
+        "genres": {
+          "properties": {
+            "concepts": {
+              "properties": {
+                "id": {
+                  "type": "keyword"
+                },
+                "sourceIdentifier": {
+                  "type": "keyword",
+                  "normalizer": "lowercase"
+                }
+              }
+            },
+            "label": {
+              "type": "keyword"
+            }
+          }
+        },
+        "identifiers": {
+          "properties": {
+            "value": {
+              "type": "keyword"
+            }
+          }
+        },
+        "items": {
+          "properties": {
+            "id": {
+              "type": "keyword"
+            },
+            "identifiers": {
+              "properties": {
+                "value": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "locations": {
+              "properties": {
+                "accessConditions": {
+                  "properties": {
+                    "status": {
+                      "properties": {
+                        "id": {
+                          "type": "keyword"
+                        }
+                      }
+                    }
+                  }
+                },
+                "license": {
+                  "properties": {
+                    "id": {
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "locationType": {
+                  "properties": {
+                    "id": {
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "createdDate": {
+                  "type": "date"
+                }
+              }
+            }
+          }
+        },
+        "languages": {
+          "properties": {
+            "id": {
+              "type": "keyword"
+            }
+          }
+        },
+        "partOf": {
+          "properties": {
+            "id": {
+              "type": "keyword"
+            },
+            "title": {
+              "type": "keyword"
+            }
+          }
+        },
+        "production": {
+          "properties": {
+            "dates": {
+              "properties": {
+                "range": {
+                  "properties": {
+                    "from": {
+                      "type": "date"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "subjects": {
+          "properties": {
+            "concepts": {
+              "properties": {
+                "id": {
+                  "type": "keyword"
+                },
+                "sourceIdentifier": {
+                  "type": "keyword",
+                  "normalizer": "lowercase"
+                }
+              }
+            },
+            "label": {
+              "type": "keyword"
+            }
+          }
+        },
+        "workType": {
+          "type": "keyword"
+        },
+        "archive": {
+          "properties": {
+            "category": {
+              "properties": {
+                "id": {
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "collection": {
+          "properties": {
+            "isRoot": {
+              "type": "boolean"
+            },
+            "root": {
+              "properties": {
+                "id": {
+                  "type": "keyword"
+                },
+                "title": {
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "query": {
+      "properties": {
+        "alternativeTitles": {
+          "type": "text",
+          "fields": {
+            "arabic": {
+              "type": "text",
+              "analyzer": "arabic"
+            },
+            "base": {
+              "type": "text",
+              "analyzer": "base"
+            },
+            "bengali": {
+              "type": "text",
+              "analyzer": "bengali"
+            },
+            "cased": {
+              "type": "text",
+              "analyzer": "cased"
+            },
+            "english": {
+              "type": "text",
+              "analyzer": "english",
+              "search_analyzer": "english_token_limited"
+            },
+            "french": {
+              "type": "text",
+              "analyzer": "french"
+            },
+            "german": {
+              "type": "text",
+              "analyzer": "german"
+            },
+            "hindi": {
+              "type": "text",
+              "analyzer": "hindi"
+            },
+            "italian": {
+              "type": "text",
+              "analyzer": "italian"
+            },
+            "persian": {
+              "type": "text",
+              "analyzer": "persian"
+            },
+            "spanish": {
+              "type": "text",
+              "analyzer": "spanish"
+            },
+            "swappable_characters": {
+              "type": "text",
+              "analyzer": "swappable_characters"
+            }
+          },
+          "analyzer": "lowercase",
+          "search_analyzer": "lowercase_token_limited"
+        },
+        "collectionPath": {
+          "properties": {
+            "label": {
+              "type": "keyword",
+              "normalizer": "lowercase",
+              "fields": {
+                "path": {
+                  "type": "text",
+                  "analyzer": "path_analyzer",
+                  "search_analyzer": "lowercase_whitespace_tokens"
+                }
+              }
+            },
+            "path": {
+              "type": "keyword",
+              "normalizer": "lowercase",
+              "fields": {
+                "path": {
+                  "type": "text",
+                  "analyzer": "path_analyzer",
+                  "search_analyzer": "lowercase_whitespace_tokens"
+                }
+              }
+            },
+            "sort": {
+              "type": "keyword"
+            }
+          }
+        },
+        "contributors": {
+          "properties": {
+            "agent": {
+              "properties": {
+                "label": {
+                  "type": "text",
+                  "analyzer": "english",
+                  "search_analyzer": "english_token_limited"
+                }
+              }
+            }
+          }
+        },
+        "description": {
+          "type": "text",
+          "fields": {
+            "arabic": {
+              "type": "text",
+              "analyzer": "arabic"
+            },
+            "base": {
+              "type": "text",
+              "analyzer": "base"
+            },
+            "bengali": {
+              "type": "text",
+              "analyzer": "bengali"
+            },
+            "cased": {
+              "type": "text",
+              "analyzer": "cased"
+            },
+            "english": {
+              "type": "text",
+              "analyzer": "english",
+              "search_analyzer": "english_token_limited"
+            },
+            "french": {
+              "type": "text",
+              "analyzer": "french"
+            },
+            "german": {
+              "type": "text",
+              "analyzer": "german"
+            },
+            "hindi": {
+              "type": "text",
+              "analyzer": "hindi"
+            },
+            "italian": {
+              "type": "text",
+              "analyzer": "italian"
+            },
+            "persian": {
+              "type": "text",
+              "analyzer": "persian"
+            },
+            "spanish": {
+              "type": "text",
+              "analyzer": "spanish"
+            }
+          },
+          "analyzer": "lowercase",
+          "search_analyzer": "lowercase_token_limited"
+        },
+        "edition": {
+          "type": "text",
+          "analyzer": "english",
+          "search_analyzer": "english_token_limited"
+        },
+        "genres": {
+          "properties": {
+            "concepts": {
+              "properties": {
+                "label": {
+                  "type": "text",
+                  "analyzer": "english",
+                  "search_analyzer": "english_token_limited"
+                }
+              }
+            }
+          }
+        },
+        "id": {
+          "type": "keyword",
+          "normalizer": "lowercase"
+        },
+        "identifiers": {
+          "properties": {
+            "value": {
+              "type": "keyword",
+              "normalizer": "lowercase"
+            }
+          }
+        },
+        "images": {
+          "properties": {
+            "id": {
+              "type": "keyword",
+              "normalizer": "lowercase"
+            },
+            "identifiers": {
+              "properties": {
+                "value": {
+                  "type": "keyword",
+                  "normalizer": "lowercase"
+                }
+              }
+            }
+          }
+        },
+        "items": {
+          "properties": {
+            "id": {
+              "type": "keyword",
+              "normalizer": "lowercase"
+            },
+            "identifiers": {
+              "properties": {
+                "value": {
+                  "type": "keyword",
+                  "normalizer": "lowercase"
+                }
+              }
+            },
+            "shelfmark": {
+              "properties": {
+                "value": {
+                  "type": "keyword",
+                  "normalizer": "lowercase",
+                  "fields": {
+                    "path": {
+                      "type": "text",
+                      "analyzer": "path_analyzer",
+                      "search_analyzer": "lowercase_whitespace_tokens"
+                    },
+                    "dot_path": {
+                      "type": "text",
+                      "analyzer": "dot_path_analyzer",
+                      "search_analyzer": "lowercase_whitespace_tokens"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "languages": {
+          "properties": {
+            "label": {
+              "type": "text",
+              "analyzer": "lowercase",
+              "search_analyzer": "lowercase_token_limited"
+            }
+          }
+        },
+        "lettering": {
+          "type": "text",
+          "fields": {
+            "arabic": {
+              "type": "text",
+              "analyzer": "arabic"
+            },
+            "base": {
+              "type": "text",
+              "analyzer": "base"
+            },
+            "bengali": {
+              "type": "text",
+              "analyzer": "bengali"
+            },
+            "cased": {
+              "type": "text",
+              "analyzer": "cased"
+            },
+            "english": {
+              "type": "text",
+              "analyzer": "english",
+              "search_analyzer": "english_token_limited"
+            },
+            "french": {
+              "type": "text",
+              "analyzer": "french"
+            },
+            "german": {
+              "type": "text",
+              "analyzer": "german"
+            },
+            "hindi": {
+              "type": "text",
+              "analyzer": "hindi"
+            },
+            "italian": {
+              "type": "text",
+              "analyzer": "italian"
+            },
+            "persian": {
+              "type": "text",
+              "analyzer": "persian"
+            },
+            "spanish": {
+              "type": "text",
+              "analyzer": "spanish"
+            },
+            "swappable_characters": {
+              "type": "text",
+              "analyzer": "swappable_characters"
+            }
+          },
+          "analyzer": "lowercase",
+          "search_analyzer": "lowercase_token_limited"
+        },
+        "notes": {
+          "properties": {
+            "contents": {
+              "type": "text",
+              "fields": {
+                "arabic": {
+                  "type": "text",
+                  "analyzer": "arabic"
+                },
+                "base": {
+                  "type": "text",
+                  "analyzer": "base"
+                },
+                "bengali": {
+                  "type": "text",
+                  "analyzer": "bengali"
+                },
+                "cased": {
+                  "type": "text",
+                  "analyzer": "cased"
+                },
+                "english": {
+                  "type": "text",
+                  "analyzer": "english",
+                  "search_analyzer": "english_token_limited"
+                },
+                "french": {
+                  "type": "text",
+                  "analyzer": "french"
+                },
+                "german": {
+                  "type": "text",
+                  "analyzer": "german"
+                },
+                "hindi": {
+                  "type": "text",
+                  "analyzer": "hindi"
+                },
+                "italian": {
+                  "type": "text",
+                  "analyzer": "italian"
+                },
+                "persian": {
+                  "type": "text",
+                  "analyzer": "persian"
+                },
+                "spanish": {
+                  "type": "text",
+                  "analyzer": "spanish"
+                },
+                "swappable_characters": {
+                  "type": "text",
+                  "analyzer": "swappable_characters"
+                }
+              },
+              "analyzer": "lowercase",
+              "search_analyzer": "lowercase_token_limited"
+            }
+          }
+        },
+        "partOf": {
+          "properties": {
+            "title": {
+              "type": "text",
+              "fields": {
+                "arabic": {
+                  "type": "text",
+                  "analyzer": "arabic"
+                },
+                "base": {
+                  "type": "text",
+                  "analyzer": "base"
+                },
+                "bengali": {
+                  "type": "text",
+                  "analyzer": "bengali"
+                },
+                "cased": {
+                  "type": "text",
+                  "analyzer": "cased"
+                },
+                "english": {
+                  "type": "text",
+                  "analyzer": "english",
+                  "search_analyzer": "english_token_limited"
+                },
+                "french": {
+                  "type": "text",
+                  "analyzer": "french"
+                },
+                "german": {
+                  "type": "text",
+                  "analyzer": "german"
+                },
+                "hindi": {
+                  "type": "text",
+                  "analyzer": "hindi"
+                },
+                "italian": {
+                  "type": "text",
+                  "analyzer": "italian"
+                },
+                "persian": {
+                  "type": "text",
+                  "analyzer": "persian"
+                },
+                "spanish": {
+                  "type": "text",
+                  "analyzer": "spanish"
+                },
+                "swappable_characters": {
+                  "type": "text",
+                  "analyzer": "swappable_characters"
+                }
+              },
+              "analyzer": "lowercase",
+              "search_analyzer": "lowercase_token_limited"
+            }
+          }
+        },
+        "physicalDescription": {
+          "type": "text",
+          "analyzer": "english",
+          "search_analyzer": "english_token_limited"
+        },
+        "production": {
+          "properties": {
+            "label": {
+              "type": "text",
+              "fields": {
+                "arabic": {
+                  "type": "text",
+                  "analyzer": "arabic"
+                },
+                "base": {
+                  "type": "text",
+                  "analyzer": "base"
+                },
+                "bengali": {
+                  "type": "text",
+                  "analyzer": "bengali"
+                },
+                "cased": {
+                  "type": "text",
+                  "analyzer": "cased"
+                },
+                "english": {
+                  "type": "text",
+                  "analyzer": "english",
+                  "search_analyzer": "english_token_limited"
+                },
+                "french": {
+                  "type": "text",
+                  "analyzer": "french"
+                },
+                "german": {
+                  "type": "text",
+                  "analyzer": "german"
+                },
+                "hindi": {
+                  "type": "text",
+                  "analyzer": "hindi"
+                },
+                "italian": {
+                  "type": "text",
+                  "analyzer": "italian"
+                },
+                "persian": {
+                  "type": "text",
+                  "analyzer": "persian"
+                },
+                "spanish": {
+                  "type": "text",
+                  "analyzer": "spanish"
+                },
+                "swappable_characters": {
+                  "type": "text",
+                  "analyzer": "swappable_characters"
+                }
+              },
+              "analyzer": "lowercase",
+              "search_analyzer": "lowercase_token_limited"
+            }
+          }
+        },
+        "referenceNumber": {
+          "type": "keyword",
+          "normalizer": "lowercase",
+          "fields": {
+            "path": {
+              "type": "text",
+              "analyzer": "path_analyzer",
+              "search_analyzer": "lowercase_whitespace_tokens"
+            }
+          }
+        },
+        "sourceIdentifier": {
+          "properties": {
+            "value": {
+              "type": "keyword",
+              "normalizer": "lowercase"
+            }
+          }
+        },
+        "subjects": {
+          "properties": {
+            "concepts": {
+              "properties": {
+                "label": {
+                  "type": "text",
+                  "analyzer": "english",
+                  "search_analyzer": "english_token_limited"
+                }
+              }
+            }
+          }
+        },
+        "title": {
+          "type": "text",
+          "fields": {
+            "arabic": {
+              "type": "text",
+              "analyzer": "arabic"
+            },
+            "base": {
+              "type": "text",
+              "analyzer": "base"
+            },
+            "bengali": {
+              "type": "text",
+              "analyzer": "bengali"
+            },
+            "cased": {
+              "type": "text",
+              "analyzer": "cased"
+            },
+            "english": {
+              "type": "text",
+              "analyzer": "english",
+              "search_analyzer": "english_token_limited"
+            },
+            "french": {
+              "type": "text",
+              "analyzer": "french"
+            },
+            "german": {
+              "type": "text",
+              "analyzer": "german"
+            },
+            "hindi": {
+              "type": "text",
+              "analyzer": "hindi"
+            },
+            "italian": {
+              "type": "text",
+              "analyzer": "italian"
+            },
+            "normalized_whole_phrase": {
+              "type": "text",
+              "analyzer": "normalized_whole_phrase"
+            },
+            "persian": {
+              "type": "text",
+              "analyzer": "persian"
+            },
+            "spanish": {
+              "type": "text",
+              "analyzer": "spanish"
+            },
+            "swappable_characters": {
+              "type": "text",
+              "analyzer": "swappable_characters"
+            }
+          },
+          "analyzer": "lowercase",
+          "search_analyzer": "lowercase_token_limited"
+        }
+      }
+    },
+    "redirectTarget": {
+      "type": "object",
+      "dynamic": false
+    },
+    "type": {
+      "type": "keyword"
+    }
+  }
+}

--- a/index_config/mappings.works_indexed.2026-07-30.json
+++ b/index_config/mappings.works_indexed.2026-07-30.json
@@ -140,6 +140,32 @@
             }
           }
         },
+        "archiveRoot": {
+          "type": "nested",
+          "properties": {
+            "id": {
+              "type": "keyword",
+              "eager_global_ordinals": true
+            },
+            "label": {
+              "type": "keyword",
+              "eager_global_ordinals": true
+            }
+          }
+        },
+        "archiveType": {
+          "type": "nested",
+          "properties": {
+            "id": {
+              "type": "keyword",
+              "eager_global_ordinals": true
+            },
+            "label": {
+              "type": "keyword",
+              "eager_global_ordinals": true
+            }
+          }
+        },
         "collection": {
           "properties": {
             "root": {
@@ -154,6 +180,19 @@
                   "eager_global_ordinals": true
                 }
               }
+            }
+          }
+        },
+        "collectionRoot": {
+          "type": "nested",
+          "properties": {
+            "id": {
+              "type": "keyword",
+              "eager_global_ordinals": true
+            },
+            "label": {
+              "type": "keyword",
+              "eager_global_ordinals": true
             }
           }
         }
@@ -351,6 +390,23 @@
             }
           }
         },
+        "archiveRoot": {
+          "properties": {
+            "id": {
+              "type": "keyword"
+            },
+            "title": {
+              "type": "keyword"
+            }
+          }
+        },
+        "archiveType": {
+          "properties": {
+            "id": {
+              "type": "keyword"
+            }
+          }
+        },
         "collection": {
           "properties": {
             "isRoot": {
@@ -367,6 +423,22 @@
               }
             }
           }
+        },
+        "collectionRoot": {
+          "properties": {
+            "id": {
+              "type": "keyword"
+            },
+            "title": {
+              "type": "keyword"
+            }
+          }
+        },
+        "isArchiveRoot": {
+          "type": "boolean"
+        },
+        "isCollectionRoot": {
+          "type": "boolean"
         }
       }
     },

--- a/pipeline/terraform/2026-07-03/elastic.tf
+++ b/pipeline/terraform/2026-07-03/elastic.tf
@@ -28,7 +28,7 @@ locals {
         // matcher_merger - graph/ingestor/indexer
         denormalised = "works_denormalised.2025-08-14"
         // graph/ingestor/indexer - API
-        indexed = "works_indexed.2026-07-30"
+        indexed = "works_indexed.2026-07-03"
       }
       images = {
         // matcher_merger - images_inferrer


### PR DESCRIPTION
## What does this change?

Adds the following fields to `index_config/mappings.works_indexed.2026-07-30.json` to match the mappings that were already manually applied to the live index:

**`aggregatableValues`**
- `archiveRoot` (nested)
- `archiveType` (nested)
- `collectionRoot` (nested)

**`filterableValues`**
- `archiveRoot`
- `archiveType`
- `collectionRoot`
- `isArchiveRoot` (boolean)
- `isCollectionRoot` (boolean)

These fields were manually applied to the `works-indexed-2026-07-30` index in the 2025-10-02 pipeline. The `index_config` file was out of sync, causing Terraform plan to show a diff. Since the mappings are strict and the apply would be subtractive, we need to include the defunct properties in the index config. This brings the file into alignment with the deployed state so that `terraform apply` on the 2025-10-02 pipeline is a no-op for this mapping.

~~We'll also want to apply these mappings in the 2026-07-03 pipeline to align it with the 2025-10-02 pipeline.~~
These added mappings properties were relevant at an intermediate stage of development but not part of the final mappings. The 2026-07-03 pipeline and `works-indexed-2026-07-03` index use a separate index config, which reflect the desired state, ie without the properties that were eventually decided against.

## How to test

Run `terraform plan` against the 2025-10-02 pipeline — the `works_indexed.2026-07-30` mapping should show no diff, apart from the expected "false" -> false on the dynamic properties 

Verify the added fields match what `GET works-indexed-2026-07-30/_mapping` returns for the live index.

Run `terraform plan` against the 2026-07-03 pipeline — the `works_indexed.2026-07-03` mapping should show no diff: the correct/final version mappings have already been applied 

## How can we measure success?

`terraform plan` on the 2025-10-02 pipeline produces no mapping diff for `works_indexed.2026-07-30`, except for the "false" -> false (9 indices)
`terraform plan` on the 2026-07-03 pipeline produces no mapping diff for `works_indexed.2026-07-03`.


## Have we considered potential risks?

Low risk — this is a purely additive change to the mapping config, aligning it with what is already deployed. No index reindexing required.