### PR TITLE
Trial: running transformer_marc_xml's tests on GitHub Actions

### DIFF
--- a/.github/workflows/scala-ci-trial.yml
+++ b/.github/workflows/scala-ci-trial.yml
@@ -1,0 +1,62 @@
+name: "Scala CI trial: transformer_marc_xml"
+
+# A trial of running our Scala tests on GitHub Actions instead of Buildkite.
+# It gates nothing: Buildkite runs the same tests and still decides the merge.
+# The point is to measure whether a hosted runner plus a restored coursier
+# cache is fast enough, and to stop depending on one NAT address that Maven
+# Central rate-limits. See wellcomecollection/platform#6698.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/scala-ci-trial.yml"
+      - "common/transformer_marc_xml/**"
+      - "project/**"
+      - "build.sbt"
+      - "builds/**"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  test:
+    name: transformer_marc_xml (library)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out project
+        uses: actions/checkout@v7
+
+      # All we need from this role is permission to pull the sbt_wrapper image.
+      # It is the one the formatting workflow already assumes; a trial does not
+      # justify its own role, but a permanent workflow would want one.
+      - name: Configure AWS credentials
+        id: aws_credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-region: eu-west-1
+          role-to-assume: ${{ secrets.GHA_SCALA_FORMATTING_ROLE_ARN }}
+          output-credentials: true
+
+      - name: Log in to private ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      # Without CODEARTIFACT_AUTH_TOKEN the build resolves from Maven Central,
+      # so this needs no CodeArtifact permissions. Add the token later if the
+      # cache alone does not keep us under the rate limits.
+      - name: Restore the coursier cache
+        uses: coursier/cache-action@v6
+
+      - name: Run tests
+        run: ./builds/run_sbt_tests.sh transformer_marc_xml
+        env:
+          AWS_ACCESS_KEY_ID: ${{ steps.aws_credentials.outputs.aws-access-key-id }}
+          AWS_SECRET_KEY: ${{ steps.aws_credentials.outputs.aws-secret-access-key }}
+          AWS_SESSION_TOKEN: ${{ steps.aws_credentials.outputs.aws-session-token }}
+
+      # sbt runs as root inside the container and leaves the mounted caches
+      # root-owned, which the cache action cannot read when it saves them.
+      - name: Make the caches readable
+        if: always()
+        run: sudo chown -R "$USER" ~/.cache/coursier ~/.sbt ~/.ivy2 || true

--- a/.github/workflows/scala-ci-trial.yml
+++ b/.github/workflows/scala-ci-trial.yml
@@ -56,7 +56,11 @@ jobs:
           AWS_SESSION_TOKEN: ${{ steps.aws_credentials.outputs.aws-session-token }}
 
       # sbt runs as root inside the container and leaves the mounted caches
-      # root-owned, which the cache action cannot read when it saves them.
-      - name: Make the caches readable
+      # root-owned, which the cache action cannot read when it saves them. The
+      # container cannot simply run as the runner instead: run_sbt.sh restores
+      # the prebaked plugins and compiler bridges from root's home.
+      - name: Take ownership of the caches
         if: always()
-        run: sudo chown -R "$USER" ~/.cache/coursier ~/.sbt ~/.ivy2 || true
+        run: |
+          mkdir -p ~/.cache/coursier ~/.sbt ~/.ivy2
+          sudo chown -R "$(id -u):$(id -g)" ~/.cache/coursier ~/.sbt ~/.ivy2

--- a/.github/workflows/scala-ci-trial.yml
+++ b/.github/workflows/scala-ci-trial.yml
@@ -11,7 +11,8 @@ on:
   pull_request:
     paths:
       - ".github/workflows/scala-ci-trial.yml"
-      - "common/transformer_marc_xml/**"
+      - "pipeline/transformer/transformer_marc_xml/**"
+      - "pipeline/transformer/transformer_marc_common/**"
       - "project/**"
       - "build.sbt"
       - "builds/**"
@@ -24,6 +25,9 @@ jobs:
   test:
     name: transformer_marc_xml (library)
     runs-on: ubuntu-latest
+    # Pull requests from forks get no repository secrets, so the role ARN would
+    # be empty and assuming it would fail before any of this ran.
+    if: github.event.pull_request.head.repo.fork != true
     steps:
       - name: Check out project
         uses: actions/checkout@v7
@@ -48,12 +52,11 @@ jobs:
       - name: Restore the coursier cache
         uses: coursier/cache-action@v6
 
+      # No AWS credentials are passed through to sbt. Docker is already
+      # authenticated to ECR by the step above, and this build needs no AWS
+      # access: build.sbt imports an AWS credentials provider but never uses it.
       - name: Run tests
         run: ./builds/run_sbt_tests.sh transformer_marc_xml
-        env:
-          AWS_ACCESS_KEY_ID: ${{ steps.aws_credentials.outputs.aws-access-key-id }}
-          AWS_SECRET_KEY: ${{ steps.aws_credentials.outputs.aws-secret-access-key }}
-          AWS_SESSION_TOKEN: ${{ steps.aws_credentials.outputs.aws-session-token }}
 
       # sbt runs as root inside the container and leaves the mounted caches
       # root-owned, which the cache action cannot read when it saves them. The


### PR DESCRIPTION
A first step towards moving Scala CI off Buildkite, tracked in wellcomecollection/platform#6698.

This runs `transformer_marc_xml`'s tests on a GitHub Actions runner using the same `run_sbt_tests.sh` Buildkite calls. It gates nothing: Buildkite runs the same tests and still decides the merge, and the workflow can be deleted in one commit.

What it is meant to tell us: whether a hosted runner plus a restored coursier cache is fast enough to be worth migrating, and whether it avoids the Maven Central rate limiting we get from sharing one NAT address across 25 agents.

Two deliberate choices. It keeps the sbt_wrapper image, so the runner is the only variable and we keep the prebaked plugins and compiler bridges. And it sets no `CODEARTIFACT_AUTH_TOKEN`, so the build resolves from Maven Central and the job needs no CodeArtifact permissions. It reuses the role the formatting workflow already assumes, purely to pull the image; a permanent workflow would want its own.

`transformer_marc_xml` was picked because it needs no docker-compose, so the job is only sbt.

## How to test

Compare this job's duration against the `transformer_marc_xml (library)` step in the Buildkite build on the same commit, on a cold cache and then on a warm one.
