### PR TITLE
Install the catalogue_graph images from uv.lock

### DIFF
--- a/.github/workflows/catalogue-graph-ci.yml
+++ b/.github/workflows/catalogue-graph-ci.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.12.6"
       - name: Check uv.lock matches pyproject.toml
         working-directory: catalogue_graph
         run: uv lock --check
@@ -52,7 +54,7 @@ jobs:
 
   build-unified-pipeline-task-image:
     runs-on: ubuntu-latest
-    needs: [ python-checks ]
+    needs: [ python-checks, check-lockfile ]
     steps:
       - uses: actions/checkout@v7
       - uses: wellcomecollection/.github/.github/actions/docker-build-and-push@main
@@ -69,7 +71,7 @@ jobs:
 
   build-unified-pipeline-lambda-image:
     runs-on: ubuntu-latest
-    needs: [ python-checks ]
+    needs: [ python-checks, check-lockfile ]
     steps:
       - uses: actions/checkout@v7
       - uses: wellcomecollection/.github/.github/actions/docker-build-and-push@main

--- a/.github/workflows/catalogue-graph-ci.yml
+++ b/.github/workflows/catalogue-graph-ci.yml
@@ -26,6 +26,15 @@ jobs:
         with:
           folder: catalogue_graph
 
+  check-lockfile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v7
+      - name: Check uv.lock matches pyproject.toml
+        working-directory: catalogue_graph
+        run: uv lock --check
+
   check-test-documents:
     runs-on: ubuntu-latest
     steps:

--- a/catalogue_graph/docker-compose.yml
+++ b/catalogue_graph/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
       args:
-        - PYTHON_IMAGE_VERSION=${PYTHON_IMAGE_VERSION:-3.13}
+        - PYTHON_IMAGE_VERSION=${PYTHON_IMAGE_VERSION:-3.12}
       dockerfile: task.Dockerfile
   unified_pipeline_lambda:
     image: ${REPOSITORY_PREFIX:-}unified_pipeline_lambda:${TAG:-dev}
@@ -13,5 +13,5 @@ services:
     build:
       context: .
       args:
-        - PYTHON_IMAGE_VERSION=${PYTHON_IMAGE_VERSION:-3.13}
+        - PYTHON_IMAGE_VERSION=${PYTHON_IMAGE_VERSION:-3.12}
       dockerfile: lambda.Dockerfile

--- a/catalogue_graph/lambda.Dockerfile
+++ b/catalogue_graph/lambda.Dockerfile
@@ -28,10 +28,11 @@ RUN update-ca-trust extract
 # This is installed separately from the main package to avoid affecting local development.
 RUN pip install pip-system-certs==5.3
 
-# Install dependencies and the package using uv pip install
-# uv pip install works with the system Python environment and installs from uv.lock
-# --system installs to system Python instead of requiring a virtual environment  
-RUN uv pip install --system .
+# Install the locked dependencies into the system interpreter.
+# --locked fails the build if uv.lock is out of date with pyproject.toml.
+# --inexact keeps packages outside the lock (pip-system-certs above, the runtime's own).
+# The project itself is not installed because src/ is copied in below.
+RUN UV_PROJECT_ENVIRONMENT=/var/lang uv sync --locked --inexact --no-dev --no-install-project
 
 # Copy application source code
 COPY src/ ${LAMBDA_TASK_ROOT}

--- a/catalogue_graph/lambda.Dockerfile
+++ b/catalogue_graph/lambda.Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /app
 COPY pyproject.toml uv.lock ./
 
 # Install uv
-RUN pip install uv 
+RUN pip install uv==0.12.6
 
 # Install ca-certificates and git
 RUN dnf install -y ca-certificates git && dnf clean all
@@ -30,7 +30,8 @@ RUN pip install pip-system-certs==5.3
 
 # Install the locked dependencies into the system interpreter.
 # --locked fails the build if uv.lock is out of date with pyproject.toml.
-# --inexact keeps packages outside the lock (pip-system-certs above, the runtime's own).
+# --inexact keeps packages outside the lock: pip-system-certs above and awslambdaric,
+# without which the Lambda cannot bootstrap.
 # The project itself is not installed because src/ is copied in below.
 RUN UV_PROJECT_ENVIRONMENT=/var/lang uv sync --locked --inexact --no-dev --no-install-project
 

--- a/catalogue_graph/task.Dockerfile
+++ b/catalogue_graph/task.Dockerfile
@@ -24,10 +24,11 @@ RUN update-ca-certificates
 # This is installed separately from the main package to avoid affecting local development.
 RUN pip install pip-system-certs==5.3
 
-# Install dependencies and the package using uv pip install
-# uv pip install works with the system Python environment and installs from uv.lock
-# --system installs to system Python instead of requiring a virtual environment  
-RUN uv pip install --system .
+# Install the locked dependencies into the system interpreter.
+# --locked fails the build if uv.lock is out of date with pyproject.toml.
+# --inexact keeps packages outside the lock (pip-system-certs above, the runtime's own).
+# The project itself is not installed because src/ is copied in below.
+RUN UV_PROJECT_ENVIRONMENT=/usr/local uv sync --locked --inexact --no-dev --no-install-project
 
 # Copy application source code
 COPY src/ ./src/

--- a/catalogue_graph/task.Dockerfile
+++ b/catalogue_graph/task.Dockerfile
@@ -11,7 +11,7 @@ COPY pyproject.toml uv.lock ./
 
 # Install uv and pip-system-certs
 # pip-system-certs allows using system CA certificates when making HTTPS requests
-RUN pip install uv
+RUN pip install uv==0.12.6
 
 # Install git and clean up apt cache
 RUN apt-get update && apt-get install -y ca-certificates git && rm -rf /var/lib/apt/lists/*
@@ -26,7 +26,7 @@ RUN pip install pip-system-certs==5.3
 
 # Install the locked dependencies into the system interpreter.
 # --locked fails the build if uv.lock is out of date with pyproject.toml.
-# --inexact keeps packages outside the lock (pip-system-certs above, the runtime's own).
+# --inexact keeps packages outside the lock, such as pip-system-certs above.
 # The project itself is not installed because src/ is copied in below.
 RUN UV_PROJECT_ENVIRONMENT=/usr/local uv sync --locked --inexact --no-dev --no-install-project
 


### PR DESCRIPTION
## What does this change?

Both catalogue_graph images installed their dependencies with `uv pip install --system .`, which resolves fresh from `pyproject.toml` on every build and never reads `uv.lock`, despite the comment above it saying otherwise. The hashes in the lock gave no protection, and lock-only Dependabot bumps such as wellcomecollection/catalogue-pipeline#3421 and wellcomecollection/catalogue-pipeline#3580 changed nothing in the built image. Both Dockerfiles now install with `uv sync --locked --inexact --no-dev --no-install-project` into the system prefix, and a new `check-lockfile` job runs `uv lock --check`, with both image builds gated on it.

uv is pinned to 0.12.6 in both Dockerfiles and in the lock-check job, since the build now depends on uv's behaviour rather than pip's. The docker-compose default `PYTHON_IMAGE_VERSION` moves from 3.13 to 3.12 to match `requires-python`; on 3.13 uv fails with a confusing error about there being no virtual environment.

Closes wellcomecollection/platform#6661

<details><summary>Why those uv sync flags</summary>

- `--locked` fails the build when `uv.lock` is out of date with `pyproject.toml`.
- `--inexact` keeps packages that are not in the lock, meaning `pip-system-certs` in both images and `awslambdaric` in the Lambda image, which a plain `uv sync` removed in testing.
- `--no-install-project` because `src/` is copied in separately and was never present at install time.

The other option in the issue, `uv export` followed by `uv pip install --require-hashes`, does not work here: the `oai-pmh-client` git dependency has no hash.
</details>

## How to test

`docker compose build` in `catalogue_graph/`. I built both images for linux/amd64 locally: structlog, lxml, oai-pmh-client 1.1.0, pip-system-certs and the Lambda `default` handler all import, and the Lambda base image's preinstalled boto3 is replaced by the locked version.

To see the guard work, change a dependency in `pyproject.toml` without relocking and rebuild. The build stops with "The lockfile at `uv.lock` needs to be updated, but `--locked` was provided".

## How can we measure success?

A Dependabot PR touching only `catalogue_graph/uv.lock` now changes what the image installs, so the version in the lock and the version in the running container agree.

## Have we considered potential risks?

Upgrades now arrive only through `uv.lock`, so anything Dependabot does not bump stays at its locked version indefinitely. Builds also fail on a lock that has drifted from `pyproject.toml`, which will block a merge until someone runs `uv lock`.
