### PR TITLE
scale up, turn on and listen to reindexer

### DIFF
--- a/infrastructure/critical/es_cluster.tf
+++ b/infrastructure/critical/es_cluster.tf
@@ -7,8 +7,11 @@ module "es_cluster_2026_07_03" {
 
   cluster_date = "2026-07-03"
 
-  memory     = "4g"
-  node_count = 3
+  # Sized for the round 3 full reindex (platform#6624), matching rounds 1 and 2.
+  # The scale-down apply only runs once a day, so it stays here until the
+  # comparison signs off rather than being taken down and brought back up.
+  memory     = "30g"
+  node_count = 2
 
   traffic_filter_ids = [
     local.shared_infra["ec_platform_privatelink_traffic_filter_id"],

--- a/pipeline/terraform/2026-07-03/main.tf
+++ b/pipeline/terraform/2026-07-03/main.tf
@@ -1,13 +1,12 @@
 module "pipeline" {
   source = "../modules/pipeline_new"
 
-  # Quiesced while the pipeline's stateful parts are cleared for round 3
-  # (platform#6623), so nothing writes into the state being wiped. Back on for
-  # the reindex, along with the enable_* flags below.
+  # Scaled up for the round 3 full reindex (platform#6624). The matcher DB comes
+  # back down as soon as the reindex finishes; tasks follow once the queues drain.
   reindexing_state = {
-    listen_to_reindexer = false
-    scale_up_tasks      = false
-    scale_up_matcher_db = false
+    listen_to_reindexer = true
+    scale_up_tasks      = true
+    scale_up_matcher_db = true
   }
 
   index_dates = {
@@ -24,11 +23,11 @@ module "pipeline" {
   # Base AMI for ECS instances
   ami_id = "resolve:ssm:arn:aws:ssm:eu-west-1:760097843905:parameter/imagebuilder/weco-al2023-ecs-optimised-x86_64/latest"
 
-  enable_adapter_transformer_trigger           = false
+  enable_adapter_transformer_trigger           = true
   disable_calm_transformer_topic_subscriptions = true
-  enable_id_minter_schedule                    = false
-  enable_graph_pipeline_schedule               = false
-  enable_image_inferrer_schedule               = false
+  enable_id_minter_schedule                    = true
+  enable_graph_pipeline_schedule               = true
+  enable_image_inferrer_schedule               = true
 
   pipeline_date = local.pipeline_date // namespaces services
   graph_date    = "2026-07-03"        // namespaces graph database


### PR DESCRIPTION
## What does this change?

Re-enables the `2026-07-03` pipeline after the round 3 clear (platform#6623 phase 7) and scales it up for the full reindex (platform#6624).

Both changes are already applied, on 2026-09-04, so this PR records a change that is live rather than proposing one. `infrastructure/critical` is shared and applied by hand, which means a merged but unapplied change there gets triggered by whoever next applies the root for an unrelated reason. `docs/pipeline/id-minter-respin.md` covers why we apply before merging on that root.

In `pipeline/terraform/2026-07-03/main.tf`, the four `enable_*` flags go back on, `listen_to_reindexer` goes on so the legacy transformers pick up the reindexer topics, and `scale_up_tasks` and `scale_up_matcher_db` go on for the bulk run.

`disable_calm_transformer_topic_subscriptions` deliberately stays at `true`. It predates the quiesce and was never part of it. Calm is only transformed in reindex mode over the third-party archive subset in `reindexer/scripts/third_party_archives.txt`, so with `listen_to_reindexer` on, the calm transformer queue picks up `calm_reindexer_topic` while still receiving nothing from `calm_adapter_topic`. That combination looks odd in the plan and is intended.

In `infrastructure/critical/es_cluster.tf`, 30g across 2 zones. This changed nothing in AWS: the cluster was already running at 30g across 2 zones, so the targeted plan reported no changes. What it fixes is the config, which still said 4g across 3 zones. Until the two agree, anyone applying `infrastructure/critical` for an unrelated reason downsizes the reindex cluster without meaning to, and since the scale-down apply only runs once a day that is not quick to reverse. The likely cause of the gap is that #3611's scale-up was applied without the PR ever being merged, so merging this is what finally closes it.

### Why not the staged PRs

#3611, #3612 and #3614 were pre-staged for this step, but all three were cut before the quiesce landed and they overlap on the same five lines of `main.tf`. #3611's diff still carries `listen_to_reindexer = true` from its base, so it needed a careful rebase rather than a merge. I think sequencing three rebased PRs to land one five-line change carries more risk than doing it once here.

### Checklist

- [ ] Does this change the display model the catalogue API returns? If so, regenerate the test documents under `catalogue_graph/document_generators/test_documents`. After merge, `sync-test-documents.yml` copies them into `wellcomecollection/catalogue-api` as an auto-PR, where OpenAPI contract tests validate the published spec against them; expect that PR to fail CI until the spec (`catalogue-api/reference/catalogue.yaml`) documents the new shape.

## How to test

Both applies are done, so this is what the plans contained and what came back.

The critical root, targeted at the cluster, reported `No changes. Your infrastructure matches the configuration.`:

```
cd infrastructure/critical
./run_terraform.sh plan -target=module.es_cluster_2026_07_03
```

Keep that one targeted. Main is still behind on other resources in this root, so an untargeted apply there has side effects.

The pipeline root planned 16 to add, 45 to change, 11 to destroy, and applied cleanly. Every change traced back to one of the flags above: the trigger and schedule state flips, the transformer and inferrer capacity changes, the matcher lambda and event source mapping sizing, the two DynamoDB tables moving to provisioned capacity, and five new reindexer topic subscriptions. No index resources, and no id-minter secret churn, which was settled in platform#6623 phase 3.

After the apply, each of the five reindexer destination topics has exactly one subscriber, the matching `catalogue-2026-07-03` transformer queue, with production on none of them. That covers the platform#6624 prerequisite about production being out of reindexing at the moment of use.

## How can we measure success?

The round 3 reindex runs (platform#6624) and the works funnel closes, with `works-source` equal to `works-identified`. That comparison also stands in for the quiesce-span id-minter replay: a full reindex resends every record through the minter, so an explicit replay is only needed if the counts differ.

## Have we considered potential risks?

platform#6624 asks for `scale_up_matcher_db` to go on last and separately, after tasks and ES, on the grounds that it should come off first. This PR turns all three on together. The cost is the idle provisioned capacity on the two matcher tables and their global secondary indexes between this apply and the start of the reindex, which is small, and nothing is blocked by it. Switching a table from on-demand to provisioned has no rate limit, and switching back is allowed up to four times in a 24 hour rolling window, so the tables can return to on-demand as soon as the reindex finishes. Neither table has used any of those switches recently.

The inferrer launch template moves from `c5.xlarge` to `c5.2xlarge`, which the replaced task definition needs: its containers total 8192 CPU units, so they would not place on a 4 vCPU instance. The ASG was at zero desired with no running instances at apply time, so there was nothing to cycle and the change takes effect on the next launch.

Scale-downs from here: the matcher DynamoDB goes back to on-demand as soon as the reindex finishes. The ES cluster and the scaled-up tasks stay exactly as they are through Monday's comparison. I think the saving is not worth the terraform round trip for those two, and taking the cluster down would put Monday behind a scale-up that can only be attempted once a day if anything went wrong with it.
