### PR TITLE
Raise the id-minter find-work lambda to 8192MB

### DIFF
--- a/pipeline/terraform/modules/pipeline_new/state_machine_id_minter.tf
+++ b/pipeline/terraform/modules/pipeline_new/state_machine_id_minter.tf
@@ -46,8 +46,9 @@ module "id_minter" {
     service_name = "id-minter-find-work"
     description  = "Finds works needing id minting within a time window and partitions them for the id-minter state machine."
     command      = ["id_minter.steps.find_work.lambda_handler"]
-    # Sized for full-scope replays, which materialise every matching id.
-    memory_size = 2048
+    # Sized for reindex-density windows, which materialise every matching id;
+    # 2048 OOMed on ~15-min windows during the round 2 bulk load.
+    memory_size = 8192
     timeout     = 600
     # Index name and ES secrets are env-derived, matching the minter itself.
     environment_variables = {


### PR DESCRIPTION
Part of wellcomecollection/platform#6505.

During the round 2 bulk load the find-work step OOMed at 2048MB on two consecutive scheduled windows (executions 5d6a86cd and 5d6a86d1, Runtime.OutOfMemory): at reindex write rates a 15-minute window holds several hundred thousand works, and the step materialises every matching id before partitioning. 8192MB was applied manually at 11:12 BST as the mitigation; this makes it permanent so the state converges rather than reverting on the next apply.

Applies to the shared pipeline module, so the 2025-10-02 stack picks it up on its next apply too; the cost is per-invocation and the step runs for seconds outside reindexes.