### PR TITLE
Record that the 2026-07-03 id-minter stops being disposable at switchover

### DIFF
--- a/infrastructure/critical/rds_id_minter.tf
+++ b/infrastructure/critical/rds_id_minter.tf
@@ -21,10 +21,10 @@ module "id_minter_rds_2026_07_03" {
   snapshot_identifier = "awsbackup:job-7adec63f-19b6-5ff9-272d-f39aad1a79a8"
 
   # A restored copy of production, respun from a fresh snapshot each testing round,
-  # so its contents are disposable for now. That changes at switchover: the respin
-  # taken inside the freeze becomes the production registry and must be kept, along
-  # with skip_final_snapshot going away. Read
-  # https://github.com/wellcomecollection/platform/issues/6541 before clearing this.
+  # so its contents are disposable for now. After switchover, the respin taken
+  # inside the freeze becomes the production registry and must be kept.
+  # Phase 6 of https://github.com/wellcomecollection/platform/issues/6541 removes
+  # skip_final_snapshot; read it before clearing this.
   skip_final_snapshot = true
 
   vpc_id             = local.vpc_id_new

--- a/infrastructure/critical/rds_id_minter.tf
+++ b/infrastructure/critical/rds_id_minter.tf
@@ -20,7 +20,11 @@ module "id_minter_rds_2026_07_03" {
   # Restore from production on August 19, 2026, 04:00 (UTC+01:00)
   snapshot_identifier = "awsbackup:job-7adec63f-19b6-5ff9-272d-f39aad1a79a8"
 
-  # A restored copy of production; its contents are never worth keeping.
+  # A restored copy of production, respun from a fresh snapshot each testing round,
+  # so its contents are disposable for now. That changes at switchover: the respin
+  # taken inside the freeze becomes the production registry and must be kept, along
+  # with skip_final_snapshot going away. Read
+  # https://github.com/wellcomecollection/platform/issues/6541 before clearing this.
   skip_final_snapshot = true
 
   vpc_id             = local.vpc_id_new


### PR DESCRIPTION
## What does this change?

A comment only. No infrastructure change.

`id_minter_rds_2026_07_03` is currently described as "a restored copy of production; its contents are never worth keeping", which is true today: it is respun from a fresh production snapshot at the start of each testing round, and round 1 respun it deliberately to resolve the shared-id-pool fork behaviour in wellcomecollection/platform#6485.

That stops being true at the Axiell switchover. The respin taken inside the freeze becomes the production registry: the canonical ids it holds are the ones the public catalogue serves, and clearing it after that point would change work URLs. The old comment reads as standing permission to wipe the cluster, so it is worth correcting before someone acts on it during the switchover window rather than before it.

The comment now says both things, and points at the switchover runbook (wellcomecollection/platform#6541).

`skip_final_snapshot = true` is left as it is on purpose. Flipping it now would get in the way of the remaining testing respins and protects nothing while the cluster really is disposable. Removing it is a task in phase 6 of the runbook, alongside considering deletion protection to match the production cluster.

### Checklist

- [x] Does this change the display model the catalogue API returns? No, this is a comment in terraform.

## How to test

Read the diff. `terraform fmt -check` passes and there is no plan change, since only a comment moved.

## How can we measure success?

Nothing to measure. The success case is that whoever runs phase 3 of wellcomecollection/platform#6541 does not clear the cluster afterwards on the strength of a stale comment.

## Have we considered potential risks?

The risk this addresses is the one worth naming: canonical ids minted in production after the final snapshot exist only in the old registry, so if the new registry were cleared or re-restored after switchover, affected works would be minted fresh ids and their URLs would change. The comment is a cheap guard, not a control. The actual controls are removing `skip_final_snapshot` and adding deletion protection, both in phase 6 of the runbook.
