### PR TITLE
Add a role the Identifiers API can assume to read the id-minter registry

### DIFF
--- a/infrastructure/critical/modules/id-minter-rds/iam.tf
+++ b/infrastructure/critical/modules/id-minter-rds/iam.tf
@@ -1,0 +1,46 @@
+locals {
+  identifiers_api_read_count = length(var.data_api_consumer_role_arns) > 0 ? 1 : 0
+}
+
+resource "aws_iam_role" "identifiers_api_read" {
+  count = local.identifiers_api_read_count
+
+  name               = "identifiers-api-registry-read${local.hyphen_suffix}"
+  assume_role_policy = data.aws_iam_policy_document.identifiers_api_assume[0].json
+}
+
+data "aws_iam_policy_document" "identifiers_api_assume" {
+  count = local.identifiers_api_read_count
+
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = var.data_api_consumer_role_arns
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "identifiers_api_read" {
+  count = local.identifiers_api_read_count
+
+  role   = aws_iam_role.identifiers_api_read[0].name
+  policy = data.aws_iam_policy_document.identifiers_api_read[0].json
+}
+
+data "aws_iam_policy_document" "identifiers_api_read" {
+  count = local.identifiers_api_read_count
+
+  statement {
+    actions   = ["rds-data:ExecuteStatement"]
+    resources = [module.identifiers_v2_serverless_rds_cluster.rds_cluster_arn]
+  }
+
+  # The Data API reads the credential on the caller's behalf, so the caller needs
+  # access to the secret as well as to the cluster.
+  statement {
+    actions   = ["secretsmanager:GetSecretValue"]
+    resources = [module.identifiers_v2_serverless_rds_cluster.master_user_secret_arn]
+  }
+}

--- a/infrastructure/critical/modules/id-minter-rds/iam.tf
+++ b/infrastructure/critical/modules/id-minter-rds/iam.tf
@@ -1,5 +1,9 @@
 locals {
   identifiers_api_read_count = length(var.data_api_consumer_role_arns) > 0 ? 1 : 0
+
+  data_api_consumer_account_roots = distinct([
+    for arn in var.data_api_consumer_role_arns : "arn:aws:iam::${split(":", arn)[4]}:root"
+  ])
 }
 
 resource "aws_iam_role" "identifiers_api_read" {
@@ -17,7 +21,13 @@ data "aws_iam_policy_document" "identifiers_api_assume" {
 
     principals {
       type        = "AWS"
-      identifiers = var.data_api_consumer_role_arns
+      identifiers = local.data_api_consumer_account_roots
+    }
+
+    condition {
+      test     = "ArnEquals"
+      variable = "aws:PrincipalArn"
+      values   = var.data_api_consumer_role_arns
     }
   }
 }
@@ -39,6 +49,11 @@ data "aws_iam_policy_document" "identifiers_api_read" {
 
   # The Data API reads the credential on the caller's behalf, so the caller needs
   # access to the secret as well as to the cluster.
+  #
+  # This is the cluster master secret, so the grant is admin-level on the registry
+  # until https://github.com/wellcomecollection/platform/issues/6533 creates a
+  # SELECT-only user with its own secret. Point this at that secret when it lands,
+  # and do not add further consumers to data_api_consumer_role_arns before then.
   statement {
     actions   = ["secretsmanager:GetSecretValue"]
     resources = [module.identifiers_v2_serverless_rds_cluster.master_user_secret_arn]

--- a/infrastructure/critical/modules/id-minter-rds/outputs.tf
+++ b/infrastructure/critical/modules/id-minter-rds/outputs.tf
@@ -10,6 +10,10 @@ output "master_user_secret_arn" {
   value = module.identifiers_v2_serverless_rds_cluster.master_user_secret_arn
 }
 
+output "identifiers_api_read_role_arn" {
+  value = one(aws_iam_role.identifiers_api_read[*].arn)
+}
+
 output "ingress_security_group_id" {
   value = aws_security_group.rds_v2_ingress_security_group.id
 }

--- a/infrastructure/critical/modules/id-minter-rds/variables.tf
+++ b/infrastructure/critical/modules/id-minter-rds/variables.tf
@@ -34,6 +34,12 @@ variable "name_suffix" {
   default     = ""
 }
 
+variable "data_api_consumer_role_arns" {
+  description = "Role ARNs allowed to assume this cluster's Data API role. No role is created when empty."
+  type        = list(string)
+  default     = []
+}
+
 variable "snapshot_identifier" {
   description = "Optional identifier (or ARN) of an RDS cluster snapshot to restore from on initial creation."
   type        = string

--- a/infrastructure/critical/outputs.tf
+++ b/infrastructure/critical/outputs.tf
@@ -10,11 +10,12 @@ locals {
 output "id_minter_rds" {
   value = {
     for name, instance in local.id_minter_rds_instances : name => {
-      cluster_id                = instance.rds_cluster_id
-      cluster_arn               = instance.rds_cluster_arn
-      ingress_security_group_id = instance.ingress_security_group_id
-      master_user_secret_arn    = instance.master_user_secret_arn
-      subnet_group_name         = instance.subnet_group_name
+      cluster_id                    = instance.rds_cluster_id
+      cluster_arn                   = instance.rds_cluster_arn
+      ingress_security_group_id     = instance.ingress_security_group_id
+      master_user_secret_arn        = instance.master_user_secret_arn
+      identifiers_api_read_role_arn = instance.identifiers_api_read_role_arn
+      subnet_group_name             = instance.subnet_group_name
     }
   }
 }

--- a/infrastructure/critical/rds_id_minter.tf
+++ b/infrastructure/critical/rds_id_minter.tf
@@ -35,4 +35,8 @@ module "id_minter_rds_2026_07_03" {
   max_scaling_capacity = 32
 
   master_username = data.aws_ssm_parameter.rds_username.value
+
+  data_api_consumer_role_arns = [
+    "arn:aws:iam::756629837203:role/lambda-role-identifiers-api-stage",
+  ]
 }


### PR DESCRIPTION
## What does this change?

Adds a role in the platform account that the Identifiers API's Lambda can assume in order to read the id-minter registry over the RDS Data API, and grants it on the 2026-07-03 cluster.

wellcomecollection/platform#6680. The Identifiers API runs in the catalogue account, and the Data API rejects a cluster owned by another account, so the Lambda has to make the call as a platform-account identity.

- `modules/id-minter-rds/iam.tf` creates the role, with `rds-data:ExecuteStatement` on the cluster and `secretsmanager:GetSecretValue` on its secret. Nothing is created when no consumer is named, so the production cluster is unaffected.
- The trust names the consumer's account with an `ArnEquals` condition on `aws:PrincipalArn`, so it does not depend on the Lambda's role existing yet.
- `rds_id_minter.tf` grants the stage Lambda on the 2026-07-03 cluster only. Production comes with wellcomecollection/platform#6543.
- The role ARN joins the `id_minter_rds` output map, which catalogue-api already reads.

## Applying it

Can be applied at any time, in either order relative to the catalogue-api side. The whole path is verified by the lookup check in wellcomecollection/platform#6531, which needs the Lambda deployed too, so this does not close wellcomecollection/platform#6680.

## Notes

- `rds-data:ExecuteStatement` covers writes as well as reads, and IAM has no read-only form of it. The read-only guarantee comes from the guard in the application, and then the SELECT-only user from wellcomecollection/platform#6533, which should also replace the master secret here.
- The production cluster's entry in the output map is null until it is granted.
- The policy names the cluster's current master secret, and a respin creates a new one, so this stack needs re-applying after each round's rebuild.
