### PR TITLE
Re-enable the 2026-07-03 pipeline after the round 3 clear

### DIFF
--- a/catalogue_graph/infra/adapters/main.tf
+++ b/catalogue_graph/infra/adapters/main.tf
@@ -16,11 +16,11 @@ module "ebsco" {
 }
 
 module "axiell" {
-  source                = "./modules/adapter"
-  namespace             = "axiell"
-  steps_namespace       = "oai_pmh"
-  s3_bucket_name        = "wellcomecollection-platform-axiell-adapter"
-  schedule_expression   = "rate(15 minutes)"
+  source              = "./modules/adapter"
+  namespace           = "axiell"
+  steps_namespace     = "oai_pmh"
+  s3_bucket_name      = "wellcomecollection-platform-axiell-adapter"
+  schedule_expression = "rate(15 minutes)"
   # Paused for the round 3 clear (platform#6623): keeps the adapter store empty
   # between the phase 6a wipe and the post-load rebuild.
   schedule_enabled      = false

--- a/catalogue_graph/infra/adapters/main.tf
+++ b/catalogue_graph/infra/adapters/main.tf
@@ -21,6 +21,9 @@ module "axiell" {
   steps_namespace       = "oai_pmh"
   s3_bucket_name        = "wellcomecollection-platform-axiell-adapter"
   schedule_expression   = "rate(15 minutes)"
+  # Paused for the round 3 clear (platform#6623): keeps the adapter store empty
+  # between the phase 6a wipe and the post-load rebuild.
+  schedule_enabled      = false
   repository_url        = data.aws_ecr_repository.unified_pipeline_lambda.repository_url
   event_bus_name        = aws_cloudwatch_event_bus.event_bus.name
   ecs_cluster_arn       = aws_ecs_cluster.adapters.arn

--- a/pipeline/terraform/2026-07-03/main.tf
+++ b/pipeline/terraform/2026-07-03/main.tf
@@ -1,8 +1,11 @@
 module "pipeline" {
   source = "../modules/pipeline_new"
 
+  # Quiesced while the pipeline's stateful parts are cleared for round 3
+  # (platform#6623), so nothing writes into the state being wiped. Back on for
+  # the reindex, along with the enable_* flags below.
   reindexing_state = {
-    listen_to_reindexer = true
+    listen_to_reindexer = false
     scale_up_tasks      = false
     scale_up_matcher_db = false
   }
@@ -21,11 +24,11 @@ module "pipeline" {
   # Base AMI for ECS instances
   ami_id = "resolve:ssm:arn:aws:ssm:eu-west-1:760097843905:parameter/imagebuilder/weco-al2023-ecs-optimised-x86_64/latest"
 
-  enable_adapter_transformer_trigger           = true
+  enable_adapter_transformer_trigger           = false
   disable_calm_transformer_topic_subscriptions = true
-  enable_id_minter_schedule                    = true
-  enable_graph_pipeline_schedule               = true
-  enable_image_inferrer_schedule               = true
+  enable_id_minter_schedule                    = false
+  enable_graph_pipeline_schedule               = false
+  enable_image_inferrer_schedule               = false
 
   pipeline_date = local.pipeline_date // namespaces services
   graph_date    = "2026-07-03"        // namespaces graph database

--- a/pipeline/terraform/2026-07-03/main.tf
+++ b/pipeline/terraform/2026-07-03/main.tf
@@ -1,11 +1,8 @@
 module "pipeline" {
   source = "../modules/pipeline_new"
 
-  # Quiesced while the pipeline's stateful parts are cleared for round 3
-  # (platform#6623), so nothing writes into the state being wiped. Back on for
-  # the reindex, along with the enable_* flags below.
   reindexing_state = {
-    listen_to_reindexer = false
+    listen_to_reindexer = true
     scale_up_tasks      = false
     scale_up_matcher_db = false
   }
@@ -24,11 +21,11 @@ module "pipeline" {
   # Base AMI for ECS instances
   ami_id = "resolve:ssm:arn:aws:ssm:eu-west-1:760097843905:parameter/imagebuilder/weco-al2023-ecs-optimised-x86_64/latest"
 
-  enable_adapter_transformer_trigger           = false
+  enable_adapter_transformer_trigger           = true
   disable_calm_transformer_topic_subscriptions = true
-  enable_id_minter_schedule                    = false
-  enable_graph_pipeline_schedule               = false
-  enable_image_inferrer_schedule               = false
+  enable_id_minter_schedule                    = true
+  enable_graph_pipeline_schedule               = true
+  enable_image_inferrer_schedule               = true
 
   pipeline_date = local.pipeline_date // namespaces services
   graph_date    = "2026-07-03"        // namespaces graph database


### PR DESCRIPTION
Pre-staged for wellcomecollection/platform#6623 phase 7, mirroring round 2's #3585. Merge and apply (`pipeline/terraform/2026-07-03`) when the clear completes: the four triggers and `listen_to_reindexer` come back on ahead of the reindex.

Phase 7 also includes the id-minter window replay across the quiesce span (see `docs/pipeline/reindex-recovery.md`), since un-quiescing does not backfill.

Based on the quiesce branch so the diff reads as just the re-enable; retargets to main when #3610 merges.