### PR TITLE
Strip the (LCSH) vocabulary marker from Axiell subject terms

### DIFF
--- a/catalogue_graph/src/adapters/transformers/axiell/subjects.py
+++ b/catalogue_graph/src/adapters/transformers/axiell/subjects.py
@@ -12,9 +12,13 @@ def extract_subject_labels(record: Record) -> list[str]:
 def extract_subjects(record: Record) -> list[Subject]:
     labels = extract_subject_labels(record)
 
-    # Some subject labels coming from Axiell/CALM have a leading <p> prefix to indicate that the subject is linked
-    # to a Library of Congress entry. Remove the prefix.
-    labels = [label.removeprefix("<p>") for label in labels]
+    # Axiell marks LCSH-linked terms with a leading tag in the term text
+    # ("<p>" originally, "(LCSH) " since the round 2 load; WEL-271 will move
+    # this to an Authority field). Strip it so labels display clean and the
+    # label-derived identifier matches the same term from other sources.
+    labels = [
+        label.removeprefix("<p>").removeprefix("(LCSH) ") for label in labels
+    ]
 
     subjects = []
     for label in labels:

--- a/catalogue_graph/src/adapters/transformers/axiell/subjects.py
+++ b/catalogue_graph/src/adapters/transformers/axiell/subjects.py
@@ -16,9 +16,7 @@ def extract_subjects(record: Record) -> list[Subject]:
     # ("<p>" originally, "(LCSH) " since the round 2 load; WEL-271 will move
     # this to an Authority field). Strip it so labels display clean and the
     # label-derived identifier matches the same term from other sources.
-    labels = [
-        label.removeprefix("<p>").removeprefix("(LCSH) ") for label in labels
-    ]
+    labels = [label.removeprefix("<p>").removeprefix("(LCSH) ") for label in labels]
 
     subjects = []
     for label in labels:

--- a/catalogue_graph/tests/adapters/transformers/axiell/bdd/features/subjects.feature
+++ b/catalogue_graph/tests/adapters/transformers/axiell/bdd/features/subjects.feature
@@ -53,6 +53,15 @@ Feature: Subjects extraction from Axiell MARC records
     When I transform the MARC record
     Then the only subject has the label "Biography"
     And its only concept has the label "Biography"
+    And it has the id.source_identifier.value "biography"
+
+  Scenario: A marked and an unmarked term derive the same concept identifier
+    Given the MARC record has a 653 field with subfield "a" value "(LCSH) Biography"
+    And the MARC record has another 653 field with subfield "a" value "Biography"
+    When I transform the MARC record
+    Then there are 2 subjects
+    And the 1st subject has the id.source_identifier.value "biography"
+    And the 2nd subject has the id.source_identifier.value "biography"
 
   Scenario: (LCSH) marker stripped alongside trailing period
     Given the MARC record has a 653 field with subfield "a" value "(LCSH) Autobiography."

--- a/catalogue_graph/tests/adapters/transformers/axiell/bdd/features/subjects.feature
+++ b/catalogue_graph/tests/adapters/transformers/axiell/bdd/features/subjects.feature
@@ -47,3 +47,19 @@ Feature: Subjects extraction from Axiell MARC records
     Given the MARC record has a 653 field with subfield "a" value "<p>Surgery."
     When I transform the MARC record
     Then the only subject has the label "Surgery"
+
+  Scenario: Leading (LCSH) marker is stripped from label
+    Given the MARC record has a 653 field with subfield "a" value "(LCSH) Biography"
+    When I transform the MARC record
+    Then the only subject has the label "Biography"
+    And its only concept has the label "Biography"
+
+  Scenario: (LCSH) marker stripped alongside trailing period
+    Given the MARC record has a 653 field with subfield "a" value "(LCSH) Autobiography."
+    When I transform the MARC record
+    Then the only subject has the label "Autobiography"
+
+  Scenario: A parenthetical that is not the LCSH marker is kept
+    Given the MARC record has a 653 field with subfield "a" value "(Unrelated) Heading"
+    When I transform the MARC record
+    Then the only subject has the label "(Unrelated) Heading"


### PR DESCRIPTION
## What does this change?

Fixes the pipeline half of wellcomecollection/platform#6577, found by the round 2 comparison (wellcomecollection/platform#6507).

The round 2 Axiell load renders the thesaurus vocabulary marker on LCSH-linked terms as literal `(LCSH) ` text in 653 $a, where the earlier export used `<p>`, which the transformer already strips. 11,466 records carry it across 13,691 terms. The prefix reaches public subject labels, and because subject concepts are identified from their labels, each affected heading mints a second concept distinct from the same heading on Sierra works (13,128 re-identified subject concepts in the comparison). Extending the existing strip to cover the new rendering clears both effects together.

[WEL-271](https://wtprojects.atlassian.net/browse/WEL-271) confirms the marker is the term's vocabulary source (marked terms are LCSH, unmarked are MeSH) and that a later CALM migration moves it into a proper Authority field, so the marker in the term text is interim. Two things this deliberately does not do:

- unmarked terms are left alone
- no identifier scheme is assigned from the marker, because we have labels here but no authority identifiers behind them

Real authority identification waits for the Authority field.

### Checklist

- [ ] Does this change the display model the catalogue API returns? No, subject label values change but the document shape does not, so the test documents do not need regenerating.

## How to test

From `catalogue_graph/`, `uv run --group dev pytest tests/adapters/transformers/axiell`. One scenario asserts the label-derived concept identifier, and one puts a marked and an unmarked form of the same heading on one record to prove they derive an identical identifier.

## How can we measure success?

After deploy, a full Axiell re-transform carries the affected works through. A "(LCSH)" search should then return zero works, and the subject concept identity diffs should collapse on a comparison re-run.

## Have we considered potential risks?

A genuine heading beginning "(LCSH) " would lose that text, which is not a real risk while the marker is the only thing producing that prefix. Parentheticals that are not the marker are untouched, and a scenario pins that. Nothing changes for existing works until they are re-transformed, so the fix ships inert.
