### PR TITLE
Add mimsy-reference to IdentifierType

### DIFF
--- a/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/IdentifierType.scala
+++ b/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/IdentifierType.scala
@@ -111,6 +111,11 @@ object IdentifierType extends Enum[IdentifierType] {
     val label = "Axiell Guid"
   }
 
+  case object MimsyReference extends IdentifierType {
+    val id = "mimsy-reference"
+    val label = "Mimsy reference"
+  }
+
   case object ISBN extends IdentifierType {
     val id = "isbn"
     val label = "International Standard Book Number"


### PR DESCRIPTION
## What does this change?

Part of wellcomecollection/platform#6505.

The Axiell transformer maps 035 `(Mimsy reference)` values to a `mimsy-reference` identifier scheme (`ORIGIN_CODE_TO_ID_TYPE` in `catalogue_graph/src/adapters/transformers/marc/other_identifiers.py`), but the Scala internal model never gained the matching type. The merger therefore throws `java.util.NoSuchElementException` in `IdentifierType.withName` (via `ElasticSourceRetriever.parseGetResponse`) when it decodes any work carrying one, and the whole matcher batch dead-letters alongside it. The failure tracks content rather than volume, so nothing in the error rate flagged it.

During the round 2 reindex on 2026-08-20 that stranded 2,733 works across 2,406 merger DLQ batches. 343 works actually carry the identifier and the rest are batch collateral. All 343 are CALM-migrated archive records that also hold calm-ref-no/calm-altref-no identifiers and calm-ref-no merge candidates, 84 of which merge with Sierra works, so the stranded batches leave real archive-tree and merge gaps until they are repaired.

### Checklist

- [ ] Does this change the display model the catalogue API returns? Only in that `identifierType` can now carry `mimsy-reference`. No test document under `catalogue_graph/document_generators/test_documents` holds one, so there is nothing to regenerate.

## How to test

The internal_model tests cover the enum itself. The real check comes after this deploys to the `2026-07-03` pipeline: redrive the merger DLQ and watch the batches drain rather than return. The works-identified documents already hold the identifier, so nothing needs re-transforming.

## How can we measure success?

The merger DLQ empties on redrive, and the 343 affected works land in the works index with their archive relations and Sierra merges intact.

## Have we considered potential risks?

Adding an enum value is additive and safe on its own. The wider risk is that the Python transformers and the Scala internal model keep their identifier registries separately, so another scheme could be minted on one side and silently break decoding on the other in the same way. Worth a follow-up to compare the two lists rather than waiting for the next reindex to find the gap.
