### PR TITLE
Scale up tasks and the ES cluster for the round 3 reindex

### DIFF
--- a/infrastructure/critical/es_cluster.tf
+++ b/infrastructure/critical/es_cluster.tf
@@ -7,8 +7,11 @@ module "es_cluster_2026_07_03" {
 
   cluster_date = "2026-07-03"
 
-  memory     = "4g"
-  node_count = 3
+  # Sized for the round 3 full reindex (platform#6624), matching rounds 1 and 2.
+  # Back to 4g across 3 zones after the comparison signs off; the scale-down
+  # apply can only run once a day.
+  memory     = "30g"
+  node_count = 2
 
   traffic_filter_ids = [
     local.shared_infra["ec_platform_privatelink_traffic_filter_id"],

--- a/pipeline/terraform/2026-07-03/main.tf
+++ b/pipeline/terraform/2026-07-03/main.tf
@@ -3,7 +3,9 @@ module "pipeline" {
 
   reindexing_state = {
     listen_to_reindexer = true
-    scale_up_tasks      = false
+    # Sized for the round 3 full reindex (platform#6624); back to false after
+    # the comparison signs off.
+    scale_up_tasks      = true
     scale_up_matcher_db = false
   }
 


### PR DESCRIPTION
Pre-staged for wellcomecollection/platform#6624, mirroring round 2's #3576. Merge and apply after the phase 7 re-enable, before the reindex starts: `infrastructure/critical` via `./run_terraform.sh` first (the ES resize), then `pipeline/terraform/2026-07-03`.

`scale_up_tasks` on, ES to 30g across 2 zones. The matcher DynamoDB scale-up is a separate PR so it goes on last and comes off first. Reverting after the comparison: the ES scale-down apply can only run once a day.

Will need a rebase once the quiesce and re-enable PRs have merged, since they touch the same block.