### PR TITLE
Heartbeat the ECS task token states so a dead task is caught in minutes

### DIFF
--- a/catalogue_graph/infra/adapters/modules/adapter/state_machine.tf
+++ b/catalogue_graph/infra/adapters/modules/adapter/state_machine.tf
@@ -102,10 +102,11 @@ locals {
         Default = "Should publish event?"
       }
       "Run enrichment" = merge({
-        Type           = "Task"
-        Resource       = "arn:aws:states:::ecs:runTask.waitForTaskToken"
-        TimeoutSeconds = var.task_token_timeout_seconds
-        Next           = "Should publish event?"
+        Type             = "Task"
+        Resource         = "arn:aws:states:::ecs:runTask.waitForTaskToken"
+        TimeoutSeconds   = var.task_token_timeout_seconds
+        HeartbeatSeconds = local.task_token_heartbeat_seconds
+        Next             = "Should publish event?"
         Retry = [
           {
             # A timed-out token means the task is gone, so retrying only waits
@@ -188,10 +189,11 @@ locals {
       # there are no automatic retries at all: failed ids come back in the
       # report for a deliberate, smaller second run.
       "Run id loader" = {
-        Type           = "Task"
-        Resource       = "arn:aws:states:::ecs:runTask.waitForTaskToken"
-        TimeoutSeconds = var.task_token_timeout_seconds
-        Next           = local.loader_next
+        Type             = "Task"
+        Resource         = "arn:aws:states:::ecs:runTask.waitForTaskToken"
+        TimeoutSeconds   = var.task_token_timeout_seconds
+        HeartbeatSeconds = local.task_token_heartbeat_seconds
+        Next             = local.loader_next
         Retry = [
           {
             ErrorEquals     = ["States.ALL"]
@@ -248,10 +250,11 @@ locals {
       ]
     }
     "Run loader" = {
-      Type           = "Task"
-      Resource       = "arn:aws:states:::ecs:runTask.waitForTaskToken"
-      TimeoutSeconds = var.task_token_timeout_seconds
-      Next           = local.loader_next
+      Type             = "Task"
+      Resource         = "arn:aws:states:::ecs:runTask.waitForTaskToken"
+      TimeoutSeconds   = var.task_token_timeout_seconds
+      HeartbeatSeconds = local.task_token_heartbeat_seconds
+      Next             = local.loader_next
       Retry = [
         {
           # A timed-out token means the task is gone, so retrying only waits
@@ -427,4 +430,14 @@ resource "aws_sfn_state_machine" "state_machine" {
 resource "aws_cloudwatch_log_group" "state_machine_logs" {
   name              = "/aws/stepfunctions/${var.namespace}-adapter-pipeline"
   retention_in_days = 14
+}
+
+module "task_token_timing" {
+  source = "../../../../../pipeline/terraform/modules/task_token_timing"
+}
+
+locals {
+  # Every adapter task is Fargate, so the shared Fargate margin applies. The timeout
+  # above stays an outer bound: liveness is this heartbeat's job.
+  task_token_heartbeat_seconds = module.task_token_timing.fargate_heartbeat_seconds
 }

--- a/pipeline/terraform/modules/pipeline_new/state_machine_image_inferrer.tf
+++ b/pipeline/terraform/modules/pipeline_new/state_machine_image_inferrer.tf
@@ -6,8 +6,12 @@
 # service. (The unified_pipeline_lambda ECR data source is declared in locals.tf.)
 
 locals {
-  # Generous timeout so EC2 capacity-provider warm-up does not trip the task token.
+  # Outer bound on the whole state. Liveness is the heartbeat's job.
   inference_task_token_timeout_seconds = 3 * 60 * 60 # 3 hours
+
+  # These tasks launch on an EC2 capacity provider running at min=0, so they wait
+  # far longer than a Fargate task before they can beat. See modules/task_token_timing.
+  inference_task_token_heartbeat_seconds = module.task_token_timing.ec2_capacity_provider_heartbeat_seconds
 
   # Retry transient ECS infrastructure errors only. Application failures (e.g. a
   # poisoned-doc error) are intentionally NOT retried so they surface promptly.
@@ -88,10 +92,11 @@ module "image_inferrer" {
 
   worker_state_name = "RunInferenceTask"
   worker_state = {
-    Type           = "Task"
-    Resource       = "arn:aws:states:::ecs:runTask.waitForTaskToken"
-    TimeoutSeconds = local.inference_task_token_timeout_seconds
-    Retry          = local.inference_ecs_retry
+    Type             = "Task"
+    Resource         = "arn:aws:states:::ecs:runTask.waitForTaskToken"
+    TimeoutSeconds   = local.inference_task_token_timeout_seconds
+    HeartbeatSeconds = local.inference_task_token_heartbeat_seconds
+    Retry            = local.inference_ecs_retry
     Arguments = {
       Cluster        = aws_ecs_cluster.cluster.arn
       TaskDefinition = module.inference_manager_ecs_task.task_definition_arn
@@ -179,4 +184,8 @@ moved {
 moved {
   from = aws_iam_role_policy.run_image_inferrer_policy
   to   = module.image_inferrer.aws_iam_role_policy.run_state_machine
+}
+
+module "task_token_timing" {
+  source = "../task_token_timing"
 }

--- a/pipeline/terraform/modules/pipeline_services/graph/locals.tf
+++ b/pipeline/terraform/modules/pipeline_services/graph/locals.tf
@@ -188,9 +188,9 @@ locals {
   # is enforced by the heartbeat below.
   ecs_task_token_timeout_seconds = 12 * 60 * 60 # 12 hours
 
-  # Tasks beat every 60s (HEARTBEAT_INTERVAL_SECONDS in utils/steps.py). The margin
-  # covers cold start before the first beat: provisioning, image pull, interpreter.
-  ecs_task_token_heartbeat_seconds = 5 * 60 # 5 minutes
+  # These tasks are Fargate, so they start in about 45s and only need the shared
+  # Fargate margin. See modules/task_token_timing for why the value is not one number.
+  ecs_task_token_heartbeat_seconds = module.task_token_timing.fargate_heartbeat_seconds
 
   state_function_default_retry = [
     {
@@ -268,4 +268,8 @@ data "aws_ecr_repository" "unified_pipeline_lambda" {
 
 data "aws_ecr_repository" "unified_pipeline_task" {
   name = "uk.ac.wellcome/unified_pipeline_task"
+}
+
+module "task_token_timing" {
+  source = "../../task_token_timing"
 }

--- a/pipeline/terraform/modules/task_token_timing/outputs.tf
+++ b/pipeline/terraform/modules/task_token_timing/outputs.tf
@@ -3,7 +3,7 @@
 # travel: a value sized for Fargate will kill a healthy EC2 task during cold start.
 #
 # The timeout is an outer bound on the whole state. Liveness is the heartbeat's job:
-# tasks beat every 60s (HEARTBEAT_INTERVAL_SECONDS in catalogue_graph utils/steps.py),
+# tasks beat every 60s (HEARTBEAT_INTERVAL_SECONDS in catalogue_graph/src/utils/steps.py),
 # so the heartbeat only has to cover the gap before the first beat, which is however
 # long the task takes to actually start running.
 

--- a/pipeline/terraform/modules/task_token_timing/outputs.tf
+++ b/pipeline/terraform/modules/task_token_timing/outputs.tf
@@ -1,0 +1,23 @@
+# Timings for Step Functions states that launch an ECS task and wait for its task
+# token. Shared because the two numbers are easy to copy and one of them does not
+# travel: a value sized for Fargate will kill a healthy EC2 task during cold start.
+#
+# The timeout is an outer bound on the whole state. Liveness is the heartbeat's job:
+# tasks beat every 60s (HEARTBEAT_INTERVAL_SECONDS in catalogue_graph utils/steps.py),
+# so the heartbeat only has to cover the gap before the first beat, which is however
+# long the task takes to actually start running.
+
+output "fargate_heartbeat_seconds" {
+  # Measured cold start on catalogue-2026-07-03: 45 to 50s across six graph tasks.
+  value       = 5 * 60
+  description = "Heartbeat for a task that launches on Fargate."
+}
+
+output "ec2_capacity_provider_heartbeat_seconds" {
+  # The inferrer ASG runs at min=0, so every task waits for an instance to launch
+  # and, in a burst, for one of the 12 to free up. The worst single state during the
+  # round 2 reindex was 769s across five bursts (609 to 769s), which bounds the wait
+  # before a first beat. 20 minutes leaves room for a larger burst.
+  value       = 20 * 60
+  description = "Heartbeat for a task that launches on an EC2 capacity provider."
+}


### PR DESCRIPTION
## What does this change?

The adapter and image inferrer task token states now declare `HeartbeatSeconds`, so a dead task fails its state in minutes rather than at the timeout. wellcomecollection/catalogue-pipeline#3595 added `TimeoutSeconds` after an axiell execution hung at `ecs:runTask.waitForTaskToken` for 31 days, and review of it noted that a timeout does not cancel the ECS task. A heartbeat tells a dead task from a slow one.

No code change is needed. `ecs_handler` in `catalogue_graph/src/utils/steps.py` already wraps every handler in `task_heartbeat`, and every task role already holds `states:SendTaskHeartbeat`. The adapter and inferrer states never declared `HeartbeatSeconds`, so those beats were discarded. The graph states already declared it.

`pipeline/terraform/modules/task_token_timing` holds two values, because the number does not travel between launch types:

- Fargate, 5 minutes. Cold start on `catalogue-2026-07-03` measured 45 to 50 seconds across six graph tasks. The three adapter states use this, and the graph module now reads it instead of its own local.
- EC2 capacity provider, 20 minutes. The inferrer ASG runs at `min=0`, so a task waits for an instance and, during a burst, for one of twelve to free up. Per-state waits during the round 2 reindex reached 769s (769, 736, 748, 732 and 609 across five bursts), so 5 minutes would fail healthy work.

The graph edit is value neutral. The adapter timeout stays at 6 hours, the inferrer keeps its 3 hour timeout as an outer bound, and 2025-10-02's own inferrer in `modules/pipeline` is untouched.

Relates to wellcomecollection/platform#6594.

### Checklist

- [ ] Does this change the display model the catalogue API returns? No, Step Functions timing only.

## How to test

Plans already run:

- `catalogue_graph/infra/adapters`: 3 state machines, `definition` only, six additions of `HeartbeatSeconds = 300`.
- `pipeline/terraform/2026-07-03`: the inferrer gets `HeartbeatSeconds = 1200`, and no graph resource changes.

That second plan also carries drift which is not from this PR: the matcher lock table's `warm_throughput.write_units_per_second` moving from 10432 to 6216, plus a dependent IAM policy and a data source re-read. Target the apply at the inferrer state machine, or deal with the drift first.

`terraform validate` and `terraform fmt -check -recursive` are clean. tflint is not installed on the machine this was written on, so CI is its first run.

## How can we measure success?

A task that dies without calling `SendTaskSuccess` fails its state within the heartbeat window, which the existing `ExecutionsFailed` alarm covers. A never-ending execution reached no alarm at all. Healthy executions should be unaffected.

## Have we considered potential risks?

- A heartbeat set too tight fails healthy work. The EC2 value carries that risk, which is why it is measured rather than copied from the Fargate one.
- Heartbeat expiry surfaces as `States.Timeout`, which the adapter states match ahead of `States.ALL` with `MaxAttempts = 0`. The execution fails immediately and the next scheduled run re-covers the window.
- Both changes are inert until applied.
