### PR TITLE
Scale the round 2 pipeline back down after the comparison

### DIFF
--- a/infrastructure/critical/es_cluster.tf
+++ b/infrastructure/critical/es_cluster.tf
@@ -7,11 +7,8 @@ module "es_cluster_2026_07_03" {
 
   cluster_date = "2026-07-03"
 
-  # Sized for the round 2 full reindex (platform#6505), matching round 1.
-  # Back to 4g across 3 zones after the comparison signs off; the scale-down
-  # apply can only run once a day.
-  memory     = "30g"
-  node_count = 2
+  memory     = "4g"
+  node_count = 3
 
   traffic_filter_ids = [
     local.shared_infra["ec_platform_privatelink_traffic_filter_id"],

--- a/pipeline/terraform/2026-07-03/main.tf
+++ b/pipeline/terraform/2026-07-03/main.tf
@@ -3,9 +3,7 @@ module "pipeline" {
 
   reindexing_state = {
     listen_to_reindexer = true
-    # Sized for the round 2 full reindex (platform#6505). Matcher DB is back to
-    # normal; keep tasks scaled up until image stages finish and verification passes.
-    scale_up_tasks      = true
+    scale_up_tasks      = false
     scale_up_matcher_db = false
   }
 


### PR DESCRIPTION
The last box on wellcomecollection/platform#6505: reverts #3576, taking `scale_up_tasks` back to false and the ES cluster back to 4g across 3 zones now the round 2 reindex and the wellcomecollection/platform#6507 comparison are done. The matcher DB scale came off separately in #3590, and the preview toggle stays in place.

Two roots to apply: `pipeline/terraform/2026-07-03` and `infrastructure/critical` (via `./run_terraform.sh`). The ES scale-down apply can only run once a day, so pick the moment; also hold the merge until the 2026-08-24 Axiell re-transform has finished draining through the funnel. The wellcomecollection/platform#6542 b-number test will run a further full Axiell re-transform at idle sizing afterwards, which today's drain shows the idle-sized stages handle.