### PR TITLE
Resume the Axiell harvest schedule after the round 2 store rebuild

### DIFF
--- a/catalogue_graph/infra/adapters/main.tf
+++ b/catalogue_graph/infra/adapters/main.tf
@@ -16,14 +16,11 @@ module "ebsco" {
 }
 
 module "axiell" {
-  source              = "./modules/adapter"
-  namespace           = "axiell"
-  steps_namespace     = "oai_pmh"
-  s3_bucket_name      = "wellcomecollection-platform-axiell-adapter"
-  schedule_expression = "rate(15 minutes)"
-  # Paused for the round 2 clear (platform#6503): keeps the adapter store empty
-  # between the phase 6a wipe and the post-load rebuild.
-  schedule_enabled      = false
+  source                = "./modules/adapter"
+  namespace             = "axiell"
+  steps_namespace       = "oai_pmh"
+  s3_bucket_name        = "wellcomecollection-platform-axiell-adapter"
+  schedule_expression   = "rate(15 minutes)"
   repository_url        = data.aws_ecr_repository.unified_pipeline_lambda.repository_url
   event_bus_name        = aws_cloudwatch_event_bus.event_bus.name
   ecs_cluster_arn       = aws_ecs_cluster.adapters.arn


### PR DESCRIPTION
Part of wellcomecollection/platform#6503 (phase 6b, final step).

Reverts the phase 6a pause on `axiell_adapter_run` by removing the explicit `schedule_enabled = false` (the module default is true). The FOLIO adapter's pause is unrelated and stays.

Merge and apply only after the store rebuild has completed and its counts are verified: re-enabling mid-rebuild recreates the concurrent-harvest exposure the rebuild tooling deliberately no longer guards against (the wipe would drop concurrently harvested records and the advanced cursor would never re-fetch them). The harvest cursor was anchored at the rebuild start (2026-08-17 07:52 UTC), so as long as the apply lands within six hours of that, the first run stays under the 360-minute lag breaker with no `MAX_LAG_MINUTES` override.