### PR TITLE
Fail a stranded adapter task token instead of waiting forever

### DIFF
--- a/catalogue_graph/infra/adapters/modules/adapter/state_machine.tf
+++ b/catalogue_graph/infra/adapters/modules/adapter/state_machine.tf
@@ -102,10 +102,17 @@ locals {
         Default = "Should publish event?"
       }
       "Run enrichment" = merge({
-        Type     = "Task"
-        Resource = "arn:aws:states:::ecs:runTask.waitForTaskToken"
-        Next     = "Should publish event?"
+        Type           = "Task"
+        Resource       = "arn:aws:states:::ecs:runTask.waitForTaskToken"
+        TimeoutSeconds = var.task_token_timeout_seconds
+        Next           = "Should publish event?"
         Retry = [
+          {
+            # A timed-out token means the task is gone, so retrying only waits
+            # again. Fail now; the next scheduled run re-covers the window.
+            ErrorEquals = ["States.Timeout"]
+            MaxAttempts = 0
+          },
           {
             ErrorEquals     = ["States.ALL"]
             IntervalSeconds = 30
@@ -181,9 +188,10 @@ locals {
       # there are no automatic retries at all: failed ids come back in the
       # report for a deliberate, smaller second run.
       "Run id loader" = {
-        Type     = "Task"
-        Resource = "arn:aws:states:::ecs:runTask.waitForTaskToken"
-        Next     = local.loader_next
+        Type           = "Task"
+        Resource       = "arn:aws:states:::ecs:runTask.waitForTaskToken"
+        TimeoutSeconds = var.task_token_timeout_seconds
+        Next           = local.loader_next
         Retry = [
           {
             ErrorEquals     = ["States.ALL"]
@@ -240,10 +248,17 @@ locals {
       ]
     }
     "Run loader" = {
-      Type     = "Task"
-      Resource = "arn:aws:states:::ecs:runTask.waitForTaskToken"
-      Next     = local.loader_next
+      Type           = "Task"
+      Resource       = "arn:aws:states:::ecs:runTask.waitForTaskToken"
+      TimeoutSeconds = var.task_token_timeout_seconds
+      Next           = local.loader_next
       Retry = [
+        {
+          # A timed-out token means the task is gone, so retrying only waits
+          # again. Fail now; the next scheduled run re-covers the window.
+          ErrorEquals = ["States.Timeout"]
+          MaxAttempts = 0
+        },
         {
           ErrorEquals     = ["States.ALL"]
           IntervalSeconds = 30

--- a/catalogue_graph/infra/adapters/modules/adapter/variables.tf
+++ b/catalogue_graph/infra/adapters/modules/adapter/variables.tf
@@ -67,3 +67,14 @@ variable "enable_reconciliation" {
   default     = false
   description = "Run a reconcile state between Run loader and Publish event, recording guid-change deletion facts before the completed event fires. Axiell-only; leave false for other adapters."
 }
+
+variable "task_token_timeout_seconds" {
+  type    = number
+  default = 21600
+  # An ECS task that dies without calling SendTaskSuccess leaves the state
+  # waiting forever: one axiell run sat at "Run loader" for 31 days. Normal runs
+  # take about 70s, the longest observed legitimate run 2h50m, and a full Axiell
+  # harvest about 4h, so 6h fails a stranded token the same day while leaving a
+  # full harvest room.
+  description = "How long a waitForTaskToken state waits for its ECS task before failing."
+}


### PR DESCRIPTION
## What does this change?

The three `ecs:runTask.waitForTaskToken` states in the shared adapter state machine ("Run loader", "Run id loader", "Run enrichment") had no `TimeoutSeconds`, so an ECS task that dies without calling `SendTaskSuccess` leaves its execution RUNNING indefinitely. An `axiell-adapter` execution sat at "Run loader" from 2026-07-21 until it was stopped by hand on 2026-08-21. It went unnoticed partly because an execution that never completes never appears in the recent-executions view people look at.

A new module variable `task_token_timeout_seconds`, defaulting to 21600 (6 hours), now applies to all three states. "Run loader" and "Run enrichment" retry `States.ALL` three times, so a bare timeout would spend a further 18 hours rediscovering that a dead task is still dead. `States.Timeout` is matched first with `MaxAttempts = 0` so those two fail immediately. "Run id loader" already retried nothing and only gains the timeout.

Same failure shape as wellcomecollection/platform#6458 in the graph pipeline, though that one had a 12 hour timeout rather than none at all.

<details><summary>Where the six hours comes from</summary>

Across the last few hundred SUCCEEDED executions of the three adapter state machines, normal runs take about 70 seconds (axiell p50 69s, ebsco p50 97s, folio p50 83s). The longest legitimate run observed was 2h50m on folio, and ebsco's worst was about 10 minutes. A full Axiell harvest takes roughly 4 hours. Six hours leaves a full harvest headroom while turning a stranded token into a same-day failure.
</details>

### Checklist

- [ ] Does this change the display model the catalogue API returns? No, it changes adapter orchestration only.

## How to test

Inert until someone runs `terraform apply` in `catalogue_graph/infra/adapters`. The plan should add `TimeoutSeconds` to the three states for all three adapters (ebsco, axiell, folio), which share this module. After applying, each `*-adapter` state machine definition carries `"TimeoutSeconds": 21600`.

`terraform fmt -check -recursive` and `terraform validate` are clean. `builds/run_tflint.sh` was not run because tflint is not installed on my machine, so CI will be the first real tflint run.

## How can we measure success?

No adapter execution sits in RUNNING beyond six hours, and a stranded task token becomes a failed execution the same day rather than something found by hand a month later.

## Have we considered potential risks?

The timeout is also a ceiling on legitimate work, so a harvest that genuinely ran past six hours would be killed mid-run. The variable is per module instance, so raising it for a single adapter is a one-line change.

Failing without a retry loses no window, because the trigger resumes from the last published window and the next scheduled run re-covers the range. Folio's schedule is currently disabled, so a folio failure would wait for that to be re-enabled or for a manual run.
