### PR TITLE
Re-enable the 2026-07-03 pipeline after the round 2 clear

### DIFF
--- a/pipeline/terraform/2026-07-03/main.tf
+++ b/pipeline/terraform/2026-07-03/main.tf
@@ -1,11 +1,8 @@
 module "pipeline" {
   source = "../modules/pipeline_new"
 
-  # Quiesced while the pipeline's stateful parts are cleared for round 2
-  # (platform#6503), so nothing writes into the state being wiped. Back on for
-  # the reindex, along with the enable_* flags below.
   reindexing_state = {
-    listen_to_reindexer = false
+    listen_to_reindexer = true
     scale_up_tasks      = false
     scale_up_matcher_db = false
   }
@@ -24,11 +21,11 @@ module "pipeline" {
   # Base AMI for ECS instances
   ami_id = "resolve:ssm:arn:aws:ssm:eu-west-1:760097843905:parameter/imagebuilder/weco-al2023-ecs-optimised-x86_64/latest"
 
-  enable_adapter_transformer_trigger           = false
+  enable_adapter_transformer_trigger           = true
   disable_calm_transformer_topic_subscriptions = true
-  enable_id_minter_schedule                    = false
-  enable_graph_pipeline_schedule               = false
-  enable_image_inferrer_schedule               = false
+  enable_id_minter_schedule                    = true
+  enable_graph_pipeline_schedule               = true
+  enable_image_inferrer_schedule               = true
 
   pipeline_date = local.pipeline_date // namespaces services
   graph_date    = "2026-07-03"        // namespaces graph database


### PR DESCRIPTION
Part of wellcomecollection/platform#6503 (phase 7, final step).

Reverts the pipeline half of #3563: the four `enable_*` flags and `reindexing_state.listen_to_reindexer` come back on, handing the cleared pipeline over to the round 2 reindex (platform#6505). The Axiell harvest half of #3563 was already reverted in #3575.

Merge and apply `pipeline/terraform/2026-07-03` only after the phase 7 baseline verification is complete and recorded on the issue. #3576 (reindex scale-up) touches the same block and should be rebased once this lands.