### PR TITLE
Scale up tasks and the ES cluster for the round 2 reindex

### DIFF
--- a/infrastructure/critical/es_cluster.tf
+++ b/infrastructure/critical/es_cluster.tf
@@ -7,8 +7,11 @@ module "es_cluster_2026_07_03" {
 
   cluster_date = "2026-07-03"
 
-  memory     = "4g"
-  node_count = 3
+  # Sized for the round 2 full reindex (platform#6505), matching round 1.
+  # Back to 4g across 3 zones after the comparison signs off; the scale-down
+  # apply can only run once a day.
+  memory     = "30g"
+  node_count = 2
 
   traffic_filter_ids = [
     local.shared_infra["ec_platform_privatelink_traffic_filter_id"],

--- a/pipeline/terraform/2026-07-03/main.tf
+++ b/pipeline/terraform/2026-07-03/main.tf
@@ -3,7 +3,9 @@ module "pipeline" {
 
   reindexing_state = {
     listen_to_reindexer = true
-    scale_up_tasks      = false
+    # Sized for the round 2 full reindex (platform#6505); back to false after
+    # the comparison signs off.
+    scale_up_tasks      = true
     scale_up_matcher_db = false
   }
 


### PR DESCRIPTION
Part of wellcomecollection/platform#6505 (round 2 full reindex prerequisites).

Sets `scale_up_tasks = true` on the `2026-07-03` pipeline and the ES cluster to 30g across 2 zones, mirroring round 1 (#3491 and #3519, both reverted 2026-08-03 after the round 1 teardown).

Two roots to apply: `pipeline/terraform/2026-07-03` and `infrastructure/critical` (via `./run_terraform.sh`). Merge after the platform#6503 clear completes; the ES resize is safe to apply ahead of the reindex start since only the scale-down is rate-limited.

`scale_up_matcher_db` is deliberately not here: it costs a flat ~$135/day, so it comes in its own PR, applied last before the reindex starts and reverted first afterwards.