### PR TITLE
Folio transformer: add title BDD tests

### DIFF
--- a/catalogue_graph/tests/adapters/transformers/folio/BDD/conftest.py
+++ b/catalogue_graph/tests/adapters/transformers/folio/BDD/conftest.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import re
 from datetime import datetime
 
 import pytest
 from pymarc.record import Record
-from pytest_bdd import then, when
+from pytest_bdd import parsers, then, when
 
 from adapters.transformers.builders.folio_work_builder import FolioWorkBuilder
 from models.pipeline.source.work import VisibleSourceWork
@@ -22,9 +23,9 @@ def do_transform(marc_record: Record) -> VisibleSourceWork:
     ).transform_visible_work()
 
 
-@then("transforming the record raises ValueError")
-def check_transform_raises_error(marc_record: Record) -> None:
-    with pytest.raises(ValueError):
+@then(parsers.parse('transforming the record raises ValueError "{message}"'))
+def check_transform_raises_error(marc_record: Record, message: str) -> None:
+    with pytest.raises(ValueError, match=re.escape(message)):
         _ = FolioWorkBuilder(
             marc_record, last_modified=datetime(2020, 1, 1)
         ).transform_visible_work()

--- a/catalogue_graph/tests/adapters/transformers/folio/BDD/features/minimal_record.feature
+++ b/catalogue_graph/tests/adapters/transformers/folio/BDD/features/minimal_record.feature
@@ -17,4 +17,4 @@ Feature: The bare minimum MARC record for an item
     Given a MARC record with field 001 "abc123"
     And the MARC record has a 999 field with indicators "f" "f" with subfield "i" value "10000000-0000-0000-0000-000000000001"
     And the MARC record has a 245 field with subfield "a" value ""
-    Then transforming the record raises ValueError
+    Then transforming the record raises ValueError "Empty title field (245) after processing subfields"

--- a/catalogue_graph/tests/adapters/transformers/folio/BDD/features/title.feature
+++ b/catalogue_graph/tests/adapters/transformers/folio/BDD/features/title.feature
@@ -1,0 +1,79 @@
+Feature: title (MARC 245)
+  The title is built from MARC 245 subfields ǂa, ǂb, ǂc, ǂh, ǂn and ǂp,
+  joined with a space in the order they appear in the field. Anything in
+  square brackets is stripped from ǂh, and a ǂh with nothing after it to
+  join to is dropped. Title is mandatory: a record without a usable 245
+  fails to transform.
+
+  These scenarios mirror the unit tests of the Scala transformer this
+  replaces (MarcTitleTest.scala), including its test data, so the two can
+  be compared directly.
+
+  http://www.loc.gov/marc/bibliographic/bd245.html
+
+  Background:
+    Given a MARC record with field 001 "abc123"
+    And the MARC record has a 999 field with indicators "f" "f" with subfield "i" value "10000000-0000-0000-0000-000000000001"
+
+  # Ported from MarcTitleTest.scala.
+
+  Scenario: The title is built from the 245 field
+    Given the MARC record has a 245 field with subfield "a" value "hello"
+    When I transform the MARC record
+    Then the work's title is "hello"
+
+  Scenario: The first 245 is used if a record erroneously has more than one
+    Given the MARC record has a 245 field with subfield "a" value "hello world"
+    And the MARC record has another 245 field with subfield "a" value "hello dolly"
+    When I transform the MARC record
+    Then the work's title is "hello world"
+
+  Scenario: The title is built from subfields ǂa, ǂb, ǂc, ǂh, ǂn and ǂp
+    Given the MARC record has a 245 field with subfield "a" value "cyntaf" and subfield "b" value "ail" and subfield "c" value "trydydd" and subfield "h" value "pedwerydd" and subfield "n" value "pumed" and subfield "p" value "chweched" and subfield "k" value "saithfed"
+    When I transform the MARC record
+    Then the work's title is "cyntaf ail trydydd pedwerydd pumed chweched"
+
+  Scenario: The chosen subfields are joined in document order
+    Given the MARC record has a 245 field with subfield "h" value "cyntaf" and subfield "p" value "ail" and subfield "c" value "trydydd" and subfield "n" value "pedwerydd" and subfield "a" value "pumed" and subfield "b" value "chweched" and subfield "k" value "saithfed"
+    When I transform the MARC record
+    Then the work's title is "cyntaf ail trydydd pedwerydd pumed chweched"
+
+  Scenario: Repeated subfields are all kept
+    # Technically only ǂn and ǂp are repeatable, but the transformer is not picky
+    Given the MARC record has a 245 field with subfield "n" value "cyntaf" and subfield "p" value "ail" and subfield "n" value "trydydd" and subfield "p" value "pedwerydd" and subfield "h" value "pumed" and subfield "p" value "chweched" and subfield "p" value "saithfed"
+    When I transform the MARC record
+    Then the work's title is "cyntaf ail trydydd pedwerydd pumed chweched saithfed"
+
+  Scenario: A trailing ǂh is dropped, with nothing to join it to
+    Given the MARC record has a 245 field with subfield "a" value "cyntaf" and subfield "h" value "ail" and subfield "p" value "trydydd" and subfield "h" value "ignore me, I'm not here!"
+    When I transform the MARC record
+    Then the work's title is "cyntaf ail trydydd"
+
+  Scenario: Square bracket content is stripped from ǂh but left in other subfields
+    Given the MARC record has a 245 field with subfield "a" value "cyntaf [un]" and subfield "h" value "ail [dau]" and subfield "p" value "trydydd"
+    When I transform the MARC record
+    Then the work's title is "cyntaf [un] ail trydydd"
+
+  Scenario: A record with no 245 field fails to transform
+    Then transforming the record raises ValueError
+
+  Scenario: A 245 with no suitable subfields fails to transform
+    Given the MARC record has a 245 field with subfield "7" value "the back of a lorry"
+    Then transforming the record raises ValueError
+
+  Scenario: A 245 whose only suitable subfield is ǂh fails to transform
+    # A trailing ǂh is discarded, so this is the same as having no subfields
+    Given the MARC record has a 245 field with subfield "h" value "the back of a lorry"
+    Then transforming the record raises ValueError
+
+  # Deliberate improvements on the Scala, which returns a blank title in the
+  # first case and mishandles the pathological second case by its own admission.
+
+  Scenario: A 245 with only whitespace content fails to transform
+    Given the MARC record has a 245 field with subfield "a" value "   "
+    Then transforming the record raises ValueError
+
+  Scenario: Only the trailing ǂh is dropped when an earlier ǂh has identical content
+    Given the MARC record has a 245 field with subfield "a" value "cyntaf" and subfield "h" value "ail" and subfield "p" value "trydydd" and subfield "h" value "ail"
+    When I transform the MARC record
+    Then the work's title is "cyntaf ail trydydd"

--- a/catalogue_graph/tests/adapters/transformers/folio/BDD/features/title.feature
+++ b/catalogue_graph/tests/adapters/transformers/folio/BDD/features/title.feature
@@ -55,23 +55,27 @@ Feature: title (MARC 245)
     Then the work's title is "cyntaf [un] ail trydydd"
 
   Scenario: A record with no 245 field fails to transform
-    Then transforming the record raises ValueError
+    Then transforming the record raises ValueError "Missing title field (245)"
+
+  Scenario: A 245 field with no subfields at all fails to transform
+    Given the MARC record has a 245 field with no subfields
+    Then transforming the record raises ValueError "Empty title field (245) after processing subfields"
 
   Scenario: A 245 with no suitable subfields fails to transform
     Given the MARC record has a 245 field with subfield "7" value "the back of a lorry"
-    Then transforming the record raises ValueError
+    Then transforming the record raises ValueError "Empty title field (245) after processing subfields"
 
   Scenario: A 245 whose only suitable subfield is ǂh fails to transform
     # A trailing ǂh is discarded, so this is the same as having no subfields
     Given the MARC record has a 245 field with subfield "h" value "the back of a lorry"
-    Then transforming the record raises ValueError
+    Then transforming the record raises ValueError "Empty title field (245) after processing subfields"
 
   # Deliberate improvements on the Scala, which returns a blank title in the
   # first case and mishandles the pathological second case by its own admission.
 
   Scenario: A 245 with only whitespace content fails to transform
     Given the MARC record has a 245 field with subfield "a" value "   "
-    Then transforming the record raises ValueError
+    Then transforming the record raises ValueError "Empty title field (245) after processing subfields"
 
   Scenario: Only the trailing ǂh is dropped when an earlier ǂh has identical content
     Given the MARC record has a 245 field with subfield "a" value "cyntaf" and subfield "h" value "ail" and subfield "p" value "trydydd" and subfield "h" value "ail"

--- a/catalogue_graph/tests/adapters/transformers/folio/BDD/test_title.py
+++ b/catalogue_graph/tests/adapters/transformers/folio/BDD/test_title.py
@@ -1,0 +1,3 @@
+from pytest_bdd import scenarios
+
+scenarios("./features/title.feature")

--- a/catalogue_graph/tests/gherkin_steps/marc.py
+++ b/catalogue_graph/tests/gherkin_steps/marc.py
@@ -51,6 +51,17 @@ def add_field(
     marc_record.add_field(Field(tag=tag, indicators=indicators, subfields=subfields))
 
 
+empty_field_step_regex = parsers.re(
+    r"the MARC record has (?:a|another) (?P<tag>\d{3}) field with no subfields"
+)
+
+
+@given(empty_field_step_regex)
+def add_empty_field(marc_record: Record, tag: str) -> None:
+    """A malformed data field: present in the record, but wholly empty."""
+    marc_record.add_field(Field(tag=tag))
+
+
 replace_field_step_regex = parsers.re(
     r"the MARC record's only (?P<tag>\d{3}) field"
     r'(?: with indicators "(?P<ind1>[^"]?)" "(?P<ind2>[^"]?)"|)'


### PR DESCRIPTION
## What does this change?

Addresses https://github.com/wellcomecollection/platform/issues/6545

The ticket asks to determine FOLIO→Work mapping for the title field. This mapping already exists: the Folio transformer extracts titles from MARC 245 (via the shared `MarcXmlWorkBuilder` class). This PR translates existing Scala unit tests into Python BDD tests to verify that the extracted Python titles match those extracted by the Sierra transformer. Two tests at the end of the feature file codify cases where the Python behaviour deliberately diverges from the Scala behaviour.

### Checklist

- [ ] Does this change the display model the catalogue API returns? If so, regenerate the test documents under `catalogue_graph/document_generators/test_documents`. After merge, `sync-test-documents.yml` copies them into `wellcomecollection/catalogue-api` as an auto-PR, where OpenAPI contract tests validate the published spec against them; expect that PR to fail CI until the spec (`catalogue-api/reference/catalogue.yaml`) documents the new shape.

## How to test

I transformed a snapshot of all Folio works and compared the extracted titles against those stored on Sierra works in the source index. This produced 761,585 matches and 39 differences (nearly a 100% match), with one caveat (see below). All 39 differences are upstream, not attributable to transformer logic differences.

**NFC normalisation**
All Sierra titles were normalised using `unicodedata.normalize("NFC", title)` before they were compared to Folio titles. Sierra uses mixed unicode normalisation, where some diacritics are stored as a decomposed combining sequence (base character followed by separate combining accent or modifier), and some diacritics are precomposed. 

Folio titles use pure NFC, which is an improvement and fixes an active bug which makes some Sierra works difficult to find in the frontend. For example, users currently cannot find [this work](https://wellcomecollection.org/works/bdmkg6dc) by typing `muṟaikaḷ`, since most standard keyboards produce NFC, and the work is only returned when the query uses the combining-mark form.

## How can we measure success?

The title field on Folio works should match its counterpart on Sierra works.

## Have we considered potential risks?

There will be additional Folio data loads which might change what the raw MARC data looks like. The Folio pipeline is non-production, and we will spot data changes in upcoming validation runs before releasing.