### PR TITLE
Consolidate the Python identifier-scheme registries and test them against the Scala model

### DIFF
--- a/catalogue_graph/src/adapters/transformers/marc/other_identifiers.py
+++ b/catalogue_graph/src/adapters/transformers/marc/other_identifiers.py
@@ -11,6 +11,8 @@ import structlog
 from pymarc.field import Field
 from pymarc.record import Record
 
+from models import identifier_schemes
+from models.identifier_schemes import IdentifierScheme
 from models.pipeline.identifier import Id, SourceIdentifier
 
 logger = structlog.get_logger(__name__)
@@ -25,13 +27,13 @@ def extract_other_identifiers(record: Record) -> list[SourceIdentifier]:
 
 
 ORIGIN_CODE_TO_ID_TYPE = {
-    "Bibliographic Number": "sierra-system-number",
-    "Mimsy reference": "mimsy-reference",
-    "Sierra Number": "sierra-identifier",
-    "WI number": "miro-image-number",
-    "accession number": "wellcome-accession-number",
-    "Calm RefNo": "calm-ref-no",
-    "AltRefNo": "calm-altref-no",
+    "Bibliographic Number": identifier_schemes.SIERRA_SYSTEM_NUMBER,
+    "Mimsy reference": identifier_schemes.MIMSY_REFERENCE,
+    "Sierra Number": identifier_schemes.SIERRA_IDENTIFIER,
+    "WI number": identifier_schemes.MIRO_IMAGE_NUMBER,
+    "accession number": identifier_schemes.WELLCOME_ACCESSION_NUMBER,
+    "Calm RefNo": identifier_schemes.CALM_REF_NO,
+    "AltRefNo": identifier_schemes.CALM_ALTREF_NO,
     # "Library Reference Number" is handled specially in format_field
     # Two other id schemes exist, but I don't know what to do with them.
     # "SCM loan accession number": ,
@@ -73,27 +75,27 @@ def format_field(field: Field) -> SourceIdentifier | None:
     # Axiell records always have a redundant "Acc" prefix, even when it is not followed by a value.
     # We remove the prefix as a temporary fix.
     # TODO: This issue should be fixed at source.
-    if identifier_type == "wellcome-accession-number":
+    if identifier_type == identifier_schemes.WELLCOME_ACCESSION_NUMBER:
         id_value = id_value.removeprefix("Acc").strip()
 
     # Axiell Collections holds Sierra bib numbers in the ".b1234567x" notation (an
     # artifact of the data migration), but the Sierra adapter and the rest of the
     # pipeline use the canonical "b1234567x". Without stripping the leading dot the
     # matcher never links an Axiell work to its Sierra record, so they fail to merge.
-    if identifier_type == "sierra-system-number":
+    if identifier_type == identifier_schemes.SIERRA_SYSTEM_NUMBER:
         id_value = id_value.lstrip(".")
 
     if not id_value:
         return None
 
     return SourceIdentifier(
-        identifier_type=Id(id=identifier_type), ontology_type="Work", value=id_value
+        identifier_type=Id(id=identifier_type.id), ontology_type="Work", value=id_value
     )
 
 
-def which_identifier_type(prefix: str, id_value: str) -> str | None:
+def which_identifier_type(prefix: str, id_value: str) -> IdentifierScheme | None:
     if prefix == "Library Reference Number":
         if "/" in id_value:
-            return "calm-altref-no"
-        return "iconographic-number"
+            return identifier_schemes.CALM_ALTREF_NO
+        return identifier_schemes.ICONOGRAPHIC_NUMBER
     return ORIGIN_CODE_TO_ID_TYPE.get(prefix)

--- a/catalogue_graph/src/ingestor/models/display/identifier.py
+++ b/catalogue_graph/src/ingestor/models/display/identifier.py
@@ -2,6 +2,7 @@ from collections.abc import Generator
 
 from pydantic import BaseModel
 
+from models.identifier_schemes import IDENTIFIER_LABEL_MAPPING
 from models.pipeline.identifier import (
     Identifiable,
     Identified,
@@ -10,40 +11,6 @@ from models.pipeline.identifier import (
 )
 
 from .id_label import DisplayIdLabel
-
-IDENTIFIER_LABEL_MAPPING = {
-    "tei-manuscript-id": "Tei manuscript id",
-    "miro-image-number": "Miro image number",
-    "miro-library-reference": "Miro library reference",
-    "sierra-system-number": "Sierra system number",
-    "sierra-identifier": "Sierra identifier",
-    "ebsco-alt-lookup": "EBSCO lookup identifier",
-    "folio-instance": "Folio instance",
-    "folio-item": "Folio item",
-    "folio-instance-hrid": "Folio instance HRID",
-    "lc-gmgpc": "Library of Congress Thesaurus for Graphic Materials",
-    "lc-subjects": "Library of Congress Subject Headings (LCSH)",
-    "lc-names": "Library of Congress Name authority records",
-    "nlm-mesh": "Medical Subject Headings (MeSH) identifier",
-    "calm-ref-no": "Calm RefNo",
-    "calm-altref-no": "Calm AltRefNo",
-    "calm-record-id": "Calm RecordIdentifier",
-    "mimsy-reference": "Mimsy reference",
-    "isbn": "International Standard Book Number",
-    "issn": "ISSN",
-    "mets": "METS",
-    "mets-image": "METS image",
-    "wellcome-digcode": "Wellcome digcode",
-    "iconographic-number": "Iconographic number",
-    "viaf": "VIAF: The Virtual International Authority File",
-    "fihrist": "Fihrist Authority",
-    "bl-estc-citation-no": "British Library English Short Title Catalogue",
-    "label-derived": "Identifier derived from the label of the referent",
-    "wellcome-accession-number": "Accession number",
-    "wikidata": "Wikidata",
-    "weco-authority": "Wellcome Concepts",
-    "axiell-guid": "Axiell GUID",
-}
 
 
 class DisplayIdentifierType(DisplayIdLabel):

--- a/catalogue_graph/src/models/identifier_schemes.py
+++ b/catalogue_graph/src/models/identifier_schemes.py
@@ -26,7 +26,8 @@ def _scheme(
     scheme_id: str, label: str, in_scala_model: bool = True
 ) -> IdentifierScheme:
     scheme = IdentifierScheme(scheme_id, label, in_scala_model)
-    assert scheme_id not in _registry, f"duplicate scheme id: {scheme_id}"
+    if scheme_id in _registry:
+        raise ValueError(f"duplicate scheme id: {scheme_id}")
     _registry[scheme_id] = scheme
     return scheme
 

--- a/catalogue_graph/src/models/identifier_schemes.py
+++ b/catalogue_graph/src/models/identifier_schemes.py
@@ -1,0 +1,75 @@
+"""
+Registry of identifier schemes, holding the scheme id and display label
+together for every displayable scheme, including those only the legacy Scala
+transformers emit (the ingestor labels works from all sources).
+
+Schemes carried by works must also exist in the Scala internal model
+(IdentifierType.scala), or the merger fails to decode them; a test enforces
+this. Concept-source schemes minted in the graph pipeline never pass through
+the Scala stages, so they set in_scala_model=False.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class IdentifierScheme:
+    id: str
+    label: str
+    in_scala_model: bool = True
+
+
+_registry: dict[str, IdentifierScheme] = {}
+
+
+def _scheme(
+    scheme_id: str, label: str, in_scala_model: bool = True
+) -> IdentifierScheme:
+    scheme = IdentifierScheme(scheme_id, label, in_scala_model)
+    assert scheme_id not in _registry, f"duplicate scheme id: {scheme_id}"
+    _registry[scheme_id] = scheme
+    return scheme
+
+
+TEI_MANUSCRIPT_ID = _scheme("tei-manuscript-id", "Tei manuscript id")
+MIRO_IMAGE_NUMBER = _scheme("miro-image-number", "Miro image number")
+MIRO_LIBRARY_REFERENCE = _scheme("miro-library-reference", "Miro library reference")
+SIERRA_SYSTEM_NUMBER = _scheme("sierra-system-number", "Sierra system number")
+SIERRA_IDENTIFIER = _scheme("sierra-identifier", "Sierra identifier")
+EBSCO_ALT_LOOKUP = _scheme("ebsco-alt-lookup", "EBSCO lookup identifier")
+FOLIO_INSTANCE = _scheme("folio-instance", "Folio instance")
+FOLIO_ITEM = _scheme("folio-item", "Folio item")
+FOLIO_INSTANCE_HRID = _scheme("folio-instance-hrid", "Folio instance HRID")
+LC_GMGPC = _scheme("lc-gmgpc", "Library of Congress Thesaurus for Graphic Materials")
+LC_SUBJECTS = _scheme("lc-subjects", "Library of Congress Subject Headings (LCSH)")
+LC_NAMES = _scheme("lc-names", "Library of Congress Name authority records")
+NLM_MESH = _scheme("nlm-mesh", "Medical Subject Headings (MeSH) identifier")
+CALM_REF_NO = _scheme("calm-ref-no", "Calm RefNo")
+CALM_ALTREF_NO = _scheme("calm-altref-no", "Calm AltRefNo")
+CALM_RECORD_ID = _scheme("calm-record-id", "Calm RecordIdentifier")
+MIMSY_REFERENCE = _scheme("mimsy-reference", "Mimsy reference")
+ISBN = _scheme("isbn", "International Standard Book Number")
+ISSN = _scheme("issn", "ISSN")
+METS = _scheme("mets", "METS")
+METS_IMAGE = _scheme("mets-image", "METS image")
+WELLCOME_DIGCODE = _scheme("wellcome-digcode", "Wellcome digcode")
+ICONOGRAPHIC_NUMBER = _scheme("iconographic-number", "Iconographic number")
+VIAF = _scheme("viaf", "VIAF: The Virtual International Authority File")
+FIHRIST = _scheme("fihrist", "Fihrist Authority")
+BL_ESTC_CITATION_NO = _scheme(
+    "bl-estc-citation-no", "British Library English Short Title Catalogue"
+)
+LABEL_DERIVED = _scheme(
+    "label-derived", "Identifier derived from the label of the referent"
+)
+WELLCOME_ACCESSION_NUMBER = _scheme("wellcome-accession-number", "Accession number")
+WIKIDATA = _scheme("wikidata", "Wikidata", in_scala_model=False)
+WECO_AUTHORITY = _scheme("weco-authority", "Wellcome Concepts", in_scala_model=False)
+AXIELL_GUID = _scheme("axiell-guid", "Axiell GUID")
+
+
+def all_schemes() -> list[IdentifierScheme]:
+    return list(_registry.values())
+
+
+IDENTIFIER_LABEL_MAPPING: dict[str, str] = {s.id: s.label for s in _registry.values()}

--- a/catalogue_graph/tests/models/test_identifier_schemes.py
+++ b/catalogue_graph/tests/models/test_identifier_schemes.py
@@ -21,7 +21,10 @@ SCALA_IDENTIFIER_TYPE_PATH = (
 
 def scala_scheme_ids() -> set[str]:
     return set(
-        re.findall(r'val id = "([^"]+)"', SCALA_IDENTIFIER_TYPE_PATH.read_text())
+        re.findall(
+            r'val id = "([^"]+)"',
+            SCALA_IDENTIFIER_TYPE_PATH.read_text(encoding="utf-8"),
+        )
     )
 
 

--- a/catalogue_graph/tests/models/test_identifier_schemes.py
+++ b/catalogue_graph/tests/models/test_identifier_schemes.py
@@ -1,0 +1,45 @@
+"""
+Checks the Python scheme registry against the Scala internal model.
+
+A scheme emitted by a Python transformer but missing from IdentifierType.scala
+fails in the merger with NoSuchElementException (mimsy-reference,
+platform#6620), so every registry scheme carried through the Scala stages must
+exist there. The reverse is fine: Scala may know schemes we do not list.
+"""
+
+import re
+from pathlib import Path
+
+from models.identifier_schemes import all_schemes
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCALA_IDENTIFIER_TYPE_PATH = (
+    REPO_ROOT
+    / "common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/IdentifierType.scala"
+)
+
+
+def scala_scheme_ids() -> set[str]:
+    return set(
+        re.findall(r'val id = "([^"]+)"', SCALA_IDENTIFIER_TYPE_PATH.read_text())
+    )
+
+
+def test_scala_extraction_finds_schemes() -> None:
+    # Guards the regex and path against IdentifierType.scala moving or changing shape
+    assert len(scala_scheme_ids()) > 10
+
+
+def test_every_registry_scheme_exists_in_scala_model() -> None:
+    registry_ids = {s.id for s in all_schemes() if s.in_scala_model}
+    missing = registry_ids - scala_scheme_ids()
+    assert not missing, (
+        f"Schemes in the Python registry but not in IdentifierType.scala: "
+        f"{sorted(missing)}. Works carrying them will fail to decode in the merger."
+    )
+
+
+def test_graph_only_schemes_are_really_absent_from_scala() -> None:
+    # If Scala learns one of these, drop its in_scala_model=False flag
+    graph_only_ids = {s.id for s in all_schemes() if not s.in_scala_model}
+    assert not graph_only_ids & scala_scheme_ids()


### PR DESCRIPTION
## What does this change?

Adding an identifier scheme means registering it in three places: the transformer map that emits it, `IdentifierType.scala` that decodes it, and the ingestor map that gives it a display label. Nothing checked they agreed, so `mimsy-reference` shipped registered in one of the three and cost two deploy-and-redrive cycles mid-reindex. Background is in wellcomecollection/platform#6620.

The two Python maps become one registry in `catalogue_graph/src/models/identifier_schemes.py` that holds the scheme id and its display label together. The transformer references registry entries instead of repeating id strings, and the ingestor derives its label lookup from the registry, so an emitted scheme can no longer be missing a label. The Scala boundary is covered by a test that pulls the `val id = "..."` declarations out of `IdentifierType.scala` and asserts every registry scheme appears there. Schemes minted in the graph pipeline for concepts never reach the Scala stages, so they carry `in_scala_model=False` and are asserted absent instead.

### Checklist

- [ ] Does this change the display model the catalogue API returns? No. The label mapping the ingestor now generates is identical to the literal it replaces (same 31 schemes, same labels), so the test documents are unaffected.

## How to test

From `catalogue_graph/`, `uv run --group dev pytest tests/models/test_identifier_schemes.py`. For the regression case, delete the `mimsy-reference` entry from `IdentifierType.scala` and the test should fail naming that scheme.

## How can we measure success?

No repeat of a scheme reaching production without a label or a Scala entry. The next opportunity to find out is the FOLIO `-hrid` schemes in wellcomecollection/platform#6418.

## Have we considered potential risks?

The check is a regex over Scala source, so a scheme declared in some other form would not be seen; a second test asserts the extraction finds more than ten ids, which catches the file moving or its shape changing. Scala knowing schemes the registry does not list stays allowed, since the legacy transformers own several the Python side never emits.
