### PR TITLE
Create replacement ES API keys before destroying the old ones

### DIFF
--- a/pipeline/terraform/modules/pipeline_es_api_key/main.tf
+++ b/pipeline/terraform/modules/pipeline_es_api_key/main.tf
@@ -2,20 +2,7 @@ locals {
   read_descriptor = {
     indices = [
       {
-        # allow_restricted_indices is false by default, but if you leave it out,
-        # terraform will recreate a new API key every time, because it compares
-        # the value reported by ElasticStack (which contains this default value)
-        # with the one you are trying to insert (which, in that case, would not).
-        # This then breaks all of your running pipeline applications because they
-        # are still trying to authenticate with the old key.
-        #
-        # This could (and possibly also should) be avoided by the careful application
-        # of replace_triggered_by in the corresponding modules, but it is unlikely
-        # that that corresponds to an actual use case we would have in a running pipeline.
-        # We don't normally want to regenerate keys in a running pipeline, but we
-        # do always terraform a pipeline twice, and would hope to be able to do so
-        # without breaking anything.
-        #
+        # Set explicitly: the provider reports the default, so omitting it causes a perpetual diff.
         allow_restricted_indices = false,
         names                    = var.read_from
         privileges               = ["read"]
@@ -47,6 +34,13 @@ locals {
 resource "elasticstack_elasticsearch_security_api_key" "pipeline_service" {
   name             = "${var.name}-${var.pipeline_date}"
   role_descriptors = jsonencode(local.role_descriptors)
+
+  # On replacement, create the new key and store it in Secrets Manager before
+  # invalidating the old one, so consumers that re-read the secret (e.g. the
+  # catalogue API on a 401) can recover without a redeploy (platform#6528).
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 module "pipeline_service_api_key_secrets" {


### PR DESCRIPTION
## What does this change?

Replacing a pipeline Elasticsearch API key currently gives the catalogue API a burst of 5xx (wellcomecollection/platform#6528). Terraform destroys before it creates, so Elasticsearch invalidates the old key before the new one exists or has reached Secrets Manager, and a consumer that re-fetches the secret on a 401 has nothing valid to fetch. With `create_before_destroy` the new key is created and stored first, so re-reading the secret is enough to recover.

Elasticsearch allows duplicate API key names, and the elasticstack provider's own rotation example uses this lifecycle. Since provider 0.16.1 a role-descriptor change updates the key in place rather than replacing it (confirmed by a plan on the 2026-07-03 stack on 2026-08-19), so this lifecycle only matters for the replacements that remain, such as a change to `name` or `expiration`.

### Checklist

- [ ] Does this change the display model the catalogue API returns? No. It changes pipeline terraform only.

## How to test

Run `terraform plan` for a pipeline stack and confirm the API key resources report no changes, so nothing is replaced by merging this on its own. To exercise the new ordering, force a replacement in a non-prod stack (for example by changing `expiration`) and check the plan shows the key created before the old one is destroyed, then confirm the value in Secrets Manager authenticates against the cluster after the apply.

## How can we measure success?

The next key replacement lands without a 5xx spike on the catalogue API, and consumers recover by re-reading the secret rather than needing a redeploy.

## Have we considered potential risks?

Both keys are briefly valid during a replacement, which is the point but does mean the old key is usable for a short window after the new one is stored. There is no automated terraform apply here, so this is inert until someone applies it for each pipeline stack.
