### PR TITLE
TEI transformer: add support for multiple b-numbers

### DIFF
--- a/pipeline/matcher_merger/merger/src/test/scala/weco/pipeline/merger/services/PlatformMergerTest.scala
+++ b/pipeline/matcher_merger/merger/src/test/scala/weco/pipeline/merger/services/PlatformMergerTest.scala
@@ -1351,6 +1351,49 @@ class PlatformMergerTest
       visibleWorks.loneElement.state.canonicalId shouldBe teiWork.state.canonicalId
     }
 
+    // A manuscript can be catalogued as several Calm records, each with its
+    // own Sierra bib, all describing what is one TEI file. The TEI file names
+    // every one of those bibs, so the whole group should collapse onto it.
+    it("merges several Sierra bibs and their Calm records into one TEI work") {
+      val sierraWorks = (1 to 3).map(_ => sierraPhysicalIdentifiedWork()).toList
+      val calmWorks = (1 to 3).map(_ => calmIdentifiedWork()).toList
+
+      val teiWork = teiIdentifiedWork()
+        .mergeCandidates(sierraWorks.map(createTeiBnumberMergeCandidateFor))
+
+      val result = merger
+        .merge(works = teiWork +: (sierraWorks ++ calmWorks))
+        .mergedWorksWithTime(now)
+
+      val redirectedWorks = result.collect {
+        case w: Work.Redirected[Merged] => w
+      }
+      val visibleWorks = result.collect { case w: Work.Visible[Merged] => w }
+
+      visibleWorks.loneElement.state.canonicalId shouldBe teiWork.state.canonicalId
+
+      redirectedWorks.map(_.state.canonicalId) should contain theSameElementsAs
+        (sierraWorks ++ calmWorks).map(_.state.canonicalId)
+      redirectedWorks.map(_.redirectTarget.canonicalId).distinct shouldBe
+        List(teiWork.state.canonicalId)
+    }
+
+    it("takes the items from every Sierra bib merged into a TEI work") {
+      val sierraWorks = (1 to 3).map(_ => sierraPhysicalIdentifiedWork()).toList
+
+      val teiWork = teiIdentifiedWork()
+        .mergeCandidates(sierraWorks.map(createTeiBnumberMergeCandidateFor))
+
+      val result = merger
+        .merge(works = teiWork +: sierraWorks)
+        .mergedWorksWithTime(now)
+
+      val visibleWorks = result.collect { case w: Work.Visible[Merged] => w }
+
+      visibleWorks.loneElement.data.items should contain theSameElementsAs
+        sierraWorks.flatMap(_.data.items)
+    }
+
     it("copies the thumbnail to the inner works") {
       val teiWork = teiIdentifiedWork()
         .mapState {

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiData.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiData.scala
@@ -31,7 +31,7 @@ import java.time.Instant
 case class TeiData(
   id: String,
   title: String,
-  bNumber: Option[String] = None,
+  bNumbers: List[String] = Nil,
   referenceNumber: Option[ReferenceNumber] = None,
   description: Option[String] = None,
   languages: List[Language] = Nil,
@@ -86,21 +86,20 @@ case class TeiData(
       value = id
     )
 
-  private def mergeCandidates: List[MergeCandidate[Identifiable]] = {
-    val bNumberMergeCandidate = for {
-      id <- bNumber
-      sourceIdentifier <- SourceIdentifier(
-        identifierType = IdentifierType.SierraSystemNumber,
-        ontologyType = "Work",
-        value = id
-      ).validatedWithWarning
-    } yield MergeCandidate(
-      identifier = sourceIdentifier,
-      reason = "Bnumber present in TEI file"
-    )
-
-    bNumberMergeCandidate.toList
-  }
+  // A manuscript can be catalogued in more than one Sierra record, so we may
+  // get several b numbers. Each one becomes a merge candidate.
+  private def mergeCandidates: List[MergeCandidate[Identifiable]] =
+    bNumbers.distinct.flatMap {
+      bNumber =>
+        SourceIdentifier(
+          identifierType = IdentifierType.SierraSystemNumber,
+          ontologyType = "Work",
+          value = bNumber
+        ).validatedWithWarning
+          .map(
+            MergeCandidate(_, reason = "Bnumber present in TEI file")
+          )
+    }
   implicit class InternalWorkOps(internalWorks: List[InternalWork.Source]) {
     def withLanguage(
       topLevel: WorkData[Unidentified]

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiXml.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiXml.scala
@@ -36,7 +36,7 @@ class TeiXml(val xml: Elem) extends Logging {
       subjects = TeiSubjects(xml)
     )
 
-  /** All the identifiers of the TEI file are in a `msIdentifier` bloc. We need
+  /** All the identifiers of the TEI file are in a `msIdentifier` block. We need
     * the `altIdentifier` nodes where `type` is `Sierra.` <TEI> <teiHeader>
     * <fileDesc> <sourceDesc> <msDesc xml:lang="en" xml:id="MS_Arabic_1">
     * <msIdentifier> <altIdentifier type="former"> <idno>WMS. Or. 1a

--- a/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiXml.scala
+++ b/pipeline/transformer/transformer_tei/src/main/scala/weco/pipeline/transformer/tei/TeiXml.scala
@@ -15,7 +15,6 @@ class TeiXml(val xml: Elem) extends Logging {
   def parse: Result[TeiData] =
     for {
       title <- title
-      bNumber <- bNumber
       summary <- summary
       languageData <- TeiLanguages(xml)
       (languages, languageNotes) = languageData
@@ -25,7 +24,7 @@ class TeiXml(val xml: Elem) extends Logging {
     } yield TeiData(
       id = id,
       title = title,
-      bNumber = bNumber,
+      bNumbers = bNumbers,
       referenceNumber = Some(referenceNumber),
       description = summary,
       languages = languages,
@@ -38,23 +37,21 @@ class TeiXml(val xml: Elem) extends Logging {
     )
 
   /** All the identifiers of the TEI file are in a `msIdentifier` bloc. We need
-    * the `altIdentifier` node where `type` is `Sierra.` <TEI> <teiHeader>
+    * the `altIdentifier` nodes where `type` is `Sierra.` <TEI> <teiHeader>
     * <fileDesc> <sourceDesc> <msDesc xml:lang="en" xml:id="MS_Arabic_1">
     * <msIdentifier> <altIdentifier type="former"> <idno>WMS. Or. 1a
     * (Iskandar)</idno> </altIdentifier> <altIdentifier type="former">
     * <idno>WMS. Or. 1a</idno> </altIdentifier> <altIdentifier type="Sierra">
     * <idno>b1234567</idno> </altIdentifier> </msIdentifier> ... </TEI>
+    *
+    * A manuscript may be catalogued in more than one Sierra record, in which
+    * case there are several such nodes and each one becomes a merge candidate.
     */
-  private def bNumber: Result[Option[String]] = {
+  private def bNumbers: List[String] = {
     val identifiersNodes = xml \\ "msDesc" \ "msIdentifier" \ "altIdentifier"
-    val seq = (identifiersNodes.filter(
+    (identifiersNodes.filter(
       n => (n \@ "type").toLowerCase == "sierra"
-    ) \ "idno").toList
-    seq match {
-      case List(node) => Right(Some(node.text.trim))
-      case Nil        => Right(None)
-      case _ => Left(new RuntimeException("More than one sierra bnumber node!"))
-    }
+    ) \ "idno").map(_.text.trim).toList
   }
 
   private def summary: Result[Option[String]] = TeiOps.summary(xml \\ "msDesc")

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiDataTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiDataTest.scala
@@ -35,7 +35,7 @@ class TeiDataTest
     val teiData = TeiData(
       id = id,
       title = title,
-      bNumber = Some(bnumber),
+      bNumbers = List(bnumber),
       description = description,
       languages = languages,
       notes = languageNotes
@@ -76,7 +76,7 @@ class TeiDataTest
     val teiData = TeiData(
       id = "id",
       title = "This is the title",
-      bNumber = Some("fjhsdg"),
+      bNumbers = List("fjhsdg"),
       description = Some("This is the description"),
       languages = List(Language("ara", "Arabic"))
     )
@@ -84,6 +84,60 @@ class TeiDataTest
     val work = teiData.toWork(Instant.now(), 1)
 
     work.state.mergeCandidates shouldBe empty
+  }
+
+  it("creates a mergeCandidate for every bnumber") {
+    val bnumbers =
+      (1 to 3).map(_ => createSierraBibNumber.withCheckDigit).toList
+
+    val teiData = TeiData(
+      id = "id",
+      title = "This is the title",
+      bNumbers = bnumbers
+    )
+
+    val work = teiData.toWork(Instant.now(), 1)
+
+    work.state.mergeCandidates shouldBe bnumbers.map {
+      bnumber =>
+        MergeCandidate(
+          createSierraSystemSourceIdentifierWith(value = bnumber),
+          reason = "Bnumber present in TEI file"
+        )
+    }
+  }
+
+  it("skips invalid bnumbers but keeps the valid ones") {
+    val bnumber = createSierraBibNumber.withCheckDigit
+
+    val teiData = TeiData(
+      id = "id",
+      title = "This is the title",
+      bNumbers = List("fjhsdg", bnumber)
+    )
+
+    val work = teiData.toWork(Instant.now(), 1)
+
+    work.state.mergeCandidates shouldBe List(
+      MergeCandidate(
+        createSierraSystemSourceIdentifierWith(value = bnumber),
+        reason = "Bnumber present in TEI file"
+      )
+    )
+  }
+
+  it("deduplicates repeated bnumbers") {
+    val bnumber = createSierraBibNumber.withCheckDigit
+
+    val teiData = TeiData(
+      id = "id",
+      title = "This is the title",
+      bNumbers = List(bnumber, bnumber)
+    )
+
+    val work = teiData.toWork(Instant.now(), 1)
+
+    work.state.mergeCandidates should have size 1
   }
 
   it("transforms authors in nestedData") {
@@ -122,7 +176,7 @@ class TeiDataTest
     val teiData = TeiData(
       id = "id",
       title = "This is the title",
-      bNumber = Some("fjhsdg"),
+      bNumbers = List("fjhsdg"),
       description = Some("This is the description"),
       nestedTeiData = List(firstInnerTeiData, secondInnerTeiData)
     )

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiXmlTest.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/TeiXmlTest.scala
@@ -9,7 +9,7 @@ import weco.pipeline.transformer.tei.generators.TeiGenerators
 import weco.sierra.generators.SierraIdentifierGenerators
 
 import java.time.Instant
-import scala.xml.Elem
+import scala.xml.NodeSeq
 
 class TeiXmlTest
     extends AnyFunSpec
@@ -74,42 +74,35 @@ class TeiXmlTest
     result.left.get.getMessage should include("title")
   }
 
-  describe("bNumber") {
-    it("parses a tei xml and returns TeiData with bNumber") {
+  describe("bNumbers") {
+    it("parses a tei xml and returns TeiData with a bNumber") {
       val bnumber = createSierraBibNumber.withCheckDigit
 
       TeiXml(
         id,
-        teiXml(id = id, identifiers = Some(sierraIdentifiers(bnumber)))
+        teiXml(id = id, identifiers = sierraIdentifiers(bnumber))
           .toString()
-      ).flatMap(_.parse).value.bNumber shouldBe Some(bnumber)
+      ).flatMap(_.parse).value.bNumbers shouldBe List(bnumber)
     }
 
-    it("fails if there's more than one b-number in the XML") {
-      val bnumber = createSierraBibNumber.withCheckDigit
+    it("returns no bNumbers if there are none in the XML") {
+      TeiXml(id, teiXml(id = id).toString())
+        .flatMap(_.parse)
+        .value
+        .bNumbers shouldBe empty
+    }
 
-      val xmlValue: Elem = <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id={id}>
-        <teiHeader>
-          <fileDesc>
-            <sourceDesc>
-              <msDesc xml:lang="en" xml:id="MS_Arabic_1">
-                <msIdentifier>
-                  {sierraIdentifiers(bnumber)}
-                  {sierraIdentifiers(bnumber)}
-                </msIdentifier>
-                <msContents>
-                </msContents>
-              </msDesc>
-            </sourceDesc>
-          </fileDesc>
-        </teiHeader>
-      </TEI>
+    it("returns every b-number if there's more than one in the XML") {
+      val bnumbers =
+        (1 to 3).map(_ => createSierraBibNumber.withCheckDigit).toList
 
-      val xml = new TeiXml(xmlValue)
-
-      val err = xml.parse
-      err shouldBe a[Left[_, _]]
-      err.left.value shouldBe a[RuntimeException]
+      TeiXml(
+        id,
+        teiXml(
+          id = id,
+          identifiers = NodeSeq.fromSeq(bnumbers.flatMap(sierraIdentifiers))
+        ).toString()
+      ).flatMap(_.parse).value.bNumbers shouldBe bnumbers
     }
   }
 

--- a/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/generators/TeiGenerators.scala
+++ b/pipeline/transformer/transformer_tei/src/test/scala/weco/pipeline/transformer/tei/generators/TeiGenerators.scala
@@ -9,7 +9,7 @@ trait TeiGenerators extends RandomGenerators { this: Suite =>
   def teiXml(
     id: String = randomAlphanumeric(),
     refNo: NodeSeq = idnoMsId("test title"),
-    identifiers: Option[Elem] = None,
+    identifiers: NodeSeq = NodeSeq.Empty,
     summary: Option[Elem] = None,
     languages: List[Elem] = Nil,
     items: List[Elem] = Nil,
@@ -30,7 +30,7 @@ trait TeiGenerators extends RandomGenerators { this: Suite =>
           <sourceDesc>
             <msDesc xml:lang="en" xml:id="MS_Arabic_1">
               <msIdentifier>
-                {identifiers.getOrElse(NodeSeq.Empty)}
+                {identifiers}
               </msIdentifier>
               {msContents(summary, languages, items, authors)}
               {parts}


### PR DESCRIPTION
## What does this change?

https://github.com/wellcomecollection/platform/issues/6506

In the TEI transformer, turn each Sierra b-number referenced in the TEI XML file into a merge candidate instead of failing the file if more than one Sierra b-number is found. We expect to start seeing TEI files referencing several b-numbers soon due to a CALM cataloguing quirk (see [this Slack thread](https://wellcome.slack.com/archives/CS4G8SAG3/p1786351628564149?thread_ts=1786106086.165139&cid=CS4G8SAG3) for more info).

Existing behaviour (rejecting invalid b-numbers) is preserved.

### Checklist

- [ ] Does this change the display model the catalogue API returns? If so, regenerate the test documents under `catalogue_graph/document_generators/test_documents`. After merge, `sync-test-documents.yml` copies them into `wellcomecollection/catalogue-api` as an auto-PR, where OpenAPI contract tests validate the published spec against them; expect that PR to fail CI until the spec (`catalogue-api/reference/catalogue.yaml`) documents the new shape.

## How to test

This change is tested, both in the transformer and in the merger.

## How can we measure success?

The TEI transformer should stop rejecting TEI files which reference more than one b-number. Instead, it should emit a merge candidate for each valid, unique b-number. The merger should then merge each Sierra work referenced as a merge candidate into the TEI work.

## Have we considered potential risks?

Adding support for multiple merge candidates on each TEI work is not a risky change. Other transformers already support this (Sierra, Axiell) and the merger already handles it (proven by the new unit tests). 