### PR TITLE
Add a GitHub Actions role that can push the Scala app images

### DIFF
--- a/builds/terraform/github/gha_role_scala_ci.tf
+++ b/builds/terraform/github/gha_role_scala_ci.tf
@@ -29,11 +29,15 @@ module "gha_scala_ci_role" {
   policy_document = data.aws_iam_policy_document.gha_scala_ci.json
   role_name       = "scala-ci"
 
-  # TEMPORARY, for testing the push from the experiment branch. Change to
-  # refs/heads/main and re-apply before this merges: the role can overwrite the
-  # floating 'latest' tag that deploys resolve, so it should not be assumable
-  # from an arbitrary branch.
-  github_repository = "wellcomecollection/catalogue-pipeline:ref:refs/heads/rk-gha-app-image"
+  # Scoped to main, matching what Buildkite does today: branches build an image
+  # but only main publishes one. The role can overwrite the floating 'latest'
+  # tag that deploys resolve, so it should not be assumable from a branch.
+  #
+  # Note this only matches push events. GitHub's OIDC subject for a
+  # pull_request run is "repo:<owner>/<repo>:pull_request", so pull request jobs
+  # cannot assume this role at all and use the pull-only formatting role to
+  # fetch the sbt_wrapper image.
+  github_repository = "wellcomecollection/catalogue-pipeline:ref:refs/heads/main"
 
   github_oidc_provider_arn = data.terraform_remote_state.aws_account_infrastructure.outputs.github_openid_connect_provider_arn
 }

--- a/builds/terraform/github/gha_role_scala_ci.tf
+++ b/builds/terraform/github/gha_role_scala_ci.tf
@@ -1,0 +1,87 @@
+locals {
+  # The sbt apps whose images publish_sbt_image_to_ecr.sh pushes, matching the
+  # app matrix in .buildkite/pipeline.yml. Listed rather than wildcarded so that
+  # adding an app is a deliberate change here.
+  scala_app_ecr_repositories = [
+    "calm_adapter",
+    "calm_deletion_checker",
+    "calm_indexer",
+    "matcher",
+    "merger",
+    "mets_adapter",
+    "reindex_worker",
+    "sierra_indexer",
+    "sierra_linker",
+    "sierra_merger",
+    "tei_adapter",
+    "tei_id_extractor",
+    "transformer_calm",
+    "transformer_mets",
+    "transformer_miro",
+    "transformer_sierra",
+    "transformer_tei",
+  ]
+}
+
+module "gha_scala_ci_role" {
+  source = "github.com/wellcomecollection/terraform-aws-gha-role?ref=v1.0.0"
+
+  policy_document = data.aws_iam_policy_document.gha_scala_ci.json
+  role_name       = "scala-ci"
+
+  # Scoped to main rather than the whole repository, because this role can
+  # overwrite the floating 'latest' tag that deploys resolve. Pull request
+  # builds can build an image but never push one.
+  github_repository = "wellcomecollection/catalogue-pipeline:ref:refs/heads/main"
+
+  github_oidc_provider_arn = data.terraform_remote_state.aws_account_infrastructure.outputs.github_openid_connect_provider_arn
+}
+
+data "aws_iam_policy_document" "gha_scala_ci" {
+  statement {
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:BatchGetImage",
+      "ecr:Describe*",
+      "ecr:Get*",
+      "ecr:List*",
+      "ecr:TagResource",
+      "ecr:PutImage",
+      "ecr:InitiateLayerUpload",
+      "ecr:UploadLayerPart",
+      "ecr:CompleteLayerUpload",
+    ]
+    resources = [
+      for repository in local.scala_app_ecr_repositories :
+      "arn:aws:ecr:eu-west-1:760097843905:repository/uk.ac.wellcome/${repository}"
+    ]
+  }
+
+  # Pulling the sbt_wrapper image the build runs in.
+  statement {
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:BatchGetImage",
+      "ecr:GetDownloadUrlForLayer",
+    ]
+    resources = [
+      "arn:aws:ecr:eu-west-1:760097843905:repository/wellcome/sbt_wrapper",
+    ]
+  }
+
+  # Has to be unscoped: the token is account-wide rather than per repository.
+  statement {
+    actions = [
+      "ecr:GetAuthorizationToken",
+    ]
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "github_actions_secret" "scala_ci" {
+  repository      = "catalogue-pipeline"
+  secret_name     = "SCALA_CI_ROLE_ARN"
+  plaintext_value = module.gha_scala_ci_role.role_arn
+}

--- a/builds/terraform/github/gha_role_scala_ci.tf
+++ b/builds/terraform/github/gha_role_scala_ci.tf
@@ -29,10 +29,11 @@ module "gha_scala_ci_role" {
   policy_document = data.aws_iam_policy_document.gha_scala_ci.json
   role_name       = "scala-ci"
 
-  # Scoped to main rather than the whole repository, because this role can
-  # overwrite the floating 'latest' tag that deploys resolve. Pull request
-  # builds can build an image but never push one.
-  github_repository = "wellcomecollection/catalogue-pipeline:ref:refs/heads/main"
+  # TEMPORARY, for testing the push from the experiment branch. Change to
+  # refs/heads/main and re-apply before this merges: the role can overwrite the
+  # floating 'latest' tag that deploys resolve, so it should not be assumable
+  # from an arbitrary branch.
+  github_repository = "wellcomecollection/catalogue-pipeline:ref:refs/heads/rk-gha-app-image"
 
   github_oidc_provider_arn = data.terraform_remote_state.aws_account_infrastructure.outputs.github_openid_connect_provider_arn
 }


### PR DESCRIPTION
## What does this change?

Adds a `scala-ci` GitHub Actions role so that an app's image build and push can move off Buildkite: no role available to Actions can push these ECR repositories today. It uses the shared `terraform-aws-gha-role` module and the same OIDC provider as the catalogue graph role beside it, and publishes the ARN as the repository secret `SCALA_CI_ROLE_ARN`. It grants push on the seventeen app repositories under `uk.ac.wellcome`, listed explicitly rather than wildcarded so that adding an app is a deliberate change, pull on `wellcome/sbt_wrapper` so the build can fetch the image it runs in, and `ecr:GetAuthorizationToken` on `*`, which cannot be scoped.

Trust is scoped to `refs/heads/main` rather than the whole repository, following the identifiers role in catalogue-api rather than the graph role next to it. That matches Buildkite today: branches build an image, only main publishes one. A branch-scoped subject also only matches push events, because GitHub's OIDC subject for a `pull_request` run is `repo:<owner>/<repo>:pull_request`, so pull request jobs cannot assume this role at all and use the existing pull-only formatting role to fetch the sbt_wrapper image.

A step towards wellcomecollection/platform#5783. The first consumer is wellcomecollection/catalogue-pipeline#3654, which runs the matcher on Actions but deliberately does not publish yet, because an app's publish is waiting on retiring promote-by-latest (wellcomecollection/platform#6598) so that a deploy resolves the commit it was triggered for.

## How to test

`terraform fmt` and `terraform validate` pass. I have applied the role and used it to push a test image to `uk.ac.wellcome/sierra_merger` under a throwaway tag, `gha-trial.099c1e8`, which can be deleted. Apply here is manual.

## Have we considered potential risks?

The role can overwrite the floating `latest` tag that deploys resolve, which is why it is assumable only from main and not from a branch or a pull request.
