### PR TITLE
Grant the production inference manager PutMetricData

### DIFF
--- a/pipeline/terraform/modules/pipeline/ecs_task_inference_manager.tf
+++ b/pipeline/terraform/modules/pipeline/ecs_task_inference_manager.tf
@@ -182,3 +182,22 @@ resource "aws_iam_role_policy" "inference_manager_s3_read" {
   role   = module.inference_manager_ecs_task.task_role_name
   policy = data.aws_iam_policy_document.inference_manager_s3_read.json
 }
+
+# The task publishes augmented_count and download_failure_count metrics.
+data "aws_iam_policy_document" "inference_manager_cloudwatch_write" {
+  statement {
+    actions   = ["cloudwatch:PutMetricData"]
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "cloudwatch:namespace"
+      values   = ["catalogue_graph_pipeline"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "inference_manager_cloudwatch_write" {
+  role   = module.inference_manager_ecs_task.task_role_name
+  policy = data.aws_iam_policy_document.inference_manager_cloudwatch_write.json
+}


### PR DESCRIPTION
The 2025-10-02 inference-manager task role cannot publish its augmented_count and download_failure_count metrics: every push logs AccessDenied on cloudwatch:PutMetricData, so production inferrer metrics (and any alarms on them) are silently absent. Found while triaging a round 2 reindex alarm on the 2026-07-03 stack, whose pipeline_new module already carries this grant.

Copies the pipeline_new grant into the older pipeline module, scoped to the catalogue_graph_pipeline namespace. Takes effect when pipeline/terraform/2025-10-02 is next applied.