### PR TITLE
Retry Neptune's transient failures instead of losing a graph window

### DIFF
--- a/catalogue_graph/src/clients/neptune_client.py
+++ b/catalogue_graph/src/clients/neptune_client.py
@@ -7,6 +7,7 @@ from collections.abc import Iterable, Iterator
 
 import backoff
 import boto3
+import botocore.exceptions
 import requests
 import structlog
 from botocore.auth import SigV4Auth
@@ -33,6 +34,32 @@ ALLOW_DATABASE_RESET = False
 
 NEPTUNE_MAX_PARALLEL_QUERIES = 10
 NEPTUNE_QUERY_THREAD_COUNT = 5
+
+# Status alone is not enough: ConstraintViolationException is a 400 that Neptune
+# documents as transient. Status is the fallback when there is no error body.
+# https://docs.aws.amazon.com/neptune/latest/userguide/errors-engine-codes.html
+TRANSIENT_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
+TRANSIENT_ERROR_CODES = frozenset({"ConstraintViolationException"})
+
+
+class NeptuneRequestError(Exception):
+    """A non-200 response from Neptune."""
+
+
+class TransientNeptuneError(NeptuneRequestError):
+    """A retryable failure, typed so that Step Functions can match it by name."""
+
+
+def _is_transient(raw_response: requests.Response) -> bool:
+    try:
+        body = raw_response.json()
+    except ValueError:
+        body = None
+
+    if isinstance(body, dict) and body.get("code") in TRANSIENT_ERROR_CODES:
+        return True
+
+    return raw_response.status_code in TRANSIENT_STATUS_CODES
 
 
 def on_request_backoff(backoff_details: typing.Any) -> None:
@@ -75,7 +102,12 @@ class NeptuneClient:
 
     @backoff.on_exception(
         backoff.constant,
-        Exception,
+        # botocore covers credential resolution, which happens inside this method.
+        (
+            TransientNeptuneError,
+            requests.exceptions.RequestException,
+            botocore.exceptions.BotoCoreError,
+        ),
         max_tries=NEPTUNE_REQUESTS_BACKOFF_RETRIES,
         interval=NEPTUNE_REQUESTS_BACKOFF_INTERVAL,
         on_backoff=on_request_backoff,
@@ -101,7 +133,9 @@ class NeptuneClient:
             )
 
         if raw_response.status_code != 200:
-            raise Exception(raw_response.content)
+            if _is_transient(raw_response):
+                raise TransientNeptuneError(raw_response.content)
+            raise NeptuneRequestError(raw_response.content)
 
         response: dict = raw_response.json()
         return response

--- a/catalogue_graph/tests/clients/test_neptune_client.py
+++ b/catalogue_graph/tests/clients/test_neptune_client.py
@@ -1,0 +1,92 @@
+import pytest
+from _pytest.monkeypatch import MonkeyPatch
+
+from clients.neptune_client import (
+    NEPTUNE_REQUESTS_BACKOFF_RETRIES,
+    NeptuneRequestError,
+    TransientNeptuneError,
+)
+from tests.mocks import MOCK_NEPTUNE_ENDPOINT, MockRequest, get_mock_neptune_client
+
+LOADER_URL = f"https://{MOCK_NEPTUNE_ENDPOINT}:8182/loader"
+
+
+@pytest.fixture(autouse=True)
+def _no_backoff_sleep(monkeypatch: MonkeyPatch) -> None:
+    # Scoped to the decorator's sleep, so later timing assertions here still work.
+    monkeypatch.setattr("backoff._sync.time.sleep", lambda *_a, **_k: None)
+
+
+def _mock_loader_response(status_code: int, code: str = "SomeException") -> None:
+    MockRequest.mock_response(
+        method="POST",
+        url=LOADER_URL,
+        status_code=status_code,
+        json_data={"code": code},
+        content_bytes=b"{}",
+    )
+
+
+@pytest.mark.parametrize("status_code", [429, 500, 502, 503, 504])
+def test_transient_status_raises_transient_error(status_code: int) -> None:
+    _mock_loader_response(status_code)
+    client = get_mock_neptune_client()
+
+    with pytest.raises(TransientNeptuneError):
+        client.initiate_bulk_load(s3_file_uri="s3://bucket/nodes.csv")
+
+
+@pytest.mark.parametrize("status_code", [400, 403, 404])
+def test_permanent_status_raises_plain_request_error(status_code: int) -> None:
+    _mock_loader_response(status_code)
+    client = get_mock_neptune_client()
+
+    with pytest.raises(NeptuneRequestError) as excinfo:
+        client.initiate_bulk_load(s3_file_uri="s3://bucket/nodes.csv")
+
+    assert not isinstance(excinfo.value, TransientNeptuneError)
+
+
+def test_permanent_status_is_not_retried() -> None:
+    _mock_loader_response(400)
+    client = get_mock_neptune_client()
+    MockRequest.clear_mock_calls()
+
+    with pytest.raises(NeptuneRequestError):
+        client.initiate_bulk_load(s3_file_uri="s3://bucket/nodes.csv")
+
+    assert len(MockRequest.calls) == 1
+
+
+def test_transient_status_is_retried_until_exhausted() -> None:
+    _mock_loader_response(500)
+    client = get_mock_neptune_client()
+    MockRequest.clear_mock_calls()
+
+    with pytest.raises(TransientNeptuneError):
+        client.initiate_bulk_load(s3_file_uri="s3://bucket/nodes.csv")
+
+    assert len(MockRequest.calls) == NEPTUNE_REQUESTS_BACKOFF_RETRIES
+
+
+def test_transient_error_subclasses_request_error() -> None:
+    # Callers catching the base type keep working once retries are exhausted.
+    assert issubclass(TransientNeptuneError, NeptuneRequestError)
+
+
+def test_retryable_400_is_transient_despite_its_status() -> None:
+    _mock_loader_response(400, code="ConstraintViolationException")
+    client = get_mock_neptune_client()
+
+    with pytest.raises(TransientNeptuneError):
+        client.initiate_bulk_load(s3_file_uri="s3://bucket/nodes.csv")
+
+
+def test_status_is_used_when_there_is_no_engine_error_body() -> None:
+    MockRequest.mock_response(
+        method="POST", url=LOADER_URL, status_code=502, content_bytes=b"<html>"
+    )
+    client = get_mock_neptune_client()
+
+    with pytest.raises(TransientNeptuneError):
+        client.initiate_bulk_load(s3_file_uri="s3://bucket/nodes.csv")

--- a/pipeline/terraform/modules/pipeline_services/graph/locals.tf
+++ b/pipeline/terraform/modules/pipeline_services/graph/locals.tf
@@ -214,6 +214,19 @@ locals {
       JitterStrategy  = "FULL"
     }
   ]
+
+  # Matched on its own so that a permanent NeptuneRequestError, and the poller's
+  # fatal "Load failed", still fail on the first attempt. What counts as transient
+  # is decided in catalogue_graph/src/clients/neptune_client.py.
+  transient_neptune_retry = [
+    {
+      ErrorEquals     = ["TransientNeptuneError"]
+      IntervalSeconds = 5
+      MaxAttempts     = 3
+      BackoffRate     = 2
+      JitterStrategy  = "FULL"
+    }
+  ]
 }
 
 data "aws_vpc" "vpc" {

--- a/pipeline/terraform/modules/pipeline_services/graph/state_machine_bulk_loader.tf
+++ b/pipeline/terraform/modules/pipeline_services/graph/state_machine_bulk_loader.tf
@@ -15,7 +15,7 @@ module "catalogue_graph_bulk_loader_state_machine" {
           "FunctionName" : module.bulk_loader_lambda.lambda_arn,
           "Payload.$" : "$"
         },
-        Retry = local.state_function_default_retry,
+        Retry = concat(local.state_function_default_retry, local.transient_neptune_retry),
         "Next" : "Wait 5 seconds"
       },
       "Wait 5 seconds" : {
@@ -31,7 +31,7 @@ module "catalogue_graph_bulk_loader_state_machine" {
           "FunctionName" : module.bulk_load_poller_lambda.lambda_arn,
           "Payload.$" : "$"
         },
-        Retry = local.state_function_default_retry,
+        Retry = concat(local.state_function_default_retry, local.transient_neptune_retry),
         "Next" : "Load complete?"
       },
       "Load complete?" : {

--- a/pipeline/terraform/modules/pipeline_services/graph/state_machine_graph_removers.tf
+++ b/pipeline/terraform/modules/pipeline_services/graph/state_machine_graph_removers.tf
@@ -31,7 +31,7 @@ module "catalogue_graph_removers_monthly_state_machine" {
                   "graph_date" : var.graph_date,
                 }
               },
-              Retry = local.state_function_default_retry,
+              Retry = concat(local.state_function_default_retry, local.transient_neptune_retry),
               End   = true
             }
           }
@@ -88,7 +88,7 @@ module "catalogue_graph_removers_incremental_state_machine" {
                 FunctionName = module.graph_remover_incremental_lambda.lambda_arn,
                 Payload      = "{% $states.input %}"
               },
-              Retry = local.state_function_default_retry,
+              Retry = concat(local.state_function_default_retry, local.transient_neptune_retry),
               End   = true
             }
           }


### PR DESCRIPTION
## What does this change?

Closes wellcomecollection/platform#6522.

On 2026-08-15 one Neptune 500 during `initiate_bulk_load` failed a whole `graph-pipeline-incremental` run. Windows come from the trigger's `end_time` minus 15 minutes rather than a cursor, so a failed window is skipped rather than retried later. That one was empty; the same blip on a weekday afternoon would drop 15 minutes of graph changes until the next monthly load.

`_make_request` raised a bare `Exception` on a non-200, so neither retry layer could separate a transient failure from a permanent one. `backoff` was keyed on `Exception` and retried permanent errors three times at ten second intervals, and Step Functions saw `Error: Exception`, which it cannot usefully match.

This classifies instead, mirroring `inferrer/image_downloader.py`: `NeptuneRequestError`, plus a `TransientNeptuneError` subclass that Step Functions matches by name. Classification follows [Neptune's error table](https://docs.aws.amazon.com/neptune/latest/userguide/errors-engine-codes.html) rather than the status alone, because `ConstraintViolationException` is a 400 the table documents as transient. Status is the fallback for responses with no error body, such as a gateway 502.

Matching that type on its own, rather than widening the default retry to `Exception`, keeps `bulk_load_poller.py:155`'s fatal "Load failed" failing on the first attempt instead of re-running known-bad loads. The retrier covers the remover tasks as well as the bulk loader, since both call Neptune from a Lambda. The graph module is shared, so 2025-10-02 and 2026-07-03 both pick this up.

### Checklist

- [x] Display model unchanged, this is error handling only.

## How to test

`tests/clients/test_neptune_client.py` asserts the classification both ways, plus call counts: a permanent failure costs one request, a transient one exhausts the backoff budget.

Replaying the failed window on 2026-08-17 succeeded and produced all eight load reports, including the three that never ran on the night.

The terraform needs a manual apply per pipeline date. The client half ships with the Lambda.

## How can we measure success?

Fewer `graph-pipeline-incremental-run-failed-*` alarms. It has fired for this cause once in three weeks, so the measure is absence over a month or two rather than a step change. Absorbed blips still log `Neptune request failed, retrying` in `service-logs-*`.

## Have we considered potential risks?

The retriers nest: up to 3 in-process tries inside each of 4 Step Functions attempts, so roughly 115 seconds and 12 requests per bulk-load task before an outage alarms. Say if that is too slow and I will drop `MaxAttempts` to 2. Permanent errors now fail immediately rather than after about 20 seconds.

The judgement call worth a second opinion is `InternalFailureException`. It is the error from 2026-08-15 and it is a 500, so it is treated as transient here, but Neptune's table marks it "Ok to Retry: No". I think a retry is still right for a bulk-load submission, because that starts a fresh job rather than resuming a failed one, and the replay bore that out. It would not be right for a query.

The ECS ingestor stages also call Neptune and cannot match by exception name, so they keep the old behaviour. Worth a follow-up rather than solving here.
