### PR TITLE
Scale up the matcher DynamoDB for the round 3 reindex

### DIFF
--- a/pipeline/terraform/2026-07-03/main.tf
+++ b/pipeline/terraform/2026-07-03/main.tf
@@ -4,7 +4,9 @@ module "pipeline" {
   reindexing_state = {
     listen_to_reindexer = true
     scale_up_tasks      = false
-    scale_up_matcher_db = false
+    # ~$135/day flat: applied last before the reindex starts, reverted first
+    # after the comparison signs off.
+    scale_up_matcher_db = true
   }
 
   index_dates = {


### PR DESCRIPTION
Pre-staged for wellcomecollection/platform#6624, mirroring round 2's #3577. Apply last, immediately before the reindex starts, and revert first after the comparison signs off: the provisioned capacity is a flat ~$135/day. Note the flag scales the whole matcher stage (lambda memory, concurrency and batch size), not only the table.