### PR TITLE
Respin the 2026-07-03 id-minter cluster from the 2026-08-19 production backup

### DIFF
--- a/infrastructure/critical/rds_id_minter.tf
+++ b/infrastructure/critical/rds_id_minter.tf
@@ -17,8 +17,8 @@ module "id_minter_rds_2026_07_03" {
   source = "./modules/id-minter-rds"
 
   name_suffix = "2026-07-03"
-  # Restore from production on August 17, 2026, 04:00 (UTC+01:00)
-  snapshot_identifier = "awsbackup:job-74fac66a-d4a1-f82e-bda3-92c19d19d21c"
+  # Restore from production on August 19, 2026, 04:00 (UTC+01:00)
+  snapshot_identifier = "awsbackup:job-7adec63f-19b6-5ff9-272d-f39aad1a79a8"
 
   # A restored copy of production; its contents are never worth keeping.
   skip_final_snapshot = true


### PR DESCRIPTION
Part of wellcomecollection/platform#6503 (phase 3 redo, while awaiting the corrected Axiell publish_to_web data).

Re-points the `2026-07-03` id-minter module at this morning's recovery point from `id-minter-backup-vault` (2026-08-19 04:00 BST, COMPLETED), replacing Monday's 2026-08-17 restore to keep the ID-parity gap small ahead of the round 2 reindex.

Same sequence as #3571: merge only inside the respin window, disable deletion protection on the current cluster first, targeted apply in `infrastructure/critical`, then re-apply the `2026-07-03` pipeline stack and restore `enable_http_endpoint`, which the snapshot restore silently drops.