### PR TITLE
Run the matcher's tests and image build on GitHub Actions

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -40,7 +40,8 @@ steps:
       - "calm_adapter"
       - "calm_deletion_checker"
       - "calm_indexer"
-      - "matcher"
+      # matcher builds and publishes in GitHub Actions, see matcher-ci.yml.
+      # Deploys still happen here.
       - "merger"
       - "mets_adapter"
       - "reindex_worker"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -40,8 +40,7 @@ steps:
       - "calm_adapter"
       - "calm_deletion_checker"
       - "calm_indexer"
-      # matcher builds and publishes in GitHub Actions, see matcher-ci.yml.
-      # Deploys still happen here.
+      - "matcher"
       - "merger"
       - "mets_adapter"
       - "reindex_worker"

--- a/.github/workflows/matcher-ci.yml
+++ b/.github/workflows/matcher-ci.yml
@@ -8,15 +8,18 @@ name: "Matcher: test, build and push"
 # elasticsearch) and it depends on internal_model, pipeline_storage_typesafe
 # and lambda, so it exercises the whole path rather than a corner of it.
 #
-# Runs on every pull request and every push to main, matching what the Buildkite
-# matrix did. No paths filter: the matcher depends on enough of the repository
-# that listing the paths would eventually miss one.
+# Triggered by push rather than pull_request. A pull_request trigger fired when
+# this branch's PR was opened but not on later pushes to it, with no run created
+# and no error reported, so it is not something to build on until understood.
+# No paths filter: the matcher depends on enough of the repository that listing
+# the paths would eventually miss one.
 
 on:
-  pull_request:
   push:
     branches:
       - main
+      # Temporary, so the branch exercises the workflow. Remove before merging.
+      - rk-matcher-gha
 
 permissions:
   contents: read
@@ -26,7 +29,6 @@ jobs:
   matcher:
     name: matcher (app)
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.fork != true
     steps:
       - name: Check out project
         uses: actions/checkout@v7

--- a/.github/workflows/matcher-ci.yml
+++ b/.github/workflows/matcher-ci.yml
@@ -32,6 +32,12 @@ jobs:
 
       # The pull-only role the formatting workflow uses. Nothing here publishes,
       # so all we need is permission to fetch the sbt_wrapper image.
+      #
+      # No CODEARTIFACT_AUTH_TOKEN, so the build resolves from Maven Central
+      # rather than our mirror. That is deliberate for now and tracked in
+      # wellcomecollection/platform#6701: minting a token needs a permission no
+      # role here has, and CodeArtifact throttles per account, so routing this
+      # through it would add load to the quota that was already failing.
       - name: Configure AWS credentials
         id: aws_credentials
         uses: aws-actions/configure-aws-credentials@v6

--- a/.github/workflows/matcher-ci.yml
+++ b/.github/workflows/matcher-ci.yml
@@ -52,9 +52,10 @@ jobs:
       - name: Restore the coursier cache
         uses: coursier/cache-action@v6
 
-      # Elasticsearch 8 binds a non-loopback address here, which puts it in
-      # production mode and enforces its bootstrap checks. Runners default to
-      # 65530, well under the 262144 it demands, so it exits at startup.
+      # Elasticsearch binds a non-loopback address here, so it runs its
+      # bootstrap checks, and a runner's default of 65530 is under the 262144
+      # it requires. Not what made it crash before, but it would be the next
+      # thing to stop it.
       - name: Raise vm.max_map_count for Elasticsearch
         run: sudo sysctl -w vm.max_map_count=262144
 

--- a/.github/workflows/matcher-ci.yml
+++ b/.github/workflows/matcher-ci.yml
@@ -46,12 +46,6 @@ jobs:
       - name: Restore the coursier cache
         uses: coursier/cache-action@v6
 
-      # Elasticsearch binds a non-loopback address here, so it runs its
-      # bootstrap checks, and a runner's default of 65530 is under the 262144
-      # it requires.
-      - name: Raise vm.max_map_count for Elasticsearch
-        run: sudo sysctl -w vm.max_map_count=262144
-
       # Starts the service containers through the host's Docker socket, which
       # run_sbt_task_in_docker.sh mounts into the sbt container.
       - name: Run tests

--- a/.github/workflows/matcher-ci.yml
+++ b/.github/workflows/matcher-ci.yml
@@ -1,0 +1,71 @@
+name: "Matcher: test, build and push"
+
+# The matcher's Buildkite app step, moved here. Deploys stay in Buildkite: this
+# publishes the image, and the deploy pipeline retags it.
+#
+# The matcher is the most demanding app we have, which is why it went first:
+# its tests start three service containers (localstack, dynamodb-local and
+# elasticsearch) and it depends on internal_model, pipeline_storage_typesafe
+# and lambda, so it exercises the whole path rather than a corner of it.
+#
+# Runs on every pull request and every push to main, matching what the Buildkite
+# matrix did. No paths filter: the matcher depends on enough of the repository
+# that listing the paths would eventually miss one.
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  matcher:
+    name: matcher (app)
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.fork != true
+    steps:
+      - name: Check out project
+        uses: actions/checkout@v7
+
+      # Two roles by design. Only main publishes, so only main needs the role
+      # that can push; pull requests get the pull-only role, which is all they
+      # need to fetch the sbt_wrapper image. The push role is scoped to
+      # refs/heads/main and could not be assumed from a pull request anyway:
+      # GitHub's OIDC subject for those runs is "repo:<owner>/<repo>:pull_request".
+      - name: Configure AWS credentials
+        id: aws_credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-region: eu-west-1
+          role-to-assume: ${{ github.ref == 'refs/heads/main' && secrets.SCALA_CI_ROLE_ARN || secrets.GHA_SCALA_FORMATTING_ROLE_ARN }}
+          output-credentials: true
+
+      - name: Log in to private ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Restore the coursier cache
+        uses: coursier/cache-action@v6
+
+      # Starts the service containers through the host's Docker socket, which
+      # run_sbt_task_in_docker.sh mounts into the sbt container.
+      - name: Run tests
+        run: ./builds/run_sbt_tests.sh matcher
+
+      - name: Build the image
+        run: ./builds/build_sbt_image.sh matcher "$GITHUB_SHA"
+
+      - name: Publish the image
+        if: github.ref == 'refs/heads/main'
+        run: ./builds/publish_sbt_image_to_ecr.sh matcher "$GITHUB_SHA"
+
+      # sbt runs as root inside the container and leaves the mounted caches
+      # root-owned, which the cache action cannot read when it saves them.
+      - name: Take ownership of the caches
+        if: always()
+        run: |
+          mkdir -p ~/.cache/coursier ~/.sbt ~/.ivy2
+          sudo chown -R "$(id -u):$(id -g)" ~/.cache/coursier ~/.sbt ~/.ivy2

--- a/.github/workflows/matcher-ci.yml
+++ b/.github/workflows/matcher-ci.yml
@@ -50,10 +50,25 @@ jobs:
       - name: Restore the coursier cache
         uses: coursier/cache-action@v6
 
+      # Elasticsearch 8 binds a non-loopback address here, which puts it in
+      # production mode and enforces its bootstrap checks. Runners default to
+      # 65530, well under the 262144 it demands, so it exits at startup.
+      - name: Raise vm.max_map_count for Elasticsearch
+        run: sudo sysctl -w vm.max_map_count=262144
+
       # Starts the service containers through the host's Docker socket, which
       # run_sbt_task_in_docker.sh mounts into the sbt container.
       - name: Run tests
         run: ./builds/run_sbt_tests.sh matcher
+
+      - name: Show the service containers if the tests failed
+        if: failure()
+        run: |
+          docker ps -a --format '{{.Names}} {{.Image}} {{.Status}}'
+          for name in $(docker ps -aq); do
+            echo "=== $name"
+            docker logs --tail 40 "$name" 2>&1 || true
+          done
 
       - name: Build the image
         run: ./builds/build_sbt_image.sh matcher "$GITHUB_SHA"

--- a/.github/workflows/matcher-ci.yml
+++ b/.github/workflows/matcher-ci.yml
@@ -1,16 +1,16 @@
-name: "Matcher: test, build and push"
+name: "Matcher: test and build"
 
-# The matcher's Buildkite app step, moved here. Deploys stay in Buildkite: this
-# publishes the image, and the deploy pipeline retags it.
+# Runs the matcher's tests and builds its image on GitHub Actions, alongside the
+# Buildkite step rather than instead of it. Buildkite still publishes the image
+# and still deploys, so nothing here can affect what is running.
 #
-# The matcher is the most demanding app we have, which is why it went first:
-# its tests start three service containers (localstack, dynamodb-local and
-# elasticsearch) and it depends on internal_model, pipeline_storage_typesafe
-# and lambda, so it exercises the whole path rather than a corner of it.
+# The matcher is the most demanding app we have: its tests start three service
+# containers (localstack, dynamodb-local and elasticsearch) and it depends on
+# internal_model, pipeline_storage_typesafe and lambda, so it exercises the whole
+# path rather than a corner of it.
 #
-# Runs on every pull request and every push to main, matching what the Buildkite
-# matrix did. No paths filter: the matcher depends on enough of the repository
-# that listing the paths would eventually miss one.
+# No paths filter: the matcher depends on enough of the repository that listing
+# the paths would eventually miss one.
 
 on:
   pull_request:
@@ -30,17 +30,14 @@ jobs:
       - name: Check out project
         uses: actions/checkout@v7
 
-      # Two roles by design. Only main publishes, so only main needs the role
-      # that can push; pull requests get the pull-only role, which is all they
-      # need to fetch the sbt_wrapper image. The push role is scoped to
-      # refs/heads/main and could not be assumed from a pull request anyway:
-      # GitHub's OIDC subject for those runs is "repo:<owner>/<repo>:pull_request".
+      # The pull-only role the formatting workflow uses. Nothing here publishes,
+      # so all we need is permission to fetch the sbt_wrapper image.
       - name: Configure AWS credentials
         id: aws_credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: eu-west-1
-          role-to-assume: ${{ github.ref == 'refs/heads/main' && secrets.SCALA_CI_ROLE_ARN || secrets.GHA_SCALA_FORMATTING_ROLE_ARN }}
+          role-to-assume: ${{ secrets.GHA_SCALA_FORMATTING_ROLE_ARN }}
           output-credentials: true
 
       - name: Log in to private ECR
@@ -51,8 +48,7 @@ jobs:
 
       # Elasticsearch binds a non-loopback address here, so it runs its
       # bootstrap checks, and a runner's default of 65530 is under the 262144
-      # it requires. Not what made it crash before, but it would be the next
-      # thing to stop it.
+      # it requires.
       - name: Raise vm.max_map_count for Elasticsearch
         run: sudo sysctl -w vm.max_map_count=262144
 
@@ -72,10 +68,6 @@ jobs:
 
       - name: Build the image
         run: ./builds/build_sbt_image.sh matcher "$GITHUB_SHA"
-
-      - name: Publish the image
-        if: github.ref == 'refs/heads/main'
-        run: ./builds/publish_sbt_image_to_ecr.sh matcher "$GITHUB_SHA"
 
       # sbt runs as root inside the container and leaves the mounted caches
       # root-owned, which the cache action cannot read when it saves them.

--- a/builds/run_sbt_task_in_docker.sh
+++ b/builds/run_sbt_task_in_docker.sh
@@ -54,10 +54,17 @@ else
   HOST_COURSIER_CACHE=~/$LINUX_COURSIER_CACHE
 fi
 
+# AWS_REGION and AWS_DEFAULT_REGION are passed without a value on purpose, so
+# Docker forwards them only when the host has them set. On a Buildkite agent the
+# SDK reads the region from EC2 instance metadata, which --net host makes
+# reachable; anywhere else, including a GitHub Actions runner, there is no
+# metadata service and the region has to come from the environment.
 docker run --tty --rm \
   -e AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-}" \
   -e AWS_SECRET_KEY="${AWS_SECRET_KEY:-}" \
   -e AWS_SESSION_TOKEN="${AWS_SESSION_TOKEN:-}" \
+  -e AWS_REGION \
+  -e AWS_DEFAULT_REGION \
   -e CODEARTIFACT_AUTH_TOKEN="${CODEARTIFACT_AUTH_TOKEN:-}" \
   --volume ~/.sbt:/root/.sbt \
   --volume ~/.ivy2:/root/.ivy2 \

--- a/pipeline/matcher_merger/matcher/docker-compose.yml
+++ b/pipeline/matcher_merger/matcher/docker-compose.yml
@@ -23,3 +23,9 @@ services:
       - "discovery.type=single-node"
       - "xpack.security.enabled=false"
       - "action.auto_create_index=false"
+      # The JDK bundled with 8.4.0 throws a NullPointerException out of its
+      # cgroup detection on a cgroups v2 host, which is what GitHub Actions
+      # runners use, and the container exits before Elasticsearch starts.
+      # Turning off container support skips that detection; the heap is set
+      # explicitly because that is what container support would otherwise size.
+      - "ES_JAVA_OPTS=-Xms1g -Xmx1g -XX:-UseContainerSupport"

--- a/pipeline/matcher_merger/matcher/docker-compose.yml
+++ b/pipeline/matcher_merger/matcher/docker-compose.yml
@@ -12,7 +12,12 @@ services:
     ports:
       - "45678:8000"
   elasticsearch:
-    image: "docker.elastic.co/elasticsearch/elasticsearch:8.4.0"
+    # 8.11.4 rather than the 8.4.0 the other projects pin: the JDK bundled with
+    # 8.4.0 throws a NullPointerException out of its cgroup detection on a
+    # cgroups v2 host, which is what GitHub Actions runners use, so the
+    # container exits before Elasticsearch starts. This one bundles JDK 21.
+    # The others want the same bump when they move off Buildkite.
+    image: "docker.elastic.co/elasticsearch/elasticsearch:8.11.4"
     ports:
       - "9200:9200"
       - "9300:9300"
@@ -23,9 +28,3 @@ services:
       - "discovery.type=single-node"
       - "xpack.security.enabled=false"
       - "action.auto_create_index=false"
-      # The JDK bundled with 8.4.0 throws a NullPointerException out of its
-      # cgroup detection on a cgroups v2 host, which is what GitHub Actions
-      # runners use, and the container exits before Elasticsearch starts.
-      # Turning off container support skips that detection; the heap is set
-      # explicitly because that is what container support would otherwise size.
-      - "ES_JAVA_OPTS=-Xms1g -Xmx1g -XX:-UseContainerSupport"


### PR DESCRIPTION
## What does this change?

Runs the matcher's tests and image build on GitHub Actions, alongside the Buildkite step rather than instead of it. A step towards wellcomecollection/platform#5783. Buildkite still publishes the image and still deploys, so nothing here can affect what is running, and the job needs no role that can push.

I took the matcher because it is the most demanding app rather than the easiest: its tests start localstack, dynamodb-local and elasticsearch, and it depends on internal_model, pipeline_storage_typesafe and lambda.

Two supporting changes, which is why files outside the workflow are touched:

- `builds/run_sbt_task_in_docker.sh` forwards `AWS_REGION` and `AWS_DEFAULT_REGION` into the container. A Buildkite agent gets the region from EC2 instance metadata, reachable because the container uses host networking, and a hosted runner has no metadata service. They are passed without values, so Docker omits them when the host has them unset and the Buildkite path is unchanged.
- The matcher's `docker-compose.yml` moves Elasticsearch from 8.4.0 to 8.11.4. The JDK bundled with 8.4.0 throws a NullPointerException from its cgroup detection on a cgroups v2 host, which is what hosted runners use, and the container exits before Elasticsearch starts. 8.11.4 bundles JDK 21. Five other projects still pin 8.4.0 and will want the same bump when they move.

## How to test

Compare this job against the `matcher (app)` step in the Buildkite build on the same commit. The last full run passed with 72 tests, 4m40s of tests and 33s to build the image.

## Have we considered potential risks?

Publishing and deploying are untouched, so the worst case is a duplicated build. Moving the publish here needs the role in wellcomecollection/catalogue-pipeline#3653, and retagging by commit rather than by `latest`, which is wellcomecollection/platform#6598.


