### PR TITLE
Version indexed works by merge time so the latest merge wins

### DIFF
--- a/catalogue_graph/src/ingestor/models/indexable/work.py
+++ b/catalogue_graph/src/ingestor/models/indexable/work.py
@@ -30,7 +30,9 @@ class IndexableWork(IndexableRecord):
         return self.debug.source.id
 
     def get_modified_time(self) -> datetime:
-        return datetime.fromisoformat(self.debug.source.modified_time)
+        # Versioned by merge time, not source modified time: re-merging a work leaves the
+        # source record untouched, so source time cannot order two merges of the same work.
+        return datetime.fromisoformat(self.debug.merged_time)
 
     @staticmethod
     def from_raw_document(work: dict) -> "IndexableWork":

--- a/catalogue_graph/tests/fixtures/ingestor/works/mock_es_inputs.json
+++ b/catalogue_graph/tests/fixtures/ingestor/works/mock_es_inputs.json
@@ -461,7 +461,7 @@
         "collection.root.title": "Twort, Frederick William"
       }
     },
-    "_version": 1751300414000,
+    "_version": 1755631433532,
     "_version_type": "external_gte"
   },
   {
@@ -1113,7 +1113,7 @@
         ]
       }
     },
-    "_version": 1752757655000,
+    "_version": 1755627040041,
     "_version_type": "external_gte"
   },
   {
@@ -1357,7 +1357,7 @@
         ]
       }
     },
-    "_version": 1757075757811,
+    "_version": 1757084694894,
     "_version_type": "external_gte"
   },
   {
@@ -1785,7 +1785,7 @@
         "collection.root.title": "Papers of Guido Pellegrino Arrigo Pontecorvo, geneticist, Professor of Genetics, University of Glasgow, Scotland"
       }
     },
-    "_version": 1701693347000,
+    "_version": 1755633615198,
     "_version_type": "external_gte"
   },
   {
@@ -2147,7 +2147,7 @@
         ]
       }
     },
-    "_version": 1641983361000,
+    "_version": 1755628630778,
     "_version_type": "external_gte"
   },
   {
@@ -2741,7 +2741,7 @@
         ]
       }
     },
-    "_version": 1720022876000,
+    "_version": 1755638267025,
     "_version_type": "external_gte"
   },
   {
@@ -3130,7 +3130,7 @@
         ]
       }
     },
-    "_version": 1692358704000,
+    "_version": 1755620768065,
     "_version_type": "external_gte"
   },
   {
@@ -3659,7 +3659,7 @@
         ]
       }
     },
-    "_version": 1692373799000,
+    "_version": 1755628639909,
     "_version_type": "external_gte"
   },
   {
@@ -4041,7 +4041,7 @@
         "collection.root.title": "Rast, Dr Hugo"
       }
     },
-    "_version": 1753957479000,
+    "_version": 1755631785995,
     "_version_type": "external_gte"
   },
   {
@@ -4401,7 +4401,7 @@
         ]
       }
     },
-    "_version": 1641983288000,
+    "_version": 1755634927952,
     "_version_type": "external_gte"
   }
 ]

--- a/catalogue_graph/tests/ingestor/test_generate_operations.py
+++ b/catalogue_graph/tests/ingestor/test_generate_operations.py
@@ -10,10 +10,13 @@ from ingestor.steps.ingestor_indexer import generate_operations
 from tests.ingestor.test_images_transformer import _build_extracted_image
 
 
-def test_generate_operations_works_version_from_source_modified_time() -> None:
+def _load_fixture_work() -> IndexableWork:
     df = pl.read_parquet("tests/fixtures/ingestor/works/00000000-00000010.parquet")
-    row = df.to_dicts()[0]
-    work = IndexableWork.from_raw_document(row)
+    return IndexableWork.from_raw_document(df.to_dicts()[0])
+
+
+def test_generate_operations_works_version_from_merged_time() -> None:
+    work = _load_fixture_work()
 
     ops = list(generate_operations("test-index", [work]))
 
@@ -22,10 +25,27 @@ def test_generate_operations_works_version_from_source_modified_time() -> None:
     assert ops[0]["_id"] == work.get_id()
     assert ops[0]["_version_type"] == "external_gte"
 
-    # Version should be epoch millis of source modified_time
-    expected_dt = datetime.fromisoformat(work.debug.source.modified_time)
+    # Version should be epoch millis of merged_time
+    expected_dt = datetime.fromisoformat(work.debug.merged_time)
     expected_version = int(expected_dt.timestamp() * 1000)
     assert ops[0]["_version"] == expected_version
+
+
+def test_generate_operations_works_version_ignores_source_modified_time() -> None:
+    """A re-merge leaves the source record untouched, so the source timestamp cannot
+    order two merges of the same work. See wellcomecollection/platform#6686."""
+    earlier = _load_fixture_work()
+    later = _load_fixture_work()
+
+    assert earlier.debug.source.modified_time == later.debug.source.modified_time
+    earlier.debug.merged_time = "2026-09-04T14:24:03.151495Z"
+    later.debug.merged_time = "2026-09-04T14:42:50.519380Z"
+
+    versions = [
+        op["_version"] for op in generate_operations("test-index", [earlier, later])
+    ]
+
+    assert versions[0] < versions[1]
 
 
 @freeze_time("2025-06-15T10:30:00Z")


### PR DESCRIPTION
## What does this change?

Works are versioned in `works-indexed` by `debug.mergedTime` instead of `debug.source.modifiedTime`. The indexed document itself is untouched, so the fixture diff moves `_version` and nothing else.

Fixes wellcomecollection/platform#6686. Round 1 saw the same defect at roughly 2,800 works and left it unexplained in wellcomecollection/platform#6464, where it was tentatively attributed to the SAME_AS traversal bound from #3529. That was a red herring: #3529 merged on 2026-08-03 and the round 3 losses are all after it.

### The real bug

Nothing re-types anything. `works-indexed` is holding a superseded merge, and a METS work is `Invisible` until a merge redirects it into its Sierra bib, so a stale copy reads as `Invisible` with no `redirectTarget`. Tracing `n9btd4g3` into `enarb2as`, all times UTC on 2026-09-04:

1. The METS work merges alone and is emitted `Invisible`, mergedTime 14:24. This is correct. The matcher's graph holds only that work, `Merger.categoriseWorks` finds no visible target, and the work passes through carrying the transformer's `MetsWorksAreNotVisible`.
2. The ingestor run for window 14:15 to 14:30 opens its point in time at 14:35, since `Open PIT` is the first state of `graph-pipeline-incremental` and the ingestor is the last.
3. The Sierra bib arrives, the work re-merges as `Redirected`, mergedTime 14:37. `works-denormalised` is now correct and stays correct.
4. That window's loader reads at 14:45, through the 14:35 snapshot, so it still sees `Invisible` and writes it to parquet.
5. The loader for window 14:30 to 14:45 reads the `Redirected` version and writes that to parquet. Both copies now exist in S3: 355 of the 484 appear as `Redirected` in the 14:30 window's output and 128 in the 14:45 window's.
6. Both indexers run concurrently, 14:35 to 15:55 and 14:50 to 15:56, because the scheduler fires every 15 minutes with no concurrency control and these runs took 51 to 80 minutes under reindex load. The stale one's bulk request lands second.
7. The version guard is the source record's 2019 modified time on both copies, identical, so `external_gte` accepts the overwrite.

Steps 1 to 5 are all working as designed. The defect is in 6 and 7, and fixing 7 makes 6 harmless.

Re-merging a work never touches its source record, so source modified time cannot order two merges of the same work. `mergedTime` can, and versioning by it means the stale write arrives with a lower version and bounces as a `version_conflict_engine_exception`, which `ingestor_indexer._is_version_conflict` already treats as benign: logged, counted in `version_conflict_count`, not fatal. That metric starts meaning something as a result.

The staleness is only visible in type counts when it flips the type. A full scroll of both indices puts it at 32,040 documents holding a superseded merge, a little over 1% of the index. Only 3 in a 1,000 id sample were merged within the last day, so almost none of that is ingest still in flight; the median stale document was last merged 99 hours ago. Most are `Visible` over `Visible` and carry stale content rather than a wrong type. They sit in three window executions, 2026-09-04 14:30 and 14:45 and 2026-09-07 08:00. Every other window is clean, because outside the reindex peak runs finish in about 8 minutes and never overlap.

### Checklist

- [x] Does this change the display model the catalogue API returns? No. The document body is identical; only the Elasticsearch version metadata changes.

## How to test

`uv run pytest tests/ingestor tests/test_ingestor_loader.py tests/test_ingestor_indexer.py` passes (149 tests); ruff and mypy are clean.

`test_generate_operations_works_version_ignores_source_modified_time` is the regression test: it builds two copies of one work with identical source modified times and different merge times, and asserts the versions order correctly. On main the two versions are equal, which is the whole bug.

To see it against the live data, pick any of the 484 and compare `debug.mergedTime` in `works-indexed-2026-07-03` against `state.mergedTime` in `works-denormalised-2026-07-03`. The indexed value is older in every one of the 484, and the redirect target carries the newer merge and was indexed correctly in 482 of them.

## How can we measure success?

The `Invisible` count at `works-indexed` should converge on `works-denormalised` the way production's does, rather than running 484 ahead. `version_conflict_count` should become non-zero during any period of overlapping runs, which is the fix working rather than a problem.

This does not repair the 32,040 documents already stale. They need re-ingesting by id, and the list is regenerable with `scripts/es_index_comparison/generate_6686_ids.py`, which diffs `state.mergedTime` at the denormalised stage against `debug.mergedTime` at the indexed stage.

## Have we considered potential risks?

I think the migration is safe without a reindex. Existing documents carry versions derived from source modified time, and across 30,000 sampled indexed works `mergedTime` was greater than or equal to `source.modifiedTime` every time, so the new version is never below what is already stored and no document starts rejecting legitimate writes. If some pathological document did carry a future-dated source time, the failure mode is a bounced write with a logged conflict rather than silent corruption.

Two things this deliberately does not address:

Concurrent runs of `graph-pipeline-incremental` are now harmless rather than corrupting, so the scheduler is left alone. Making runs non-overlapping needs a watermark so that a delayed run extends its window instead of dropping the skipped span, which is a larger change.

The related-works pass in `WorksIndexExtractor.extract_raw` rebuilds ancestors and descendants so their `partOf` and `parts` stay current, and those documents carry their own unchanged `mergedTime`. Two concurrent runs still write them at the same version, so a hierarchy refresh can still be clobbered by an older run. Same shape as this bug, narrower blast radius.

Replaying an old window will now bounce instead of applying, which is the intended behaviour but is a change for anyone used to replaying windows to backfill.
