### PR TITLE
Commit the round 2 Axiell-CALM comparison config

### DIFF
--- a/scripts/es_index_comparison/configs/6507_axiell_calm_identified_full.yaml
+++ b/scripts/es_index_comparison/configs/6507_axiell_calm_identified_full.yaml
@@ -1,0 +1,40 @@
+# platform#6507 section 3: the round 2 Axiell works against their CALM
+# predecessors at works-identified, shared canonical ids.
+#
+# Population pinned by ids_file (the round 1 method): the Axiell-owned
+# canonical ids exported from works-identified-2026-07-03 on 2026-08-21.
+# The 6464 config's per-side filter_queries cannot work at works-identified:
+# state.sourceIdentifier is not an indexed field there on either cluster,
+# so a term filter silently matches nothing. The ids clause needs no mapping
+# support and applies to both sides.
+
+index_sources:
+  - prod-works-identified
+  - new-works-identified
+
+ids_file: ../data/6507_axiell_canonical_ids.txt
+
+ignore_fields:
+  # Per-run stamps and counters.
+  - indexed_at
+  - version
+  - state.modifiedTime
+  - state.sourceModifiedTime
+  # The source swap itself: identifiers, relations and predecessor linkage
+  # legitimately differ between a CALM work and its Axiell successor.
+  - state.sourceIdentifier
+  - state.sourceIdentifier.**
+  - state.relations
+  - state.relations.**
+  - state.predecessorIdentifier
+  - state.predecessorIdentifier.**
+  - state.mergeCandidates[].id.type
+  - data.production[].dates[].type
+  # Added to the internal model after round 1's baseline; absent on the CALM
+  # side by construction, so it is comparison noise here.
+  - state.removedInternalWorkStubs
+
+sample_size: 40
+hash_bucket_count: 8
+namespace: 6507-axiell-calm-identified-full
+output_dir: data

--- a/scripts/es_index_comparison/configs/6507_axiell_calm_identified_full.yaml
+++ b/scripts/es_index_comparison/configs/6507_axiell_calm_identified_full.yaml
@@ -2,7 +2,8 @@
 # predecessors at works-identified, shared canonical ids.
 #
 # Population pinned by ids_file (the round 1 method): the Axiell-owned
-# canonical ids exported from works-identified-2026-07-03 on 2026-08-21.
+# canonical ids from works-identified-2026-07-03. The file is gitignored;
+# regenerate it with `uv run python generate_6507_ids.py` before running.
 # The 6464 config's per-side filter_queries cannot work at works-identified:
 # state.sourceIdentifier is not an indexed field there on either cluster,
 # so a term filter silently matches nothing. The ids clause needs no mapping

--- a/scripts/es_index_comparison/generate_6507_ids.py
+++ b/scripts/es_index_comparison/generate_6507_ids.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Regenerate the ids file for the 6507 Axiell-CALM comparison config.
+
+Scrolls the round 2 works-identified index (the `new-works-identified` source
+in configs/source_configuration.yaml) and writes the canonical ids of every
+axiell-guid work to data/6507_axiell_canonical_ids.txt. The scheme lives only
+in _source there, so this is a full scroll rather than a filtered query.
+
+Usage, from scripts/es_index_comparison:
+
+    uv run python generate_6507_ids.py
+"""
+
+from pathlib import Path
+
+from elasticsearch import helpers
+
+from es_index_comparison.es_client import build_client
+from es_index_comparison.source_config import load_source_configuration
+
+HERE = Path(__file__).parent
+OUT = HERE / "data" / "6507_axiell_canonical_ids.txt"
+SOURCE_ID = "new-works-identified"
+
+source_config = load_source_configuration(HERE / "configs" / "source_configuration.yaml")
+source = source_config.resolve_index_sources([SOURCE_ID])[0]
+client = build_client(source.cloud_id, source.api_key)
+
+count = 0
+with OUT.open("w") as f:
+    for hit in helpers.scan(
+        client,
+        index=source.index,
+        _source=["state.sourceIdentifier.identifierType.id"],
+        query={"query": {"match_all": {}}},
+        size=10_000,
+    ):
+        scheme = (
+            hit["_source"]
+            .get("state", {})
+            .get("sourceIdentifier", {})
+            .get("identifierType", {})
+            .get("id")
+        )
+        if scheme == "axiell-guid":
+            f.write(hit["_id"] + "\n")
+            count += 1
+
+print(f"wrote {count} ids to {OUT}")


### PR DESCRIPTION
Part of wellcomecollection/platform#6507, keeping the round 2 comparison reproducible alongside the committed round 1 configs (#3556).

The config pins the population with an ids file rather than the 6464 configs' per-side filter queries, and documents why: `state.sourceIdentifier` is not an indexed field at works-identified on either cluster, so a term filter there silently matches nothing. The ids file itself lives under the tool's gitignored data directory and is regenerated by scrolling works-identified for axiell-guid works (the comparison write-up records the exact method).

Also carries the `state.removedInternalWorkStubs` ignore entry: the field joined the internal model after round 1's baseline, so it is comparison noise against CALM-era documents.