### PR TITLE
Merge audiovisual clusters one e-bib at a time

### DIFF
--- a/pipeline/matcher_merger/merger/src/main/scala/weco/pipeline/merger/services/Merger.scala
+++ b/pipeline/matcher_merger/merger/src/main/scala/weco/pipeline/merger/services/Merger.scala
@@ -1,6 +1,10 @@
 package weco.pipeline.merger.services
 
-import weco.catalogue.internal_model.identifiers.{DataState, IdState}
+import weco.catalogue.internal_model.identifiers.{
+  CanonicalId,
+  DataState,
+  IdState
+}
 import weco.catalogue.internal_model.locations.DigitalLocation
 import weco.catalogue.internal_model.work.WorkState.Identified
 import weco.catalogue.internal_model.work._
@@ -13,6 +17,7 @@ import weco.pipeline.merger.models.{
   WorkMergingOps
 }
 import weco.pipeline.merger.rules._
+import weco.pipeline.merger.rules.WorkPredicates.{sierraDigitisedAv, sierraWork}
 
 /*
  * The implementor of a Merger must provide:
@@ -70,12 +75,61 @@ trait Merger extends MergerLogging {
     }
 
   def merge(works: Seq[Work[Identified]]): MergerOutcome = {
-    val outcome = mergeWorks(works)
-    outcome.copy(
-      resultWorks =
-        outcome.resultWorks ++ deletedInternalWorks(works, outcome.resultWorks)
+    val outcomes = partitionAudiovisual(works).map(mergeWorks)
+    val resultWorks = outcomes.flatMap(_.resultWorks)
+    MergerOutcome(
+      resultWorks = resultWorks ++ deletedInternalWorks(works, resultWorks),
+      imagesWithSources = outcomes.flatMap(_.imagesWithSources)
     )
   }
+
+  /** AV bibs are never merged with each other, but their 776 links still put a
+    * physical bib and all of its e-bibs in one cluster, so whole-cluster
+    * merging elected one arbitrary e-bib and gave it every METS manifest. Carve
+    * each AV e-bib out with the works linked directly to it and merge the rest
+    * as before.
+    *
+    * See https://github.com/wellcomecollection/platform/issues/6643
+    */
+  private def partitionAudiovisual(
+    works: Seq[Work[Identified]]
+  ): Seq[Seq[Work[Identified]]] =
+    if (!findTarget(works).exists(sierraWork)) {
+      Seq(works)
+    } else {
+      val avEbibs = works.filter(sierraDigitisedAv)
+      val others = works.filterNot(sierraWork)
+
+      def linked(a: Work[Identified], b: Work[Identified]): Boolean =
+        a.state.mergeCandidates.exists(_.id.canonicalId == b.state.canonicalId)
+
+      val ownerOf: Map[CanonicalId, CanonicalId] = others.flatMap {
+        other =>
+          avEbibs.filter(e => linked(other, e) || linked(e, other)) match {
+            case Seq(single) =>
+              Some(other.state.canonicalId -> single.state.canonicalId)
+            case Nil => None
+            case several =>
+              warn(
+                s"${describeWork(other)} is linked to several audiovisual e-bibs, leaving it in the main group: ${describeWorks(several)}"
+              )
+              None
+          }
+      }.toMap
+
+      val groups = avEbibs.flatMap {
+        ebib =>
+          val attached = others.filter(
+            o =>
+              ownerOf.get(o.state.canonicalId).contains(ebib.state.canonicalId)
+          )
+          if (attached.isEmpty) None else Some(ebib +: attached)
+      }
+      val carved = groups.flatten.map(_.state.canonicalId).toSet
+      val remainder = works.filterNot(w => carved.contains(w.state.canonicalId))
+
+      if (remainder.isEmpty) groups else groups :+ remainder
+    }
 
   private def mergeWorks(works: Seq[Work[Identified]]): MergerOutcome = {
     works match {

--- a/pipeline/matcher_merger/merger/src/main/scala/weco/pipeline/merger/services/Merger.scala
+++ b/pipeline/matcher_merger/merger/src/main/scala/weco/pipeline/merger/services/Merger.scala
@@ -94,7 +94,7 @@ trait Merger extends MergerLogging {
   private def partitionAudiovisual(
     works: Seq[Work[Identified]]
   ): Seq[Seq[Work[Identified]]] =
-    if (!findTarget(works).exists(sierraWork)) {
+    if (works.size < 2 || !findTarget(works).exists(sierraWork)) {
       Seq(works)
     } else {
       val avEbibs = works.filter(sierraDigitisedAv)

--- a/pipeline/matcher_merger/merger/src/test/scala/weco/pipeline/merger/services/PlatformMergerTest.scala
+++ b/pipeline/matcher_merger/merger/src/test/scala/weco/pipeline/merger/services/PlatformMergerTest.scala
@@ -940,7 +940,7 @@ class PlatformMergerTest
   }
 
   it(
-    "keeps a METS work linked to several audiovisual e-bibs in the main group"
+    "redirects a METS work linked to several audiovisual e-bibs to the e-bib that was not carved out"
   ) {
     val physical = sierraIdentifiedWork()
       .format(Format.Audio)
@@ -971,9 +971,47 @@ class PlatformMergerTest
       .map(w => w.id -> w.redirectTarget.canonicalId)
       .toMap
     redirects(metsForFirstEbib.id) shouldBe ebibs(0).state.canonicalId
-    redirects.get(ambiguousMets.id) should not contain ebibs(
-      0
-    ).state.canonicalId
+    redirects(ambiguousMets.id) shouldBe ebibs(1).state.canonicalId
+  }
+
+  it(
+    "redirects a METS work linked to several audiovisual e-bibs to the physical bib once every e-bib is carved out"
+  ) {
+    val physical = sierraIdentifiedWork()
+      .format(Format.Audio)
+      .items(List(createIdentifiedPhysicalItem))
+    val ebibs = (1 to 2).map {
+      _ =>
+        sierraIdentifiedWork()
+          .format(Format.Audio)
+          .mergeCandidates(List(createSierraPairMergeCandidateFor(physical)))
+    }.toList
+    val metsForEbibs = ebibs.map {
+      ebib =>
+        identifiedWork(sourceIdentifier = createMetsSourceIdentifier)
+          .mergeCandidates(List(createMetsMergeCandidateFor(ebib)))
+          .items(List(createDigitalItem))
+          .invisible()
+    }
+    val ambiguousMets =
+      identifiedWork(sourceIdentifier = createMetsSourceIdentifier)
+        .mergeCandidates(ebibs.map(createMetsMergeCandidateFor))
+        .items(List(createDigitalItem))
+        .invisible()
+
+    val result = merger
+      .merge(physical :: ebibs ++ metsForEbibs :+ ambiguousMets)
+      .mergedWorksWithTime(now)
+
+    val redirects = result
+      .collect { case w: Work.Redirected[Merged] => w }
+      .map(w => w.id -> w.redirectTarget.canonicalId)
+      .toMap
+    redirects shouldBe Map(
+      metsForEbibs(0).id -> ebibs(0).state.canonicalId,
+      metsForEbibs(1).id -> ebibs(1).state.canonicalId,
+      ambiguousMets.id -> physical.state.canonicalId
+    )
   }
 
   it("gives each audiovisual e-bib its own METS work") {

--- a/pipeline/matcher_merger/merger/src/test/scala/weco/pipeline/merger/services/PlatformMergerTest.scala
+++ b/pipeline/matcher_merger/merger/src/test/scala/weco/pipeline/merger/services/PlatformMergerTest.scala
@@ -891,6 +891,91 @@ class PlatformMergerTest
     redirected.head.redirectTarget.canonicalId shouldBe workForEbib.state.canonicalId
   }
 
+  it(
+    "merges a METS work that names the physical bib into it once the e-bibs are carved out"
+  ) {
+    val physical = sierraIdentifiedWork()
+      .format(Format.Audio)
+      .items(List(createIdentifiedPhysicalItem))
+    val ebibs = (1 to 2).map {
+      _ =>
+        sierraIdentifiedWork()
+          .format(Format.Audio)
+          .mergeCandidates(List(createSierraPairMergeCandidateFor(physical)))
+    }.toList
+    val metsForEbibs = ebibs.map {
+      ebib =>
+        identifiedWork(sourceIdentifier = createMetsSourceIdentifier)
+          .mergeCandidates(List(createMetsMergeCandidateFor(ebib)))
+          .items(List(createDigitalItem))
+          .invisible()
+    }
+    val metsForPhysical =
+      identifiedWork(sourceIdentifier = createMetsSourceIdentifier)
+        .mergeCandidates(List(createMetsMergeCandidateFor(physical)))
+        .items(List(createDigitalItem))
+        .invisible()
+
+    val result = merger
+      .merge(physical :: ebibs ++ metsForEbibs :+ metsForPhysical)
+      .mergedWorksWithTime(now)
+
+    val redirects = result
+      .collect { case w: Work.Redirected[Merged] => w }
+      .map(w => w.id -> w.redirectTarget.canonicalId)
+      .toMap
+    redirects shouldBe Map(
+      metsForEbibs(0).id -> ebibs(0).state.canonicalId,
+      metsForEbibs(1).id -> ebibs(1).state.canonicalId,
+      metsForPhysical.id -> physical.state.canonicalId
+    )
+    result
+      .collect { case w: Work.Visible[Merged] if w.id == physical.id => w }
+      .head
+      .data
+      .items
+      .flatMap(_.locations) should contain theSameElementsAs
+      physical.data.items.flatMap(_.locations) ++ metsForPhysical.data.items
+        .flatMap(_.locations)
+  }
+
+  it(
+    "keeps a METS work linked to several audiovisual e-bibs in the main group"
+  ) {
+    val physical = sierraIdentifiedWork()
+      .format(Format.Audio)
+      .items(List(createIdentifiedPhysicalItem))
+    val ebibs = (1 to 2).map {
+      _ =>
+        sierraIdentifiedWork()
+          .format(Format.Audio)
+          .mergeCandidates(List(createSierraPairMergeCandidateFor(physical)))
+    }.toList
+    val ambiguousMets =
+      identifiedWork(sourceIdentifier = createMetsSourceIdentifier)
+        .mergeCandidates(ebibs.map(createMetsMergeCandidateFor))
+        .items(List(createDigitalItem))
+        .invisible()
+    val metsForFirstEbib =
+      identifiedWork(sourceIdentifier = createMetsSourceIdentifier)
+        .mergeCandidates(List(createMetsMergeCandidateFor(ebibs(0))))
+        .items(List(createDigitalItem))
+        .invisible()
+
+    val result = merger
+      .merge(physical :: ebibs ++ List(ambiguousMets, metsForFirstEbib))
+      .mergedWorksWithTime(now)
+
+    val redirects = result
+      .collect { case w: Work.Redirected[Merged] => w }
+      .map(w => w.id -> w.redirectTarget.canonicalId)
+      .toMap
+    redirects(metsForFirstEbib.id) shouldBe ebibs(0).state.canonicalId
+    redirects.get(ambiguousMets.id) should not contain ebibs(
+      0
+    ).state.canonicalId
+  }
+
   it("gives each audiovisual e-bib its own METS work") {
     // Based on a real example: a two-sided audio cassette catalogued as one
     // physical bib and two e-bibs, both linking to the physical bib via 776.

--- a/pipeline/matcher_merger/merger/src/test/scala/weco/pipeline/merger/services/PlatformMergerTest.scala
+++ b/pipeline/matcher_merger/merger/src/test/scala/weco/pipeline/merger/services/PlatformMergerTest.scala
@@ -863,6 +863,127 @@ class PlatformMergerTest
     visibleWorks(workForEbib.id).data.items shouldBe workForMets.data.items
   }
 
+  it("still merges a METS work that names the physical bib into the e-bib") {
+    val workForPhysicalCassette = sierraIdentifiedWork()
+      .format(Format.Audio)
+      .items(List(createIdentifiedPhysicalItem))
+
+    val workForEbib = sierraIdentifiedWork()
+      .format(Format.Audio)
+      .mergeCandidates(
+        List(createSierraPairMergeCandidateFor(workForPhysicalCassette))
+      )
+
+    val workForMets =
+      identifiedWork(sourceIdentifier = createMetsSourceIdentifier)
+        .mergeCandidates(
+          List(createMetsMergeCandidateFor(workForPhysicalCassette))
+        )
+        .items(List(createDigitalItem))
+        .invisible()
+
+    val result = merger
+      .merge(List(workForPhysicalCassette, workForEbib, workForMets))
+      .mergedWorksWithTime(now)
+
+    val redirected = result.collect { case w: Work.Redirected[Merged] => w }
+    redirected.map(_.id) shouldBe List(workForMets.id)
+    redirected.head.redirectTarget.canonicalId shouldBe workForEbib.state.canonicalId
+  }
+
+  it("gives each audiovisual e-bib its own METS work") {
+    // Based on a real example: a two-sided audio cassette catalogued as one
+    // physical bib and two e-bibs, both linking to the physical bib via 776.
+    // Both METS works were being attached to whichever e-bib was elected as
+    // the cluster target, leaving the other e-bib with no manifest.
+    //
+    // See https://github.com/wellcomecollection/platform/issues/6643
+    val workForPhysicalCassette = sierraIdentifiedWork()
+      .title("A physical cassette tape")
+      .format(Format.Audio)
+      .items(List(createIdentifiedPhysicalItem))
+
+    val workForSideA = sierraIdentifiedWork()
+      .title("Side A")
+      .format(Format.Audio)
+      .items(
+        List(
+          createUnidentifiableItemWith(locations = List(createDigitalLocation))
+        )
+      )
+      .mergeCandidates(
+        List(createSierraPairMergeCandidateFor(workForPhysicalCassette))
+      )
+
+    val workForSideB = sierraIdentifiedWork()
+      .title("Side B")
+      .format(Format.Audio)
+      .mergeCandidates(
+        List(createSierraPairMergeCandidateFor(workForPhysicalCassette))
+      )
+
+    val metsForSideA =
+      identifiedWork(sourceIdentifier = createMetsSourceIdentifier)
+        .mergeCandidates(List(createMetsMergeCandidateFor(workForSideA)))
+        .items(List(createDigitalItem))
+        .invisible()
+
+    val metsForSideB =
+      identifiedWork(sourceIdentifier = createMetsSourceIdentifier)
+        .mergeCandidates(List(createMetsMergeCandidateFor(workForSideB)))
+        .items(List(createDigitalItem))
+        .invisible()
+
+    val sierraWorks = List(workForPhysicalCassette, workForSideA, workForSideB)
+
+    // The outcome must not depend on the order the works arrive in
+    forAll(
+      Table(
+        "works",
+        sierraWorks ++ List(metsForSideA, metsForSideB),
+        List(
+          metsForSideB,
+          workForSideB,
+          workForSideA,
+          metsForSideA,
+          workForPhysicalCassette
+        )
+      )
+    ) {
+      works =>
+        val result = merger.merge(works).mergedWorksWithTime(now)
+
+        val visibleWorks = result
+          .collect { case w: Work.Visible[_] => w }
+          .map(w => w.id -> w)
+          .toMap
+        val redirectedWorks = result
+          .collect { case w: Work.Redirected[Merged] => w }
+          .map(w => w.id -> w.redirectTarget.canonicalId)
+          .toMap
+
+        visibleWorks.keys should contain theSameElementsAs sierraWorks.map(_.id)
+        redirectedWorks shouldBe Map(
+          metsForSideA.id -> workForSideA.state.canonicalId,
+          metsForSideB.id -> workForSideB.state.canonicalId
+        )
+
+        visibleWorks(
+          workForPhysicalCassette.id
+        ).data.items shouldBe workForPhysicalCassette.data.items
+        visibleWorks(workForSideA.id).data.items shouldBe
+          List(
+            workForSideA.data.items.head.copy(
+              locations =
+                workForSideA.data.items.head.locations ++ metsForSideA.data.items.head.locations
+            )
+          )
+        visibleWorks(
+          workForSideB.id
+        ).data.items shouldBe metsForSideB.data.items
+    }
+  }
+
   it("ignores online resources for physical/digital bib merging rules") {
     // This test case is based on a real example of three related works that
     // were being merged incorrectly.  In particular, the METS work (and associated


### PR DESCRIPTION
Closes wellcomecollection/platform#6643.

## What does this change?

A physical AV bib and its e-bibs land in one matcher cluster because of their 776 links, but AV Sierra bibs are never merged with each other (`Sources.findFirstLinkedDigitisedSierraWorkFor`, wellcomecollection/platform#4876). Merging the cluster as a whole elected one arbitrary e-bib as the target and `ItemsRule.mergeMetsIntoSierraTarget` handed that one work every METS manifest, leaving the other e-bibs with none. The example in the issue is a two-sided cassette, b2472497x and b24724981, where the 2025-10-02 and 2026-07-03 pipelines picked opposite e-bibs for the same cluster.

`Merger.merge` now runs a `partitionAudiovisual` step first. When the cluster target would be a Sierra work, each AV e-bib is carved out along with the non-Sierra works linked directly to it by merge candidate in either direction, and each group is merged on its own. Whatever is left over merges as before. A work linked to more than one AV e-bib has no single owner, so it stays in the main group and logs a warning.

The partition is narrow on purpose. Clusters with a Calm, Axiell or TEI target never reach it, and non-AV physical and e-bib pairs pulled into an AV cluster stay in the remainder group, so both keep their current outcome. A METS record that names the physical bib also stays in the remainder; when nothing is carved out that merges as before, and when the e-bibs are carved out the remainder elects the physical bib, so the manifest lands on the bib the METS record names.

### Checklist

- [ ] Does this change the display model the catalogue API returns? No. It changes which works merge together, not the shape of the documents we produce.

## How to test

`sbt merger/test` with a local DynamoDB running. The full merger suite passes locally, 263 tests. New `PlatformMergerTest` cases cover: two e-bibs with a METS work each, run table-driven over two input orders so an order-dependent target fails the test; a METS work naming the physical bib with a single bare e-bib, which still merges into the e-bib; the same with the e-bibs carved out, where it merges into the physical bib; and a METS work linked to two e-bibs, which does not follow the carved-out one.

Once this is deployed and the affected records have moved through, eb5qwcxy and a6g3k8eq should each carry their own IIIF manifest instead of one carrying both.

## How can we measure success?

The issue asks for a count of affected multi-part AV recordings against `works-identified` after deployment. There is no ongoing metric beyond that.

## Have we considered potential risks?

The partition changes cluster membership, so a predicate that is scoped too widely would re-merge unrelated works without raising an error. `sierraDigitisedAv` requires a Sierra work with an audiovisual format and no identified items, and the carve-out only pulls in non-Sierra works that hold a direct merge-candidate link, which keeps the blast radius to AV clusters. A mistake here surfaces as works gaining or losing items rather than as a failure, so it is worth looking at AV records again after the next reindex.

