### PR TITLE
Scale up the matcher DynamoDB for the round 2 reindex

### DIFF
--- a/pipeline/terraform/2026-07-03/main.tf
+++ b/pipeline/terraform/2026-07-03/main.tf
@@ -6,7 +6,9 @@ module "pipeline" {
     # Sized for the round 2 full reindex (platform#6505); back to false after
     # the comparison signs off.
     scale_up_tasks      = true
-    scale_up_matcher_db = false
+    # ~$135/day flat: applied last before the reindex starts, reverted first
+    # after the comparison signs off.
+    scale_up_matcher_db = true
   }
 
   index_dates = {

--- a/pipeline/terraform/2026-07-03/main.tf
+++ b/pipeline/terraform/2026-07-03/main.tf
@@ -5,7 +5,7 @@ module "pipeline" {
     listen_to_reindexer = true
     # Sized for the round 2 full reindex (platform#6505); back to false after
     # the comparison signs off.
-    scale_up_tasks      = true
+    scale_up_tasks = true
     # ~$135/day flat: applied last before the reindex starts, reverted first
     # after the comparison signs off.
     scale_up_matcher_db = true


### PR DESCRIPTION
Part of wellcomecollection/platform#6505, stacked on #3576.

Sets `scale_up_matcher_db = true` on the `2026-07-03` pipeline. Split from #3576 because this costs a flat ~$135/day regardless of load (deliberate provisioned capacity for the reindex; it has tripped the DynamoDB budget alert before). Merge and apply `pipeline/terraform/2026-07-03` immediately before starting the reindex, and revert it first once the comparison signs off.