### PR TITLE
Deploy tracker messages go to #wc-platform-deploys

### DIFF
--- a/catalogue_graph/.deploy-tracker.yml
+++ b/catalogue_graph/.deploy-tracker.yml
@@ -7,7 +7,7 @@
 version: 1
 
 slack:
-  channel: "#wc-deploys"
+  channel: "#wc-platform-deploys"
 
 environments:
   prod: {}


### PR DESCRIPTION
## What does this change?

The deploy feed is splitting by team: `#wc-platform-deploys` replaces `#wc-deploys` for this repository.

## How to test

Merge only after wellcomecollection/deploy-tracker#23 is on the tracker's prod, otherwise the tracker reports an unknown channel in a configuration issue here. The merge is itself a deploy and should appear in `#wc-platform-deploys`.

## Have we considered potential risks?

None beyond the ordering above.