### PR TITLE
Cap coursier's download parallelism in CI

### DIFF
--- a/builds/run_sbt_task_in_docker.sh
+++ b/builds/run_sbt_task_in_docker.sh
@@ -54,11 +54,17 @@ else
   HOST_COURSIER_CACHE=~/$LINUX_COURSIER_CACHE
 fi
 
+# Coursier fetches 6 artefacts at a time per JVM by default. Our builds fan out
+# to 20+ parallel jobs, and that was enough to be rate-limited (HTTP 429) by both
+# Maven Central and the CodeArtifact mirror.
+COURSIER_PARALLELISM=2
+
 docker run --tty --rm \
   -e AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-}" \
   -e AWS_SECRET_KEY="${AWS_SECRET_KEY:-}" \
   -e AWS_SESSION_TOKEN="${AWS_SESSION_TOKEN:-}" \
   -e CODEARTIFACT_AUTH_TOKEN="${CODEARTIFACT_AUTH_TOKEN:-}" \
+  -e SBT_OPTS="-Dcoursier.parallel-download-count=$COURSIER_PARALLELISM" \
   --volume ~/.sbt:/root/.sbt \
   --volume ~/.ivy2:/root/.ivy2 \
   --volume "$HOST_COURSIER_CACHE:/root/$LINUX_COURSIER_CACHE" \


### PR DESCRIPTION
Coursier fetches 6 artefacts at a time per JVM. Our builds fan out to 20+ parallel sbt jobs, so a cold build could have 130+ requests in flight from one egress address and one AWS account. That is enough to be rate-limited by Maven Central and, as seen in storage-service build 2033, by the CodeArtifact mirror as well: one job there failed on 159 jar downloads, every one a 429 from the mirror.

This caps concurrent downloads at 2 per job via `SBT_OPTS`. Cold builds will be a little slower.

It goes in this repo rather than the sbt_wrapper image because agents run the image by tag without pulling, so an image change only reaches agents as they recycle.

Tracked in wellcomecollection/platform#6698.

## How to test

I ran the wrapper end to end against the published image: sbt reports `coursier.parallel-download-count` as 2 inside the container.
