### PR TITLE
Ignore terraform plan files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.iml
 .lambda_hashes.json
 terraform.plan
+*.tfplan
 .terraform
 **/.terraform
 shared_infra/.releases


### PR DESCRIPTION
`.gitignore` had `terraform.plan`, which only catches that one filename. Plan files are ephemeral and carry a full rendering of the state they were generated against, so none of them should ever be committed.

Three were sitting untracked in the working tree after today's applies: `infrastructure/critical/respin.tfplan` and a `graph-retry.tfplan` in each of the two pipeline roots. Those are deleted; this stops the next ones being offered up by `git add`.

### Checklist

- [x] Display model unchanged, this is repo hygiene only.

## How to test

`terraform plan -out=x.tfplan` in any root, then `git status` shows nothing.

## How can we measure success?

No plan file appears in a future diff.

## Have we considered potential risks?

None tracked today, verified with `git ls-files | grep tfplan`, so nothing is being removed from version control.