### PR TITLE
Take the terms-of-use access word from the status, not the subfield the date came from

### DIFF
--- a/catalogue_graph/src/adapters/transformers/axiell/access_status.py
+++ b/catalogue_graph/src/adapters/transformers/axiell/access_status.py
@@ -5,12 +5,9 @@ Extract access status from field
 https://www.loc.gov/marc/bibliographic/bd506.html
 """
 
-from datetime import date
-
 import structlog
 from pymarc.record import Record
 
-from adapters.transformers.axiell.dates import extract_closed_until_date
 from adapters.transformers.marc.common import non_empty_subfields
 from adapters.transformers.marc.identifier import extract_id
 from models.pipeline.access_status import (
@@ -64,14 +61,6 @@ def extract_access_status(record: Record) -> AccessStatus | None:
 
     if status in ACCESS_STATUS_MAPPING:
         return ACCESS_STATUS_MAPPING[status]
-
-    # Most closed material does not (yet) carry a CLOSED status value: the Calm-to-Axiell
-    # migration delivered Calm's 'Closed' as 'Certain restrictions apply' until the next
-    # data load restores the full status vocabulary. For records without a usable status,
-    # a 'closed until' date in the future marks the item as closed.
-    closed_until = extract_closed_until_date(record)
-    if closed_until and closed_until >= date.today():
-        return Closed
 
     if status is not None:
         logger.warning(

--- a/catalogue_graph/src/adapters/transformers/axiell/dates.py
+++ b/catalogue_graph/src/adapters/transformers/axiell/dates.py
@@ -28,12 +28,8 @@ def _date_from(record: Record, field: str, subfield: str) -> date | None:
     return _try_parse_date(value) if value else None
 
 
-def extract_closed_until_date(record: Record) -> date | None:
+def extract_restricted_or_closed_until_date(record: Record) -> date | None:
     return _date_from(record, "506", "g")
-
-
-def extract_restricted_until_date(record: Record) -> date | None:
-    return _date_from(record, "540", "g")
 
 
 def _parse_production_date(value: str, month: int, day: int) -> date | None:

--- a/catalogue_graph/src/adapters/transformers/axiell/terms_of_use.py
+++ b/catalogue_graph/src/adapters/transformers/axiell/terms_of_use.py
@@ -5,13 +5,15 @@ import structlog
 from pymarc.record import Record
 
 from adapters.transformers.axiell.access_status import extract_access_status
-from adapters.transformers.axiell.dates import (
-    extract_closed_until_date,
-    extract_restricted_until_date,
-)
+from adapters.transformers.axiell.dates import extract_restricted_or_closed_until_date
 from adapters.transformers.marc.common import first_non_empty_subfield
 from adapters.transformers.marc.identifier import extract_id
-from models.pipeline.access_status import Closed, PermissionRequired, Restricted
+from models.pipeline.access_status import (
+    AccessStatus,
+    Closed,
+    PermissionRequired,
+    Restricted,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -51,75 +53,63 @@ def _has_restrictions(text: str) -> bool:
     return "restricted" in lower or "restrictions" in lower
 
 
-def extract_terms_of_use(record: Record) -> str | None:
-    """Construct a 'terms of use' note from various access fields."""
-    conditions = extract_access_conditions(record)
-    access_status = extract_access_status(record)
-    closed_until = extract_closed_until_date(record)
-    restricted_until = extract_restricted_until_date(record)
+def _until_label(
+    access_status: AccessStatus | None, conditions: str | None
+) -> str | None:
+    """The word that introduces the date.
 
-    # No conditions and no dates: nothing useful to output
-    if not conditions and not closed_until and not restricted_until:
-        return None
-
-    # Conditions with no dates: return them as-is
-    if conditions and not closed_until and not restricted_until:
-        return conditions
-
-    # Closed status with a closed until date
-    if access_status == Closed and closed_until:
-        closed_until_message = f"Closed until {_display_date(closed_until)}."
-        if not conditions:
-            return closed_until_message
-
-        # Don't repeat the access status/date if they're already included in the text
-        if "closed" in conditions.lower() and _contains_date(conditions, closed_until):
-            return conditions
-
-        return f"{conditions} {closed_until_message}"
-
-    # Restricted status with a restricted until date
-    if access_status == Restricted and restricted_until:
-        restricted_until_message = (
-            f"Restricted until {_display_date(restricted_until)}."
-        )
-
-        if not conditions:
-            return restricted_until_message
-
-        if "restricted" in conditions.lower() and _contains_date(
-            conditions, restricted_until
-        ):
-            return conditions
-
-        return f"{conditions} {restricted_until_message}"
-
-    # PermissionRequired with a restricted until date where conditions already mention
-    # both permission and restrictions
+    Axiell holds the restricted-until and closed-until date in the same 506 $g
+    subfield, so the status is what says which of the two it is. A status that
+    says neither cannot label a date. PermissionRequired counts as restricted,
+    but only when the conditions already talk about permission and restrictions.
+    """
+    if access_status == Closed:
+        return "Closed"
+    if access_status == Restricted:
+        return "Restricted"
     if (
         access_status == PermissionRequired
-        and restricted_until
         and conditions
         and "permission" in conditions.lower()
         and _has_restrictions(conditions)
     ):
-        if _contains_date(conditions, restricted_until):
-            return conditions
-        return f"{conditions} Restricted until {_display_date(restricted_until)}."
+        return "Restricted"
+    return None
 
-    # Catch-all: log a warning and combine what we have. This affects very few
-    # records and typically reflects a data issue in the source system.
-    logger.warning(
-        "Unclear how to create a 'terms of use' note",
-        record_id=extract_id(record),
+
+def _already_stated(conditions: str, label: str, until: date) -> bool:
+    """Whether the conditions text already carries both the word and the date."""
+    stated = (
+        _has_restrictions(conditions)
+        if label == "Restricted"
+        else label.lower() in conditions.lower()
     )
+    return stated and _contains_date(conditions, until)
 
-    parts = []
-    if conditions:
-        parts.append(conditions)
-    if restricted_until:
-        parts.append(f"Restricted until {_display_date(restricted_until)}.")
-    if closed_until:
-        parts.append(f"Closed until {_display_date(closed_until)}.")
 
-    return " ".join(parts) if parts else None
+def extract_terms_of_use(record: Record) -> str | None:
+    """Construct a 'terms of use' note from 506 $a, $f and $g."""
+    conditions = extract_access_conditions(record)
+    until = extract_restricted_or_closed_until_date(record)
+
+    if not until:
+        return conditions
+
+    label = _until_label(extract_access_status(record), conditions)
+    if label is None:
+        # Catch-all: a date with no status to label it. Keep the conditions and
+        # drop the date rather than assert an access status the record does not
+        # give. This affects very few records and typically reflects a data
+        # issue in the source system.
+        logger.warning(
+            "Unclear how to create a 'terms of use' note",
+            record_id=extract_id(record),
+        )
+        return conditions
+
+    sentence = f"{label} until {_display_date(until)}."
+    if not conditions:
+        return sentence
+    if _already_stated(conditions, label, until):
+        return conditions
+    return f"{conditions} {sentence}"

--- a/catalogue_graph/src/adapters/transformers/marc/other_identifiers.py
+++ b/catalogue_graph/src/adapters/transformers/marc/other_identifiers.py
@@ -48,7 +48,7 @@ IGNORED_PREFIXES = {
     "Previous number",
     "Previouse number",
     "Archivematica UUID",
-    "AV  barcode",
+    "AV barcode",
 }
 
 

--- a/catalogue_graph/tests/adapters/transformers/axiell/bdd/features/items.feature
+++ b/catalogue_graph/tests/adapters/transformers/axiell/bdd/features/items.feature
@@ -37,7 +37,7 @@ Feature: Items from Axiell MARC records
     Then there is 1 item
     And the item has no access conditions
 
-  Scenario: 506 $f sets the access condition and a closed-until date does not change it
+  Scenario: 506 $f sets the access condition and a 506 $g date does not change it
     Given the MARC record has a 506 field with subfield "f" value "OPEN" and subfield "g" value "2030-01-01"
     When I transform the MARC record
     Then there is 1 item

--- a/catalogue_graph/tests/adapters/transformers/axiell/bdd/features/items.feature
+++ b/catalogue_graph/tests/adapters/transformers/axiell/bdd/features/items.feature
@@ -1,8 +1,7 @@
 Feature: Items from Axiell MARC records
   Axiell records always produce exactly one item, placed in Closed stores.
-  An optional access condition is derived from MARC 506 $f (status value) or 506 $g
-  (closed-until date). A future closed-until date produces a Closed status when no
-  recognised $f value is present.
+  An optional access condition is derived from MARC 506 $f. The restricted-until
+  or closed-until date in 506 $g feeds the terms-of-use note, not the status.
   - https://www.loc.gov/marc/bibliographic/bd506.html
 
   Background:
@@ -38,19 +37,7 @@ Feature: Items from Axiell MARC records
     Then there is 1 item
     And the item has no access conditions
 
-  Scenario: Future closed-until date — item has Closed access condition
-    Given the MARC record has a 506 field with subfield "g" value "2030-01-01"
-    When I transform the MARC record
-    Then there is 1 item
-    And the item has 1 access condition with status "Closed"
-
-  Scenario: Past closed-until date — item has no access conditions
-    Given the MARC record has a 506 field with subfield "g" value "2020-01-01"
-    When I transform the MARC record
-    Then there is 1 item
-    And the item has no access conditions
-
-  Scenario: Recognised 506 $f value takes precedence over future closed-until date
+  Scenario: 506 $f sets the access condition and a closed-until date does not change it
     Given the MARC record has a 506 field with subfield "f" value "OPEN" and subfield "g" value "2030-01-01"
     When I transform the MARC record
     Then there is 1 item

--- a/catalogue_graph/tests/adapters/transformers/axiell/test_access_status.py
+++ b/catalogue_graph/tests/adapters/transformers/axiell/test_access_status.py
@@ -18,7 +18,9 @@ def test_closed_status_maps_to_closed_without_closed_until_date() -> None:
     assert extract_access_status(record) == Closed
 
 
-def test_mapped_status_wins_over_closed_until_date() -> None:
+def test_closed_until_date_does_not_affect_the_status() -> None:
+    # 506 $g holds the restricted-until or closed-until date. It is the note text
+    # that reads it; the status comes from $f alone.
     record = make_axiell_record()
     add_506(record, "f", "OPEN")
     add_506(record, "g", "2999-01-01")
@@ -31,20 +33,8 @@ def test_restrictionsapply_maps_to_restricted() -> None:
     assert extract_access_status(record) == Restricted
 
 
-def test_no_status_with_future_closed_until_is_closed() -> None:
+def test_no_access_status_field_maps_to_none() -> None:
+    # 506 $f is the only source of access status. A record without one has none,
+    # whatever else the 506 field carries.
     record = make_axiell_record()
-    add_506(record, "g", "2999-01-01")
-    assert extract_access_status(record) == Closed
-
-
-def test_no_status_with_past_closed_until_is_none() -> None:
-    record = make_axiell_record()
-    add_506(record, "g", "2001-01-01")
     assert extract_access_status(record) is None
-
-
-def test_unrecognised_status_with_future_closed_until_is_closed() -> None:
-    record = make_axiell_record()
-    add_506(record, "f", "PRIVATE")
-    add_506(record, "g", "2999-01-01")
-    assert extract_access_status(record) == Closed

--- a/catalogue_graph/tests/adapters/transformers/axiell/test_access_status.py
+++ b/catalogue_graph/tests/adapters/transformers/axiell/test_access_status.py
@@ -18,7 +18,7 @@ def test_closed_status_maps_to_closed_without_closed_until_date() -> None:
     assert extract_access_status(record) == Closed
 
 
-def test_closed_until_date_does_not_affect_the_status() -> None:
+def test_until_date_does_not_affect_the_status() -> None:
     # 506 $g holds the restricted-until or closed-until date. It is the note text
     # that reads it; the status comes from $f alone.
     record = make_axiell_record()
@@ -37,4 +37,13 @@ def test_no_access_status_field_maps_to_none() -> None:
     # 506 $f is the only source of access status. A record without one has none,
     # whatever else the 506 field carries.
     record = make_axiell_record()
+    assert extract_access_status(record) is None
+
+
+def test_future_until_date_without_a_status_is_not_closed() -> None:
+    # A future 506 $g used to infer Closed when no recognised $f was present.
+    # That inference is gone: $g now holds either a restricted-until or a
+    # closed-until date, so it cannot say which status applies.
+    record = make_axiell_record()
+    add_506(record, "g", "2999-01-01")
     assert extract_access_status(record) is None

--- a/catalogue_graph/tests/adapters/transformers/axiell/test_access_status.py
+++ b/catalogue_graph/tests/adapters/transformers/axiell/test_access_status.py
@@ -40,6 +40,15 @@ def test_no_access_status_field_maps_to_none() -> None:
     assert extract_access_status(record) is None
 
 
+def test_future_until_date_with_an_unrecognised_status_is_not_closed() -> None:
+    # The other side of the same removal: an unrecognised $f used to fall through
+    # to the date and come back Closed.
+    record = make_axiell_record()
+    add_506(record, "f", "PRIVATE")
+    add_506(record, "g", "2999-01-01")
+    assert extract_access_status(record) is None
+
+
 def test_future_until_date_without_a_status_is_not_closed() -> None:
     # A future 506 $g used to infer Closed when no recognised $f was present.
     # That inference is gone: $g now holds either a restricted-until or a

--- a/catalogue_graph/tests/adapters/transformers/axiell/test_notes.py
+++ b/catalogue_graph/tests/adapters/transformers/axiell/test_notes.py
@@ -89,7 +89,7 @@ def test_506_terms_of_use_normalised_by_axiell_logic() -> None:
 def test_540_text_content_not_emitted_as_terms_of_use() -> None:
     """540 $a text is ignored by the Axiell terms-of-use logic.
 
-    The Axiell path reads 540 $g (a restricted-until date), not $a. A record
+    The Axiell path reads 540 $g (a restrictedor-closed-until date), not $a. A record
     with only a 540 $a value therefore produces no TERMS_OF_USE note, whereas
     the base MARC logic would have emitted one verbatim.
     """

--- a/catalogue_graph/tests/adapters/transformers/axiell/test_notes.py
+++ b/catalogue_graph/tests/adapters/transformers/axiell/test_notes.py
@@ -89,9 +89,10 @@ def test_506_terms_of_use_normalised_by_axiell_logic() -> None:
 def test_540_text_content_not_emitted_as_terms_of_use() -> None:
     """540 $a text is ignored by the Axiell terms-of-use logic.
 
-    The Axiell path reads 540 $g (a restrictedor-closed-until date), not $a. A record
-    with only a 540 $a value therefore produces no TERMS_OF_USE note, whereas
-    the base MARC logic would have emitted one verbatim.
+    The Axiell path takes its restricted-until or closed-until date from 506 $g
+    and ignores 540 entirely. A record with only a 540 $a value therefore
+    produces no TERMS_OF_USE note, whereas the base MARC logic would have
+    emitted one verbatim.
     """
     record = Record()
     record.add_field(Field(tag="001", data="test_id"))

--- a/catalogue_graph/tests/adapters/transformers/axiell/test_terms_of_use.py
+++ b/catalogue_graph/tests/adapters/transformers/axiell/test_terms_of_use.py
@@ -2,6 +2,7 @@
 
 # mypy: allow-untyped-calls
 
+import pytest
 from freezegun import freeze_time
 from pymarc.record import Field, Record, Subfield
 
@@ -11,10 +12,14 @@ from adapters.transformers.axiell.terms_of_use import extract_terms_of_use
 def _make_record(
     status: str | None = None,
     conditions: str | None = None,
-    closed_until: str | None = None,
-    restricted_until: str | None = None,
+    until: str | None = None,
 ) -> Record:
-    """Build a minimal MARC record with access fields populated. Dates must be in yyyy/M/d format."""
+    """Build a minimal MARC record with access fields populated.
+
+    Axiell holds the restricted-until and closed-until date in the same 506 $g
+    subfield; the access status in $f says which of the two it is. Dates must be
+    in yyyy-mm-dd format, matching what the transformer parses.
+    """
     record = Record()
     record.add_field(Field(tag="001", data="test_id"))
 
@@ -23,15 +28,10 @@ def _make_record(
         subfields_506.append(Subfield(code="f", value=status))
     if conditions:
         subfields_506.append(Subfield(code="a", value=conditions))
-    if closed_until:
-        subfields_506.append(Subfield(code="g", value=closed_until))
+    if until:
+        subfields_506.append(Subfield(code="g", value=until))
     if subfields_506:
         record.add_field(Field(tag="506", subfields=subfields_506))
-
-    if restricted_until:
-        record.add_field(
-            Field(tag="540", subfields=[Subfield(code="g", value=restricted_until)])
-        )
 
     return record
 
@@ -65,7 +65,7 @@ def test_restricted_date_already_in_conditions() -> None:
     record = _make_record(
         status="RESTRICTED",
         conditions=conditions,
-        restricted_until="01/01/2039",
+        until="2039-01-01",
     )
     assert extract_terms_of_use(record) == conditions
 
@@ -81,22 +81,19 @@ def test_restricted_date_not_in_conditions() -> None:
     record = _make_record(
         status="RESTRICTED",
         conditions=conditions,
-        restricted_until="2060-01-01",
+        until="2060-01-01",
     )
     assert (
         extract_terms_of_use(record) == f"{conditions}Restricted until 1 January 2060."
     )
 
 
-def test_just_a_status_no_conditions_no_dates() -> None:
-    """Item with only an access status: nothing useful to output."""
-    record = _make_record(status="OPEN")
-    assert extract_terms_of_use(record) is None
-
-
-def test_no_access_information() -> None:
-    """Item with no access fields at all: returns None."""
-    assert extract_terms_of_use(_make_record()) is None
+@pytest.mark.parametrize("status", [None, "OPEN", "RESTRICTED", "CLOSED"])
+def test_status_alone_produces_no_note(status: str | None) -> None:
+    """A status on its own never synthesises a note, and that holds for Closed
+    and Restricted too: those only produce one when 506 $g supplies a date for
+    the status to label."""
+    assert extract_terms_of_use(_make_record(status=status)) is None
 
 
 @freeze_time("2025-01-01T12:00:00Z")
@@ -113,7 +110,7 @@ def test_permission_required_with_restrictions_date_not_in_conditions() -> None:
     record = _make_record(
         status="PERMISSIONREQUIRED",
         conditions=conditions,
-        restricted_until="2072-01-01",
+        until="2072-01-01",
     )
     assert (
         extract_terms_of_use(record) == f"{conditions} Restricted until 1 January 2072."
@@ -130,14 +127,16 @@ def test_removes_trailing_whitespace() -> None:
     record = _make_record(
         status="RESTRICTED",
         conditions=conditions,
-        restricted_until="2054-01-01",
+        until="2054-01-01",
     )
     assert extract_terms_of_use(record) == conditions.strip()
 
 
 @freeze_time("2025-01-01T12:00:00Z")
-def test_fallback_case() -> None:
-    """By Appointment + conditions + restricted until date: catch-all appends 'Restricted until <date>'."""
+def test_date_with_no_status_to_label_it_is_dropped() -> None:
+    """A 506 $g date only becomes a sentence when the status says the item is
+    closed or restricted. By Appointment says neither, so the date is dropped
+    rather than asserting an access status the record does not give."""
     conditions = (
         "The papers are available subject to the usual conditions of access to Archives and Manuscripts material. "
         "In addition a Restricted Access form must be completed to apply for access to this file."
@@ -145,18 +144,16 @@ def test_fallback_case() -> None:
     record = _make_record(
         status="BYAPPOINTMENT",
         conditions=conditions,
-        restricted_until="2066-01-01",
+        until="2066-01-01",
     )
-    assert (
-        extract_terms_of_use(record) == f"{conditions} Restricted until 1 January 2066."
-    )
+    assert extract_terms_of_use(record) == conditions
 
 
 @freeze_time("2025-01-01T12:00:00Z")
 def test_closed_date_already_in_conditions() -> None:
     """Closed item, date already present in conditions (with ordinal): no repetition."""
     conditions = "Closed under the Data Protection Act until 1st January 2039."
-    record = _make_record(conditions=conditions, closed_until="2039-01-01")
+    record = _make_record(status="CLOSED", conditions=conditions, until="2039-01-01")
     assert extract_terms_of_use(record) == conditions
 
 
@@ -164,8 +161,9 @@ def test_closed_date_already_in_conditions() -> None:
 def test_closed_date_not_in_conditions() -> None:
     """Closed item, date not in conditions: append 'Closed until <date>'."""
     record = _make_record(
+        status="CLOSED",
         conditions="Closed under the Data Protection Act.",
-        closed_until="2039-01-01",
+        until="2039-01-01",
     )
     assert extract_terms_of_use(record) == (
         "Closed under the Data Protection Act. Closed until 1 January 2039."
@@ -175,7 +173,7 @@ def test_closed_date_not_in_conditions() -> None:
 @freeze_time("2025-01-01T12:00:00Z")
 def test_closed_no_conditions() -> None:
     """Closed item with no conditions: synthesise 'Closed until <date>' note."""
-    record = _make_record(closed_until="2068-01-01")
+    record = _make_record(status="CLOSED", until="2068-01-01")
     assert extract_terms_of_use(record) == "Closed until 1 January 2068."
 
 
@@ -183,8 +181,9 @@ def test_closed_no_conditions() -> None:
 def test_adds_missing_full_stop() -> None:
     """Conditions lacking a trailing period get one before appending the date."""
     record = _make_record(
+        status="CLOSED",
         conditions="This file is closed for data protection reasons and cannot be accessed",
-        closed_until="2055-01-01",
+        until="2055-01-01",
     )
     assert extract_terms_of_use(record) == (
         "This file is closed for data protection reasons and cannot be accessed. "


### PR DESCRIPTION
Axiell holds the restricted-until and closed-until date in the same `506 $g` subfield, confirmed with collections staff. The transformer was reading `506 $g` as a closed-until date and `540 $g` as a restricted-until date, so a Restricted record whose date sat in `506 $g` matched neither the Closed branch (its status is not Closed) nor the Restricted branch (no `540 $g` date). It fell through to the catch-all, which appended a closed-until sentence to text saying the item is restricted:

> This item is restricted. You will need to complete a Restricted Access form agreeing to anonymise personal data before you will be allowed to view this item. [...] **Closed until 1 January 2054.**

That affected 5,564 records. With one date field and the status deciding which word introduces it, the catch-all now fires on 15.

## The status can no longer be derived from the date

`extract_access_status` had a fallback: a record with no usable status but a future closed-until date was treated as Closed. That worked when the date could only be a closed-until date. Now that `506 $g` carries either kind, a date on its own no longer tells us whether the item is closed or restricted, so the fallback is gone.

The consequence is that a date needs a status to label it. Where the status says neither closed nor restricted, the date is dropped and the conditions text is published unchanged, rather than asserting an access status the record does not give.

## The 15 records that still reach the catch-all

| `506 $f` | records | what the conditions say |
|---|---:|---|
| `OPEN` | 7 | "This item was previously restricted until 01/01/2026. It was reassessed..." |
| `MISSING` | 7 | Winnicott Trust permission, restricted-access forms, one "This item is closed and cannot be accessed" |
| `PERMISSIONREQUIRED` | 1 | Winnicott Trust permission, but the conditions do not mention restrictions, so the guard does not admit it |

Dropping the date is right for the seven `OPEN` records: the item is open now and the conditions already explain that it used to be restricted until that date, so appending the sentence would contradict the status.

The seven `MISSING` ones are worth a look by collections rather than in code. `MISSING` maps to `Unavailable`, yet their conditions describe live access arrangements, including one asserting the item is closed. Ids are in the issue.

## Why removing the fallback is safe on the current data

863 records have no access status the transformer can resolve: 25 carrying the unmapped value `DATAISSUES`, and 838 with no `506 $f` at all. **None of them has a `506 $g` date**, so no record in the corpus was relying on the fallback to acquire a status. All 8,843 Closed items in the round 3 index get their status from a genuine `CLOSED` value in `$f`, against production's 8,828, so #6476's parity does not depend on it either.

The fallback's own comment described it as a bridge held "until the next data load restores the full status vocabulary". On this data that vocabulary is present.

If a status-less record with a date does appear in a future load, the catch-all warning is what surfaces it. That is why the warning keeps its existing wording rather than being renamed to describe one specific cause.

## Also in this branch

`IGNORED_PREFIXES` in `marc/other_identifiers.py` contained `"AV  barcode"` with two spaces, and all 412 AV barcode identifiers in the corpus (on 311 records) use one, so none matched and each logged an "Unknown identifier prefix" warning. Those identifiers are dropped either way, since the prefix has no type mapping; the entry only controls whether the drop is logged. The one-character fix removes 2,040 warning lines, 27% of the transformer's warnings over a four-day window. Discussed with the team and small enough to carry here.

## Tests

`extract_terms_of_use` collapses from four branches to one, since the only thing that varied between Closed, Restricted and PermissionRequired was the word introducing the date. Verified byte-identical against the pre-refactor code across all 209,608 records in the Axiell adapter store.

Four tests were passing without exercising the behaviour they described, and mutation testing was what surfaced them:

- two wrote their date to `540 $g` using a `dd/mm/yyyy` value the ISO parser rejects, so the record had no date at all and took the "no dates" branch
- two supplied no `506 $f`, so they were relying on the removed status fallback rather than testing de-duplication

The fixture now takes a single `until` parameter writing `506 $g`, matching the code. The tests for the removed fallback are gone, in `test_access_status.py` and in `items.feature`, along with the feature header sentence describing it. Two scenario names claimed a precedence between `$f` and `$g` that no longer exists and now say what they check.
