### PR TITLE
Skip MARC records with a missing or empty 001 instead of failing

### DIFF
--- a/catalogue_graph/src/adapters/transformers/marc/identifier.py
+++ b/catalogue_graph/src/adapters/transformers/marc/identifier.py
@@ -6,3 +6,12 @@ from .common import mandatory_field
 @mandatory_field("001", "id")
 def extract_id(marc_record: Record) -> str:
     return marc_record["001"].format_field().strip()
+
+
+def has_id(marc_record: Record) -> bool:
+    """Whether 001 is present and non-empty; id-less records are skipped upstream."""
+    try:
+        extract_id(marc_record)
+    except ValueError:
+        return False
+    return True

--- a/catalogue_graph/src/adapters/transformers/marcxml_transformer.py
+++ b/catalogue_graph/src/adapters/transformers/marcxml_transformer.py
@@ -4,9 +4,11 @@ from datetime import datetime
 from typing import Any
 
 import structlog
+from elasticsearch import Elasticsearch
 from pymarc.record import Record
 
 from adapters.transformers.builders.marc_xml_work_builder import MarcXmlWorkBuilder
+from adapters.transformers.marc.identifier import has_id
 from adapters.transformers.source_work_transformer import SourceWorkTransformer
 from ingestor.models.shared.deleted_reason import DeletedFromSource
 from models.pipeline.source.work import (
@@ -18,9 +20,23 @@ logger = structlog.get_logger(__name__)
 
 
 class MarcXmlTransformer(SourceWorkTransformer, ABC):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.skipped_no_id_count = 0
+
     @property
     @abstractmethod
     def work_builder(self) -> type[MarcXmlWorkBuilder]: ...
+
+    def stream_to_index(self, es_client: Elasticsearch, index_name: str) -> None:
+        self.skipped_no_id_count = 0
+        super().stream_to_index(es_client, index_name)
+        # One summary line per run instead of a warning per record (platform#6619).
+        if self.skipped_no_id_count:
+            logger.warning(
+                "Skipped records with a missing or empty id field (001)",
+                skipped_count=self.skipped_no_id_count,
+            )
 
     def transform(
         self, rows: Iterable[dict[str, Any]]
@@ -33,6 +49,12 @@ class MarcXmlTransformer(SourceWorkTransformer, ABC):
         Subclasses override this to handle non-MARC rows (e.g. deletion facts)."""
         marc_record = self._row_to_marc_record(row)
         if not marc_record:
+            return
+
+        # A record with no id cannot be processed for any source, so skip it
+        # (no work, no deletion, no failure) rather than error in the builder.
+        if not has_id(marc_record):
+            self.skipped_no_id_count += 1
             return
 
         row_id, last_modified = row["id"], row["last_modified"]

--- a/catalogue_graph/src/adapters/transformers/marcxml_transformer.py
+++ b/catalogue_graph/src/adapters/transformers/marcxml_transformer.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from typing import Any
 
 import structlog
-from elasticsearch import Elasticsearch
 from pymarc.record import Record
 
 from adapters.transformers.builders.marc_xml_work_builder import MarcXmlWorkBuilder
@@ -20,23 +19,9 @@ logger = structlog.get_logger(__name__)
 
 
 class MarcXmlTransformer(SourceWorkTransformer, ABC):
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
-        self.skipped_no_id_count = 0
-
     @property
     @abstractmethod
     def work_builder(self) -> type[MarcXmlWorkBuilder]: ...
-
-    def stream_to_index(self, es_client: Elasticsearch, index_name: str) -> None:
-        self.skipped_no_id_count = 0
-        super().stream_to_index(es_client, index_name)
-        # One summary line per run instead of a warning per record (platform#6619).
-        if self.skipped_no_id_count:
-            logger.warning(
-                "Skipped records with a missing or empty id field (001)",
-                skipped_count=self.skipped_no_id_count,
-            )
 
     def transform(
         self, rows: Iterable[dict[str, Any]]
@@ -54,7 +39,10 @@ class MarcXmlTransformer(SourceWorkTransformer, ABC):
         # A record with no id cannot be processed for any source, so skip it
         # (no work, no deletion, no failure) rather than error in the builder.
         if not has_id(marc_record):
-            self.skipped_no_id_count += 1
+            logger.warning(
+                "Skipping record with a missing or empty id field (001)",
+                row_id=row["id"],
+            )
             return
 
         row_id, last_modified = row["id"], row["last_modified"]

--- a/catalogue_graph/tests/adapters/transformers/axiell/test_transformer.py
+++ b/catalogue_graph/tests/adapters/transformers/axiell/test_transformer.py
@@ -148,6 +148,47 @@ def test_transformer_end_to_end_includes_deletions(
     assert deleted["deletedReason"]["info"] == "Marked as deleted from source"
 
 
+def test_transformer_skips_records_with_no_id_without_failing(
+    temporary_table: IcebergTable,
+    deletion_facts_temporary_table: IcebergTable,
+    reconciler_temporary_table: IcebergTable,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Axiell-native records have an empty 001; they are skipped, not failed."""
+    empty_001 = "<record><leader>00000nam a2200000   4500</leader><controlfield tag='005'>20251225123045.0</controlfield><controlfield tag='001'></controlfield><datafield tag='245' ind1='0' ind2='0'><subfield code='a'>Created in Axiell</subfield></datafield></record>"
+    records_by_id = {
+        "ax00001": TEST_RECORD_ONE,
+        "110209585": empty_001,
+    }
+    changeset_id = prepare_changeset(
+        temporary_table,
+        monkeypatch,
+        records_by_id,
+        namespace=AXIELL_NAMESPACE,
+        transformer_type="axiell",
+    )
+
+    MockElasticsearchClient.inputs.clear()
+
+    result = _run_transform(
+        monkeypatch,
+        changeset_ids=[changeset_id],
+        index_date="2025-01-01",
+        facts_table=deletion_facts_temporary_table,
+        reconciler_table=reconciler_temporary_table,
+    )
+
+    assert result.success_count == 1
+    assert result.failure_count == 0
+
+    report = read_transformer_report(result)
+    assert report["successful_ids"] == ["Work[axiell-guid/ax00001]"]
+    assert report["errors"] == []
+
+    indexed_ids = {op["_id"] for op in MockElasticsearchClient.inputs}
+    assert indexed_ids == {"Work[axiell-guid/ax00001]"}
+
+
 def test_transformer_id_run_transforms_only_named_ids(
     temporary_table: IcebergTable, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/catalogue_graph/tests/adapters/transformers/marc/test_transformer.py
+++ b/catalogue_graph/tests/adapters/transformers/marc/test_transformer.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from typing import Any, cast
 
 import pytest
+import structlog.testing
 from elasticsearch import Elasticsearch
 
 from adapters.utils.adapter_store import AdapterStore
@@ -124,6 +125,167 @@ def test_transform_handles_transform_record_exception(
     assert transformer.errors
     assert transformer.errors[0].stage == "transform"
     assert "boom: bad data" in transformer.errors[0].detail
+
+
+MISSING_001_XML = (
+    "<record>"
+    "<leader>00000nam a2200000   4500</leader>"
+    "<datafield tag='245' ind1='0' ind2='0'>"
+    "<subfield code='a'>No Id At All</subfield>"
+    "</datafield>"
+    "</record>"
+)
+
+EMPTY_001_XML = (
+    "<record>"
+    "<leader>00000nam a2200000   4500</leader>"
+    "<controlfield tag='001'></controlfield>"
+    "<datafield tag='245' ind1='0' ind2='0'>"
+    "<subfield code='a'>Empty Id</subfield>"
+    "</datafield>"
+    "</record>"
+)
+
+
+def test_transform_skips_record_with_missing_001(adapter_store: AdapterStore) -> None:
+    transformer = MarcXmlTransformerForTests(adapter_store, [])
+
+    works = list(
+        transformer.transform(
+            [
+                {
+                    "id": "work3",
+                    "content": MISSING_001_XML,
+                    "last_modified": datetime.now(),
+                }
+            ]
+        )
+    )
+
+    assert works == []
+    assert transformer.errors == []
+    assert transformer.skipped_no_id_count == 1
+
+
+def test_transform_skips_record_with_empty_001(adapter_store: AdapterStore) -> None:
+    transformer = MarcXmlTransformerForTests(adapter_store, [])
+
+    works = list(
+        transformer.transform(
+            [{"id": "work4", "content": EMPTY_001_XML, "last_modified": datetime.now()}]
+        )
+    )
+
+    assert works == []
+    assert transformer.errors == []
+    assert transformer.skipped_no_id_count == 1
+
+
+def test_transform_skips_deleted_record_without_001(
+    adapter_store: AdapterStore,
+) -> None:
+    """An id-less deleted row must not emit a tombstone either."""
+    transformer = MarcXmlTransformerForTests(adapter_store, [])
+
+    works = list(
+        transformer.transform(
+            [
+                {
+                    "id": "work5",
+                    "content": MISSING_001_XML,
+                    "last_modified": datetime.now(),
+                    "deleted": True,
+                }
+            ]
+        )
+    )
+
+    assert works == []
+    assert transformer.errors == []
+    assert transformer.skipped_no_id_count == 1
+
+
+def test_stream_to_index_skips_id_less_records_and_logs_summary_once(
+    adapter_store: AdapterStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    missing_title_xml = (
+        "<record>"
+        "<leader>00000nam a2200000   4500</leader>"
+        "<controlfield tag='001'>idbad</controlfield>"
+        "</record>"
+    )
+    transformer = MarcXmlTransformerForTests(adapter_store, [])
+    transformer.source = _StubSource(  # type: ignore[assignment]
+        [
+            {
+                "id": "id1",
+                "content": "<record><leader>00000nam a2200000   4500</leader><controlfield tag='001'>id1</controlfield><datafield tag='245' ind1='0' ind2='0'><subfield code='a'>Title 1</subfield></datafield></record>",
+                "last_modified": datetime.now(),
+            },
+            {"id": "id2", "content": MISSING_001_XML, "last_modified": datetime.now()},
+            {"id": "id3", "content": EMPTY_001_XML, "last_modified": datetime.now()},
+            {
+                "id": "idbad",
+                "content": missing_title_xml,
+                "last_modified": datetime.now(),
+            },
+        ]
+    )
+
+    # Cached structlog config makes capture_logs unreliable; patch the module logger.
+    logger = structlog.testing.CapturingLogger()
+    monkeypatch.setattr("adapters.transformers.marcxml_transformer.logger", logger)
+
+    MockElasticsearchClient.inputs.clear()
+    es_client = MockElasticsearchClient({}, "")
+    transformer.stream_to_index(cast(Elasticsearch, es_client), "works-source-dev")
+
+    # The valid record is indexed as before.
+    assert {a["_id"] for a in MockElasticsearchClient.inputs} == {"Work[marc-test/id1]"}
+
+    # Other failure classes still count as failures.
+    assert len(transformer.errors) == 1
+    assert transformer.errors[0].row_id == "idbad"
+    assert "Missing title field (245)" in transformer.errors[0].detail
+
+    # Id-less records are skipped with one summary line for the whole run.
+    assert transformer.skipped_no_id_count == 2
+    summaries = [
+        call
+        for call in logger.calls
+        if call.args
+        and call.args[0] == "Skipped records with a missing or empty id field (001)"
+    ]
+    assert len(summaries) == 1
+    assert summaries[0].method_name == "warning"
+    assert summaries[0].kwargs["skipped_count"] == 2
+
+
+def test_stream_to_index_no_summary_when_nothing_skipped(
+    adapter_store: AdapterStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    transformer = MarcXmlTransformerForTests(adapter_store, [])
+    transformer.source = _StubSource(  # type: ignore[assignment]
+        [
+            {
+                "id": "id1",
+                "content": "<record><leader>00000nam a2200000   4500</leader><controlfield tag='001'>id1</controlfield><datafield tag='245' ind1='0' ind2='0'><subfield code='a'>Title 1</subfield></datafield></record>",
+                "last_modified": datetime.now(),
+            }
+        ]
+    )
+
+    logger = structlog.testing.CapturingLogger()
+    monkeypatch.setattr("adapters.transformers.marcxml_transformer.logger", logger)
+
+    MockElasticsearchClient.inputs.clear()
+    es_client = MockElasticsearchClient({}, "")
+    transformer.stream_to_index(cast(Elasticsearch, es_client), "works-source-dev")
+
+    assert transformer.skipped_no_id_count == 0
+    assert not [
+        call for call in logger.calls if call.args and "Skipped records" in call.args[0]
+    ]
 
 
 def test_stream_to_index_success_no_errors(

--- a/catalogue_graph/tests/adapters/transformers/marc/test_transformer.py
+++ b/catalogue_graph/tests/adapters/transformers/marc/test_transformer.py
@@ -164,7 +164,6 @@ def test_transform_skips_record_with_missing_001(adapter_store: AdapterStore) ->
 
     assert works == []
     assert transformer.errors == []
-    assert transformer.skipped_no_id_count == 1
 
 
 def test_transform_skips_record_with_empty_001(adapter_store: AdapterStore) -> None:
@@ -178,7 +177,6 @@ def test_transform_skips_record_with_empty_001(adapter_store: AdapterStore) -> N
 
     assert works == []
     assert transformer.errors == []
-    assert transformer.skipped_no_id_count == 1
 
 
 def test_transform_skips_deleted_record_without_001(
@@ -202,10 +200,9 @@ def test_transform_skips_deleted_record_without_001(
 
     assert works == []
     assert transformer.errors == []
-    assert transformer.skipped_no_id_count == 1
 
 
-def test_stream_to_index_skips_id_less_records_and_logs_summary_once(
+def test_stream_to_index_skips_id_less_records_and_warns_per_record(
     adapter_store: AdapterStore, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     missing_title_xml = (
@@ -248,20 +245,18 @@ def test_stream_to_index_skips_id_less_records_and_logs_summary_once(
     assert transformer.errors[0].row_id == "idbad"
     assert "Missing title field (245)" in transformer.errors[0].detail
 
-    # Id-less records are skipped with one summary line for the whole run.
-    assert transformer.skipped_no_id_count == 2
-    summaries = [
+    # Id-less records are skipped with a warning naming each row.
+    warnings = [
         call
         for call in logger.calls
         if call.args
-        and call.args[0] == "Skipped records with a missing or empty id field (001)"
+        and call.args[0] == "Skipping record with a missing or empty id field (001)"
     ]
-    assert len(summaries) == 1
-    assert summaries[0].method_name == "warning"
-    assert summaries[0].kwargs["skipped_count"] == 2
+    assert all(call.method_name == "warning" for call in warnings)
+    assert {call.kwargs["row_id"] for call in warnings} == {"id2", "id3"}
 
 
-def test_stream_to_index_no_summary_when_nothing_skipped(
+def test_stream_to_index_no_skip_warning_when_all_records_have_ids(
     adapter_store: AdapterStore, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     transformer = MarcXmlTransformerForTests(adapter_store, [])
@@ -282,9 +277,8 @@ def test_stream_to_index_no_summary_when_nothing_skipped(
     es_client = MockElasticsearchClient({}, "")
     transformer.stream_to_index(cast(Elasticsearch, es_client), "works-source-dev")
 
-    assert transformer.skipped_no_id_count == 0
     assert not [
-        call for call in logger.calls if call.args and "Skipped records" in call.args[0]
+        call for call in logger.calls if call.args and "Skipping record" in call.args[0]
     ]
 
 


### PR DESCRIPTION
## What does this change?

Every full Axiell transform fails on the same 1,262 records and fires the `axiell-transformer-failures-2026-07-03` alarm, most recently during the round 2 reindex and the subject-label re-transform. Those records were created directly in Axiell Collections, have an empty 001, no Calm RefNo, and are all marked as not for publication. `MarcXmlWorkBuilder` reads the id in its constructor, so they raise before any per-source handling can skip them.

The shared MARC XML transform loop now checks for a usable 001 first and skips the record with no work, no deletion and no failure. Each skipped record logs a warning naming the row id. The check sits above per-source logic because a record with no id cannot be processed for any source; it applies to the Axiell, FOLIO and EBSCO transformers alike, though only Axiell has records in this state today.

Relates to wellcomecollection/platform#6619, which closes after verification on a deployed run rather than on merge.

### Checklist

- [ ] Does this change the display model the catalogue API returns? No. Records that are skipped produced no document before and produce none now.

## How to test

From `catalogue_graph/`, `uv run --group dev pytest tests/adapters/transformers`. The new tests cover a missing 001, an empty 001, a deleted record with no 001, and that the skip warning names each skipped row and is absent when every record has an id.

After deploy, run a full Axiell transform. It should finish with no "Empty id field (001)" failures, log 1,262 skipped-record warnings, and leave works-source counts unchanged.

## How can we measure success?

The `axiell-transformer-failures-2026-07-03` alarm stops firing on every full transform. The failures that remain should be the 82 missing-level records tracked in wellcomecollection/platform#6579.

## Have we considered potential risks?

We give up the errored-record signal for the case where a publishable record lacks an id. That would instead surface through the reconciler's skip accounting and works-source count checks. If the number of skipped records on a full run drifts away from 1,262, something has changed in the source data and is worth looking at.