### PR TITLE
Add scripts to build the Axiell b number import CSV

### DIFF
--- a/scripts/axiell_bnumber_import/README.md
+++ b/scripts/axiell_bnumber_import/README.md
@@ -65,9 +65,11 @@ rows where several AxC records share one (`ambiguous_refs.csv`) or where the
 matched record has no AltRefNo at all (`no_public_ref.csv`).
 
 RecordIDs with several bibs produce one row each (035 is repeatable).
-Conflicts, where AxC already cites a different live b number, are excluded
-from the import CSV and reported for review with each existing value's
-Sierra status. Pairs with no AxC record are expected
+Conflicts, where AxC already cites a different live b number, are reported
+with each existing value's Sierra status, format and title. By default they
+are excluded from the import CSV; with `--include-live-conflicts` our value
+is imported anyway, per the collections decision of 2026-08-19 that the
+harvest b number wins and the duplicate cataloguing is resolved in Axiell. Pairs with no AxC record are expected
 for manuscripts moving to TEI and for returned PSY material.
 
 ## Re-running

--- a/scripts/axiell_bnumber_import/README.md
+++ b/scripts/axiell_bnumber_import/README.md
@@ -1,0 +1,59 @@
+# Axiell Collections b number import
+
+Generates the CSV for importing Sierra b numbers into Axiell Collections
+archive records, so digitised archive works keep their METS content when the
+CALM-synced Sierra bibs retire without FOLIO successors.
+
+Background: RFC 092 ([wellcomecollection/docs#164](https://github.com/wellcomecollection/docs/pull/164)),
+tracked in [wellcomecollection/platform#6525](https://github.com/wellcomecollection/platform/issues/6525).
+
+## The two steps
+
+1. `extract_pairs.py` reads the production pipeline's `works-source` index and
+   emits `pairs.csv`: one row per Sierra bib carrying a `calm-record-id` merge
+   candidate (the bib's 035, the same link the merger uses). The candidates
+   are not indexed, so the script scrolls all Sierra source works and filters
+   client side.
+
+   ```
+   AWS_PROFILE=platform-developer uv run --project catalogue_graph \
+       python scripts/axiell_bnumber_import/extract_pairs.py
+   ```
+
+2. `build_import_csv.py` joins `pairs.csv` against the live Axiell adapter
+   store, keyed on the CALM RecordID each AxC record carries in MARC 907, and
+   writes `axiell_bnumber_import.csv` plus `conflicts.csv`, `unmatched.csv`
+   and `report.md`.
+
+   ```
+   AWS_PROFILE=platform-read_only uv run --project catalogue_graph \
+       python scripts/axiell_bnumber_import/build_import_csv.py
+   ```
+
+`extract_pairs.py` needs `platform-developer` because the pipeline ES
+credentials live in Secrets Manager; the store scan works with
+`platform-read_only`.
+
+## The import CSV
+
+Columns are `RecordID,Bnumber,RefNo`: the CALM RecordID to match the AxC
+record on, the b number to write, and the AxC record's RefNo as a human
+cross-check. These headers are a working guess pending agreement with
+collections staff on the Collections Import tool's expectations; only the
+headers and column order should need changing.
+
+RecordIDs with several bibs produce one row each (035 is repeatable).
+Conflicts, where AxC already cites a different b number, are excluded from
+the import CSV and reported for review. Pairs with no AxC record are expected
+for manuscripts moving to TEI and for returned PSY material.
+
+## Re-running
+
+Both steps are read only and deterministic (sorted output), so re-run them
+any time; digitisation continues, so the mapping needs re-cutting at least
+once near cutover. `--since <previous import csv>` emits only rows not
+already in an earlier CSV, for incremental imports.
+
+After an import lands and a harvest completes, re-running step 2 should show
+the imported rows move from "to import" to "already present", which is the
+verification step on platform#6525.

--- a/scripts/axiell_bnumber_import/README.md
+++ b/scripts/axiell_bnumber_import/README.md
@@ -7,7 +7,7 @@ CALM-synced Sierra bibs retire without FOLIO successors.
 Background: RFC 092 ([wellcomecollection/docs#164](https://github.com/wellcomecollection/docs/pull/164)),
 tracked in [wellcomecollection/platform#6525](https://github.com/wellcomecollection/platform/issues/6525).
 
-## The two steps
+## The steps
 
 1. `extract_pairs.py` reads the production pipeline's `works-source` index and
    emits `pairs.csv`: one row per Sierra bib carrying a `calm-record-id` merge
@@ -30,9 +30,22 @@ tracked in [wellcomecollection/platform#6525](https://github.com/wellcomecollect
        python scripts/axiell_bnumber_import/build_import_csv.py
    ```
 
-`extract_pairs.py` needs `platform-developer` because the pipeline ES
-credentials live in Secrets Manager; the store scan works with
-`platform-read_only`.
+3. Optionally, `check_bnumbers.py` resolves every `035 (Bibliographic
+   Number)` already in the store against the Sierra source works and writes
+   `bnumber_status.csv` (live, deleted, or absent, with the Sierra record's
+   format and title). Passing that file to step 2 as `--bnumber-status`
+   imports conflict rows whose existing value is dead in Sierra, since
+   nothing usable is lost whether the import appends or replaces, and leaves
+   only live-valued conflicts withheld for review.
+
+   ```
+   AWS_PROFILE=platform-developer uv run --project catalogue_graph \
+       python scripts/axiell_bnumber_import/check_bnumbers.py
+   ```
+
+`extract_pairs.py` and `check_bnumbers.py` need `platform-developer` because
+the pipeline ES credentials live in Secrets Manager; the store scan alone
+works with `platform-read_only`.
 
 ## The import CSV
 
@@ -52,8 +65,9 @@ rows where several AxC records share one (`ambiguous_refs.csv`) or where the
 matched record has no AltRefNo at all (`no_public_ref.csv`).
 
 RecordIDs with several bibs produce one row each (035 is repeatable).
-Conflicts, where AxC already cites a different b number, are excluded from
-the import CSV and reported for review. Pairs with no AxC record are expected
+Conflicts, where AxC already cites a different live b number, are excluded
+from the import CSV and reported for review with each existing value's
+Sierra status. Pairs with no AxC record are expected
 for manuscripts moving to TEI and for returned PSY material.
 
 ## Re-running

--- a/scripts/axiell_bnumber_import/README.md
+++ b/scripts/axiell_bnumber_import/README.md
@@ -36,11 +36,20 @@ credentials live in Secrets Manager; the store scan works with
 
 ## The import CSV
 
-Columns are `RecordID,Bnumber,RefNo`: the CALM RecordID to match the AxC
-record on, the b number to write, and the AxC record's RefNo as a human
-cross-check. These headers are a working guess pending agreement with
-collections staff on the Collections Import tool's expectations; only the
-headers and column order should need changing.
+Columns follow the format agreed with collections staff on 2026-08-17:
+
+```
+object_number,alternative_number,alternative_number.type
+WT/D/1/20/1/35/95,b33174192,Bibliographic Number
+```
+
+`object_number` is the archive reference (RefNo) the import matches AxC
+records on, `alternative_number` is the b number to write, and
+`alternative_number.type` is the constant `Bibliographic Number`. Because the
+import matches on RefNo rather than the CALM RecordID, the build step uses
+the 907 join to derive each record's RefNo and withholds rows where several
+AxC records share one (`ambiguous_refnos.csv`) or where the matched record
+has no RefNo at all.
 
 RecordIDs with several bibs produce one row each (035 is repeatable).
 Conflicts, where AxC already cites a different b number, are excluded from

--- a/scripts/axiell_bnumber_import/README.md
+++ b/scripts/axiell_bnumber_import/README.md
@@ -43,13 +43,13 @@ object_number,alternative_number,alternative_number.type
 WT/D/1/20/1/35/95,b33174192,Bibliographic Number
 ```
 
-`object_number` is the archive reference (RefNo) the import matches AxC
-records on, `alternative_number` is the b number to write, and
+`object_number` is the public reference (the AltRefNo) the import matches
+AxC records on, `alternative_number` is the b number to write, and
 `alternative_number.type` is the constant `Bibliographic Number`. Because the
-import matches on RefNo rather than the CALM RecordID, the build step uses
-the 907 join to derive each record's RefNo and withholds rows where several
-AxC records share one (`ambiguous_refnos.csv`) or where the matched record
-has no RefNo at all.
+import matches on the public reference rather than the CALM RecordID, the
+build step uses the 907 join to derive each record's AltRefNo and withholds
+rows where several AxC records share one (`ambiguous_refs.csv`) or where the
+matched record has no AltRefNo at all (`no_public_ref.csv`).
 
 RecordIDs with several bibs produce one row each (035 is repeatable).
 Conflicts, where AxC already cites a different b number, are excluded from

--- a/scripts/axiell_bnumber_import/build_import_csv.py
+++ b/scripts/axiell_bnumber_import/build_import_csv.py
@@ -53,8 +53,10 @@ def scan_axiell_store() -> dict[str, dict]:
     )
     by_uuid: dict[str, dict] = {}
     scanned = 0
+    # The store schema allows several sources per table; take only Axiell rows.
     reader = table.scan(
-        selected_fields=("id", "content", "deleted")
+        row_filter=f"namespace = '{AXIELL_ADAPTER_CONFIG.adapter_namespace}'",
+        selected_fields=("id", "content", "deleted"),
     ).to_arrow_batch_reader()
     for batch in reader:
         d = batch.to_pydict()

--- a/scripts/axiell_bnumber_import/build_import_csv.py
+++ b/scripts/axiell_bnumber_import/build_import_csv.py
@@ -8,7 +8,9 @@ keyed on the CALM RecordID each AxC record carries in MARC 907, and writes:
   reference, the AltRefNo; alternative_number = the b number;
   alternative_number.type = the constant "Bibliographic Number") for records
   matched in AxC that do not already cite the b number
-- conflicts.csv where the AxC record cites a different b number
+- conflicts.csv where the AxC record cites a different b number that is
+  still live in Sierra (with --bnumber-status, conflicts whose existing value
+  is dead in Sierra are imported instead of withheld)
 - ambiguous_refs.csv where several AxC records share the public reference the
   import would match on
 - no_public_ref.csv where the matched record carries no AltRefNo to match on
@@ -36,6 +38,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "catalogue_graph" /
 
 from adapters.extractors.oai_pmh.axiell.config import AXIELL_ADAPTER_CONFIG
 from adapters.utils.iceberg import get_rest_api_table
+from check_bnumbers import normalise
 
 RE_907 = re.compile(
     r'tag="907"[^>]*>.*?<(?:marc:)?subfield code="a">([^<]*)</', re.DOTALL
@@ -109,6 +112,11 @@ def main() -> None:
         type=Path,
         help="A previous import CSV; only rows not already in it are emitted",
     )
+    parser.add_argument(
+        "--bnumber-status",
+        type=Path,
+        help="Output of check_bnumbers.py; lets dead-valued conflicts import",
+    )
     args = parser.parse_args()
 
     with args.pairs.open() as f:
@@ -117,6 +125,12 @@ def main() -> None:
         ]
 
     by_uuid = scan_axiell_store()
+
+    status: dict[str, tuple[str, str]] = {}
+    if args.bnumber_status:
+        with args.bnumber_status.open() as f:
+            for r in csv.DictReader(f):
+                status[r["bnumber"]] = (r["status"], r["sierra_format"])
 
     ref_owners: dict[str, set[str]] = {}
     for uuid, record in by_uuid.items():
@@ -136,15 +150,26 @@ def main() -> None:
         elif b_number in record["bnumbers"]:
             already.append([uuid, b_number])
         elif record["bnumbers"]:
-            conflicts.append(
-                [
-                    uuid,
-                    b_number,
-                    ";".join(sorted(record["bnumbers"])),
-                    record["altrefno"],
-                    record["refno"],
-                ]
-            )
+            statuses = [
+                status.get(normalise(b), ("unknown", ""))[0]
+                for b in sorted(record["bnumbers"])
+            ]
+            if status and all(
+                s in ("deleted", "absent", "malformed") for s in statuses
+            ):
+                # Nothing usable is lost whether the import appends or replaces.
+                to_import.append([record["altrefno"], b_number, "Bibliographic Number"])
+            else:
+                conflicts.append(
+                    [
+                        uuid,
+                        b_number,
+                        ";".join(sorted(record["bnumbers"])),
+                        ";".join(statuses),
+                        record["altrefno"],
+                        record["refno"],
+                    ]
+                )
         elif not record["altrefno"]:
             no_public_ref.append([uuid, b_number, record["refno"]])
         elif len(ref_owners[record["altrefno"]]) > 1:
@@ -168,7 +193,14 @@ def main() -> None:
     )
     write_csv(
         out / "conflicts.csv",
-        ["RecordID", "Bnumber", "axc_bnumbers", "AltRefNo", "RefNo"],
+        [
+            "RecordID",
+            "Bnumber",
+            "axc_bnumbers",
+            "axc_bnumber_status",
+            "AltRefNo",
+            "RefNo",
+        ],
         conflicts,
     )
     write_csv(

--- a/scripts/axiell_bnumber_import/build_import_csv.py
+++ b/scripts/axiell_bnumber_import/build_import_csv.py
@@ -4,20 +4,21 @@
 Joins pairs.csv (see extract_pairs.py) against the live Axiell adapter store,
 keyed on the CALM RecordID each AxC record carries in MARC 907, and writes:
 
-- the import CSV in the agreed format (object_number = the record's RefNo,
-  alternative_number = the b number, alternative_number.type = the constant
-  "Bibliographic Number") for records matched in AxC that do not already cite
-  the b number
+- the import CSV in the agreed format (object_number = the record's public
+  reference, the AltRefNo; alternative_number = the b number;
+  alternative_number.type = the constant "Bibliographic Number") for records
+  matched in AxC that do not already cite the b number
 - conflicts.csv where the AxC record cites a different b number
-- ambiguous_refnos.csv where several AxC records share the RefNo the import
-  would match on
+- ambiguous_refs.csv where several AxC records share the public reference the
+  import would match on
+- no_public_ref.csv where the matched record carries no AltRefNo to match on
 - unmatched.csv for pairs with no AxC record (expected for manuscripts moving
   to TEI and returned PSY material)
 - report.md with the counts
 
 The Axiell import matches records on object_number, so the join here on the
-CALM RecordID is what derives and verifies each record's RefNo before it is
-used as the match key. Tracked in wellcomecollection/platform#6525.
+CALM RecordID is what derives and verifies each record's public reference
+before it is used as the match key. Tracked in wellcomecollection/platform#6525.
 
 Run from the repo root with the catalogue_graph environment:
 
@@ -68,13 +69,21 @@ def scan_axiell_store() -> dict[str, dict]:
             if not RE_UUID.match(uuid):
                 continue
             refno = ""
+            altrefno = ""
             bnumbers = set()
             for prefix, value in RE_035.findall(content):
                 if prefix == "Calm RefNo" and not refno:
                     refno = value.strip()
+                elif prefix == "AltRefNo" and not altrefno:
+                    altrefno = value.strip()
                 elif prefix == "Bibliographic Number":
                     bnumbers.add(value.strip().lstrip("."))
-            by_uuid[uuid] = {"record_id": rid, "refno": refno, "bnumbers": bnumbers}
+            by_uuid[uuid] = {
+                "record_id": rid,
+                "refno": refno,
+                "altrefno": altrefno,
+                "bnumbers": bnumbers,
+            }
     print(
         f"Scanned {scanned} adapter store rows, {len(by_uuid)} with a 907 RecordID",
         file=sys.stderr,
@@ -107,16 +116,16 @@ def main() -> None:
 
     by_uuid = scan_axiell_store()
 
-    refno_owners: dict[str, set[str]] = {}
+    ref_owners: dict[str, set[str]] = {}
     for uuid, record in by_uuid.items():
-        if record["refno"]:
-            refno_owners.setdefault(record["refno"], set()).add(uuid)
+        if record["altrefno"]:
+            ref_owners.setdefault(record["altrefno"], set()).add(uuid)
 
     to_import: list[list[str]] = []
     already: list[list[str]] = []
     conflicts: list[list[str]] = []
     ambiguous: list[list[str]] = []
-    no_refno: list[list[str]] = []
+    no_public_ref: list[list[str]] = []
     unmatched: list[list[str]] = []
     for uuid, b_number in pairs:
         record = by_uuid.get(uuid)
@@ -126,14 +135,20 @@ def main() -> None:
             already.append([uuid, b_number])
         elif record["bnumbers"]:
             conflicts.append(
-                [uuid, b_number, ";".join(sorted(record["bnumbers"])), record["refno"]]
+                [
+                    uuid,
+                    b_number,
+                    ";".join(sorted(record["bnumbers"])),
+                    record["altrefno"],
+                    record["refno"],
+                ]
             )
-        elif not record["refno"]:
-            no_refno.append([uuid, b_number])
-        elif len(refno_owners[record["refno"]]) > 1:
-            ambiguous.append([record["refno"], uuid, b_number])
+        elif not record["altrefno"]:
+            no_public_ref.append([uuid, b_number, record["refno"]])
+        elif len(ref_owners[record["altrefno"]]) > 1:
+            ambiguous.append([record["altrefno"], uuid, b_number])
         else:
-            to_import.append([record["refno"], b_number, "Bibliographic Number"])
+            to_import.append([record["altrefno"], b_number, "Bibliographic Number"])
 
     if args.since:
         with args.since.open() as f:
@@ -151,10 +166,15 @@ def main() -> None:
     )
     write_csv(
         out / "conflicts.csv",
-        ["RecordID", "Bnumber", "axc_bnumbers", "RefNo"],
+        ["RecordID", "Bnumber", "axc_bnumbers", "AltRefNo", "RefNo"],
         conflicts,
     )
-    write_csv(out / "ambiguous_refnos.csv", ["RefNo", "RecordID", "Bnumber"], ambiguous)
+    write_csv(
+        out / "ambiguous_refs.csv", ["AltRefNo", "RecordID", "Bnumber"], ambiguous
+    )
+    write_csv(
+        out / "no_public_ref.csv", ["RecordID", "Bnumber", "RefNo"], no_public_ref
+    )
     write_csv(out / "unmatched.csv", ["RecordID", "Bnumber"], unmatched)
 
     report = "\n".join(
@@ -166,8 +186,8 @@ def main() -> None:
             + (" (delta since previous CSV)" if args.since else ""),
             f"- already present in AxC: {len(already)}",
             f"- conflicts (AxC cites a different b number): {len(conflicts)}",
-            f"- RefNo shared by several AxC records: {len(ambiguous)}",
-            f"- AxC record has no RefNo to match on: {len(no_refno)}",
+            f"- public ref (AltRefNo) shared by several AxC records: {len(ambiguous)}",
+            f"- AxC record has no AltRefNo to match on: {len(no_public_ref)}",
             f"- no AxC record for the RecordID: {len(unmatched)}",
             "",
         ]

--- a/scripts/axiell_bnumber_import/build_import_csv.py
+++ b/scripts/axiell_bnumber_import/build_import_csv.py
@@ -124,6 +124,14 @@ def main() -> None:
         type=Path,
         help="Output of check_bnumbers.py; lets dead-valued conflicts import",
     )
+    parser.add_argument(
+        "--include-live-conflicts",
+        action="store_true",
+        help="Also import our b number where the record cites a different live "
+        "one (collections decision of 2026-08-19: import ours, the duplicate "
+        "cataloguing is resolved on the Axiell side); conflicts.csv is still "
+        "written for that follow-up",
+    )
     args = parser.parse_args()
 
     with args.pairs.open() as f:
@@ -165,12 +173,13 @@ def main() -> None:
                 status.get(normalise(b), ("unknown", "", ""))
                 for b in sorted(record["bnumbers"])
             ]
-            if status and all(
-                s in ("deleted", "absent", "malformed") for s, _, _ in resolved
+            if args.include_live_conflicts or (
+                status
+                and all(s in ("deleted", "absent", "malformed") for s, _, _ in resolved)
             ):
                 # Nothing usable is lost whether the import appends or replaces.
                 to_import.append([record["altrefno"], b_number, "Bibliographic Number"])
-            else:
+            if not all(s in ("deleted", "absent", "malformed") for s, _, _ in resolved):
                 conflicts.append(
                     [
                         record["altrefno"],

--- a/scripts/axiell_bnumber_import/build_import_csv.py
+++ b/scripts/axiell_bnumber_import/build_import_csv.py
@@ -38,8 +38,12 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "catalogue_graph" /
 
 from adapters.extractors.oai_pmh.axiell.config import AXIELL_ADAPTER_CONFIG
 from adapters.utils.iceberg import get_rest_api_table
+
 from check_bnumbers import normalise
 
+RE_245 = re.compile(
+    r'tag="245"[^>]*>.*?<(?:marc:)?subfield code="a">([^<]*)</', re.DOTALL
+)
 RE_907 = re.compile(
     r'tag="907"[^>]*>.*?<(?:marc:)?subfield code="a">([^<]*)</', re.DOTALL
 )
@@ -75,6 +79,8 @@ def scan_axiell_store() -> dict[str, dict]:
                 continue
             refno = ""
             altrefno = ""
+            m245 = RE_245.search(content)
+            title = m245.group(1).strip() if m245 else ""
             bnumbers = set()
             for prefix, value in RE_035.findall(content):
                 if prefix == "Calm RefNo" and not refno:
@@ -87,6 +93,7 @@ def scan_axiell_store() -> dict[str, dict]:
                 "record_id": rid,
                 "refno": refno,
                 "altrefno": altrefno,
+                "title": title,
                 "bnumbers": bnumbers,
             }
     print(
@@ -126,11 +133,15 @@ def main() -> None:
 
     by_uuid = scan_axiell_store()
 
-    status: dict[str, tuple[str, str]] = {}
+    status: dict[str, tuple[str, str, str]] = {}
     if args.bnumber_status:
         with args.bnumber_status.open() as f:
             for r in csv.DictReader(f):
-                status[r["bnumber"]] = (r["status"], r["sierra_format"])
+                status[r["bnumber"]] = (
+                    r["status"],
+                    r["sierra_format"],
+                    r["sierra_title"],
+                )
 
     ref_owners: dict[str, set[str]] = {}
     for uuid, record in by_uuid.items():
@@ -150,24 +161,27 @@ def main() -> None:
         elif b_number in record["bnumbers"]:
             already.append([uuid, b_number])
         elif record["bnumbers"]:
-            statuses = [
-                status.get(normalise(b), ("unknown", ""))[0]
+            resolved = [
+                status.get(normalise(b), ("unknown", "", ""))
                 for b in sorted(record["bnumbers"])
             ]
             if status and all(
-                s in ("deleted", "absent", "malformed") for s in statuses
+                s in ("deleted", "absent", "malformed") for s, _, _ in resolved
             ):
                 # Nothing usable is lost whether the import appends or replaces.
                 to_import.append([record["altrefno"], b_number, "Bibliographic Number"])
             else:
                 conflicts.append(
                     [
-                        uuid,
-                        b_number,
-                        ";".join(sorted(record["bnumbers"])),
-                        ";".join(statuses),
                         record["altrefno"],
                         record["refno"],
+                        record["title"],
+                        b_number,
+                        ";".join(sorted(record["bnumbers"])),
+                        ";".join(s for s, _, _ in resolved),
+                        ";".join(f for _, f, _ in resolved),
+                        ";".join(ti for _, _, ti in resolved),
+                        uuid,
                     ]
                 )
         elif not record["altrefno"]:
@@ -194,12 +208,15 @@ def main() -> None:
     write_csv(
         out / "conflicts.csv",
         [
-            "RecordID",
-            "Bnumber",
-            "axc_bnumbers",
-            "axc_bnumber_status",
             "AltRefNo",
             "RefNo",
+            "axc_title",
+            "our_bnumber",
+            "axc_bnumbers",
+            "axc_bnumber_status",
+            "axc_bnumber_sierra_format",
+            "axc_bnumber_sierra_title",
+            "RecordID",
         ],
         conflicts,
     )

--- a/scripts/axiell_bnumber_import/build_import_csv.py
+++ b/scripts/axiell_bnumber_import/build_import_csv.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Build the Axiell Collections b number import CSV from extracted pairs.
+
+Joins pairs.csv (see extract_pairs.py) against the live Axiell adapter store,
+keyed on the CALM RecordID each AxC record carries in MARC 907, and writes:
+
+- the import CSV (RecordID, Bnumber, RefNo) for records matched in AxC that
+  do not already cite the b number
+- conflicts.csv where the AxC record cites a different b number
+- unmatched.csv for pairs with no AxC record (expected for manuscripts moving
+  to TEI and returned PSY material)
+- report.md with the counts
+
+Column headers on the import CSV are a working guess pending agreement with
+collections staff. Tracked in wellcomecollection/platform#6525.
+
+Run from the repo root with the catalogue_graph environment:
+
+    AWS_PROFILE=platform-read_only uv run --project catalogue_graph \
+        python scripts/axiell_bnumber_import/build_import_csv.py
+"""
+
+import argparse
+import csv
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "catalogue_graph" / "src"))
+
+from adapters.extractors.oai_pmh.axiell.config import AXIELL_ADAPTER_CONFIG
+from adapters.utils.iceberg import get_rest_api_table
+
+RE_907 = re.compile(
+    r'tag="907"[^>]*>.*?<(?:marc:)?subfield code="a">([^<]*)</', re.DOTALL
+)
+RE_035 = re.compile(
+    r'tag="035"[^>]*>\s*<(?:marc:)?subfield code="a">\s*\(([^)]+)\)([^<]*)</', re.DOTALL
+)
+RE_UUID = re.compile(r"^[0-9a-fA-F-]{36}$")
+
+
+def scan_axiell_store() -> dict[str, dict]:
+    """Map each record's 907 CALM RecordID to its RefNo and existing b numbers."""
+    table = get_rest_api_table(
+        AXIELL_ADAPTER_CONFIG.rest_api_iceberg_config, create_if_not_exists=False
+    )
+    by_uuid: dict[str, dict] = {}
+    scanned = 0
+    reader = table.scan(
+        selected_fields=("id", "content", "deleted")
+    ).to_arrow_batch_reader()
+    for batch in reader:
+        d = batch.to_pydict()
+        for rid, content, deleted in zip(d["id"], d["content"], d["deleted"]):
+            scanned += 1
+            if deleted or not content:
+                continue
+            m907 = RE_907.search(content)
+            if not m907:
+                continue
+            uuid = m907.group(1).strip().lower()
+            if not RE_UUID.match(uuid):
+                continue
+            refno = ""
+            bnumbers = set()
+            for prefix, value in RE_035.findall(content):
+                if prefix == "Calm RefNo" and not refno:
+                    refno = value.strip()
+                elif prefix == "Bibliographic Number":
+                    bnumbers.add(value.strip().lstrip("."))
+            by_uuid[uuid] = {"record_id": rid, "refno": refno, "bnumbers": bnumbers}
+    print(
+        f"Scanned {scanned} adapter store rows, {len(by_uuid)} with a 907 RecordID",
+        file=sys.stderr,
+    )
+    return by_uuid
+
+
+def write_csv(path: Path, header: list[str], rows: list[list[str]]) -> None:
+    with path.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(header)
+        writer.writerows(sorted(rows))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pairs", default="pairs.csv", type=Path)
+    parser.add_argument("--output-dir", default=Path("."), type=Path)
+    parser.add_argument(
+        "--since",
+        type=Path,
+        help="A previous import CSV; only rows not already in it are emitted",
+    )
+    args = parser.parse_args()
+
+    with args.pairs.open() as f:
+        pairs = [
+            (r["calm_record_id"].lower(), r["b_number"]) for r in csv.DictReader(f)
+        ]
+
+    by_uuid = scan_axiell_store()
+
+    to_import: list[list[str]] = []
+    already: list[list[str]] = []
+    conflicts: list[list[str]] = []
+    unmatched: list[list[str]] = []
+    for uuid, b_number in pairs:
+        record = by_uuid.get(uuid)
+        if record is None:
+            unmatched.append([uuid, b_number])
+        elif b_number in record["bnumbers"]:
+            already.append([uuid, b_number])
+        elif record["bnumbers"]:
+            conflicts.append(
+                [uuid, b_number, ";".join(sorted(record["bnumbers"])), record["refno"]]
+            )
+        else:
+            to_import.append([uuid, b_number, record["refno"]])
+
+    if args.since:
+        with args.since.open() as f:
+            previous = {(r["RecordID"], r["Bnumber"]) for r in csv.DictReader(f)}
+        to_import = [row for row in to_import if (row[0], row[1]) not in previous]
+
+    out = args.output_dir
+    out.mkdir(parents=True, exist_ok=True)
+    write_csv(
+        out / "axiell_bnumber_import.csv", ["RecordID", "Bnumber", "RefNo"], to_import
+    )
+    write_csv(
+        out / "conflicts.csv",
+        ["RecordID", "Bnumber", "axc_bnumbers", "RefNo"],
+        conflicts,
+    )
+    write_csv(out / "unmatched.csv", ["RecordID", "Bnumber"], unmatched)
+
+    report = "\n".join(
+        [
+            "# Axiell b number import build",
+            "",
+            f"- pairs read: {len(pairs)}",
+            f"- to import: {len(to_import)}"
+            + (" (delta since previous CSV)" if args.since else ""),
+            f"- already present in AxC: {len(already)}",
+            f"- conflicts (AxC cites a different b number): {len(conflicts)}",
+            f"- no AxC record for the RecordID: {len(unmatched)}",
+            "",
+        ]
+    )
+    (out / "report.md").write_text(report)
+    print(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/axiell_bnumber_import/build_import_csv.py
+++ b/scripts/axiell_bnumber_import/build_import_csv.py
@@ -4,15 +4,20 @@
 Joins pairs.csv (see extract_pairs.py) against the live Axiell adapter store,
 keyed on the CALM RecordID each AxC record carries in MARC 907, and writes:
 
-- the import CSV (RecordID, Bnumber, RefNo) for records matched in AxC that
-  do not already cite the b number
+- the import CSV in the agreed format (object_number = the record's RefNo,
+  alternative_number = the b number, alternative_number.type = the constant
+  "Bibliographic Number") for records matched in AxC that do not already cite
+  the b number
 - conflicts.csv where the AxC record cites a different b number
+- ambiguous_refnos.csv where several AxC records share the RefNo the import
+  would match on
 - unmatched.csv for pairs with no AxC record (expected for manuscripts moving
   to TEI and returned PSY material)
 - report.md with the counts
 
-Column headers on the import CSV are a working guess pending agreement with
-collections staff. Tracked in wellcomecollection/platform#6525.
+The Axiell import matches records on object_number, so the join here on the
+CALM RecordID is what derives and verifies each record's RefNo before it is
+used as the match key. Tracked in wellcomecollection/platform#6525.
 
 Run from the repo root with the catalogue_graph environment:
 
@@ -102,9 +107,16 @@ def main() -> None:
 
     by_uuid = scan_axiell_store()
 
+    refno_owners: dict[str, set[str]] = {}
+    for uuid, record in by_uuid.items():
+        if record["refno"]:
+            refno_owners.setdefault(record["refno"], set()).add(uuid)
+
     to_import: list[list[str]] = []
     already: list[list[str]] = []
     conflicts: list[list[str]] = []
+    ambiguous: list[list[str]] = []
+    no_refno: list[list[str]] = []
     unmatched: list[list[str]] = []
     for uuid, b_number in pairs:
         record = by_uuid.get(uuid)
@@ -116,24 +128,33 @@ def main() -> None:
             conflicts.append(
                 [uuid, b_number, ";".join(sorted(record["bnumbers"])), record["refno"]]
             )
+        elif not record["refno"]:
+            no_refno.append([uuid, b_number])
+        elif len(refno_owners[record["refno"]]) > 1:
+            ambiguous.append([record["refno"], uuid, b_number])
         else:
-            to_import.append([uuid, b_number, record["refno"]])
+            to_import.append([record["refno"], b_number, "Bibliographic Number"])
 
     if args.since:
         with args.since.open() as f:
-            previous = {(r["RecordID"], r["Bnumber"]) for r in csv.DictReader(f)}
+            previous = {
+                (r["object_number"], r["alternative_number"]) for r in csv.DictReader(f)
+            }
         to_import = [row for row in to_import if (row[0], row[1]) not in previous]
 
     out = args.output_dir
     out.mkdir(parents=True, exist_ok=True)
     write_csv(
-        out / "axiell_bnumber_import.csv", ["RecordID", "Bnumber", "RefNo"], to_import
+        out / "axiell_bnumber_import.csv",
+        ["object_number", "alternative_number", "alternative_number.type"],
+        to_import,
     )
     write_csv(
         out / "conflicts.csv",
         ["RecordID", "Bnumber", "axc_bnumbers", "RefNo"],
         conflicts,
     )
+    write_csv(out / "ambiguous_refnos.csv", ["RefNo", "RecordID", "Bnumber"], ambiguous)
     write_csv(out / "unmatched.csv", ["RecordID", "Bnumber"], unmatched)
 
     report = "\n".join(
@@ -145,6 +166,8 @@ def main() -> None:
             + (" (delta since previous CSV)" if args.since else ""),
             f"- already present in AxC: {len(already)}",
             f"- conflicts (AxC cites a different b number): {len(conflicts)}",
+            f"- RefNo shared by several AxC records: {len(ambiguous)}",
+            f"- AxC record has no RefNo to match on: {len(no_refno)}",
             f"- no AxC record for the RecordID: {len(unmatched)}",
             "",
         ]

--- a/scripts/axiell_bnumber_import/check_bnumbers.py
+++ b/scripts/axiell_bnumber_import/check_bnumbers.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Resolve every 035 (Bibliographic Number) in the Axiell store against Sierra.
+
+Writes bnumber_status.csv with one row per (record, b number): the value as
+found, its normalised form, and its status in Sierra (live, deleted, or
+absent), with the Sierra record's format and title where it exists. Feed the
+output to build_import_csv.py --bnumber-status so conflicts whose existing
+value is dead are imported rather than withheld.
+
+Run from the repo root with the catalogue_graph environment; needs
+platform-developer for the pipeline ES secret:
+
+    AWS_PROFILE=platform-developer uv run --project catalogue_graph \
+        python scripts/axiell_bnumber_import/check_bnumbers.py
+"""
+
+import argparse
+import csv
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "catalogue_graph" / "src"))
+
+from adapters.extractors.oai_pmh.axiell.config import AXIELL_ADAPTER_CONFIG
+from adapters.utils.iceberg import get_rest_api_table
+from utils.elasticsearch import get_client
+
+RE_035 = re.compile(
+    r'tag="035"[^>]*>\s*<(?:marc:)?subfield code="a">\s*\(([^)]+)\)([^<]*)</', re.DOTALL
+)
+RE_B = re.compile(r"^b[0-9]{7}[0-9x]$")
+
+
+def normalise(value: str) -> str:
+    return value.strip().lstrip(".").lower().replace(" ", "")
+
+
+def scan_store() -> list[list[str]]:
+    table = get_rest_api_table(
+        AXIELL_ADAPTER_CONFIG.rest_api_iceberg_config, create_if_not_exists=False
+    )
+    rows = []
+    reader = table.scan(
+        row_filter=f"namespace = '{AXIELL_ADAPTER_CONFIG.adapter_namespace}'",
+        selected_fields=("id", "content", "deleted"),
+    ).to_arrow_batch_reader()
+    for batch in reader:
+        d = batch.to_pydict()
+        for rid, content, deleted in zip(d["id"], d["content"], d["deleted"]):
+            if deleted or not content:
+                continue
+            ref = ""
+            for prefix, value in RE_035.findall(content):
+                if prefix == "AltRefNo" and not ref:
+                    ref = value.strip()
+            for prefix, value in RE_035.findall(content):
+                if prefix == "Bibliographic Number":
+                    rows.append([rid, ref, value.strip(), normalise(value)])
+    return rows
+
+
+def lookup_sierra(pipeline_date: str, es_mode: str, values: set[str]) -> dict:
+    es = get_client("read_only", pipeline_date, es_mode)
+    index = f"works-source-{pipeline_date}"
+    found = {}
+    vals = sorted(values)
+    for i in range(0, len(vals), 500):
+        resp = es.search(
+            index=index,
+            size=500,
+            query={
+                "bool": {
+                    "filter": [
+                        {"terms": {"state.sourceIdentifier.value": vals[i : i + 500]}},
+                        {
+                            "term": {
+                                "state.sourceIdentifier.identifierType.id": "sierra-system-number"
+                            }
+                        },
+                    ]
+                }
+            },
+            _source=[
+                "state.sourceIdentifier.value",
+                "type",
+                "data.format.label",
+                "data.title",
+            ],
+        )
+        for hit in resp["hits"]["hits"]:
+            source = hit["_source"]
+            found[source["state"]["sourceIdentifier"]["value"]] = (
+                "deleted" if source.get("type") == "Deleted" else "live",
+                source.get("data", {}).get("format", {}).get("label", ""),
+                (source.get("data", {}).get("title") or "")[:80],
+            )
+    return found
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pipeline-date", default="2025-10-02")
+    parser.add_argument("--es-mode", default="public", choices=["public", "private"])
+    parser.add_argument("--output", default="bnumber_status.csv", type=Path)
+    args = parser.parse_args()
+
+    rows = scan_store()
+    wellformed = {r[3] for r in rows if RE_B.match(r[3])}
+    found = lookup_sierra(args.pipeline_date, args.es_mode, wellformed)
+
+    out = []
+    for rid, ref, raw, norm in rows:
+        if not RE_B.match(norm):
+            status, fmt, title = "malformed", "", ""
+        else:
+            status, fmt, title = found.get(norm, ("absent", "", ""))
+        out.append([rid, ref, raw, norm, status, fmt, title])
+
+    with args.output.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(
+            [
+                "axc_id",
+                "ref",
+                "raw_bnumber",
+                "bnumber",
+                "status",
+                "sierra_format",
+                "sierra_title",
+            ]
+        )
+        writer.writerows(sorted(out))
+
+    from collections import Counter
+
+    print(f"{len(out)} rows written to {args.output}")
+    print("status counts:", dict(Counter(r[4] for r in out)))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/axiell_bnumber_import/extract_pairs.py
+++ b/scripts/axiell_bnumber_import/extract_pairs.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Extract (CALM RecordID, b number) pairs from Sierra source works.
+
+Reads the production pipeline's works-source index and emits one CSV row per
+Sierra bib that carries a calm-record-id merge candidate (the bib's 035, i.e.
+the exact link the merger uses today). See README.md; tracked in
+wellcomecollection/platform#6525.
+
+Run from the repo root with the catalogue_graph environment:
+
+    AWS_PROFILE=platform-developer uv run --project catalogue_graph \
+        python scripts/axiell_bnumber_import/extract_pairs.py
+"""
+
+import argparse
+import csv
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "catalogue_graph" / "src"))
+
+from elasticsearch.helpers import scan
+from utils.elasticsearch import get_client
+
+SIERRA_FILTER = {
+    "term": {"state.sourceIdentifier.identifierType.id": "sierra-system-number"}
+}
+SOURCE_FIELDS = ["state.sourceIdentifier.value", "state.mergeCandidates"]
+
+
+def extract(es, index: str) -> tuple[set[tuple[str, str]], int, int]:
+    pairs: set[tuple[str, str]] = set()
+    scanned = 0
+    with_candidate = 0
+    for hit in scan(
+        es,
+        index=index,
+        query={"query": {"bool": {"filter": [SIERRA_FILTER]}}},
+        _source_includes=SOURCE_FIELDS,
+        size=2000,
+        preserve_order=False,
+    ):
+        scanned += 1
+        state = hit["_source"]["state"]
+        b_number = state["sourceIdentifier"]["value"]
+        found = False
+        for candidate in state.get("mergeCandidates", []):
+            sid = candidate.get("id", {}).get("sourceIdentifier", {})
+            if sid.get("identifierType", {}).get("id") == "calm-record-id":
+                pairs.add((sid["value"], b_number))
+                found = True
+        if found:
+            with_candidate += 1
+        if scanned % 200_000 == 0:
+            print(f"...{scanned} scanned, {len(pairs)} pairs", file=sys.stderr)
+    return pairs, scanned, with_candidate
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pipeline-date", default="2025-10-02")
+    parser.add_argument("--es-mode", default="public", choices=["public", "private"])
+    parser.add_argument("--output", default="pairs.csv", type=Path)
+    args = parser.parse_args()
+
+    es = get_client("read_only", args.pipeline_date, args.es_mode)
+    index = f"works-source-{args.pipeline_date}"
+    pairs, scanned, with_candidate = extract(es, index)
+
+    with args.output.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["calm_record_id", "b_number"])
+        writer.writerows(sorted(pairs))
+
+    uuids = {u for u, _ in pairs}
+    multi = len(pairs) - len(uuids)
+    print(
+        f"Scanned {scanned} Sierra source works in {index}: "
+        f"{with_candidate} carry a calm-record-id merge candidate, "
+        f"{len(pairs)} pairs over {len(uuids)} distinct RecordIDs "
+        f"({multi} extra rows from RecordIDs with multiple bibs)."
+    )
+    print(f"Wrote {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What does this change?

Adds read-only tooling that builds the CSV collections staff use to import Sierra b numbers into Axiell Collections archive records. Digitised archive works reach their METS content only through the CALM-synced Sierra bibs, which retire without FOLIO successors, so the b number has to live on the AxC record instead (RFC 092, wellcomecollection/docs#164). Nothing here writes to Axiell.

```mermaid
flowchart LR
    ES["works-source<br/>Sierra source works"] -->|extract_pairs.py| P["pairs.csv<br/>CALM RecordID, b number"]
    AX["Axiell adapter store<br/>907 = CALM RecordID"] --> B
    P -->|build_import_csv.py| B["import CSV<br/>+ conflicts, unmatched, report"]
```

- `extract_pairs.py` scrolls Sierra source works for `calm-record-id` merge candidates (not indexed, so filtered client side) and emits the pairs.
- `build_import_csv.py` joins the pairs to AxC records on the 907 RecordID and writes the import CSV in the agreed format (`object_number,alternative_number,alternative_number.type`, matching on the public ref) plus conflict, shared-ref and unmatched reports.
- `check_bnumbers.py` resolves every 035 already in the store against Sierra; passing its output to the build as `--bnumber-status` imports conflict rows whose existing value is dead (deleted or absent) and withholds only live-valued conflicts, annotated with what they point at.
- `--since` emits only rows new since a previous CSV, for the second pass after the final delta migration load.

Relates to wellcomecollection/platform#6525.

### Checklist

- [x] Does this change the display model the catalogue API returns? No, these are standalone scripts under `scripts/`.

## How to test

Run both steps per the README (the first needs `platform-developer` for the ES secret, the second `platform-read_only`); output is sorted, so re-runs are identical. The 19 August cut gave 246,204 pairs, 197,108 importable, 6,476 already present, 20 live-valued conflicts (18 are GC179 records whose existing value is a live Sierra film bib, the item having been catalogued in both systems) and 42,600 with no AxC record yet (mostly records committed after the migration extract, which arrive with the delta load). A 10-row sample has been imported by collections staff and verified end to end via OAI and the Axiell transformer.

## How can we measure success?

Re-running the build after an import and harvest moves imported rows from "to import" to "already present", and digitised archive works keep their METS items once the CALM-synced bibs are gone.

## Have we considered potential risks?

The scripts are read only, hand-run, and outside the deployed pipeline. Rows where AxC already cites a different b number, shares a public ref with another record, or lacks one are withheld into report files rather than imported, and the mapping needs re-cutting near cutover as digitisation continues.
