### PR TITLE
Folio transformer: add languages field

### DIFF
--- a/catalogue_graph/src/adapters/transformers/builders/folio_work_builder.py
+++ b/catalogue_graph/src/adapters/transformers/builders/folio_work_builder.py
@@ -4,6 +4,7 @@ from adapters.transformers.folio.identifier import extract_hrid, extract_instanc
 from adapters.transformers.marc.current_frequency import extract_current_frequency
 from adapters.transformers.marc.edition import extract_edition
 from adapters.transformers.marc.former_frequency import extract_former_frequency
+from adapters.transformers.marc.languages import extract_languages
 from adapters.transformers.marc.physical_description import (
     extract_physical_description,
 )
@@ -11,6 +12,7 @@ from adapters.transformers.marc.predecessor_identifier import (
     extract_sierra_predecessor_id,
 )
 from ingestor.models.shared.deleted_reason import SuppressedFromSource
+from models.pipeline.id_label import Language
 from models.pipeline.identifier import (
     Id,
     Identifiable,
@@ -38,6 +40,10 @@ class FolioWorkBuilder(MarcXmlWorkBuilder):
     @property
     def physical_description(self) -> str | None:
         return extract_physical_description(self.record)
+
+    @property
+    def languages(self) -> list[Language]:
+        return extract_languages(self.record)
 
     @property
     def edition(self) -> str | None:

--- a/catalogue_graph/src/adapters/transformers/marc/languages.py
+++ b/catalogue_graph/src/adapters/transformers/marc/languages.py
@@ -1,0 +1,83 @@
+"""
+Extracting languages from the Sierra LANG fixed field (MARC 998 ǂf), falling
+back to the MARC language code in 008/35-37, plus additional languages from 041.
+
+https://www.loc.gov/marc/bibliographic/bd008a.html
+https://www.loc.gov/marc/bibliographic/bd041.html
+"""
+
+import structlog
+from pymarc.record import Record
+
+from adapters.transformers.ebsco.parsers.field008 import RawField008
+from lookups.languages import from_code
+from models.pipeline.id_label import Language
+
+logger = structlog.get_logger(__name__)
+
+# Codes that tell us nothing about the language, so are not worth displaying.
+SUPPRESSED_CODES = {
+    "mul",  # Multiple languages
+    "und",  # Undetermined
+    "zxx",  # No linguistic content
+}
+
+
+def extract_languages(record: Record) -> list[Language]:
+    """The primary language first, then 041 ǂa in document order, deduplicated."""
+    codes = [_primary_code(record)] + [
+        value
+        for field in record.get_fields("041")
+        for value in field.get_subfields("a")
+    ]
+
+    languages: list[Language] = []
+    for code in codes:
+        language = _resolve(code)
+        if language is not None and language not in languages:
+            languages.append(language)
+
+    return languages
+
+
+def _primary_code(record: Record) -> str | None:
+    """Prefer 998 ǂf, the Sierra LANG field, which is curated where 008/35-37 is often
+    left as fill characters, `und`, or stale. A blank ǂf is a deliberate "no language",
+    so only a missing ǂf falls back to 008.
+
+    TODO: 998 is a Sierra field carried over by the migration. Confirm whether FOLIO
+    keeps maintaining ǂf, or whether records edited in FOLIO update only 008/35-37,
+    in which case the preference here should flip after cutover.
+    """
+    for field in record.get_fields("998"):
+        if values := field.get_subfields("f"):
+            return values[0]
+
+    if field_008 := RawField008.from_record(record):
+        return field_008.languagecode
+
+    return None
+
+
+def _resolve(code: str | None) -> Language | None:
+    """Codes that are absent, mean "no language", or are suppressed produce nothing."""
+    if code is None or _is_no_language(code):
+        return None
+
+    language = from_code(code.strip().lower())
+    if language is None:
+        # TODO: Some 041 ǂa values pack several codes into one subfield (e.g. "engger").
+        # Matching the Scala, these are dropped; they could be split into 3-character codes.
+        logger.error("Unrecognised language code", code=code)
+        return None
+
+    if language.id in SUPPRESSED_CODES:
+        return None
+
+    return language
+
+
+def _is_no_language(code: str) -> bool:
+    """Blanks and MARC fill characters both mean the record has no language, which is
+    not a data error: some records legitimately have none, e.g. paintings."""
+    return not code.strip("| ")

--- a/catalogue_graph/tests/adapters/transformers/folio/BDD/features/languages.feature
+++ b/catalogue_graph/tests/adapters/transformers/folio/BDD/features/languages.feature
@@ -1,0 +1,132 @@
+Feature: languages (MARC 998 ǂf and 041)
+  The primary language comes from the Sierra LANG fixed field, carried into FOLIO
+  as MARC 998 ǂf, falling back to the MARC language code in 008/35-37 when the
+  record has no ǂf at all. Additional languages come from 041 ǂa, in document
+  order. Codes are trimmed and lowercased, resolved against the MARC language
+  code list, and codes that say nothing about the language are suppressed. The
+  primary language comes first and the list is deduplicated.
+
+  These scenarios mirror the unit tests of the Scala transformer this replaces
+  (SierraLanguagesTest.scala), including its test data, so the two can be
+  compared directly. Where the Scala reads the Sierra API's "lang" field, these
+  read 998 ǂf.
+
+  https://www.loc.gov/marc/bibliographic/bd008a.html
+  https://www.loc.gov/marc/bibliographic/bd041.html
+
+  Background:
+    Given a MARC record with field 001 "abc123"
+    And the MARC record has a 999 field with indicators "f" "f" with subfield "i" value "10000000-0000-0000-0000-000000000001"
+    And the MARC record has a 245 field with subfield "a" value "Some Title"
+
+  # Ported from SierraLanguagesTest.scala.
+
+  Scenario: A record with no language fields has no languages
+    When I transform the MARC record
+    Then there are no languages
+
+  Scenario: A single language comes from 998 ǂf
+    Given the MARC record has a 998 field with subfield "f" value "fre"
+    When I transform the MARC record
+    Then the only language has the label "French"
+
+  Scenario: 998 ǂf is combined with 041, and ǂb is ignored
+    Given the MARC record has a 998 field with subfield "f" value "fre"
+    And the MARC record has a 041 field with subfield "a" value "ger" and subfield "b" value "dut" and subfield "a" value "eng"
+    When I transform the MARC record
+    Then the work has 3 languages with label:
+      | French  |
+      | German  |
+      | English |
+
+  Scenario: Languages come from multiple instances of 041
+    Given the MARC record has a 998 field with subfield "f" value "fre"
+    And the MARC record has a 041 field with subfield "a" value "ger"
+    And the MARC record has another 041 field with subfield "a" value "eng"
+    When I transform the MARC record
+    Then the work has 3 languages with label:
+      | French  |
+      | German  |
+      | English |
+
+  Scenario: An unrecognised code in 041 is dropped and logged
+    Given the MARC record has a 998 field with subfield "f" value "chi"
+    And the MARC record has a 041 field with subfield "a" value "???"
+    When I transform the MARC record
+    Then an error "Unrecognised language code" is logged with code "???"
+    And the only language has the label "Chinese"
+
+  Scenario: The list is deduplicated, with 998 ǂf first
+    Given the MARC record has a 998 field with subfield "f" value "ger"
+    And the MARC record has a 041 field with subfield "a" value "fre" and subfield "a" value "eng" and subfield "a" value "ger"
+    When I transform the MARC record
+    Then the work has 3 languages with label:
+      | German  |
+      | French  |
+      | English |
+
+  Scenario: Codes that don't correspond to a language are suppressed
+    Given the MARC record has a 998 field with subfield "f" value "chi"
+    And the MARC record has a 041 field with subfield "a" value "mul" and subfield "a" value "eng" and subfield "a" value "und" and subfield "a" value "fre" and subfield "a" value "zxx"
+    When I transform the MARC record
+    Then the work has 3 languages with label:
+      | Chinese |
+      | English |
+      | French  |
+
+  Scenario: Whitespace is stripped from 041 values
+    Given the MARC record has a 041 field with subfield "a" value "eng "
+    When I transform the MARC record
+    Then the only language has the label "English"
+
+  Scenario: 041 values are lowercased
+    Given the MARC record has a 041 field with subfield "a" value "ENG" and subfield "a" value "Lat"
+    When I transform the MARC record
+    Then the work has 2 languages with label:
+      | English |
+      | Latin   |
+
+  Scenario: An unidentifiable primary code is dropped and logged
+    Given the MARC record has a 998 field with subfield "f" value "idk"
+    When I transform the MARC record
+    Then an error "Unrecognised language code" is logged with code "idk"
+    And there are no languages
+
+  Scenario: A primary code of only whitespace gives no languages
+    Given the MARC record has a 998 field with subfield "f" value "   "
+    When I transform the MARC record
+    Then there are no languages
+
+  # FOLIO-specific behaviour, verified against the FOLIO data.
+
+  Scenario: 008/35-37 is used when the record has no 998 ǂf
+    Given the MARC record's only 008 field with the value "140303s1958    enk     s     000 0 ger  "
+    When I transform the MARC record
+    Then the only language has the label "German"
+
+  Scenario: 998 ǂf wins over 008/35-37 when both carry a language
+    # 008/35-37 is often left as fill characters, "und", or stale, so the curated
+    # ǂf is preferred wherever the two disagree
+    Given the MARC record's only 008 field with the value "140303s1958    enk     s     000 0 eng  "
+    And the MARC record has a 998 field with subfield "f" value "fre"
+    When I transform the MARC record
+    Then the only language has the label "French"
+
+  Scenario: A blank 998 ǂf means no language and does not fall back to 008
+    # 998 ǂf is the curated field, so a blank there is a deliberate "no language";
+    # falling back would invent a language from a stale or default 008
+    Given the MARC record's only 008 field with the value "140303s1958    enk     s     000 0 eng  "
+    And the MARC record has a 998 field with subfield "f" value "   "
+    When I transform the MARC record
+    Then there are no languages
+
+  Scenario: Fill characters in 008 mean no language, and are not an error
+    Given the MARC record's only 008 field with the value "140303s1958    enk     s     000 0 |||  "
+    When I transform the MARC record
+    Then there are no languages
+
+  Scenario: A code of "n/a" is dropped and logged
+    Given the MARC record has a 998 field with subfield "f" value "n/a"
+    When I transform the MARC record
+    Then an error "Unrecognised language code" is logged with code "n/a"
+    And there are no languages

--- a/catalogue_graph/tests/adapters/transformers/folio/BDD/test_languages.py
+++ b/catalogue_graph/tests/adapters/transformers/folio/BDD/test_languages.py
@@ -1,0 +1,3 @@
+from pytest_bdd import scenarios
+
+scenarios("./features/languages.feature")

--- a/catalogue_graph/tests/gherkin_steps/work.py
+++ b/catalogue_graph/tests/gherkin_steps/work.py
@@ -31,6 +31,7 @@ ATTR_ALIASES: dict[str, str] = {
     "alternative title": "alternative_titles",
     "alternative titles": "alternative_titles",
     "genre": "genres",
+    "language": "languages",
     "subject": "subjects",
     "concept": "concepts",
     "other identifier": "other_identifiers",


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g. what is the problem / why is the change needed, how does it solve it, and any questions or points of discussion. -->

### Checklist

- [ ] Does this change the display model the catalogue API returns? If so, regenerate the test documents under `catalogue_graph/document_generators/test_documents`. After merge, `sync-test-documents.yml` copies them into `wellcomecollection/catalogue-api` as an auto-PR, where OpenAPI contract tests validate the published spec against them; expect that PR to fail CI until the spec (`catalogue-api/reference/catalogue.yaml`) documents the new shape.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z." -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? -->
