### PR TITLE
Give the Identifiers API its own read-only registry credential

### DIFF
--- a/infrastructure/critical/README.md
+++ b/infrastructure/critical/README.md
@@ -23,3 +23,17 @@ aws stepfunctions start-execution \
 ```
 
 The `id` field must contain only letters, digits, and hyphens, and the resulting `ExportTaskIdentifier` (`id-exp-{id}`) must be at most 60 characters. When triggered by EventBridge, the event ID (a UUID) is used automatically.
+
+## Identifiers API read-only credential (id-minter)
+
+The Identifiers API reads the registry as `identifiers_api_read`, a user with `SELECT` on one table, rather than as the master user. Terraform creates the secret and configures its rotation; the database user and the secret's first value come from `create_identifiers_api_user.sh`, so that no password passes through terraform state.
+
+After applying to a cluster with `data_api_consumer_role_arns` set, run the script with platform account credentials, passing the cluster and the secret terraform created:
+
+```bash
+./create_identifiers_api_user.sh \
+  identifiers-v2-serverless-2026-07-03 \
+  rds/identifiers-v2-serverless-2026-07-03/identifiers_api_read
+```
+
+Each run resets the password and rewrites the secret, so it is safe to repeat, and it needs repeating for any other cluster the API reads. Rotation does not fire on creation because the secret is empty until the script has run, so trigger the first one with `aws secretsmanager rotate-secret`.

--- a/infrastructure/critical/README.md
+++ b/infrastructure/critical/README.md
@@ -26,7 +26,7 @@ The `id` field must contain only letters, digits, and hyphens, and the resulting
 
 ## Identifiers API read-only credential (id-minter)
 
-The Identifiers API reads the registry as `identifiers_api_read`, a user with `SELECT` on one table, rather than as the master user. Terraform creates the secret and configures its rotation; the database user and the secret's first value come from `create_identifiers_api_user.sh`, so that no password passes through terraform state.
+The Identifiers API reads the registry as `identifiers_api_read`, a user with `SELECT` on one table, rather than as the master user. Terraform generates the password and holds it in the credential secret; creating the MySQL user is SQL, so `create_identifiers_api_user.sh` does that part and sets the user's password to match the secret.
 
 After applying to a cluster with `data_api_consumer_role_arns` set, run the script with platform account credentials, passing the cluster and the secret terraform created:
 
@@ -36,4 +36,4 @@ After applying to a cluster with `data_api_consumer_role_arns` set, run the scri
   rds/identifiers-v2-serverless-2026-07-03/identifiers_api_read
 ```
 
-Each run resets the password and rewrites the secret, so it is safe to repeat, and it needs repeating for any other cluster the API reads. Rotation does not fire on creation because the secret is empty until the script has run, so trigger the first one with `aws secretsmanager rotate-secret`.
+It is safe to re-run, and it needs running for any other cluster the API reads. The password does not rotate on a schedule: to change it, replace `random_password.identifiers_api_read` in terraform, apply, and run the script again.

--- a/infrastructure/critical/create_identifiers_api_user.sh
+++ b/infrastructure/critical/create_identifiers_api_user.sh
@@ -79,8 +79,11 @@ PASSWORD="$(
 echo "Creating ${DB_USER} and granting SELECT on ${DB_NAME}.${DB_TABLE}"
 
 # CREATE then ALTER so a re-run sets the password whether or not the user exists.
+# REVOKE before GRANT so a re-run leaves exactly SELECT, rather than adding it to
+# whatever the user already had.
 run_as_master <<< "CREATE USER IF NOT EXISTS '${DB_USER}'@'%' IDENTIFIED BY '${PASSWORD}'"
 run_as_master <<< "ALTER USER '${DB_USER}'@'%' IDENTIFIED BY '${PASSWORD}'"
+run_as_master <<< "REVOKE IF EXISTS ALL PRIVILEGES, GRANT OPTION FROM '${DB_USER}'@'%'"
 run_as_master <<< "GRANT SELECT ON \`${DB_NAME}\`.\`${DB_TABLE}\` TO '${DB_USER}'@'%'"
 
 echo "Writing ${SECRET_ID}"

--- a/infrastructure/critical/create_identifiers_api_user.sh
+++ b/infrastructure/critical/create_identifiers_api_user.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
-# Create the Identifiers API's read-only database user on an id-minter cluster
-# and write its credentials into the secret Terraform created for it
-# (platform#6533).
+# Make an id-minter cluster agree with the Identifiers API's credential secret
+# (platform#6533): create the read-only MySQL user if it is missing, set its
+# password to the one Terraform generated, and grant it SELECT on one table.
 #
-# Runs as the cluster master user, over the Data API so it needs no VPC access.
-# Re-running resets the password and rewrites the secret. Run it once per cluster
-# the API reads: again for production, and again for the FOLIO registry.
+# Run after applying Terraform, and again after changing the password there.
+# Re-running is safe. It runs as the cluster master user over the Data API, so it
+# needs no VPC access.
 #
 # Usage:
 #   ./create_identifiers_api_user.sh \
@@ -19,14 +19,8 @@ set -o pipefail
 CLUSTER_IDENTIFIER="${1:?usage: $0 <cluster-identifier> <secret-id>}"
 SECRET_ID="${2:?usage: $0 <cluster-identifier> <secret-id>}"
 
-DB_USER="identifiers_api_read"
 DB_NAME="identifiers"
 DB_TABLE="identifiers"
-
-# Kept in step with excludeCharacters in
-# modules/id-minter-rds/identifiers_api_credential.tf, so rotated passwords stay
-# compatible. Change them together.
-EXCLUDE_CHARACTERS="\"'@/\\\`"
 
 REQUEST_FILE="$(mktemp)"
 chmod 600 "${REQUEST_FILE}"
@@ -34,15 +28,27 @@ trap 'rm -f "${REQUEST_FILE}"' EXIT
 
 echo "Resolving ${CLUSTER_IDENTIFIER}"
 
-read -r CLUSTER_ARN MASTER_SECRET_ARN DB_HOST DB_PORT < <(
+read -r CLUSTER_ARN MASTER_SECRET_ARN < <(
   aws rds describe-db-clusters \
     --db-cluster-identifier "${CLUSTER_IDENTIFIER}" \
-    --query 'DBClusters[0].[DBClusterArn,MasterUserSecret.SecretArn,Endpoint,Port]' \
+    --query 'DBClusters[0].[DBClusterArn,MasterUserSecret.SecretArn]' \
     --output text
 )
 
 if [[ -z "${MASTER_SECRET_ARN}" || "${MASTER_SECRET_ARN}" == "None" ]]; then
   echo "No master user secret on ${CLUSTER_IDENTIFIER}" >&2
+  exit 1
+fi
+
+echo "Reading ${SECRET_ID}"
+
+SECRET="$(aws secretsmanager get-secret-value --secret-id "${SECRET_ID}" --output json)"
+SECRET_ARN="$(printf '%s' "${SECRET}" | jq -r '.ARN')"
+DB_USER="$(printf '%s' "${SECRET}" | jq -r '.SecretString | fromjson | .username')"
+PASSWORD="$(printf '%s' "${SECRET}" | jq -r '.SecretString | fromjson | .password')"
+
+if [[ -z "${DB_USER}" || "${DB_USER}" == "null" ]]; then
+  echo "${SECRET_ID} has no username; has Terraform been applied?" >&2
   exit 1
 fi
 
@@ -67,55 +73,15 @@ run_as_master() {
     >/dev/null
 }
 
-PASSWORD="$(
-  aws secretsmanager get-random-password \
-    --password-length 32 \
-    --exclude-characters "${EXCLUDE_CHARACTERS}" \
-    --require-each-included-type \
-    --query RandomPassword \
-    --output text
-)"
+echo "Setting up ${DB_USER} with SELECT on ${DB_NAME}.${DB_TABLE}"
 
-echo "Creating ${DB_USER} and granting SELECT on ${DB_NAME}.${DB_TABLE}"
-
-# CREATE then ALTER so a re-run sets the password whether or not the user exists.
-# REVOKE before GRANT so a re-run leaves exactly SELECT, rather than adding it to
-# whatever the user already had.
+# CREATE then ALTER so the password is set whether or not the user exists, and
+# REVOKE before GRANT so the result is exactly SELECT rather than SELECT plus
+# whatever was there before.
 run_as_master <<< "CREATE USER IF NOT EXISTS '${DB_USER}'@'%' IDENTIFIED BY '${PASSWORD}'"
 run_as_master <<< "ALTER USER '${DB_USER}'@'%' IDENTIFIED BY '${PASSWORD}'"
 run_as_master <<< "REVOKE IF EXISTS ALL PRIVILEGES, GRANT OPTION FROM '${DB_USER}'@'%'"
 run_as_master <<< "GRANT SELECT ON \`${DB_NAME}\`.\`${DB_TABLE}\` TO '${DB_USER}'@'%'"
-
-echo "Writing ${SECRET_ID}"
-
-# engine, host, port and dbname are for the rotation function; the Data API reads
-# only username and password.
-jq -n \
-  --arg secretId "${SECRET_ID}" \
-  --arg host "${DB_HOST}" \
-  --argjson port "${DB_PORT}" \
-  --arg username "${DB_USER}" \
-  --arg dbname "${DB_NAME}" \
-  --rawfile password <(printf '%s' "${PASSWORD}") \
-  '{
-    SecretId: $secretId,
-    SecretString: ({
-      engine: "mysql",
-      host: $host,
-      port: $port,
-      username: $username,
-      password: $password,
-      dbname: $dbname
-    } | tostring)
-  }' > "${REQUEST_FILE}"
-
-SECRET_ARN="$(
-  aws secretsmanager put-secret-value \
-    --cli-input-json "file://${REQUEST_FILE}" \
-    --no-cli-pager \
-    --query ARN \
-    --output text
-)"
 
 echo "Verifying ${DB_USER} can read"
 
@@ -144,6 +110,5 @@ if delete_error="$(
 fi
 
 echo "  refused with: ${delete_error}"
-
 echo
-echo "Done. Secret: ${SECRET_ARN}"
+echo "Done."

--- a/infrastructure/critical/create_identifiers_api_user.sh
+++ b/infrastructure/critical/create_identifiers_api_user.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Create the Identifiers API's read-only database user on an id-minter cluster
+# and write its credentials into the secret Terraform created for it
+# (platform#6533).
+#
+# Runs as the cluster master user, over the Data API so it needs no VPC access.
+# Re-running resets the password and rewrites the secret. Run it once per cluster
+# the API reads: again for production, and again for the FOLIO registry.
+#
+# Usage:
+#   ./create_identifiers_api_user.sh \
+#     identifiers-v2-serverless-2026-07-03 \
+#     rds/identifiers-v2-serverless-2026-07-03/identifiers_api_read
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+CLUSTER_IDENTIFIER="${1:?usage: $0 <cluster-identifier> <secret-id>}"
+SECRET_ID="${2:?usage: $0 <cluster-identifier> <secret-id>}"
+
+DB_USER="identifiers_api_read"
+DB_NAME="identifiers"
+DB_TABLE="identifiers"
+
+# Kept in step with excludeCharacters in
+# modules/id-minter-rds/identifiers_api_credential.tf, so rotated passwords stay
+# compatible. Change them together.
+EXCLUDE_CHARACTERS="\"'@/\\\`"
+
+REQUEST_FILE="$(mktemp)"
+chmod 600 "${REQUEST_FILE}"
+trap 'rm -f "${REQUEST_FILE}"' EXIT
+
+echo "Resolving ${CLUSTER_IDENTIFIER}"
+
+read -r CLUSTER_ARN MASTER_SECRET_ARN DB_HOST DB_PORT < <(
+  aws rds describe-db-clusters \
+    --db-cluster-identifier "${CLUSTER_IDENTIFIER}" \
+    --query 'DBClusters[0].[DBClusterArn,MasterUserSecret.SecretArn,Endpoint,Port]' \
+    --output text
+)
+
+if [[ -z "${MASTER_SECRET_ARN}" || "${MASTER_SECRET_ARN}" == "None" ]]; then
+  echo "No master user secret on ${CLUSTER_IDENTIFIER}" >&2
+  exit 1
+fi
+
+# Statement on stdin, request in a file, so a password-bearing statement never
+# reaches an argument list. continueAfterTimeout is advised for DDL.
+run_as_master() {
+  jq -Rs \
+    --arg resourceArn "${CLUSTER_ARN}" \
+    --arg secretArn "${MASTER_SECRET_ARN}" \
+    --arg database "${DB_NAME}" \
+    '{
+      resourceArn: $resourceArn,
+      secretArn: $secretArn,
+      database: $database,
+      continueAfterTimeout: true,
+      sql: (. | rtrimstr("\n"))
+    }' > "${REQUEST_FILE}"
+
+  aws rds-data execute-statement \
+    --cli-input-json "file://${REQUEST_FILE}" \
+    --no-cli-pager \
+    >/dev/null
+}
+
+PASSWORD="$(
+  aws secretsmanager get-random-password \
+    --password-length 32 \
+    --exclude-characters "${EXCLUDE_CHARACTERS}" \
+    --require-each-included-type \
+    --query RandomPassword \
+    --output text
+)"
+
+echo "Creating ${DB_USER} and granting SELECT on ${DB_NAME}.${DB_TABLE}"
+
+# CREATE then ALTER so a re-run sets the password whether or not the user exists.
+run_as_master <<< "CREATE USER IF NOT EXISTS '${DB_USER}'@'%' IDENTIFIED BY '${PASSWORD}'"
+run_as_master <<< "ALTER USER '${DB_USER}'@'%' IDENTIFIED BY '${PASSWORD}'"
+run_as_master <<< "GRANT SELECT ON \`${DB_NAME}\`.\`${DB_TABLE}\` TO '${DB_USER}'@'%'"
+
+echo "Writing ${SECRET_ID}"
+
+# engine, host, port and dbname are for the rotation function; the Data API reads
+# only username and password.
+jq -n \
+  --arg secretId "${SECRET_ID}" \
+  --arg host "${DB_HOST}" \
+  --argjson port "${DB_PORT}" \
+  --arg username "${DB_USER}" \
+  --arg dbname "${DB_NAME}" \
+  --rawfile password <(printf '%s' "${PASSWORD}") \
+  '{
+    SecretId: $secretId,
+    SecretString: ({
+      engine: "mysql",
+      host: $host,
+      port: $port,
+      username: $username,
+      password: $password,
+      dbname: $dbname
+    } | tostring)
+  }' > "${REQUEST_FILE}"
+
+SECRET_ARN="$(
+  aws secretsmanager put-secret-value \
+    --cli-input-json "file://${REQUEST_FILE}" \
+    --no-cli-pager \
+    --query ARN \
+    --output text
+)"
+
+echo "Verifying ${DB_USER} can read"
+
+aws rds-data execute-statement \
+  --resource-arn "${CLUSTER_ARN}" \
+  --secret-arn "${SECRET_ARN}" \
+  --database "${DB_NAME}" \
+  --no-cli-pager \
+  --sql "SELECT CanonicalId FROM ${DB_TABLE} LIMIT 1" \
+  >/dev/null
+
+echo "Verifying ${DB_USER} cannot write"
+
+# WHERE 1 = 0 matches nothing, so this cannot remove a row even if the grant were
+# wider than intended.
+if delete_error="$(
+  aws rds-data execute-statement \
+    --resource-arn "${CLUSTER_ARN}" \
+    --secret-arn "${SECRET_ARN}" \
+    --database "${DB_NAME}" \
+    --no-cli-pager \
+    --sql "DELETE FROM ${DB_TABLE} WHERE 1 = 0" 2>&1
+)"; then
+  echo "${DB_USER} was allowed to delete; the grant is wider than SELECT" >&2
+  exit 1
+fi
+
+echo "  refused with: ${delete_error}"
+
+echo
+echo "Done. Secret: ${SECRET_ARN}"

--- a/infrastructure/critical/modules/id-minter-rds/iam.tf
+++ b/infrastructure/critical/modules/id-minter-rds/iam.tf
@@ -48,14 +48,10 @@ data "aws_iam_policy_document" "identifiers_api_read" {
   }
 
   # The Data API reads the credential on the caller's behalf, so the caller needs
-  # access to the secret as well as to the cluster.
-  #
-  # This is the cluster master secret, so the grant is admin-level on the registry
-  # until https://github.com/wellcomecollection/platform/issues/6533 creates a
-  # SELECT-only user with its own secret. Point this at that secret when it lands,
-  # and do not add further consumers to data_api_consumer_role_arns before then.
+  # access to the secret as well as to the cluster. This is the API's own
+  # SELECT-only credential, not the cluster master secret.
   statement {
     actions   = ["secretsmanager:GetSecretValue"]
-    resources = [module.identifiers_v2_serverless_rds_cluster.master_user_secret_arn]
+    resources = [aws_secretsmanager_secret.identifiers_api_read[0].arn]
   }
 }

--- a/infrastructure/critical/modules/id-minter-rds/identifiers_api_credential.tf
+++ b/infrastructure/critical/modules/id-minter-rds/identifiers_api_credential.tf
@@ -1,14 +1,16 @@
 # The Identifiers API's own read-only database credential, granted to the Data
-# API role in iam.tf (platform#6533).
-#
-# create_identifiers_api_user.sh creates the MySQL user and writes the first
-# value, so Terraform never holds the password and rotation owns it from the
-# start. That is also why this is a bare secret rather than terraform-aws-secrets,
-# which writes a value.
+# API role in iam.tf (platform#6533). Terraform owns the password and the secret;
+# create_identifiers_api_user.sh creates the MySQL user and makes its password
+# match, because that is SQL and there is no AWS API for it.
 
-locals {
-  # Kept in step with EXCLUDE_CHARACTERS in create_identifiers_api_user.sh.
-  identifiers_api_password_exclude_characters = "\"'@/\\`"
+resource "random_password" "identifiers_api_read" {
+  count = local.identifiers_api_read_count
+
+  length = 32
+
+  # Excludes quotes, backslash, @, / and backtick, which would need escaping in
+  # the statements the script issues.
+  override_special = "!#$%^&*()-_=+[]{}<>:?"
 }
 
 resource "aws_secretsmanager_secret" "identifiers_api_read" {
@@ -17,74 +19,18 @@ resource "aws_secretsmanager_secret" "identifiers_api_read" {
   name        = "rds/identifiers-v2-serverless${local.hyphen_suffix}/identifiers_api_read"
   description = "Read-only credential for the Identifiers API"
 
-  # The script regenerates these credentials from scratch, so a recovery window
+  # The credential is reproducible from this configuration, so a recovery window
   # protects nothing and would leave the name reserved against a later recreate.
   recovery_window_in_days = 0
 }
 
-# The rotation function connects to the database on 3306 rather than through the
-# Data API, so unlike the API itself it has to sit in the VPC.
-#
-# It needs two security groups: this one for outbound access, and the cluster's
-# ingress group for the database to accept it. That group declares no egress
-# rules, which removes the default allow-all, so it grants no outbound access on
-# its own. The id-minter Lambda carries the same pair.
-resource "aws_security_group" "identifiers_api_rotation_egress" {
+resource "aws_secretsmanager_secret_version" "identifiers_api_read" {
   count = local.identifiers_api_read_count
 
-  name        = "identifiers_api_rotation_egress${local.underscore_suffix}"
-  description = "Allow the Identifiers API rotation function egress"
-  vpc_id      = var.vpc_id
+  secret_id = aws_secretsmanager_secret.identifiers_api_read[0].id
 
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  tags = {
-    Name = "identifiers-api-rotation-egress${local.hyphen_suffix}"
-  }
-}
-
-# AWS's published rotation function. Single user rather than alternating users,
-# because that variant changes the password by connecting as the user itself and
-# so needs no administrative credential.
-resource "aws_serverlessapplicationrepository_cloudformation_stack" "identifiers_api_rotation" {
-  count = local.identifiers_api_read_count
-
-  name             = "identifiers-api-read-rotation${local.hyphen_suffix}"
-  application_id   = "arn:aws:serverlessrepo:us-east-1:297356227824:applications/SecretsManagerRDSMySQLRotationSingleUser"
-  semantic_version = "1.1.722"
-  capabilities     = ["CAPABILITY_IAM", "CAPABILITY_RESOURCE_POLICY"]
-
-  parameters = {
-    functionName      = "identifiers-api-read-rotation${local.hyphen_suffix}"
-    excludeCharacters = local.identifiers_api_password_exclude_characters
-    vpcSubnetIds      = join(",", var.private_subnet_ids)
-
-    # The function runs in the VPC, so it needs telling where Secrets Manager is.
-    endpoint = "https://secretsmanager.eu-west-1.amazonaws.com"
-
-    vpcSecurityGroupIds = join(",", [
-      aws_security_group.identifiers_api_rotation_egress[0].id,
-      aws_security_group.rds_v2_ingress_security_group.id,
-    ])
-  }
-}
-
-resource "aws_secretsmanager_secret_rotation" "identifiers_api_read" {
-  count = local.identifiers_api_read_count
-
-  secret_id           = aws_secretsmanager_secret.identifiers_api_read[0].id
-  rotation_lambda_arn = aws_serverlessapplicationrepository_cloudformation_stack.identifiers_api_rotation[0].outputs["RotationLambdaARN"]
-
-  # create_identifiers_api_user.sh writes the first value, so rotating on creation
-  # would run against an empty secret. Trigger the first rotation by hand.
-  rotate_immediately = false
-
-  rotation_rules {
-    automatically_after_days = 30
-  }
+  secret_string = jsonencode({
+    username = "identifiers_api_read"
+    password = random_password.identifiers_api_read[0].result
+  })
 }

--- a/infrastructure/critical/modules/id-minter-rds/identifiers_api_credential.tf
+++ b/infrastructure/critical/modules/id-minter-rds/identifiers_api_credential.tf
@@ -1,0 +1,90 @@
+# The Identifiers API's own read-only database credential, granted to the Data
+# API role in iam.tf (platform#6533).
+#
+# create_identifiers_api_user.sh creates the MySQL user and writes the first
+# value, so Terraform never holds the password and rotation owns it from the
+# start. That is also why this is a bare secret rather than terraform-aws-secrets,
+# which writes a value.
+
+locals {
+  # Kept in step with EXCLUDE_CHARACTERS in create_identifiers_api_user.sh.
+  identifiers_api_password_exclude_characters = "\"'@/\\`"
+}
+
+resource "aws_secretsmanager_secret" "identifiers_api_read" {
+  count = local.identifiers_api_read_count
+
+  name        = "rds/identifiers-v2-serverless${local.hyphen_suffix}/identifiers_api_read"
+  description = "Read-only credential for the Identifiers API"
+
+  # The script regenerates these credentials from scratch, so a recovery window
+  # protects nothing and would leave the name reserved against a later recreate.
+  recovery_window_in_days = 0
+}
+
+# The rotation function connects to the database on 3306 rather than through the
+# Data API, so unlike the API itself it has to sit in the VPC.
+#
+# It needs two security groups: this one for outbound access, and the cluster's
+# ingress group for the database to accept it. That group declares no egress
+# rules, which removes the default allow-all, so it grants no outbound access on
+# its own. The id-minter Lambda carries the same pair.
+resource "aws_security_group" "identifiers_api_rotation_egress" {
+  count = local.identifiers_api_read_count
+
+  name        = "identifiers_api_rotation_egress${local.underscore_suffix}"
+  description = "Allow the Identifiers API rotation function egress"
+  vpc_id      = var.vpc_id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "identifiers-api-rotation-egress${local.hyphen_suffix}"
+  }
+}
+
+# AWS's published rotation function. Single user rather than alternating users,
+# because that variant changes the password by connecting as the user itself and
+# so needs no administrative credential.
+resource "aws_serverlessapplicationrepository_cloudformation_stack" "identifiers_api_rotation" {
+  count = local.identifiers_api_read_count
+
+  name             = "identifiers-api-read-rotation${local.hyphen_suffix}"
+  application_id   = "arn:aws:serverlessrepo:us-east-1:297356227824:applications/SecretsManagerRDSMySQLRotationSingleUser"
+  semantic_version = "1.1.722"
+  capabilities     = ["CAPABILITY_IAM", "CAPABILITY_RESOURCE_POLICY"]
+
+  parameters = {
+    functionName      = "identifiers-api-read-rotation${local.hyphen_suffix}"
+    excludeCharacters = local.identifiers_api_password_exclude_characters
+    vpcSubnetIds      = join(",", var.private_subnet_ids)
+
+    # The function runs in the VPC, so it needs telling where Secrets Manager is.
+    endpoint = "https://secretsmanager.eu-west-1.amazonaws.com"
+
+    vpcSecurityGroupIds = join(",", [
+      aws_security_group.identifiers_api_rotation_egress[0].id,
+      aws_security_group.rds_v2_ingress_security_group.id,
+    ])
+  }
+}
+
+resource "aws_secretsmanager_secret_rotation" "identifiers_api_read" {
+  count = local.identifiers_api_read_count
+
+  secret_id           = aws_secretsmanager_secret.identifiers_api_read[0].id
+  rotation_lambda_arn = aws_serverlessapplicationrepository_cloudformation_stack.identifiers_api_rotation[0].outputs["RotationLambdaARN"]
+
+  # create_identifiers_api_user.sh writes the first value, so rotating on creation
+  # would run against an empty secret. Trigger the first rotation by hand.
+  rotate_immediately = false
+
+  rotation_rules {
+    automatically_after_days = 30
+  }
+}

--- a/infrastructure/critical/modules/id-minter-rds/outputs.tf
+++ b/infrastructure/critical/modules/id-minter-rds/outputs.tf
@@ -14,6 +14,10 @@ output "identifiers_api_read_role_arn" {
   value = one(aws_iam_role.identifiers_api_read[*].arn)
 }
 
+output "identifiers_api_read_secret_arn" {
+  value = one(aws_secretsmanager_secret.identifiers_api_read[*].arn)
+}
+
 output "ingress_security_group_id" {
   value = aws_security_group.rds_v2_ingress_security_group.id
 }

--- a/infrastructure/critical/outputs.tf
+++ b/infrastructure/critical/outputs.tf
@@ -10,12 +10,13 @@ locals {
 output "id_minter_rds" {
   value = {
     for name, instance in local.id_minter_rds_instances : name => {
-      cluster_id                    = instance.rds_cluster_id
-      cluster_arn                   = instance.rds_cluster_arn
-      ingress_security_group_id     = instance.ingress_security_group_id
-      master_user_secret_arn        = instance.master_user_secret_arn
-      identifiers_api_read_role_arn = instance.identifiers_api_read_role_arn
-      subnet_group_name             = instance.subnet_group_name
+      cluster_id                      = instance.rds_cluster_id
+      cluster_arn                     = instance.rds_cluster_arn
+      ingress_security_group_id       = instance.ingress_security_group_id
+      master_user_secret_arn          = instance.master_user_secret_arn
+      identifiers_api_read_role_arn   = instance.identifiers_api_read_role_arn
+      identifiers_api_read_secret_arn = instance.identifiers_api_read_secret_arn
+      subnet_group_name               = instance.subnet_group_name
     }
   }
 }


### PR DESCRIPTION
## What does this change?

Gives the Identifiers API its own read-only credential on the id-minter registry, so it no longer needs the cluster master secret. Three of the six items on wellcomecollection/platform#6533.

The role added in #3624 grants `GetSecretValue` on the cluster's master secret, which is admin-level on the registry. This points that grant at a secret holding `identifiers_api_read`, a MySQL user with `SELECT` on `identifiers.identifiers` and nothing else.

`modules/id-minter-rds/identifiers_api_credential.tf` generates the password and stores the credential in a secret. `iam.tf` points the grant at that secret, and its ARN is exported through the `id_minter_rds` map so #6531's Terraform can read it through remote state.

Creating a MySQL user is SQL, so `create_identifiers_api_user.sh` does that part: it reads the secret, creates the user if it is missing, sets its password to match, revokes everything and grants `SELECT`. It runs as the master user over the Data API, so it needs no VPC access, and re-running it is safe.

The password does not rotate. To change it, replace `random_password.identifiers_api_read`, apply, and run the script again. #6533's `with rotation` is therefore unmet. Terraform generating the password also means it is held in Terraform state.

### Checklist

- [x] Does this change the display model the catalogue API returns? No, nothing here touches the pipeline or the transformers.

## How to test

Plan first:

```bash
cd infrastructure/critical && ./run_terraform.sh plan
```

Expect three additions, a `random_password`, a secret and its version, plus one in-place update to the inline IAM policy. Nothing should be replaced or destroyed.

After applying, set the database up to match:

```bash
./create_identifiers_api_user.sh \
  identifiers-v2-serverless-2026-07-03 \
  rds/identifiers-v2-serverless-2026-07-03/identifiers_api_read
```

The script checks its own work: it confirms the new user can run one of the API's two lookups, and that a `DELETE` is refused by the database.

## How can we measure success?

A lookup succeeds with the new credential, and a write is refused at the database rather than only by the `_assert_read_only` guard in the application. Both are checked by the script.

The rest of #6533 needs #6531's Lambda, which is what makes the deployed API read through this credential, so #6533 stays open after this merges.

## Have we considered potential risks?

`infrastructure/critical` is shared with the production id-minter and carries deletion protection. Every new resource shares the `count` driven by `data_api_consumer_role_arns`, which is set only on the 2026-07-03 cluster, so the production cluster gets nothing. The only change to an existing resource is one statement in an inline IAM policy.

Narrowing that grant is safe now because no Lambda holds the role yet, so no running service loses access to a secret it is still configured to read.

Changing the password later is a two-step operation with an outage between the steps. Applying a replaced `random_password` leaves the secret holding a password the database does not accept, and lookups fail until the script runs. The order is forced, because the script reads the password out of the secret. That is the operational cost of not rotating, and it does not apply yet because the Lambda from #6531 does not exist.
