### PR TITLE
Use UTC datetimes consistently

### DIFF
--- a/catalogue_graph/src/adapters/transformers/builders/source_work_builder.py
+++ b/catalogue_graph/src/adapters/transformers/builders/source_work_builder.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from datetime import datetime
+from datetime import UTC, datetime
 
 import dateutil.parser
 
@@ -46,7 +46,7 @@ class SourceWorkBuilder(ABC):
         return SourceWorkState(
             source_identifier=self.source_identifier,
             source_modified_time=self.source_modified_time,
-            modified_time=convert_datetime_to_utc_iso(datetime.now()),
+            modified_time=convert_datetime_to_utc_iso(datetime.now(UTC)),
         )
 
     @property

--- a/catalogue_graph/src/adapters/transformers/marc/parsers/date_from_005.py
+++ b/catalogue_graph/src/adapters/transformers/marc/parsers/date_from_005.py
@@ -5,7 +5,7 @@ def datetime_from_005(value_005: str) -> datetime:
     """
     Converts a MARC 005 field string in 'YYYYMMDDHHMMSS.f' format to a datetime.
 
-    MARC 005 values are defined as UTC, so the returned datetime is timezone-aware.
+    Interpret MARC 005 values as UTC, so the returned datetime is timezone-aware.
     Returning a naive datetime would make downstream conversions (e.g.
     `convert_datetime_to_utc_iso`, which calls `astimezone`) interpret the value as
     system-local time and shift it by the local UTC offset.

--- a/catalogue_graph/src/adapters/transformers/marc/parsers/date_from_005.py
+++ b/catalogue_graph/src/adapters/transformers/marc/parsers/date_from_005.py
@@ -1,18 +1,23 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 
 def datetime_from_005(value_005: str) -> datetime:
     """
     Converts a MARC 005 field string in 'YYYYMMDDHHMMSS.f' format to a datetime.
 
+    MARC 005 values are defined as UTC, so the returned datetime is timezone-aware.
+    Returning a naive datetime would make downstream conversions (e.g.
+    `convert_datetime_to_utc_iso`, which calls `astimezone`) interpret the value as
+    system-local time and shift it by the local UTC offset.
+
     Args:
         value_005 (str): The MARC 005 field string.
 
     Returns:
-        datetime: The parsed datetime object from the MARC 005 field string.
+        datetime: The parsed UTC datetime from the MARC 005 field string.
 
 
     >>> datetime_from_005("20251225123045.0")
-    datetime.datetime(2025, 12, 25, 12, 30, 45)
+    datetime.datetime(2025, 12, 25, 12, 30, 45, tzinfo=datetime.timezone.utc)
     """
-    return datetime.strptime(value_005, "%Y%m%d%H%M%S.%f")
+    return datetime.strptime(value_005, "%Y%m%d%H%M%S.%f").replace(tzinfo=UTC)

--- a/catalogue_graph/src/ingestor/models/debug/work.py
+++ b/catalogue_graph/src/ingestor/models/debug/work.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from ingestor.models.merged.work import (
     DeletedMergedWork,
@@ -38,7 +38,7 @@ class WorkDebug(ElasticsearchModel):
                 modified_time=work.state.source_modified_time,
             ),
             merged_time=work.state.merged_time,
-            indexed_time=convert_datetime_to_utc_iso(datetime.now()),
+            indexed_time=convert_datetime_to_utc_iso(datetime.now(UTC)),
             merge_candidates=work.state.merge_candidates,
         )
 

--- a/catalogue_graph/src/ingestor/models/indexable/image.py
+++ b/catalogue_graph/src/ingestor/models/indexable/image.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from ingestor.extractors.images.images_extractor import ExtractedImage
 from ingestor.models.aggregate.image import ImageAggregatableValues
@@ -39,6 +39,8 @@ class IndexableImage(IndexableRecord):
             aggregatable_values=ImageAggregatableValues.from_extracted_image(extracted),
             filterable_values=ImageFilterableValues.from_extracted_image(extracted),
             vector_values=ImageVectorValues.from_augmented_image(extracted.image),
-            debug=ImageDebug(indexed_time=convert_datetime_to_utc_iso(datetime.now())),
+            debug=ImageDebug(
+                indexed_time=convert_datetime_to_utc_iso(datetime.now(UTC))
+            ),
             modified_time=extracted.image.modified_time,
         )

--- a/catalogue_graph/src/utils/timezone.py
+++ b/catalogue_graph/src/utils/timezone.py
@@ -2,13 +2,16 @@ from datetime import UTC, datetime
 
 
 def ensure_datetime_utc(dt: datetime) -> datetime:
-    """Ensure a datetime object is in UTC timezone."""
+    """Ensure a datetime object is in UTC timezone. Timezone-naive datetimes are assumed to be in UTC."""
     if dt.tzinfo is None:
         return dt.replace(tzinfo=UTC)
     return dt.astimezone(UTC)
 
 
 def convert_datetime_to_utc_iso(dt: datetime) -> str:
-    """Convert a datetime object to an ISO 8601 string in UTC timezone."""
+    """
+    Convert a datetime object to an ISO 8601 string in UTC timezone.
+    Timezone-naive datetimes are assumed to be in local timezone.
+    """
     # strip +00:00 and replace with Z
     return dt.astimezone(UTC).isoformat().replace("+00:00", "Z")

--- a/catalogue_graph/tests/test_ingestor_loader.py
+++ b/catalogue_graph/tests/test_ingestor_loader.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any, cast
 
 import polars as pl
@@ -679,9 +679,7 @@ def test_ingestor_loader_non_visible_works(pass_objects_to_index: bool) -> None:
     invisible_work = [i for i in items if i["type"] == "Invisible"][0]
     redirected_work = [i for i in items if i["type"] == "Redirected"][0]
 
-    # Time is frozen in local timezone, convert_datetime_to_utc_iso will handle conversion
-    now = datetime.now()
-    now_iso = convert_datetime_to_utc_iso(now)
+    now_iso = convert_datetime_to_utc_iso(datetime.now(UTC))
 
     assert DeletedIndexableWork(**deleted_work) == DeletedIndexableWork(
         debug=DeletedWorkDebug(

--- a/catalogue_graph/tests/utils/test_timezone.py
+++ b/catalogue_graph/tests/utils/test_timezone.py
@@ -1,0 +1,78 @@
+"""
+Regression tests for timestamps which must not depend on the local timezone.
+"""
+
+import time
+from collections.abc import Iterator
+from datetime import UTC, datetime
+
+import pytest
+from freezegun import freeze_time
+from pymarc.record import Field, Record
+
+from adapters.transformers.builders.ebsco_work_builder import EbscoWorkBuilder
+from adapters.transformers.marc.parsers.date_from_005 import datetime_from_005
+from ingestor.extractors.images.images_extractor import ExtractedImage
+from ingestor.extractors.works.base_works_extractor import VisibleExtractedWork
+from ingestor.models.augmented.image import AugmentedImage
+from ingestor.models.debug.work import VisibleWorkDebug
+from ingestor.models.indexable.image import IndexableImage
+from ingestor.models.merged.work import VisibleMergedWork
+from ingestor.models.neptune.query_result import WorkHierarchy
+from tests.test_utils import load_json_fixture
+from utils.timezone import convert_datetime_to_utc_iso
+
+FROZEN_TIME = "2001-01-01T01:01:01Z"
+
+
+def _extracted_work() -> VisibleExtractedWork:
+    work = VisibleMergedWork(**load_json_fixture("ingestor/single_merged.json"))
+    hierarchy = WorkHierarchy(id=work.state.canonical_id, ancestors=[], children=[])
+    return VisibleExtractedWork(work=work, hierarchy=hierarchy, concepts=[])
+
+
+@pytest.fixture(autouse=True)
+def local_timezone_ahead_of_utc(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Run every test in this module one hour ahead of UTC, with no DST."""
+    # POSIX inverts the sign of these zone names, so `Etc/GMT-1` is UTC+1.
+    monkeypatch.setenv("TZ", "Etc/GMT-1")
+    time.tzset()
+    yield
+    monkeypatch.undo()
+    time.tzset()
+
+
+@freeze_time(FROZEN_TIME)
+def test_work_indexed_time_is_the_current_utc_time() -> None:
+    debug = VisibleWorkDebug.from_merged_work(_extracted_work().work)
+
+    assert debug.indexed_time == FROZEN_TIME
+
+
+@freeze_time(FROZEN_TIME)
+def test_image_indexed_time_is_the_current_utc_time() -> None:
+    image = AugmentedImage.model_validate(
+        load_json_fixture("ingestor/single_augmented_image.json")
+    )
+
+    indexable = IndexableImage.from_extracted_image(
+        ExtractedImage(image=image, work=_extracted_work())
+    )
+
+    assert indexable.debug.indexed_time == FROZEN_TIME
+
+
+@freeze_time(FROZEN_TIME)
+def test_source_work_modified_time_is_the_current_utc_time() -> None:
+    record = Record(fields=[Field(tag="001", data="ebs1234")])
+
+    builder = EbscoWorkBuilder(record, last_modified=datetime(2020, 1, 1, tzinfo=UTC))
+
+    assert builder.deleted_work_state.modified_time == FROZEN_TIME
+
+
+def test_datetime_from_005_is_read_as_utc() -> None:
+    parsed = datetime_from_005("20251225123045.0")
+
+    assert parsed == datetime(2025, 12, 25, 12, 30, 45, tzinfo=UTC)
+    assert convert_datetime_to_utc_iso(parsed) == "2025-12-25T12:30:45Z"


### PR DESCRIPTION
## What does this change?

**Make document generators consistent across time zones**

Document generator scripts use freezegun's `@freeze_time("2001-01-01T01:01:01Z")` so that the generated documents always have the same `indexedTime` regardless of when the generator scripts are run. However, the pipeline creates naive `datetime.now()` objects and then converts them to UTC via `astimezone(UTC)`. This interprets the frozen time as local and then incorrectly adds a UTC conversion on top. For example, in UTC+1, the outputted frozen timestamp is `2001-01-01T00:01:01Z` (one hour earlier than it should be). 

Instantiating the datetime object with `UTC` avoids this issue and makes document generators consistent across time zones.

**Make datetime_from_005 consistent across time zones**

The transformer reads MARC 005 values into timezone naive datetimes, causing the same issue as above. Interpreting these values as `UTC` makes the transformer output the same date regardless of which time zone it runs in.

We haven't seen this issue in production (Axiell `state.sourceModifiedTime` values are correct in the source index), probably because AWS Lambdas/ECS tasks run in UTC by default. Running the transformer locally in BST or in any other non-UTC time zone does produce incorrect dates without the fix in this PR.

Note: MARC 005 does not guarantee UTC timestamps. Interpreting them as UTC is an informed guess. Production behaviour is unchanged, since naive datetimes are assumed to be in UTC and production pipeline services always run in UTC. The main effect of this change is aligning local runs with production regardless of local time zone.

## How to test

I added new unit tests to prevent regressions.