### PR TITLE
Document the OAI harvest lag breaker and its one-run override

### DIFF
--- a/docs/pipeline/reindex-recovery.md
+++ b/docs/pipeline/reindex-recovery.md
@@ -14,7 +14,7 @@ Works flow through works-source, works-identified (id-minter), matcher, merger a
 
 ## Resuming a paused OAI harvest
 
-The OAI trigger has a lag breaker: it refuses to run when the last successful window ended more than `MAX_LAG_MINUTES` ago (env var on the trigger lambda, default 360). A harvest paused for longer than that trips the breaker on its first scheduled run after resuming. The trigger emits one window from the cursor to now, so a single successful run catches up in full; the options, in order of preference: resume within the breaker's limit of the last harvest activity so it never trips; or bump `MAX_LAG_MINUTES` on the trigger lambda's environment for one scheduled tick and revert it. The lambda event cannot disable the check; `enforce_lag` is only a local CLI option.
+The OAI trigger has a lag breaker: it refuses to run when the last successful window ended more than the configured max lag ago (default 360 minutes; `MAX_LAG_MINUTES` for Axiell, `FOLIO_MAX_LAG_MINUTES` for Folio). A harvest paused for longer than that trips the breaker on its first scheduled run after resuming. The trigger emits one window from the cursor to now, so a single successful run catches up in full; the options, in order of preference: resume within the breaker's limit of the last harvest activity so it never trips; or bump the relevant `*_MAX_LAG_MINUTES` env var on the trigger lambda's environment for one scheduled tick and revert it. The lambda event cannot disable the check; `--enforce-lag` is only a local CLI option.
 
 ## Replaying id-minter windows
 

--- a/docs/pipeline/reindex-recovery.md
+++ b/docs/pipeline/reindex-recovery.md
@@ -12,6 +12,10 @@ Works flow through works-source, works-identified (id-minter), matcher, merger a
 - **Un-quiescing does not backfill.** If the pipeline was quiesced while live transformers kept writing works-source, those works keep their original `indexed_at` and no window will ever cover the quiesce span. After re-enabling, run an explicit id-minter window replay across the whole quiesce period as a standard step, then confirm works-source equals works-identified.
 - **App logs are not in CloudWatch.** The transformer, graph extractor and ingestor log groups hold only the fluentbit sidecar; per-record errors go to the shared logging cluster (`service-logs-*`, secrets under `shared/logging/`). An empty CloudWatch filter is a false negative.
 
+## Resuming a paused OAI harvest
+
+The OAI trigger has a lag breaker: it refuses to run when the last successful window ended more than `MAX_LAG_MINUTES` ago (env var on the trigger lambda, default 360). A harvest paused for longer than that trips the breaker on its first scheduled run after resuming. The trigger emits one window from the cursor to now, so a single successful run catches up in full; the options, in order of preference: resume within the breaker's limit of the last harvest activity so it never trips; or bump `MAX_LAG_MINUTES` on the trigger lambda's environment for one scheduled tick and revert it. The lambda event cannot disable the check; `enforce_lag` is only a local CLI option.
+
 ## Replaying id-minter windows
 
 The id-minter state machine accepts an explicit window and job id:


### PR DESCRIPTION
Follow-up to the runbook pass (#3606): the lag-breaker warning appears on wellcomecollection/platform#6623 and the pre-staged harvest-resume PR (#3613) but the mechanism was not written down anywhere. Verified from the trigger code: the breaker is `_enforce_lag` on `last_success_end` against `MAX_LAG_MINUTES` (trigger lambda env, default 360), the lambda event cannot disable it, and one successful run catches up in full because the trigger emits a single cursor-to-now window. The section states the preferred path (resume within the limit so it never trips) and the one-tick env override.

## How to test

Documentation only; claims verified against `catalogue_graph/src/adapters/steps/oai_pmh/trigger.py`.