### PR TITLE
Report the real exception type from ECS steps to Step Functions

### DIFF
--- a/catalogue_graph/src/utils/steps.py
+++ b/catalogue_graph/src/utils/steps.py
@@ -78,9 +78,12 @@ class StepFunctionOutput:
             logger.error(
                 "Sending task failure to Step Functions", error_output=error_output
             )
+            # Step Functions matches Retry/Catch on this name, so send the real
+            # exception type. Class names cannot contain a dot, so they can never
+            # collide with the Lambda./ECS./States. prefixes already matched on.
             self.stepfunctions_client.send_task_failure(
                 taskToken=self.task_token,
-                error="IngestorLoaderError",
+                error=type(error).__name__,
                 cause=error_output,
             )
         else:

--- a/catalogue_graph/tests/utils/test_steps.py
+++ b/catalogue_graph/tests/utils/test_steps.py
@@ -124,7 +124,7 @@ def test_ecs_handler_reports_failure(
     assert len(MockStepFunctionsClient.task_failures) == 1
     failure = MockStepFunctionsClient.task_failures[0]
     assert failure["taskToken"] == token
-    assert failure["error"] == "IngestorLoaderError"
+    assert failure["error"] == "RuntimeError"
     cause = json.loads(failure["cause"])
     assert cause["message"] == "unexpected kaboom"
     assert cause["type"] == "RuntimeError"
@@ -419,7 +419,7 @@ def test_step_function_output_send_failure_reports(
     assert len(MockStepFunctionsClient.task_failures) == 1
     failure = MockStepFunctionsClient.task_failures[0]
     assert failure["taskToken"] == "token-555"
-    assert failure["error"] == "IngestorLoaderError"
+    assert failure["error"] == "RuntimeError"
     cause = json.loads(failure["cause"])
     assert cause["message"] == "boom"
     assert cause["type"] == "RuntimeError"
@@ -436,3 +436,15 @@ def test_step_function_output_send_failure_without_token_logs(
 
     assert MockStepFunctionsClient.task_failures == []
     assert "Task error" in caplog.text
+
+
+def test_step_function_output_send_failure_names_the_exception_type() -> None:
+    # The name is what Step Functions matches Retry/Catch on, so distinct
+    # exception types must not collapse to one string.
+    output = StepFunctionOutput("token-666", MockStepFunctionsClient())
+
+    output.send_failure(ValueError("bad input"))
+    output.send_failure(TimeoutError("too slow"))
+
+    errors = [f["error"] for f in MockStepFunctionsClient.task_failures]
+    assert errors == ["ValueError", "TimeoutError"]

--- a/pipeline/terraform/modules/pipeline_services/graph/locals.tf
+++ b/pipeline/terraform/modules/pipeline_services/graph/locals.tf
@@ -227,6 +227,25 @@ locals {
       JitterStrategy  = "FULL"
     }
   ]
+
+  # Covers what the extractor's in-process retry does not: core/source.py retries
+  # TransportError and ApiError for up to five minutes, but GZipSource streams over
+  # raw requests and is not retried at all. NotFoundError is deliberately absent,
+  # because pit_id is fixed in the state input, so a retry reuses the expired PIT.
+  # Two attempts, to stay inside the 15m PIT keep-alive.
+  transient_extractor_retry = [
+    {
+      ErrorEquals = [
+        "ChunkedEncodingError",
+        "ConnectionError",
+        "ConnectionTimeout",
+      ]
+      IntervalSeconds = 5
+      MaxAttempts     = 2
+      BackoffRate     = 2
+      JitterStrategy  = "FULL"
+    }
+  ]
 }
 
 data "aws_vpc" "vpc" {

--- a/pipeline/terraform/modules/pipeline_services/graph/locals.tf
+++ b/pipeline/terraform/modules/pipeline_services/graph/locals.tf
@@ -235,9 +235,14 @@ locals {
   # Two attempts, to stay inside the 15m PIT keep-alive.
   transient_extractor_retry = [
     {
+      # Matched by exact name, so both spellings are needed: requests raises
+      # ConnectTimeout/ReadTimeout on the GZipSource path, elasticsearch raises
+      # ConnectionTimeout once its in-process budget is spent.
       ErrorEquals = [
         "ChunkedEncodingError",
         "ConnectionError",
+        "ConnectTimeout",
+        "ReadTimeout",
         "ConnectionTimeout",
       ]
       IntervalSeconds = 5

--- a/pipeline/terraform/modules/pipeline_services/graph/state_machine_extractor.tf
+++ b/pipeline/terraform/modules/pipeline_services/graph/state_machine_extractor.tf
@@ -13,7 +13,7 @@ module "catalogue_graph_extractor_state_machine" {
         Output           = "{% $states.input %}"
         TimeoutSeconds   = local.ecs_task_token_timeout_seconds
         HeartbeatSeconds = local.ecs_task_token_heartbeat_seconds
-        Retry            = local.state_function_default_retry,
+        Retry            = concat(local.state_function_default_retry, local.transient_extractor_retry),
         Next             = "Success"
         Arguments = {
           Cluster        = var.ecs_cluster_arn

--- a/pipeline/terraform/modules/pipeline_services/graph/state_machine_ingestor.tf
+++ b/pipeline/terraform/modules/pipeline_services/graph/state_machine_ingestor.tf
@@ -12,7 +12,7 @@ module "catalogue_graph_ingestor_state_machine" {
         Resource         = "arn:aws:states:::ecs:runTask.waitForTaskToken"
         TimeoutSeconds   = local.ecs_task_token_timeout_seconds
         HeartbeatSeconds = local.ecs_task_token_heartbeat_seconds
-        Retry            = local.state_function_default_retry,
+        Retry            = concat(local.state_function_default_retry, local.transient_neptune_retry),
         Next             = "Run indexer"
         Arguments = {
           Cluster        = var.ecs_cluster_arn


### PR DESCRIPTION
## What does this change?

Follow-up to #3572, and part of wellcomecollection/platform#6522. Stacked on that branch because it uses the `transient_neptune_retry` local it adds, so review that one first.

`StepFunctionOutput.send_failure` hardcoded `error="IngestorLoaderError"`, so every failure from every `ecs_handler` call site reported under that one name. There are ten of them: both ingestor steps, the graph extractor, `find_work`, `id_minter`, the EBSCO and OAI-PMH loaders, `axiell_folio_sync` and `inference_manager`. Live `graph-extractor` executions show the effect, an expired ES point-in-time and a truncated response both landing as `IngestorLoaderError`:

```
error = IngestorLoaderError
cause = {"message": "NotFoundError(404, 'search_phase_execution_exception',
          'No search context found for id [6856645]')", "type": "NotFoundError"}

error = IngestorLoaderError
cause = {"message": "Response ended prematurely", "type": "ChunkedEncodingError"}
```

Step Functions matches `Retry` and `Catch` on that name, so flattening it means no state machine can act on what actually failed. This sends `type(error).__name__` instead. The type was already being recorded in `cause.type`, so nothing new is being computed, it just stops being discarded at the boundary.

With the type preserved, two ECS tasks can retry on it.

The ingestor loader takes the same `TransientNeptuneError` retrier as the bulk loader and removers. It is the only ECS step that constructs a `NeptuneClient`, so the indexer and deletions tasks are left alone.

The extractor gets its own retrier for transport failures. `core/source.py` already retries `TransportError` and `ApiError` in-process for up to five minutes, but `GZipSource` streams over raw `requests` and is not retried at all, which is how the `ChunkedEncodingError` above failed a live run. `NotFoundError` is deliberately excluded: it is an expired PIT, and `pit_id` is fixed in the state input by the Open PIT step, so a retry would reuse the dead id and fail identically. The in-process layer gives up on 4xx for the same reason. Two attempts, to stay inside the 15m PIT keep-alive. Both `graph-extractors-monthly` and `graph-extractors-incremental` fan out to this state machine.

### Checklist

- [x] Display model unchanged, this is error reporting only.

## How to test

`test_step_function_output_send_failure_names_the_exception_type` asserts two different exception types produce two different names, which is the property that matters. The two existing assertions on the old constant are updated.

## How can we measure success?

Failures in `service-logs-*` and in execution histories name the thing that broke. The practical gain is that the ingestor loader now retries a transient Neptune failure, and the extractor retries a dropped stream, rather than either dropping a window.

## Have we considered potential risks?

The risk is a state machine that matches the old constant, so I checked four places and found no references outside this file and its tests: the deployed state machine definitions in eu-west-1, CloudWatch metric filters, CloudWatch alarms, and a code search across the `wellcomecollection` org.

New names cannot accidentally match an existing matcher. Every `ErrorEquals` entry in these state machines is either a `States.` built-in or a `Lambda.`/`ECS.` service error, and a Python class name cannot contain a dot.

The change widens what a `Catch` on a specific name would see in future, but no such `Catch` exists yet, so there is nothing to migrate. Anything matching `States.ALL` or `States.TaskFailed` is unaffected, since those match on the failure rather than its name.

Re-running an extractor task is idempotent: it overwrites its output by S3 key. The retries do eat into the PIT keep-alive, which is why the extractor gets two attempts rather than three.
