### PR TITLE
Switch off the CALM adapter

### DIFF
--- a/calm_adapter/README.md
+++ b/calm_adapter/README.md
@@ -1,7 +1,8 @@
 # CALM adapter
 
 CALM is our archive catalogue.
-The CALM adapter fetches new records from CALM and keeps our copy of the CALM database up-to-date.
+The CALM adapter fetched new records from CALM and kept our copy of the CALM database up to date.
+It no longer runs, and our copy stays as it was on 2026-09-10.
 
 ## Harvesting is switched off
 
@@ -33,6 +34,7 @@ Decommissioning the CALM code and infrastructure is separate, later work.
     [api_guide]: https://us-east-1.console.aws.amazon.com/s3/object/wellcomecollection-platform-infra?prefix=Calm.API.Guide.pdf&region=eu-west-1
 
 *   The `calm_adapter` service fetches updated records from CALM.
+    It is still deployed, but nothing sends it work while harvesting is off.
 
     It receives queries from the `calm_window_generator`, which tell it what sort of records to fetch.
     e.g.
@@ -51,6 +53,7 @@ Decommissioning the CALM code and infrastructure is separate, later work.
 
     The window generator runs as a Lambda on a fixed schedule, or it can be run locally if you want to do a one-off query.
     e.g. you can refetch all the records modified on a given day.
+    The schedule is disabled, so the local CLI is the only way it runs now.
 
     TODO: Should we rename this to "query generator"?
 
@@ -61,6 +64,8 @@ Decommissioning the CALM code and infrastructure is separate, later work.
 
     Because we want to spot when records are deleted, we have the `calm_deletion_checker` that polls CALM to look for deleted records (by looking for every record we know about, and checking if it's still in the API).
     It's triggered by the `calm_deletion_check_initiator`.
+    Both are switched off, and CALM is read-only, so there are no new deletions to find.
 
 *   The `calm_indexer` service indexes CALM records in the reporting cluster.
     This is meant for ad hoc analysis of the CALM data, e.g. when designing a new transformation rule.
+    It is scaled to zero, so the `calm_catalog` index holds whatever it last indexed.

--- a/calm_adapter/README.md
+++ b/calm_adapter/README.md
@@ -3,6 +3,21 @@
 CALM is our archive catalogue.
 The CALM adapter fetches new records from CALM and keeps our copy of the CALM database up-to-date.
 
+## Harvesting is switched off
+
+CALM went read-only on 2026-09-10 ahead of the Axiell Collections migration, so
+we stopped harvesting from it (wellcomecollection/platform#6689). Both schedules
+are disabled in terraform via `harvesting_enabled` and `deletion_checking_enabled`
+in [terraform/locals.tf](terraform/locals.tf), which turns off the window
+generator, the deletion check initiator and the deletion checker service.
+
+Everything else is still in place. The adapter store keeps the records it already
+holds, and the production pipeline still transforms CALM works out of it. To run a
+one-off query against CALM, invoke the window generator Lambda directly: the
+schedule is disabled but the service behind it is not.
+
+Decommissioning the CALM code and infrastructure is a separate, later piece of work.
+
 ## Key services/libraries
 
 *   The `calm_api_client` library is a generic client for the CALM API.

--- a/calm_adapter/README.md
+++ b/calm_adapter/README.md
@@ -5,18 +5,23 @@ The CALM adapter fetches new records from CALM and keeps our copy of the CALM da
 
 ## Harvesting is switched off
 
-CALM went read-only on 2026-09-10 ahead of the Axiell Collections migration, so
-we stopped harvesting from it (wellcomecollection/platform#6689). Both schedules
-are disabled in terraform via `harvesting_enabled` and `deletion_checking_enabled`
-in [terraform/locals.tf](terraform/locals.tf), which turns off the window
-generator, the deletion check initiator and the deletion checker service.
+CALM went read-only on 2026-09-10 ahead of the Axiell Collections migration, and
+we no longer harvest from it. See wellcomecollection/platform#6689.
 
-Everything else is still in place. The adapter store keeps the records it already
-holds, and the production pipeline still transforms CALM works out of it. To run a
-one-off query against CALM, invoke the window generator Lambda directly: the
-schedule is disabled but the service behind it is not.
+Three flags in [terraform/locals.tf](terraform/locals.tf) hold this in place.
+`harvesting_enabled` disables the window generator's schedule,
+`deletion_checking_enabled` disables the deletion check initiator's schedule and
+scales the deletion checker to zero, and `indexing_enabled` scales the indexer
+to zero.
 
-Decommissioning the CALM code and infrastructure is a separate, later piece of work.
+The adapter store keeps the records it already holds, and the production pipeline
+still transforms CALM works out of it. The adapter service and the `calm-windows`
+queue are untouched, so a one-off re-harvest still works by running the window
+generator CLI locally, as described below. The deletion checker and the indexer
+have no running tasks, so anything published to their queues will sit there
+unconsumed until it ages out to the DLQ.
+
+Decommissioning the CALM code and infrastructure is separate, later work.
 
 ## Key services/libraries
 

--- a/calm_adapter/terraform/indexer.tf
+++ b/calm_adapter/terraform/indexer.tf
@@ -11,7 +11,7 @@ module "calm_indexer" {
   ]
 
   min_capacity = 0
-  max_capacity = 1
+  max_capacity = local.indexing_enabled ? 1 : 0
 
   env_vars = {
     es_index          = "calm_catalog"

--- a/calm_adapter/terraform/locals.tf
+++ b/calm_adapter/terraform/locals.tf
@@ -16,7 +16,11 @@ locals {
 
   calm_api_url = "https://archives.wellcome.org/CalmAPI/ContentService.asmx"
 
-  deletion_checking_enabled = true
+  # CALM went read-only on 2026-09-10 ahead of the Axiell Collections migration,
+  # so we no longer harvest from it. See wellcomecollection/platform#6689.
+  # The adapter store is untouched: the production pipeline still reads it.
+  harvesting_enabled        = false
+  deletion_checking_enabled = false
 
   window_generator_interval = "60 minutes"
   deletion_check_interval   = "7 days"

--- a/calm_adapter/terraform/locals.tf
+++ b/calm_adapter/terraform/locals.tf
@@ -16,11 +16,13 @@ locals {
 
   calm_api_url = "https://archives.wellcome.org/CalmAPI/ContentService.asmx"
 
-  # CALM went read-only on 2026-09-10 ahead of the Axiell Collections migration,
-  # so we no longer harvest from it. See wellcomecollection/platform#6689.
-  # The adapter store is untouched: the production pipeline still reads it.
+  # CALM is read-only ahead of the Axiell Collections migration, so we do not
+  # harvest from it, check it for deletions, or index it for reporting. The
+  # adapter store stays in place for the production pipeline to read.
+  # See wellcomecollection/platform#6689.
   harvesting_enabled        = false
   deletion_checking_enabled = false
+  indexing_enabled          = false
 
   window_generator_interval = "60 minutes"
   deletion_check_interval   = "7 days"

--- a/calm_adapter/terraform/terraform.tf
+++ b/calm_adapter/terraform/terraform.tf
@@ -1,6 +1,8 @@
 terraform {
   backend "s3" {
-    role_arn = "arn:aws:iam::760097843905:role/platform-developer"
+    assume_role = {
+      role_arn = "arn:aws:iam::760097843905:role/platform-developer"
+    }
 
     bucket         = "wellcomecollection-platform-infra"
     key            = "terraform/calm_adapter.tfstate"
@@ -13,7 +15,9 @@ data "terraform_remote_state" "monitoring" {
   backend = "s3"
 
   config = {
-    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    assume_role = {
+      role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    }
 
     bucket = "wellcomecollection-platform-infra"
     key    = "terraform/monitoring.tfstate"
@@ -25,7 +29,9 @@ data "terraform_remote_state" "shared_infra" {
   backend = "s3"
 
   config = {
-    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    assume_role = {
+      role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    }
 
     bucket = "wellcomecollection-platform-infra"
     key    = "terraform/platform-infrastructure/shared.tfstate"
@@ -37,7 +43,9 @@ data "terraform_remote_state" "accounts_catalogue" {
   backend = "s3"
 
   config = {
-    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    assume_role = {
+      role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    }
 
     bucket = "wellcomecollection-platform-infra"
     key    = "terraform/aws-account-infrastructure/catalogue.tfstate"
@@ -49,10 +57,12 @@ data "terraform_remote_state" "reindexer" {
   backend = "s3"
 
   config = {
-    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
-    bucket   = "wellcomecollection-platform-infra"
-    key      = "terraform/catalogue/reindexer.tfstate"
-    region   = "eu-west-1"
+    assume_role = {
+      role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    }
+    bucket = "wellcomecollection-platform-infra"
+    key    = "terraform/catalogue/reindexer.tfstate"
+    region = "eu-west-1"
   }
 }
 

--- a/calm_adapter/terraform/window_generator.tf
+++ b/calm_adapter/terraform/window_generator.tf
@@ -11,6 +11,8 @@ module "window_generator_lambda" {
   env_vars = {
     TOPIC_ARN = aws_sns_topic.calm_windows_topic.arn
   }
+
+  events_enabled = local.harvesting_enabled
 }
 
 data "aws_iam_policy_document" "publish_to_windows_topic" {

--- a/docs/fetching-records-from-source-catalogues/calm-our-archive-catalogue.md
+++ b/docs/fetching-records-from-source-catalogues/calm-our-archive-catalogue.md
@@ -26,10 +26,10 @@ There's no publicly available documentation, but there's a [CALM API guide][api_
 
 ## How we get updates
 
-> We stopped harvesting from CALM on 2026-09-10, when it went read-only ahead of
-> the Axiell Collections migration (wellcomecollection/platform#6689). The polling
-> and deletion-checking schedules below are disabled. Our copy of the records is
-> frozen at that point, and the pipeline still transforms works out of it.
+> We no longer harvest from CALM. It went read-only on 2026-09-10 ahead of the
+> Axiell Collections migration, so the polling and deletion-checking schedules
+> described below are disabled (wellcomecollection/platform#6689). Our copy of
+> the records stays as it is, and the pipeline still transforms works out of it.
 
 *   We poll CALM on a fixed interval, and retrieve any records which have been created or modified since the last poll.
 

--- a/docs/fetching-records-from-source-catalogues/calm-our-archive-catalogue.md
+++ b/docs/fetching-records-from-source-catalogues/calm-our-archive-catalogue.md
@@ -26,6 +26,11 @@ There's no publicly available documentation, but there's a [CALM API guide][api_
 
 ## How we get updates
 
+> We stopped harvesting from CALM on 2026-09-10, when it went read-only ahead of
+> the Axiell Collections migration (wellcomecollection/platform#6689). The polling
+> and deletion-checking schedules below are disabled. Our copy of the records is
+> frozen at that point, and the pipeline still transforms works out of it.
+
 *   We poll CALM on a fixed interval, and retrieve any records which have been created or modified since the last poll.
 
 *   We don't pull complete CALM records into the pipeline; we suppress a handful of fields, e.g. those which contain personally identifiable information (PII).


### PR DESCRIPTION
## What does this change?

CALM went read-only on 2026-09-10 ahead of the Axiell Collections migration, so anything harvested from it now is an accidental or experimental edit that will be lost at the final migration. This stops the adapter doing that work. `harvesting_enabled`, `deletion_checking_enabled` and `indexing_enabled` in `calm_adapter/terraform/locals.tf` are all false, which disables the window generator and deletion check schedules and scales the deletion checker and indexer to zero. The window generator's schedule was unconditional because it never passed the `events_enabled` flag its module already supported.

Our copy of the records is untouched and the pipeline still transforms CALM works out of it. The `calm_adapter` service and the `calm-windows` queue keep their capacity, so a one-off re-harvest is still possible by running `calm_window_generator/src/cli.py` locally.

A later decommission ticket covers the adapter store, the reindexer's CALM job configs, the CALM transformers in both pipeline stacks, and the CALM to Sierra harvester, which is already disabled on the collections side.

A follow-up will turn on DynamoDB deletion protection and point-in-time recovery for `vhs-calm-adapter`. That needs an upstream change to `terraform-aws-vhs`, in flight as a separate PR on that repo, and does not block this one.

Refs wellcomecollection/platform#6689.

## How to test

`terraform fmt -check -recursive` is clean. `terraform validate` reports four errors in the `terraform.tf` remote state data sources; those are pre-existing, caused by local Terraform 1.14.4 being newer than the version this root is applied with, and `terraform.tf` is not in the diff. tflint is not installed on this machine, so the tflint workflow covers it.

After apply, the `calm_window_generator` and `calm_deletion_check_initiator` EventBridge rules should be disabled, and the `calm_deletion_checker` and `calm_indexer` services should drain to zero tasks.

## How can we measure success?

No new windows arrive on the `calm-windows` topic and there are no further writes to the adapter store.

## Have we considered potential risks?

There is no apply workflow for `calm_adapter/terraform`, so this is inert until applied by hand while the README and docs page assert the present tense. Apply at merge.

