### PR TITLE
Respin the 2026-07-03 id-minter cluster from the 2026-08-17 production backup

### DIFF
--- a/infrastructure/critical/rds_id_minter.tf
+++ b/infrastructure/critical/rds_id_minter.tf
@@ -17,8 +17,8 @@ module "id_minter_rds_2026_07_03" {
   source = "./modules/id-minter-rds"
 
   name_suffix = "2026-07-03"
-  # Restore from production on July 30, 2026, 04:00 (UTC+01:00)
-  snapshot_identifier = "awsbackup:job-23667bdb-6b2b-92c9-d653-03f01ced06ce"
+  # Restore from production on August 17, 2026, 04:00 (UTC+01:00)
+  snapshot_identifier = "awsbackup:job-74fac66a-d4a1-f82e-bda3-92c19d19d21c"
 
   # A restored copy of production; its contents are never worth keeping.
   skip_final_snapshot = true


### PR DESCRIPTION
Part of wellcomecollection/platform#6503 (phase 3, round 2 clear).

Re-points the `2026-07-03` id-minter module at this morning's recovery point from `id-minter-backup-vault` (2026-08-17 04:00 BST, COMPLETED). Applying forces replacement of the cluster and instance, resolving the shared-id-pool fork found in round 1 (wellcomecollection/platform#6485) and closing the ID-parity gap ahead of the round 2 reindex.

Merge only inside the respin window: `infrastructure/critical` is applied by hand, and the apply must be preceded by `aws rds modify-db-cluster --no-deletion-protection` on the current cluster or the destroy fails partway. After the cluster is available, re-apply the `2026-07-03` pipeline stack (lambda secret name + IAM) and re-plan this root to restore `enable_http_endpoint`, which a snapshot restore silently drops.