### PR TITLE
Resolve sbt plugins via CodeArtifact and drop committed metals.sbt files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -282,6 +282,7 @@ Session.vim
 tags
 # metals scala language server
 .metals
+metals.sbt
 # bloop scala build server
 .bloop
 .bsp

--- a/project/metals.sbt
+++ b/project/metals.sbt
@@ -1,8 +1,0 @@
-// format: off
-// DO NOT EDIT! This file is auto-generated.
-
-// This file enables sbt-bloop to create bloop config files.
-
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "2.0.19")
-
-// format: on

--- a/project/project/metals.sbt
+++ b/project/project/metals.sbt
@@ -1,8 +1,0 @@
-// format: off
-// DO NOT EDIT! This file is auto-generated.
-
-// This file enables sbt-bloop to create bloop config files.
-
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "2.0.19")
-
-// format: on

--- a/project/project/project/metals.sbt
+++ b/project/project/project/metals.sbt
@@ -1,8 +1,0 @@
-// format: off
-// DO NOT EDIT! This file is auto-generated.
-
-// This file enables sbt-bloop to create bloop config files.
-
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "2.0.19")
-
-// format: on

--- a/project/resolvers.sbt
+++ b/project/resolvers.sbt
@@ -10,10 +10,6 @@ val codeArtifact: Seq[Resolver] = codeArtifactToken.map(_ =>
 // and dedupes, so overriding externalResolvers alone leaves the mirror last.
 sbtResolvers := (Seq(Resolver.defaultLocal) ++ codeArtifact ++ sbtResolvers.value).distinct
 
-// The Zinc compiler bridge for this build is resolved via the launcher's boot
-// repositories, which put Maven Central first regardless of the above.
-scalaCompilerBridgeResolvers := (Seq(Resolver.defaultLocal) ++ codeArtifact ++ scalaCompilerBridgeResolvers.value).distinct
-
 credentials ++= codeArtifactToken.map(token =>
   Credentials(
     "wellcomecollection-maven-mirror/wellcomecollection-maven-mirror",

--- a/project/resolvers.sbt
+++ b/project/resolvers.sbt
@@ -1,16 +1,20 @@
 // Plugin resolution for the meta-build. Mirrors Common.scala, which only
 // covers the application projects; plugins are resolved before it compiles.
-//
+val codeArtifactToken = sys.env.get("CODEARTIFACT_AUTH_TOKEN").filter(_.nonEmpty)
+
+val codeArtifact: Seq[Resolver] = codeArtifactToken.map(_ =>
+  "CodeArtifact" at "https://wellcomecollection-maven-mirror-760097843905.d.codeartifact.eu-west-1.amazonaws.com/maven/wellcomecollection-maven-mirror/"
+).toSeq
+
 // For plugin builds sbt composes fullResolvers as sbtResolvers ++ externalResolvers
 // and dedupes, so overriding externalResolvers alone leaves the mirror last.
-sbtResolvers := {
-  val codeArtifact = sys.env.get("CODEARTIFACT_AUTH_TOKEN").filter(_.nonEmpty).map(_ =>
-    "CodeArtifact" at "https://wellcomecollection-maven-mirror-760097843905.d.codeartifact.eu-west-1.amazonaws.com/maven/wellcomecollection-maven-mirror/"
-  ).toSeq
-  Seq(Resolver.defaultLocal) ++ codeArtifact ++ sbtResolvers.value
-}
+sbtResolvers := (Seq(Resolver.defaultLocal) ++ codeArtifact ++ sbtResolvers.value).distinct
 
-credentials ++= sys.env.get("CODEARTIFACT_AUTH_TOKEN").filter(_.nonEmpty).map(token =>
+// The Zinc compiler bridge for this build is resolved via the launcher's boot
+// repositories, which put Maven Central first regardless of the above.
+scalaCompilerBridgeResolvers := (Seq(Resolver.defaultLocal) ++ codeArtifact ++ scalaCompilerBridgeResolvers.value).distinct
+
+credentials ++= codeArtifactToken.map(token =>
   Credentials(
     "wellcomecollection-maven-mirror/wellcomecollection-maven-mirror",
     "wellcomecollection-maven-mirror-760097843905.d.codeartifact.eu-west-1.amazonaws.com",

--- a/project/resolvers.sbt
+++ b/project/resolvers.sbt
@@ -1,10 +1,13 @@
 // Plugin resolution for the meta-build. Mirrors Common.scala, which only
 // covers the application projects; plugins are resolved before it compiles.
-externalResolvers := {
+//
+// For plugin builds sbt composes fullResolvers as sbtResolvers ++ externalResolvers
+// and dedupes, so overriding externalResolvers alone leaves the mirror last.
+sbtResolvers := {
   val codeArtifact = sys.env.get("CODEARTIFACT_AUTH_TOKEN").filter(_.nonEmpty).map(_ =>
     "CodeArtifact" at "https://wellcomecollection-maven-mirror-760097843905.d.codeartifact.eu-west-1.amazonaws.com/maven/wellcomecollection-maven-mirror/"
   ).toSeq
-  Seq(Resolver.defaultLocal) ++ codeArtifact ++ Seq(Resolver.DefaultMavenRepository)
+  Seq(Resolver.defaultLocal) ++ codeArtifact ++ sbtResolvers.value
 }
 
 credentials ++= sys.env.get("CODEARTIFACT_AUTH_TOKEN").filter(_.nonEmpty).map(token =>

--- a/project/resolvers.sbt
+++ b/project/resolvers.sbt
@@ -1,0 +1,17 @@
+// Plugin resolution for the meta-build. Mirrors Common.scala, which only
+// covers the application projects; plugins are resolved before it compiles.
+externalResolvers := {
+  val codeArtifact = sys.env.get("CODEARTIFACT_AUTH_TOKEN").filter(_.nonEmpty).map(_ =>
+    "CodeArtifact" at "https://wellcomecollection-maven-mirror-760097843905.d.codeartifact.eu-west-1.amazonaws.com/maven/wellcomecollection-maven-mirror/"
+  ).toSeq
+  Seq(Resolver.defaultLocal) ++ codeArtifact ++ Seq(Resolver.DefaultMavenRepository)
+}
+
+credentials ++= sys.env.get("CODEARTIFACT_AUTH_TOKEN").filter(_.nonEmpty).map(token =>
+  Credentials(
+    "wellcomecollection-maven-mirror/wellcomecollection-maven-mirror",
+    "wellcomecollection-maven-mirror-760097843905.d.codeartifact.eu-west-1.amazonaws.com",
+    "aws",
+    token
+  )
+).toSeq


### PR DESCRIPTION
## What does this change?

Buildkite sbt jobs have been failing with HTTP 429 from Maven Central. Two things in this repo left the build exposed to that.

Three Metals-generated `metals.sbt` files were committed, one per meta-build level. They pinned sbt-bloop 2.0.19, which defeated the 2.0.2 prebaked into the sbt_wrapper image, and they added two meta-build levels to every job. They are removed and `metals.sbt` is gitignored.

Plugin resolution never used the CodeArtifact mirror from wellcomecollection/catalogue-pipeline#3374, because `Common.scala` only applies to the application projects. `project/resolvers.sbt` puts the mirror first for the meta-build. It overrides `sbtResolvers` rather than `externalResolvers` because sbt composes plugin-build resolvers as `sbtResolvers ++ externalResolvers` deduped, which would leave the mirror last.

This does not fix the compiler-bridge fetch failing on cold agents today; that is wellcomecollection/platform-infrastructure#546. storage-service has the same plugin-resolver gap.

## How to test

`sbt "reload plugins" "show fullResolvers"` with and without `CODEARTIFACT_AUTH_TOKEN`. With the token: local, CodeArtifact, Maven Central, then the sbt plugin repos. Without it: sbt's defaults.
