### PR TITLE
Record catalogue_graph deploys as GitHub Deployments for the deploy tracker

### DIFF
--- a/.github/workflows/catalogue-graph-ci.yml
+++ b/.github/workflows/catalogue-graph-ci.yml
@@ -16,6 +16,8 @@ on:
 permissions:
   contents: read
   id-token: write
+  # The called deploy workflow records a GitHub Deployment
+  deployments: write
 
 jobs:
   python-checks:

--- a/.github/workflows/catalogue-graph-deploy.yml
+++ b/.github/workflows/catalogue-graph-deploy.yml
@@ -21,6 +21,7 @@ on:
 permissions:
   contents: read
   id-token: write
+  deployments: write
 
 # Claim the shared group only when triggered directly: called from CI, the
 # calling job already holds it. github.workflow is the caller's, not ours.
@@ -29,6 +30,29 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # One GitHub Deployment per run, for the deploy tracker: the tag is the
+  # commit being deployed. Task names the catalogue_graph unit.
+  start-deployment:
+    runs-on: ubuntu-latest
+    outputs:
+      id: ${{ steps.create.outputs.id }}
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Create GitHub Deployment
+        id: create
+        run: |
+          id=$(gh api "repos/$GITHUB_REPOSITORY/deployments" --input - --jq .id <<EOF
+          {"ref": "${{ inputs.deploy_tag }}", "environment": "prod",
+           "task": "deploy:catalogue_graph", "auto_merge": false,
+           "required_contexts": [], "description": "catalogue_graph lambdas"}
+          EOF
+          )
+          echo "id=$id" >> "$GITHUB_OUTPUT"
+          gh api "repos/$GITHUB_REPOSITORY/deployments/$id/statuses" \
+            -f state=in_progress \
+            -f log_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" > /dev/null
+
   discover-pipeline-dates:
     runs-on: ubuntu-latest
     outputs:
@@ -43,6 +67,7 @@ jobs:
 
   retag-prod-images:
     runs-on: ubuntu-latest
+    needs: [ start-deployment ]
     strategy:
       matrix:
         image_name: [ unified_pipeline_task, unified_pipeline_lambda ]
@@ -58,7 +83,7 @@ jobs:
 
   retag-dated-images:
     runs-on: ubuntu-latest
-    needs: [ discover-pipeline-dates ]
+    needs: [ start-deployment, discover-pipeline-dates ]
     strategy:
       matrix:
         pipeline_date: ${{ fromJSON(needs.discover-pipeline-dates.outputs.pipeline_dates) }}
@@ -134,3 +159,24 @@ jobs:
           role_to_assume: ${{ secrets.CATALOGUE_GRAPH_CI_ROLE_ARN }}
           aws_region: eu-west-1
           lambda_suffix: ${{ matrix.component }}
+
+  finish-deployment:
+    if: always() && needs.start-deployment.outputs.id != ''
+    runs-on: ubuntu-latest
+    needs:
+      - start-deployment
+      - discover-pipeline-dates
+      - deploy-unified-pipeline-lambdas
+      - deploy-dated-unified-pipeline-lambdas
+    env:
+      GH_TOKEN: ${{ github.token }}
+      # Any deploy job not succeeding is a failed deployment
+      STATE: ${{ (needs.deploy-unified-pipeline-lambdas.result == 'success' && needs.deploy-dated-unified-pipeline-lambdas.result == 'success') && 'success' || 'failure' }}
+      DATES: ${{ join(fromJSON(needs.discover-pipeline-dates.outputs.pipeline_dates), ', ') }}
+    steps:
+      - name: Report deployment outcome
+        run: |
+          gh api "repos/$GITHUB_REPOSITORY/deployments/${{ needs.start-deployment.outputs.id }}/statuses" \
+            -f state="$STATE" \
+            -f description="catalogue_graph lambdas; pipelines: $DATES" \
+            -f log_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" > /dev/null

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,22 @@
+# Backstage-format description of this repository, gathered into
+# https://github.com/wellcomecollection/catalog. Folders that deploy
+# independently describe themselves in their own catalog-info.yaml, listed
+# here as Location targets.
+apiVersion: backstage.io/v1alpha1
+kind: System
+metadata:
+  name: catalogue-pipeline
+  description: The data pipeline services extracting and transforming catalogue data
+  annotations:
+    github.com/project-slug: wellcomecollection/catalogue-pipeline
+spec:
+  owner: digital-platform
+---
+apiVersion: backstage.io/v1alpha1
+kind: Location
+metadata:
+  name: catalogue-pipeline-units
+spec:
+  type: url
+  targets:
+    - ./catalogue_graph/catalog-info.yaml

--- a/catalogue_graph/.deploy-tracker.yml
+++ b/catalogue_graph/.deploy-tracker.yml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/wellcomecollection/deploy-tracker/main/schema/deploy-tracker.schema.json
+# Deploy tracker config for the catalogue_graph unit: the Python lambdas the
+# "Catalogue pipeline: Deploy" workflow updates. Only pull requests touching
+# this directory are reported. Deployments carry task deploy:catalogue_graph.
+# There is no stage and no HTTP surface, so no checkpoints: "deployed" is as
+# far as the tracker can see.
+version: 1
+
+slack:
+  channel: "#wc-deploys"
+
+environments:
+  prod: {}
+
+labels: true
+pr_comments: true

--- a/catalogue_graph/catalog-info.yaml
+++ b/catalogue_graph/catalog-info.yaml
@@ -1,0 +1,17 @@
+# Backstage-format description of this folder's software, gathered into
+# https://github.com/wellcomecollection/catalog. The Component points at the
+# deploy tracker config in this directory.
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: catalogue-graph
+  description: Python lambdas for the catalogue adapters, graph and dated pipelines
+  annotations:
+    github.com/project-slug: wellcomecollection/catalogue-pipeline
+    backstage.io/source-location: url:https://github.com/wellcomecollection/catalogue-pipeline/tree/main/catalogue_graph/
+    wellcomecollection.org/deploy-tracker: .deploy-tracker.yml
+spec:
+  type: service
+  lifecycle: production
+  owner: digital-platform
+  system: catalogue-pipeline


### PR DESCRIPTION
## What does this change?

Lets the [deploy tracker](https://github.com/wellcomecollection/deploy-tracker) report which pull requests each `catalogue_graph` deploy shipped, in Slack and on the pull requests.

- `.github/workflows/catalogue-graph-deploy.yml`: a first job creates one GitHub Deployment per run for `prod`, ref the deployed tag and task `deploy:catalogue_graph`, and posts `in_progress`; the retag jobs depend on it; a final `if: always()` job posts `success` or `failure`, with the pipeline dates in the description. `deployments: write` is added to this workflow and to its caller, `catalogue-graph-ci.yml`.
- `catalogue_graph/.deploy-tracker.yml`: the tracker config for this folder as a deploy unit. Only pull requests touching `catalogue_graph/` are reported. `prod` only, no checkpoints: the Lambdas have no HTTP surface, so the tracker reports "deployed" rather than "seen".
- `catalog-info.yaml` and `catalogue_graph/catalog-info.yaml`: Backstage-format description for the [catalog](https://github.com/wellcomecollection/catalog), a `catalogue-pipeline` System and a `catalogue-graph` service Component owned by digital-platform, whose annotation is what opts the folder into the tracker.

The Scala pipeline services deployed by Buildkite are untouched and untracked; they could become a second unit later.

## How to test

Merging is the test: this file is in the CI workflow's path filter, so the merge runs CI, calls Deploy, and the run should show a Deployment on the repository's Deployments page and a `catalogue-pipeline · catalogue_graph · prod` message from the tracker listing this pull request. A manual `workflow_dispatch` with an older sha should produce a rollback message.

Order matters: wellcomecollection/deploy-tracker#21 must be on the tracker's prod first (it teaches the tracker the checkpoint-less pointer form), and the deploy tracker GitHub App must be installed on this repository, otherwise the first run is reported as a configuration error in an issue here.

## Have we considered potential risks?

The Deployment calls use `GITHUB_TOKEN` and can only fail the two small bookkeeping jobs, not the deploy jobs between them. `workflow_dispatch` with a tag that is not a commit sha would fail to create the Deployment; the deploy jobs then don't run, which matches the existing assumption that `deploy_tag` is a sha.