### PR TITLE
Stop declaring warm throughput on the matcher lock table GSI

### DIFF
--- a/pipeline/terraform/modules/pipeline_services/matcher/main.tf
+++ b/pipeline/terraform/modules/pipeline_services/matcher/main.tf
@@ -144,10 +144,11 @@ resource "aws_dynamodb_table" "lock_table" {
     read_capacity  = local.lock_table_billing_mode == "PROVISIONED" ? 1000 : 0
     write_capacity = local.lock_table_billing_mode == "PROVISIONED" ? 2500 : 0
 
-    warm_throughput {
-      read_units_per_second  = 12000
-      write_units_per_second = 6216
-    }
+    # No warm_throughput here on purpose. DynamoDB raises it by itself as usage
+    # grows and will not let it be lowered again, so a declared figure goes stale
+    # after the first heavy reindex and then plans a reduction that can never
+    # apply. 6216 was the live value captured in July for that reason and drifted
+    # straight back. Declaring a higher one would hold, but pre-warming is billed.
   }
 
   ttl {


### PR DESCRIPTION
## What does this change?

The matcher lock table's `context-ids-index` GSI no longer declares a warm throughput, and a comment explains why nothing is declared in its place. [DynamoDB raises the value by itself as usage grows and will not let it be lowered again](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/warm-throughput.html), so a declared figure goes stale after the first heavy reindex and then plans a reduction the API cannot perform. That plan never clears, and it drags a dependent IAM policy and a data source read along with it, so an unrelated apply of the root picks up three changes nobody asked for: applying wellcomecollection/catalogue-pipeline#3597 on 2026-08-24 had to be `-target`ed to avoid exactly that.

The declared 6216 was itself the live value captured on 2026-07-16 to silence this same diff, and it has already drifted back, with 2026-07-03 now at 10432 after the round 2 reindex while 2025-10-02 is still at 6216. Re-declaring the new number would buy quiet only until the next reindex, DynamoDB manages the value without being asked and for free, and pre-warming above what it settles on is billed.

### Checklist

- [ ] Does this change the display model the catalogue API returns? No. It changes a DynamoDB capacity declaration only.

## How to test

Plan both roots, which share this module. On `2026-07-03` the matcher no longer appears in the plan at all, so this clears it; that root currently plans 32 changes, all from wellcomecollection/catalogue-pipeline#3598 (the round 2 scale-down) which is merged and awaiting its own apply, and none from this PR. On `2025-10-02` this change shows `warm_throughput` moving from `[{12000, 6216}]` to `None`, alongside 7 pre-existing Elasticsearch index diffs that I confirmed as the baseline by stashing this change and re-planning.

## How can we measure success?

A plan of a matcher-affecting root comes back clean once its other pending work has been applied, instead of showing the same three changes again after every heavy reindex.

## Have we considered potential risks?

On `2025-10-02` terraform will send an update that unsets warm throughput. Since the value cannot be lowered, I think that is a no-op where the provider stops tracking it, but I have not proved it, so it is worth knowing before applying that root. Applies should be targeted wherever the root carries drift, which is both of them right now; `2026-07-03` needs no apply for this PR since it contributes nothing there.

Closes wellcomecollection/platform#6603
