### PR TITLE
Add mimsy-reference to the ingestor identifier label map

### DIFF
--- a/catalogue_graph/src/ingestor/models/display/identifier.py
+++ b/catalogue_graph/src/ingestor/models/display/identifier.py
@@ -28,6 +28,7 @@ IDENTIFIER_LABEL_MAPPING = {
     "calm-ref-no": "Calm RefNo",
     "calm-altref-no": "Calm AltRefNo",
     "calm-record-id": "Calm RecordIdentifier",
+    "mimsy-reference": "Mimsy reference",
     "isbn": "International Standard Book Number",
     "issn": "ISSN",
     "mets": "METS",


### PR DESCRIPTION
Part of wellcomecollection/platform#6505; the third registry in the mimsy-reference chain after #3588.

The graph ingestor's display transform looks identifier labels up in `IDENTIFIER_LABEL_MAPPING` and raised `KeyError: 'mimsy-reference'` when the 343 repaired works from the merger redrive reached the ingest stage (graph-pipeline-ingestors execution 80587ced, 16:27 BST), failing the whole window. Adds the missing entry, matching the Scala label.

After deploy, the failed incremental window (works merged roughly 16:00-16:15Z... BST 17:00-17:15 window range in mergedTime terms) needs a fresh StartExecution replay per the no-redrive rule; presence should be spot-checked first since other batches in the window may have written before the failure.

There are now three separately-maintained identifier registries (the Python transformer origin map, the Scala IdentifierType enum, and this label map); a cross-registry consistency test is a platform#6508 candidate.