### PR TITLE
re-enable axiell harvest

### DIFF
--- a/catalogue_graph/infra/adapters/main.tf
+++ b/catalogue_graph/infra/adapters/main.tf
@@ -16,14 +16,11 @@ module "ebsco" {
 }
 
 module "axiell" {
-  source              = "./modules/adapter"
-  namespace           = "axiell"
-  steps_namespace     = "oai_pmh"
-  s3_bucket_name      = "wellcomecollection-platform-axiell-adapter"
-  schedule_expression = "rate(15 minutes)"
-  # Paused for the round 3 clear (platform#6623): keeps the adapter store empty
-  # between the phase 6a wipe and the post-load rebuild.
-  schedule_enabled      = false
+  source                = "./modules/adapter"
+  namespace             = "axiell"
+  steps_namespace       = "oai_pmh"
+  s3_bucket_name        = "wellcomecollection-platform-axiell-adapter"
+  schedule_expression   = "rate(15 minutes)"
   repository_url        = data.aws_ecr_repository.unified_pipeline_lambda.repository_url
   event_bus_name        = aws_cloudwatch_event_bus.event_bus.name
   ecs_cluster_arn       = aws_ecs_cluster.adapters.arn


### PR DESCRIPTION
Replaces and closes https://github.com/wellcomecollection/catalogue-pipeline/pull/3613 that got mangled in a squash and merge of https://github.com/wellcomecollection/catalogue-pipeline/pull/3610
