### PR TITLE
Let the window store be opened without creating it

### DIFF
--- a/catalogue_graph/src/adapters/extractors/oai_pmh/runtime.py
+++ b/catalogue_graph/src/adapters/extractors/oai_pmh/runtime.py
@@ -165,9 +165,14 @@ class OAIPMHRuntimeConfig(ABC):
             self._config.local_window_status_iceberg_config, create_if_not_exists
         )
 
-    def build_window_store(self, *, use_rest_api_table: bool = True) -> WindowStore:
+    def build_window_store(
+        self, *, use_rest_api_table: bool = True, create_if_not_exists: bool = True
+    ) -> WindowStore:
         """Build the window status store for tracking harvest progress."""
-        table = self._build_window_status_table(use_rest_api_table=use_rest_api_table)
+        table = self._build_window_status_table(
+            use_rest_api_table=use_rest_api_table,
+            create_if_not_exists=create_if_not_exists,
+        )
         return WindowStore(table)
 
     def build_adapter_store(self, *, use_rest_api_table: bool = True) -> AdapterStore:

--- a/catalogue_graph/tests/adapters/extractors/oai_pmh/test_runtime_window_store.py
+++ b/catalogue_graph/tests/adapters/extractors/oai_pmh/test_runtime_window_store.py
@@ -1,0 +1,49 @@
+"""How `build_window_store` decides whether to create the table it opens."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from adapters.extractors.oai_pmh import runtime as runtime_module
+from adapters.extractors.oai_pmh.runtime import OAIPMHRuntimeConfig
+
+
+@pytest.fixture
+def created(monkeypatch: pytest.MonkeyPatch) -> list[bool]:
+    """Record the create flag each table getter is called with."""
+    calls: list[bool] = []
+
+    def record(_config: Any, create_if_not_exists: bool) -> object:
+        calls.append(create_if_not_exists)
+        return object()
+
+    monkeypatch.setattr(runtime_module, "get_rest_api_table", record)
+    monkeypatch.setattr(runtime_module, "get_local_table", record)
+    return calls
+
+
+@pytest.mark.parametrize("use_rest_api_table", [True, False])
+def test_opting_out_reaches_the_table_getter(
+    adapter_runtime_config: OAIPMHRuntimeConfig,
+    created: list[bool],
+    use_rest_api_table: bool,
+) -> None:
+    """A read-only caller must not trigger s3tables:CreateNamespace."""
+    adapter_runtime_config.build_window_store(
+        use_rest_api_table=use_rest_api_table, create_if_not_exists=False
+    )
+
+    assert created == [False]
+
+
+@pytest.mark.parametrize("use_rest_api_table", [True, False])
+def test_the_default_still_creates(
+    adapter_runtime_config: OAIPMHRuntimeConfig,
+    created: list[bool],
+    use_rest_api_table: bool,
+) -> None:
+    adapter_runtime_config.build_window_store(use_rest_api_table=use_rest_api_table)
+
+    assert created == [True]


### PR DESCRIPTION
## What does this change?

`build_window_store` now takes a `create_if_not_exists` keyword and forwards it to the table builder, which already accepted one. The flag was previously fixed at its default on the way down, so a caller that only wanted to read window status still went through `create_namespace` and `create_table_if_not_exists`. A read-only IAM role is denied `s3tables:CreateNamespace`, so the read failed on permissions even though there was nothing to create. `build_adapter_table` already exposes the same keyword, so this brings the window status table into line with it.

The default is unchanged and no existing caller passes the new argument, so the harvest path behaves as it did before.

This came up while building a read-only status tool that reads the window status tables through this path. That tool is parked and is not part of this PR, and the fix is independently useful to any read-only consumer of the window store, so it is raised on its own.

### Checklist

- [ ] Does this change the display model the catalogue API returns? No. It only changes how an Iceberg table handle is opened, not the documents we produce.

## How to test

From `catalogue_graph/`, `uv run --group dev pytest tests -k "window or runtime or oai"` passes (354 passed, 1428 deselected). `ruff format --check`, `ruff check` and `mypy` are clean on the changed file.

## How can we measure success?

No metric to watch. The check is that a caller holding only read permissions can open the window store and read status without an `AccessDenied` on `s3tables:CreateNamespace`.

## Have we considered potential risks?

Low. The change is additive and the default preserves current behaviour for every caller in `steps/oai_pmh` and `scripts/rebuild_adapter.py`. A caller that opts out and points at a table that does not exist yet will get a load error rather than having the table created for it, which is what a read-only caller should want.
