### PR TITLE
Scale the matcher DynamoDB back down after the round 2 bulk load

### DIFF
--- a/pipeline/terraform/2026-07-03/main.tf
+++ b/pipeline/terraform/2026-07-03/main.tf
@@ -5,10 +5,8 @@ module "pipeline" {
     listen_to_reindexer = true
     # Sized for the round 2 full reindex (platform#6505); back to false after
     # the comparison signs off.
-    scale_up_tasks = true
-    # ~$135/day flat: applied last before the reindex starts, reverted first
-    # after the comparison signs off.
-    scale_up_matcher_db = true
+    scale_up_tasks      = true
+    scale_up_matcher_db = false
   }
 
   index_dates = {

--- a/pipeline/terraform/2026-07-03/main.tf
+++ b/pipeline/terraform/2026-07-03/main.tf
@@ -3,8 +3,8 @@ module "pipeline" {
 
   reindexing_state = {
     listen_to_reindexer = true
-    # Sized for the round 2 full reindex (platform#6505); back to false after
-    # the comparison signs off.
+    # Sized for the round 2 full reindex (platform#6505). Matcher DB is back to
+    # normal; keep tasks scaled up until image stages finish and verification passes.
     scale_up_tasks      = true
     scale_up_matcher_db = false
   }


### PR DESCRIPTION
Part of wellcomecollection/platform#6505.

Reverts #3577: the matcher finished the round 2 works bulk (the remaining image processing does not touch the matcher DB), so the flat ~$135/day provisioned capacity comes off. `scale_up_tasks` and the ES sizing stay up until the image stages finish and the reindex verification passes.

Merge and apply `pipeline/terraform/2026-07-03` once works-identified has caught works-source and the matcher and merger queues have drained.