### PR TITLE
scaling matcher down, DDB done manually EOD Friday

### DIFF
--- a/pipeline/terraform/2026-07-03/main.tf
+++ b/pipeline/terraform/2026-07-03/main.tf
@@ -1,12 +1,12 @@
 module "pipeline" {
   source = "../modules/pipeline_new"
 
-  # Scaled up for the round 3 full reindex (platform#6624). The matcher DB comes
-  # back down as soon as the reindex finishes; tasks follow once the queues drain.
+  # Matching is done for round 3, so the matcher DB goes back to on demand.
+  # Tasks stay up until the comparison signs off (platform#6642).
   reindexing_state = {
     listen_to_reindexer = true
     scale_up_tasks      = true
-    scale_up_matcher_db = true
+    scale_up_matcher_db = false
   }
 
   index_dates = {


### PR DESCRIPTION
## What does this change?

Scaling down matcher after reindex
Keeping ES and other tasks scaled up until verification sign-off
NOTE: the DDB billing mode was set to "PAY_PER_REQUEST" via CLI on Friday to minimise costs
The rest of the matcher was still scaled up as needed for end of reindex: id-minter replay gap + miro images

### Checklist

- [ ] Does this change the display model the catalogue API returns? If so, regenerate the test documents under `catalogue_graph/document_generators/test_documents`. After merge, `sync-test-documents.yml` copies them into `wellcomecollection/catalogue-api` as an auto-PR, where OpenAPI contract tests validate the published spec against them; expect that PR to fail CI until the spec (`catalogue-api/reference/catalogue.yaml`) documents the new shape.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z." -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? -->
