### PR TITLE
Add a tool to snapshot a VHS to parquet

### DIFF
--- a/catalogue_graph/scripts/snapshot_vhs.py
+++ b/catalogue_graph/scripts/snapshot_vhs.py
@@ -1,0 +1,394 @@
+"""Write a parquet snapshot of the latest version of every record in a VHS.
+
+A VHS (versioned hybrid store) keeps an index in DynamoDB and the record
+bodies in S3. The DynamoDB row is the only thing that says which S3 object is
+current: the bucket holds every version a record has ever had, so the snapshot
+scans the table, reads the object each row points at, and writes one parquet
+row per record.
+
+This exists because a VHS becomes the only copy of its source dataset once its
+adapter stops harvesting, which is happening to the CALM store under
+wellcomecollection/platform#6689. The other two stores have the same shape and
+will reach the same point as their sources are retired.
+
+The snapshot is written to a `.partial` file and moved into place only on a
+complete, successful run, so a file at the output path is always whole.
+
+Usage:
+    uv run python scripts/snapshot_vhs.py --store calm --output-path /tmp/calm.parquet
+    uv run python scripts/snapshot_vhs.py --store calm --output-path /tmp/calm.parquet --upload-to s3://bucket/prefix/
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from typing import Any
+
+import boto3
+import pyarrow as pa
+import pyarrow.parquet as pq
+import structlog
+from botocore.config import Config as BotocoreConfig
+from pyiceberg.io.pyarrow import schema_to_pyarrow
+from pyiceberg.schema import Schema
+from pyiceberg.types import (
+    BooleanType,
+    IntegerType,
+    NestedField,
+    StringType,
+    TimestamptzType,
+)
+
+from utils.logger import ExecutionContext, get_trace_id, setup_logging
+
+logger = structlog.get_logger(__name__)
+
+BATCH_SIZE = 10_000
+"""Records per parquet row group. Each batch's bodies are held in memory while
+it is assembled, so this bounds peak usage rather than the record count."""
+
+SCAN_SEGMENTS = 16
+"""Parallel DynamoDB scan segments."""
+
+FETCH_WORKERS = 32
+"""Concurrent S3 GETs. The bodies are small and the run is one-off, so this is
+set for a sensible wall-clock rather than to saturate anything."""
+
+PROGRESS_LOG_EVERY = 25_000
+
+
+# The first six fields match ADAPTER_STORE_ICEBERG_SCHEMA in
+# adapters/utils/schemata.py, so selecting them gives a table that loads
+# through the adapter store's own snapshot path. `version` and `s3_key` are
+# VHS-specific provenance on top.
+VHS_SNAPSHOT_ICEBERG_SCHEMA = Schema(
+    NestedField(field_id=1, name="namespace", field_type=StringType(), required=True),
+    NestedField(field_id=2, name="id", field_type=StringType(), required=True),
+    NestedField(field_id=3, name="content", field_type=StringType(), required=False),
+    NestedField(field_id=4, name="changeset", field_type=StringType(), required=False),
+    NestedField(
+        field_id=5, name="last_modified", field_type=TimestamptzType(), required=True
+    ),
+    NestedField(
+        field_id=6,
+        name="deleted",
+        field_type=BooleanType(),
+        required=False,
+        default_value=False,
+    ),
+    NestedField(field_id=7, name="version", field_type=IntegerType(), required=True),
+    NestedField(field_id=8, name="s3_key", field_type=StringType(), required=True),
+)
+VHS_SNAPSHOT_ARROW_SCHEMA: pa.Schema = schema_to_pyarrow(VHS_SNAPSHOT_ICEBERG_SCHEMA)
+
+
+@dataclass(frozen=True)
+class VHSStoreConfig:
+    table_name: str
+    namespace: str
+    id_field: str | None = None
+    """Key in the record body holding the record's own id, where the body has
+    one. Used to check the DynamoDB row and the S3 object agree."""
+
+
+VHS_STORES: dict[str, VHSStoreConfig] = {
+    "calm": VHSStoreConfig(
+        table_name="vhs-calm-adapter", namespace="calm", id_field="id"
+    ),
+    "sierra": VHSStoreConfig(
+        table_name="vhs-sierra-sierra-adapter-20200604", namespace="sierra"
+    ),
+    "miro": VHSStoreConfig(table_name="vhs-sourcedata-miro", namespace="miro"),
+}
+
+
+@dataclass(frozen=True)
+class IndexRow:
+    """One DynamoDB row, pointing at the current body for a record."""
+
+    id: str
+    version: int
+    bucket: str
+    key: str
+    deleted: bool
+
+
+class SnapshotError(Exception):
+    pass
+
+
+def _parse_index_row(item: dict[str, Any]) -> IndexRow:
+    """Read a VHS index row.
+
+    The S3 location lives under `payload` in some stores and `location` in
+    others. The key is taken verbatim and never rebuilt from the version,
+    because the CALM deletion checker bumps the version without writing a new
+    object, leaving the two disagreeing for deleted records.
+    """
+    location = item.get("payload") or item.get("location")
+    if not location:
+        raise SnapshotError(f"Row {item.get('id')} has no payload or location")
+
+    return IndexRow(
+        id=item["id"],
+        version=int(item["version"]),
+        bucket=location["bucket"],
+        key=location["key"],
+        deleted=bool(item.get("isDeleted", False)),
+    )
+
+
+def scan_index(dynamodb_resource: Any, table_name: str) -> list[IndexRow]:
+    """Read every row of the VHS index table, scanning segments in parallel."""
+    client = dynamodb_resource.meta.client
+
+    def scan_segment(segment: int) -> list[IndexRow]:
+        rows: list[IndexRow] = []
+        paginator = client.get_paginator("scan")
+        pages = paginator.paginate(
+            TableName=table_name, Segment=segment, TotalSegments=SCAN_SEGMENTS
+        )
+        for page in pages:
+            rows.extend(_parse_index_row(item) for item in page["Items"])
+        return rows
+
+    started_at = time.time()
+    with ThreadPoolExecutor(max_workers=SCAN_SEGMENTS) as pool:
+        segments = pool.map(scan_segment, range(SCAN_SEGMENTS))
+        rows = [row for segment_rows in segments for row in segment_rows]
+
+    logger.info(
+        "Index scanned",
+        table_name=table_name,
+        rows=len(rows),
+        seconds=round(time.time() - started_at),
+    )
+    if not rows:
+        raise SnapshotError(
+            f"Table {table_name} returned 0 rows. This is almost certainly an "
+            "error rather than an empty store."
+        )
+    return rows
+
+
+def _fetch_row(s3_client: Any, config: VHSStoreConfig, row: IndexRow) -> dict[str, Any]:
+    """Read one record body and turn it into a snapshot row."""
+    try:
+        response = s3_client.get_object(Bucket=row.bucket, Key=row.key)
+    except Exception as error:
+        raise SnapshotError(
+            f"Could not read {row.bucket}/{row.key} for record {row.id}: {error}"
+        ) from error
+
+    content = response["Body"].read().decode("utf8")
+
+    try:
+        body = json.loads(content)
+    except json.JSONDecodeError as error:
+        raise SnapshotError(
+            f"Body at {row.bucket}/{row.key} for record {row.id} is not JSON: {error}"
+        ) from error
+
+    if config.id_field is not None:
+        body_id = body.get(config.id_field)
+        if body_id != row.id:
+            raise SnapshotError(
+                f"Record {row.id} points at {row.key}, whose {config.id_field} "
+                f"is {body_id!r}. The index and the body disagree."
+            )
+
+    return {
+        "namespace": config.namespace,
+        "id": row.id,
+        "content": content,
+        "changeset": None,
+        "last_modified": response["LastModified"],
+        "deleted": row.deleted,
+        "version": row.version,
+        "s3_key": row.key,
+    }
+
+
+def _iter_batches(rows: list[IndexRow], size: int) -> Iterator[list[IndexRow]]:
+    for start in range(0, len(rows), size):
+        yield rows[start : start + size]
+
+
+def write_snapshot(
+    s3_client: Any,
+    config: VHSStoreConfig,
+    rows: list[IndexRow],
+    output_path: str,
+) -> int:
+    """Fetch every record body and write the snapshot, returning the row count.
+
+    Writes to a `.partial` file moved into place only once the whole run has
+    succeeded, so an interrupted run cannot leave a truncated snapshot behind
+    for someone to mistake for a complete one.
+    """
+    partial_path = f"{output_path}.partial"
+    written = 0
+    started_at = time.time()
+    logged_at = 0
+
+    try:
+        with (
+            pq.ParquetWriter(partial_path, VHS_SNAPSHOT_ARROW_SCHEMA) as writer,
+            ThreadPoolExecutor(max_workers=FETCH_WORKERS) as pool,
+        ):
+            for batch in _iter_batches(rows, BATCH_SIZE):
+                records = list(
+                    pool.map(lambda row: _fetch_row(s3_client, config, row), batch)
+                )
+                writer.write_table(
+                    pa.Table.from_pylist(records, schema=VHS_SNAPSHOT_ARROW_SCHEMA)
+                )
+                written += len(records)
+
+                if written - logged_at >= PROGRESS_LOG_EVERY:
+                    elapsed = max(time.time() - started_at, 1e-6)
+                    logger.info(
+                        "Snapshot progress",
+                        written=written,
+                        total=len(rows),
+                        records_per_second=round(written / elapsed, 1),
+                    )
+                    logged_at = written
+    except BaseException:
+        # A partial file left next to the output is the one thing that could
+        # be mistaken for a snapshot, so never leave one behind.
+        if os.path.exists(partial_path):
+            os.remove(partial_path)
+        raise
+
+    os.replace(partial_path, output_path)
+    return written
+
+
+def verify_snapshot(output_path: str, rows: list[IndexRow]) -> None:
+    """Check the written file against the index it was built from."""
+    table = pq.read_table(output_path, columns=["id", "deleted"])
+
+    if table.num_rows != len(rows):
+        raise SnapshotError(
+            f"Snapshot has {table.num_rows} rows but the index had {len(rows)}"
+        )
+
+    snapshot_ids = set(table.column("id").to_pylist())
+    missing = {row.id for row in rows} - snapshot_ids
+    if missing:
+        raise SnapshotError(
+            f"{len(missing)} record(s) in the index are not in the snapshot, "
+            f"for example {sorted(missing)[:3]}"
+        )
+
+    logger.info(
+        "Snapshot verified",
+        path=output_path,
+        rows=table.num_rows,
+        deleted=sum(bool(value) for value in table.column("deleted").to_pylist()),
+        bytes=os.path.getsize(output_path),
+    )
+
+
+def upload_snapshot(s3_client: Any, output_path: str, destination: str) -> str:
+    """Copy the finished snapshot to S3, returning the URI it was written to."""
+    if not destination.startswith("s3://"):
+        raise ValueError(f"--upload-to must be an s3:// URI, got {destination!r}")
+
+    bucket, _, prefix = destination[len("s3://") :].partition("/")
+    key = f"{prefix.rstrip('/')}/{os.path.basename(output_path)}".lstrip("/")
+
+    s3_client.upload_file(Filename=output_path, Bucket=bucket, Key=key)
+    uri = f"s3://{bucket}/{key}"
+    logger.info("Snapshot uploaded", uri=uri)
+    return uri
+
+
+def snapshot_vhs(
+    store: str,
+    output_path: str,
+    *,
+    upload_to: str | None = None,
+    limit: int | None = None,
+    session: Any | None = None,
+) -> int:
+    config = VHS_STORES[store]
+    session = session or boto3.Session()
+
+    rows = scan_index(session.resource("dynamodb"), config.table_name)
+
+    if limit is not None:
+        logger.warning(
+            "Smoke test only. The file this writes covers part of the store and "
+            "is not a snapshot of it.",
+            limit=limit,
+            index_rows=len(rows),
+        )
+        rows = rows[:limit]
+
+    # botocore pools 10 connections by default, so most of the fetch workers
+    # spend the run discarding connections they could have reused. A handful
+    # still spill while the pool fills, which raising this further does not
+    # change.
+    s3_client = session.client(
+        "s3", config=BotocoreConfig(max_pool_connections=FETCH_WORKERS)
+    )
+    written = write_snapshot(s3_client, config, rows, output_path)
+    verify_snapshot(output_path, rows)
+
+    if upload_to is not None:
+        if limit is not None:
+            raise ValueError("--limit writes a partial file, so it cannot be uploaded")
+        upload_snapshot(s3_client, output_path, upload_to)
+
+    return written
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Write a parquet snapshot of the latest version of every record in a VHS"
+    )
+    parser.add_argument(
+        "--store",
+        required=True,
+        choices=sorted(VHS_STORES),
+        help="Which VHS to snapshot",
+    )
+    parser.add_argument(
+        "--output-path",
+        required=True,
+        metavar="PATH",
+        help="Where to write the parquet file",
+    )
+    parser.add_argument(
+        "--upload-to",
+        metavar="S3_URI",
+        help="Optional s3:// prefix to copy the finished snapshot to",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        metavar="N",
+        help="Fetch only the first N records, to smoke-test against real data. The file this writes is not a snapshot and cannot be uploaded.",
+    )
+    args = parser.parse_args()
+
+    setup_logging(
+        ExecutionContext(trace_id=get_trace_id(), pipeline_step="snapshot_vhs")
+    )
+
+    written = snapshot_vhs(
+        args.store, args.output_path, upload_to=args.upload_to, limit=args.limit
+    )
+    logger.info("Snapshot complete", store=args.store, rows=written)
+
+
+if __name__ == "__main__":
+    main()

--- a/catalogue_graph/scripts/snapshot_vhs.py
+++ b/catalogue_graph/scripts/snapshot_vhs.py
@@ -6,10 +6,10 @@ current: the bucket holds every version a record has ever had, so the snapshot
 scans the table, reads the object each row points at, and writes one parquet
 row per record.
 
-This exists because a VHS becomes the only copy of its source dataset once its
-adapter stops harvesting, which is happening to the CALM store under
+This exists because a VHS stops being rebuildable once its adapter stops
+harvesting, which is happening to the CALM store under
 wellcomecollection/platform#6689. The other two stores have the same shape and
-will reach the same point as their sources are retired.
+reach the same point as their sources are retired.
 
 The snapshot is written to a `.partial` file and moved into place only on a
 complete, successful run, so a file at the output path is always whole.

--- a/catalogue_graph/scripts/snapshot_vhs.py
+++ b/catalogue_graph/scripts/snapshot_vhs.py
@@ -22,12 +22,15 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import base64
+import decimal
 import json
 import os
 import time
 from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import Any
 
 import boto3
@@ -62,11 +65,19 @@ set for a sensible wall-clock rather than to saturate anything."""
 
 PROGRESS_LOG_EVERY = 25_000
 
+EPOCH = datetime(1970, 1, 1, tzinfo=UTC)
+"""Stand-in `last_modified` for a row whose object could not be read. The
+column is non-optional, and a row like that is reported separately anyway."""
+
 
 # The first six fields match ADAPTER_STORE_ICEBERG_SCHEMA in
 # adapters/utils/schemata.py, so selecting them gives a table that loads
-# through the adapter store's own snapshot path. `version` and `s3_key` are
-# VHS-specific provenance on top.
+# through the adapter store's own snapshot path. test_snapshot_vhs.py holds
+# the two to that promise. The rest is VHS-specific provenance.
+#
+# `last_modified` is the S3 object's timestamp, so for a record marked deleted
+# it is when the last live body was written rather than when the deletion was
+# recorded. The deletion is only ever a DynamoDB-side fact.
 VHS_SNAPSHOT_ICEBERG_SCHEMA = Schema(
     NestedField(field_id=1, name="namespace", field_type=StringType(), required=True),
     NestedField(field_id=2, name="id", field_type=StringType(), required=True),
@@ -84,6 +95,12 @@ VHS_SNAPSHOT_ICEBERG_SCHEMA = Schema(
     ),
     NestedField(field_id=7, name="version", field_type=IntegerType(), required=True),
     NestedField(field_id=8, name="s3_key", field_type=StringType(), required=True),
+    # The whole DynamoDB row, verbatim. Some stores keep state here that exists
+    # nowhere else: Miro rows carry `isClearedForCatalogueAPI`, `events` and
+    # `overrides`, which are curated by hand through scripts/suppress_miro and
+    # are not in the S3 body. Naming the fields we know about would quietly
+    # drop the ones we do not.
+    NestedField(field_id=9, name="index_row", field_type=StringType(), required=True),
 )
 VHS_SNAPSHOT_ARROW_SCHEMA: pa.Schema = schema_to_pyarrow(VHS_SNAPSHOT_ICEBERG_SCHEMA)
 
@@ -95,6 +112,10 @@ class VHSStoreConfig:
     id_field: str | None = None
     """Key in the record body holding the record's own id, where the body has
     one. Used to check the DynamoDB row and the S3 object agree."""
+    deleted_table_name: str | None = None
+    """Companion table holding records deleted from the main one. Sierra moved
+    its pre-2018 deletions out rather than marking them in place, so a snapshot
+    that reads only the main table silently omits them."""
 
 
 VHS_STORES: dict[str, VHSStoreConfig] = {
@@ -102,7 +123,9 @@ VHS_STORES: dict[str, VHSStoreConfig] = {
         table_name="vhs-calm-adapter", namespace="calm", id_field="id"
     ),
     "sierra": VHSStoreConfig(
-        table_name="vhs-sierra-sierra-adapter-20200604", namespace="sierra"
+        table_name="vhs-sierra-sierra-adapter-20200604",
+        namespace="sierra",
+        deleted_table_name="vhs-sierra-sierra-adapter-20200604-deleted",
     ),
     "miro": VHSStoreConfig(table_name="vhs-sourcedata-miro", namespace="miro"),
 }
@@ -117,13 +140,26 @@ class IndexRow:
     bucket: str
     key: str
     deleted: bool
+    raw: str
+    """The whole row as JSON, so nothing a store keeps here is lost."""
 
 
 class SnapshotError(Exception):
     pass
 
 
-def _parse_index_row(item: dict[str, Any]) -> IndexRow:
+def _json_default(value: Any) -> Any:
+    """Render the types boto3's deserialiser produces that JSON has no place for."""
+    if isinstance(value, decimal.Decimal):
+        return int(value) if value == int(value) else float(value)
+    if isinstance(value, set):
+        return sorted(value)
+    if isinstance(value, bytes | bytearray):
+        return base64.b64encode(value).decode("ascii")
+    raise TypeError(f"Cannot serialise {type(value).__name__} to JSON")
+
+
+def _parse_index_row(item: dict[str, Any], *, deleted: bool = False) -> IndexRow:
     """Read a VHS index row.
 
     The S3 location lives under `payload` in some stores and `location` in
@@ -140,14 +176,12 @@ def _parse_index_row(item: dict[str, Any]) -> IndexRow:
         version=int(item["version"]),
         bucket=location["bucket"],
         key=location["key"],
-        deleted=bool(item.get("isDeleted", False)),
+        deleted=deleted or bool(item.get("isDeleted", False)),
+        raw=json.dumps(item, default=_json_default, sort_keys=True),
     )
 
 
-def scan_index(dynamodb_resource: Any, table_name: str) -> list[IndexRow]:
-    """Read every row of the VHS index table, scanning segments in parallel."""
-    client = dynamodb_resource.meta.client
-
+def _scan_table(client: Any, table_name: str, *, deleted: bool) -> list[IndexRow]:
     def scan_segment(segment: int) -> list[IndexRow]:
         rows: list[IndexRow] = []
         paginator = client.get_paginator("scan")
@@ -155,7 +189,9 @@ def scan_index(dynamodb_resource: Any, table_name: str) -> list[IndexRow]:
             TableName=table_name, Segment=segment, TotalSegments=SCAN_SEGMENTS
         )
         for page in pages:
-            rows.extend(_parse_index_row(item) for item in page["Items"])
+            rows.extend(
+                _parse_index_row(item, deleted=deleted) for item in page["Items"]
+            )
         return rows
 
     started_at = time.time()
@@ -164,54 +200,74 @@ def scan_index(dynamodb_resource: Any, table_name: str) -> list[IndexRow]:
         rows = [row for segment_rows in segments for row in segment_rows]
 
     logger.info(
-        "Index scanned",
+        "Table scanned",
         table_name=table_name,
         rows=len(rows),
         seconds=round(time.time() - started_at),
     )
+    return rows
+
+
+def scan_index(dynamodb_resource: Any, config: VHSStoreConfig) -> list[IndexRow]:
+    """Read every row of the store's index, including its deleted companion."""
+    client = dynamodb_resource.meta.client
+
+    rows = _scan_table(client, config.table_name, deleted=False)
     if not rows:
         raise SnapshotError(
-            f"Table {table_name} returned 0 rows. This is almost certainly an "
-            "error rather than an empty store."
+            f"Table {config.table_name} returned 0 rows. This is almost "
+            "certainly an error rather than an empty store."
         )
+
+    if config.deleted_table_name is not None:
+        rows.extend(_scan_table(client, config.deleted_table_name, deleted=True))
+
     return rows
 
 
 def _fetch_row(s3_client: Any, config: VHSStoreConfig, row: IndexRow) -> dict[str, Any]:
-    """Read one record body and turn it into a snapshot row."""
+    """Read one record body and turn it into a snapshot row.
+
+    A row that cannot be read keeps its index fields and gets a null `content`,
+    so one bad object does not cost a 17-minute run over the other 408,709.
+    Whether the run may finish with any of these is the caller's decision.
+    """
+    content: str | None = None
+    last_modified = None
+
     try:
         response = s3_client.get_object(Bucket=row.bucket, Key=row.key)
-    except Exception as error:
-        raise SnapshotError(
-            f"Could not read {row.bucket}/{row.key} for record {row.id}: {error}"
-        ) from error
-
-    content = response["Body"].read().decode("utf8")
-
-    try:
+        last_modified = response["LastModified"]
+        content = response["Body"].read().decode("utf8")
         body = json.loads(content)
-    except json.JSONDecodeError as error:
-        raise SnapshotError(
-            f"Body at {row.bucket}/{row.key} for record {row.id} is not JSON: {error}"
-        ) from error
 
-    if config.id_field is not None:
-        body_id = body.get(config.id_field)
-        if body_id != row.id:
+        if config.id_field is not None and body.get(config.id_field) != row.id:
             raise SnapshotError(
-                f"Record {row.id} points at {row.key}, whose {config.id_field} "
-                f"is {body_id!r}. The index and the body disagree."
+                f"its {config.id_field} is {body.get(config.id_field)!r}, so "
+                "the index and the body disagree"
             )
+    except Exception as error:
+        logger.error(
+            "Could not read record body",
+            record_id=row.id,
+            bucket=row.bucket,
+            key=row.key,
+            error=str(error),
+        )
+        content = None
 
     return {
         "namespace": config.namespace,
         "id": row.id,
         "content": content,
         "changeset": None,
-        "last_modified": response["LastModified"],
+        # Falls back to the epoch only for a row whose object could not be
+        # read, which the caller has to account for before the run counts.
+        "last_modified": last_modified or EPOCH,
         "deleted": row.deleted,
         "version": row.version,
         "s3_key": row.key,
+        "index_row": row.raw,
     }
 
 
@@ -225,17 +281,24 @@ def write_snapshot(
     config: VHSStoreConfig,
     rows: list[IndexRow],
     output_path: str,
+    *,
+    allow_unreadable: int = 0,
 ) -> int:
     """Fetch every record body and write the snapshot, returning the row count.
 
     Writes to a `.partial` file moved into place only once the whole run has
     succeeded, so an interrupted run cannot leave a truncated snapshot behind
     for someone to mistake for a complete one.
+
+    Unreadable bodies are collected rather than raised on, so a run surfaces
+    every bad record at once instead of one per 17-minute attempt, and then
+    fails at the end unless `allow_unreadable` covers them.
     """
     partial_path = f"{output_path}.partial"
     written = 0
     started_at = time.time()
     logged_at = 0
+    unreadable = 0
 
     try:
         with (
@@ -250,6 +313,7 @@ def write_snapshot(
                     pa.Table.from_pylist(records, schema=VHS_SNAPSHOT_ARROW_SCHEMA)
                 )
                 written += len(records)
+                unreadable += sum(1 for r in records if r["content"] is None)
 
                 if written - logged_at >= PROGRESS_LOG_EVERY:
                     elapsed = max(time.time() - started_at, 1e-6)
@@ -260,6 +324,14 @@ def write_snapshot(
                         records_per_second=round(written / elapsed, 1),
                     )
                     logged_at = written
+
+        if unreadable > allow_unreadable:
+            raise SnapshotError(
+                f"{unreadable} record(s) had no readable body, over the "
+                f"{allow_unreadable} allowed. Each one was logged above. Fix "
+                "them and run again, or pass --allow-unreadable to accept a "
+                "snapshot with null content for those records."
+            )
     except BaseException:
         # A partial file left next to the output is the one thing that could
         # be mistaken for a snapshot, so never leave one behind.
@@ -267,13 +339,20 @@ def write_snapshot(
             os.remove(partial_path)
         raise
 
+    if unreadable:
+        logger.warning("Snapshot has records with no body", unreadable=unreadable)
+
     os.replace(partial_path, output_path)
     return written
 
 
 def verify_snapshot(output_path: str, rows: list[IndexRow]) -> None:
-    """Check the written file against the index it was built from."""
-    table = pq.read_table(output_path, columns=["id", "deleted"])
+    """Re-read the written file and check it against the index it came from.
+
+    This reads the file back from disk rather than trusting the writer, so it
+    catches a truncated or unreadable parquet as much as a miscount.
+    """
+    table = pq.read_table(output_path, columns=["id", "deleted", "content"])
 
     if table.num_rows != len(rows):
         raise SnapshotError(
@@ -281,11 +360,10 @@ def verify_snapshot(output_path: str, rows: list[IndexRow]) -> None:
         )
 
     snapshot_ids = set(table.column("id").to_pylist())
-    missing = {row.id for row in rows} - snapshot_ids
-    if missing:
+    if snapshot_ids != {row.id for row in rows}:
         raise SnapshotError(
-            f"{len(missing)} record(s) in the index are not in the snapshot, "
-            f"for example {sorted(missing)[:3]}"
+            "The ids in the snapshot are not the ids in the index, despite the "
+            "counts matching"
         )
 
     logger.info(
@@ -317,12 +395,20 @@ def snapshot_vhs(
     *,
     upload_to: str | None = None,
     limit: int | None = None,
+    allow_unreadable: int = 0,
     session: Any | None = None,
 ) -> int:
     config = VHS_STORES[store]
+
+    if limit is not None:
+        if limit < 1:
+            raise ValueError(f"--limit must be at least 1, got {limit}")
+        if upload_to is not None:
+            raise ValueError("--limit writes a partial file, so it cannot be uploaded")
+
     session = session or boto3.Session()
 
-    rows = scan_index(session.resource("dynamodb"), config.table_name)
+    rows = scan_index(session.resource("dynamodb"), config)
 
     if limit is not None:
         logger.warning(
@@ -340,12 +426,12 @@ def snapshot_vhs(
     s3_client = session.client(
         "s3", config=BotocoreConfig(max_pool_connections=FETCH_WORKERS)
     )
-    written = write_snapshot(s3_client, config, rows, output_path)
+    written = write_snapshot(
+        s3_client, config, rows, output_path, allow_unreadable=allow_unreadable
+    )
     verify_snapshot(output_path, rows)
 
     if upload_to is not None:
-        if limit is not None:
-            raise ValueError("--limit writes a partial file, so it cannot be uploaded")
         upload_snapshot(s3_client, output_path, upload_to)
 
     return written
@@ -378,6 +464,13 @@ def main() -> None:
         metavar="N",
         help="Fetch only the first N records, to smoke-test against real data. The file this writes is not a snapshot and cannot be uploaded.",
     )
+    parser.add_argument(
+        "--allow-unreadable",
+        type=int,
+        default=0,
+        metavar="N",
+        help="Finish the run even if up to N records have no readable body. Those rows keep their index fields and get null content.",
+    )
     args = parser.parse_args()
 
     setup_logging(
@@ -385,7 +478,11 @@ def main() -> None:
     )
 
     written = snapshot_vhs(
-        args.store, args.output_path, upload_to=args.upload_to, limit=args.limit
+        args.store,
+        args.output_path,
+        upload_to=args.upload_to,
+        limit=args.limit,
+        allow_unreadable=args.allow_unreadable,
     )
     logger.info("Snapshot complete", store=args.store, rows=written)
 

--- a/catalogue_graph/scripts/snapshot_vhs.py
+++ b/catalogue_graph/scripts/snapshot_vhs.py
@@ -332,6 +332,12 @@ def write_snapshot(
                 "them and run again, or pass --allow-unreadable to accept a "
                 "snapshot with null content for those records."
             )
+        if unreadable:
+            logger.warning("Snapshot has records with no body", unreadable=unreadable)
+
+        # Inside the cleanup scope: a move that fails, say onto an unwritable
+        # path, would otherwise leave the partial file it was meant to consume.
+        os.replace(partial_path, output_path)
     except BaseException:
         # A partial file left next to the output is the one thing that could
         # be mistaken for a snapshot, so never leave one behind.
@@ -339,10 +345,6 @@ def write_snapshot(
             os.remove(partial_path)
         raise
 
-    if unreadable:
-        logger.warning("Snapshot has records with no body", unreadable=unreadable)
-
-    os.replace(partial_path, output_path)
     return written
 
 

--- a/catalogue_graph/tests/test_snapshot_vhs.py
+++ b/catalogue_graph/tests/test_snapshot_vhs.py
@@ -1,3 +1,4 @@
+import decimal
 import io
 import json
 from datetime import UTC, datetime
@@ -93,13 +94,14 @@ def build_store(record_ids: list[str]) -> tuple[list[IndexRow], FakeS3Client]:
 def test_parse_index_row_reads_the_payload_form() -> None:
     row = _parse_index_row(index_item("rec001", version=7))
 
-    assert row == IndexRow(
-        id="rec001",
-        version=7,
-        bucket="vhs-bucket",
-        key="rec001/7/abc.json",
-        deleted=False,
+    assert (row.id, row.version, row.bucket, row.key, row.deleted) == (
+        "rec001",
+        7,
+        "vhs-bucket",
+        "rec001/7/abc.json",
+        False,
     )
+    assert json.loads(row.raw)["payload"]["bucket"] == "vhs-bucket"
 
 
 def test_parse_index_row_reads_the_location_form() -> None:
@@ -136,14 +138,14 @@ def test_parse_index_row_rejects_a_row_with_no_location() -> None:
 def test_scan_index_reads_every_row() -> None:
     resource = FakeDynamoResource([index_item(f"rec{n:03}") for n in range(5)])
 
-    rows = scan_index(resource, "vhs-calm-adapter")
+    rows = scan_index(resource, CALM)
 
     assert sorted(row.id for row in rows) == [f"rec{n:03}" for n in range(5)]
 
 
 def test_scan_index_refuses_an_empty_table() -> None:
     with pytest.raises(SnapshotError, match="0 rows"):
-        scan_index(FakeDynamoResource([]), "vhs-calm-adapter")
+        scan_index(FakeDynamoResource([]), CALM)
 
 
 def test_write_snapshot_round_trips_every_record(tmp_path: Path) -> None:
@@ -167,20 +169,80 @@ def test_write_snapshot_round_trips_every_record(tmp_path: Path) -> None:
     assert json.loads(str(row["content"]))["id"] == "rec002"
 
 
-def test_write_snapshot_rejects_a_body_that_is_not_json(tmp_path: Path) -> None:
-    rows, s3_client = build_store(["rec001"])
-    s3_client.objects[rows[0].key] = "<html>not json</html>"
+def test_write_snapshot_preserves_the_whole_index_row(tmp_path: Path) -> None:
+    """Miro keeps isClearedForCatalogueAPI, events and overrides on the row and
+    nowhere else, so naming only the fields we parse would drop them."""
+    item = index_item("rec001", isClearedForCatalogueAPI=False, overrides={"a": "b"})
+    rows = [_parse_index_row(item)]
+    s3_client = FakeS3Client({rows[0].key: calm_body("rec001")})
+    output_path = str(tmp_path / "miro.parquet")
 
-    with pytest.raises(SnapshotError, match="is not JSON"):
+    write_snapshot(s3_client, CALM, rows, output_path)
+
+    stored = json.loads(str(pq.read_table(output_path).to_pylist()[0]["index_row"]))
+    assert stored["isClearedForCatalogueAPI"] is False
+    assert stored["overrides"] == {"a": "b"}
+
+
+def test_write_snapshot_serialises_the_types_dynamodb_returns(tmp_path: Path) -> None:
+    item = index_item("rec001")
+    item["version"] = decimal.Decimal(3)
+    item["tags"] = {"b", "a"}
+    rows = [_parse_index_row(item)]
+    s3_client = FakeS3Client({rows[0].key: calm_body("rec001")})
+    output_path = str(tmp_path / "calm.parquet")
+
+    write_snapshot(s3_client, CALM, rows, output_path)
+
+    stored = json.loads(str(pq.read_table(output_path).to_pylist()[0]["index_row"]))
+    assert stored["version"] == 3
+    assert stored["tags"] == ["a", "b"]
+
+
+@pytest.mark.parametrize(
+    ("body", "reason"),
+    [
+        ("<html>not json</html>", "a body that is not JSON"),
+        (calm_body("a-different-record"), "a body whose id disagrees"),
+    ],
+)
+def test_write_snapshot_fails_the_run_on(
+    tmp_path: Path, body: str, reason: str
+) -> None:
+    rows, s3_client = build_store(["rec001"])
+    s3_client.objects[rows[0].key] = body
+
+    with pytest.raises(SnapshotError, match="over the 0 allowed"):
+        write_snapshot(s3_client, CALM, rows, str(tmp_path / "calm.parquet"))
+
+    assert list(tmp_path.iterdir()) == [], reason
+
+
+def test_write_snapshot_reports_every_bad_record_in_one_run(tmp_path: Path) -> None:
+    """One bad object must not cost the run, or a store with three of them
+    takes three full passes to discover them all."""
+    rows, s3_client = build_store(["rec001", "rec002", "rec003"])
+    del s3_client.objects[rows[0].key]
+    s3_client.objects[rows[2].key] = "not json"
+
+    with pytest.raises(SnapshotError, match=r"2 record\(s\) had no readable body"):
         write_snapshot(s3_client, CALM, rows, str(tmp_path / "calm.parquet"))
 
 
-def test_write_snapshot_rejects_a_body_whose_id_disagrees(tmp_path: Path) -> None:
-    rows, s3_client = build_store(["rec001"])
-    s3_client.objects[rows[0].key] = calm_body("a-different-record")
+def test_write_snapshot_can_be_allowed_to_finish_with_null_content(
+    tmp_path: Path,
+) -> None:
+    rows, s3_client = build_store(["rec001", "rec002"])
+    del s3_client.objects[rows[1].key]
+    output_path = str(tmp_path / "calm.parquet")
 
-    with pytest.raises(SnapshotError, match="index and the body disagree"):
-        write_snapshot(s3_client, CALM, rows, str(tmp_path / "calm.parquet"))
+    written = write_snapshot(s3_client, CALM, rows, output_path, allow_unreadable=1)
+
+    assert written == 2
+    by_id = {str(r["id"]): r for r in pq.read_table(output_path).to_pylist()}
+    assert by_id["rec002"]["content"] is None
+    # The index fields survive, so the record is still accounted for.
+    assert by_id["rec002"]["s3_key"] == "rec002/1/abc.json"
 
 
 def test_write_snapshot_skips_the_id_check_for_stores_without_one(
@@ -198,7 +260,7 @@ def test_write_snapshot_leaves_no_partial_file_behind(tmp_path: Path) -> None:
     del s3_client.objects[rows[1].key]
     output_path = str(tmp_path / "calm.parquet")
 
-    with pytest.raises(SnapshotError, match="Could not read"):
+    with pytest.raises(SnapshotError, match="no readable body"):
         write_snapshot(s3_client, CALM, rows, output_path)
 
     assert list(tmp_path.iterdir()) == []
@@ -256,3 +318,83 @@ def test_snapshot_vhs_scans_fetches_and_verifies(tmp_path: Path) -> None:
 
     assert written == 2
     assert pq.read_table(output_path).num_rows == 2
+
+
+class FakeMultiTableDynamoResource:
+    """Serves different items per table, so the deleted companion is visible."""
+
+    def __init__(self, items_by_table: dict[str, list[dict]]) -> None:
+        outer = self
+
+        class Client:
+            def get_paginator(self, name: str) -> Any:
+                class Paginator:
+                    def paginate(
+                        self,
+                        TableName: str,  # noqa: N803
+                        Segment: int,  # noqa: N803
+                        TotalSegments: int,  # noqa: N803
+                        **kwargs: Any,
+                    ) -> list[dict]:
+                        if Segment != 0:
+                            return [{"Items": []}]
+                        return [{"Items": outer.items_by_table.get(TableName, [])}]
+
+                return Paginator()
+
+        self.items_by_table = items_by_table
+        self.meta = type("Meta", (), {"client": Client()})()
+
+
+def test_scan_index_includes_the_deleted_companion_table() -> None:
+    """Sierra moved its pre-2018 deletions into a separate table rather than
+    marking them in place, so reading only the main table loses 557,348 of them."""
+    resource = FakeMultiTableDynamoResource(
+        {
+            "vhs-sierra-sierra-adapter-20200604": [index_item("live001")],
+            "vhs-sierra-sierra-adapter-20200604-deleted": [index_item("gone001")],
+        }
+    )
+
+    rows = scan_index(resource, VHS_STORES["sierra"])
+
+    by_id = {row.id: row for row in rows}
+    assert by_id["live001"].deleted is False
+    assert by_id["gone001"].deleted is True
+
+
+def test_scan_index_leaves_a_store_without_a_companion_table_alone() -> None:
+    resource = FakeMultiTableDynamoResource(
+        {"vhs-calm-adapter": [index_item("rec001")]}
+    )
+
+    assert len(scan_index(resource, CALM)) == 1
+
+
+@pytest.mark.parametrize("limit", [0, -1])
+def test_snapshot_vhs_rejects_a_limit_below_one(tmp_path: Path, limit: int) -> None:
+    """--limit 0 would write a valid empty parquet over the output path, and a
+    negative one a file silently short of the store."""
+    with pytest.raises(ValueError, match="must be at least 1"):
+        snapshot_vhs("calm", str(tmp_path / "calm.parquet"), limit=limit)
+
+
+def test_snapshot_vhs_rejects_uploading_a_limited_run(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="cannot be uploaded"):
+        snapshot_vhs(
+            "calm", str(tmp_path / "calm.parquet"), limit=5, upload_to="s3://infra/x/"
+        )
+
+
+def test_snapshot_schema_still_matches_the_adapter_store() -> None:
+    """The first six fields are deliberately the adapter store's, so a snapshot
+    loads through its path. Nothing else enforces that if schemata.py moves."""
+    from adapters.utils.schemata import ADAPTER_STORE_ICEBERG_SCHEMA
+    from scripts.snapshot_vhs import VHS_SNAPSHOT_ICEBERG_SCHEMA
+
+    adapter_fields = ADAPTER_STORE_ICEBERG_SCHEMA.fields
+    snapshot_fields = VHS_SNAPSHOT_ICEBERG_SCHEMA.fields[: len(adapter_fields)]
+
+    assert [(f.name, f.field_type, f.required) for f in snapshot_fields] == [
+        (f.name, f.field_type, f.required) for f in adapter_fields
+    ]

--- a/catalogue_graph/tests/test_snapshot_vhs.py
+++ b/catalogue_graph/tests/test_snapshot_vhs.py
@@ -398,3 +398,18 @@ def test_snapshot_schema_still_matches_the_adapter_store() -> None:
     assert [(f.name, f.field_type, f.required) for f in snapshot_fields] == [
         (f.name, f.field_type, f.required) for f in adapter_fields
     ]
+
+
+def test_write_snapshot_cleans_up_when_the_final_move_fails(tmp_path: Path) -> None:
+    """The move into place is the last thing that can fail, and it consumes the
+    partial file, so a failure there must not leave one behind either."""
+    rows, s3_client = build_store(["rec001"])
+    # A directory at the output path makes os.replace fail, standing in for any
+    # unwritable destination.
+    output_path = tmp_path / "calm.parquet"
+    output_path.mkdir()
+
+    with pytest.raises(OSError):
+        write_snapshot(s3_client, CALM, rows, str(output_path))
+
+    assert list(tmp_path.iterdir()) == [output_path]

--- a/catalogue_graph/tests/test_snapshot_vhs.py
+++ b/catalogue_graph/tests/test_snapshot_vhs.py
@@ -1,0 +1,258 @@
+import io
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pyarrow.parquet as pq
+import pytest
+
+from scripts.snapshot_vhs import (
+    VHS_STORES,
+    IndexRow,
+    SnapshotError,
+    VHSStoreConfig,
+    _parse_index_row,
+    scan_index,
+    snapshot_vhs,
+    upload_snapshot,
+    verify_snapshot,
+    write_snapshot,
+)
+
+CALM = VHS_STORES["calm"]
+LAST_MODIFIED = datetime(2026, 9, 10, 12, 0, tzinfo=UTC)
+
+
+def calm_body(record_id: str) -> str:
+    return json.dumps(
+        {
+            "id": record_id,
+            "data": {"RefNo": ["PP/ABC/1"]},
+            "retrievedAt": "2026-09-01T00:00:00Z",
+            "published": True,
+        }
+    )
+
+
+def index_item(record_id: str, version: int = 1, **extra: Any) -> dict[str, Any]:
+    return {
+        "id": record_id,
+        "version": version,
+        "payload": {
+            "bucket": "vhs-bucket",
+            "key": f"{record_id}/{version}/abc.json",
+        },
+        **extra,
+    }
+
+
+class FakeS3Client:
+    """Serves object bodies by key, and records uploads."""
+
+    def __init__(self, objects: dict[str, str]) -> None:
+        self.objects = objects
+        self.uploads: list[tuple[str, str, str]] = []
+
+    def get_object(self, Bucket: str, Key: str) -> dict[str, Any]:  # noqa: N803
+        if Key not in self.objects:
+            raise KeyError(f"No such key: {Key}")
+        return {
+            "Body": io.BytesIO(self.objects[Key].encode("utf8")),
+            "LastModified": LAST_MODIFIED,
+        }
+
+    def upload_file(self, Filename: str, Bucket: str, Key: str) -> None:  # noqa: N803
+        self.uploads.append((Filename, Bucket, Key))
+
+
+class FakePaginator:
+    def __init__(self, items_by_segment: dict[int, list[dict]]) -> None:
+        self.items_by_segment = items_by_segment
+
+    def paginate(
+        self, TableName: str, Segment: int, TotalSegments: int, **kwargs: Any
+    ) -> list[dict]:  # noqa: N803
+        return [{"Items": self.items_by_segment.get(Segment, [])}]
+
+
+class FakeDynamoResource:
+    def __init__(self, items: list[dict]) -> None:
+        # Everything lands in segment 0; the split is DynamoDB's job, not ours.
+        paginator = FakePaginator({0: items})
+        client = type("Client", (), {"get_paginator": lambda self, name: paginator})()
+        self.meta = type("Meta", (), {"client": client})()
+
+
+def build_store(record_ids: list[str]) -> tuple[list[IndexRow], FakeS3Client]:
+    rows = [_parse_index_row(index_item(record_id)) for record_id in record_ids]
+    objects = {row.key: calm_body(row.id) for row in rows}
+    return rows, FakeS3Client(objects)
+
+
+def test_parse_index_row_reads_the_payload_form() -> None:
+    row = _parse_index_row(index_item("rec001", version=7))
+
+    assert row == IndexRow(
+        id="rec001",
+        version=7,
+        bucket="vhs-bucket",
+        key="rec001/7/abc.json",
+        deleted=False,
+    )
+
+
+def test_parse_index_row_reads_the_location_form() -> None:
+    item = {
+        "id": "rec001",
+        "version": 2,
+        "location": {"bucket": "vhs-bucket", "key": "rec001/2/abc.json"},
+    }
+
+    assert _parse_index_row(item).key == "rec001/2/abc.json"
+
+
+def test_parse_index_row_carries_the_deletion_marker() -> None:
+    assert _parse_index_row(index_item("rec001", isDeleted=True)).deleted is True
+
+
+def test_parse_index_row_keeps_the_key_when_the_version_has_moved_on() -> None:
+    """The deletion checker bumps the version without writing a new object, so
+    the key must come from the row rather than being rebuilt from the version."""
+    item = index_item("rec001", version=4, isDeleted=True)
+    item["version"] = 5
+
+    row = _parse_index_row(item)
+
+    assert row.version == 5
+    assert row.key == "rec001/4/abc.json"
+
+
+def test_parse_index_row_rejects_a_row_with_no_location() -> None:
+    with pytest.raises(SnapshotError, match="no payload or location"):
+        _parse_index_row({"id": "rec001", "version": 1})
+
+
+def test_scan_index_reads_every_row() -> None:
+    resource = FakeDynamoResource([index_item(f"rec{n:03}") for n in range(5)])
+
+    rows = scan_index(resource, "vhs-calm-adapter")
+
+    assert sorted(row.id for row in rows) == [f"rec{n:03}" for n in range(5)]
+
+
+def test_scan_index_refuses_an_empty_table() -> None:
+    with pytest.raises(SnapshotError, match="0 rows"):
+        scan_index(FakeDynamoResource([]), "vhs-calm-adapter")
+
+
+def test_write_snapshot_round_trips_every_record(tmp_path: Path) -> None:
+    rows, s3_client = build_store(["rec001", "rec002", "rec003"])
+    output_path = str(tmp_path / "calm.parquet")
+
+    written = write_snapshot(s3_client, CALM, rows, output_path)
+
+    assert written == 3
+    table = pq.read_table(output_path)
+    assert table.num_rows == 3
+
+    by_id = {str(row["id"]): row for row in table.to_pylist()}
+    assert sorted(by_id) == ["rec001", "rec002", "rec003"]
+
+    row = by_id["rec002"]
+    assert row["namespace"] == "calm"
+    assert row["deleted"] is False
+    assert row["version"] == 1
+    assert row["s3_key"] == "rec002/1/abc.json"
+    assert json.loads(str(row["content"]))["id"] == "rec002"
+
+
+def test_write_snapshot_rejects_a_body_that_is_not_json(tmp_path: Path) -> None:
+    rows, s3_client = build_store(["rec001"])
+    s3_client.objects[rows[0].key] = "<html>not json</html>"
+
+    with pytest.raises(SnapshotError, match="is not JSON"):
+        write_snapshot(s3_client, CALM, rows, str(tmp_path / "calm.parquet"))
+
+
+def test_write_snapshot_rejects_a_body_whose_id_disagrees(tmp_path: Path) -> None:
+    rows, s3_client = build_store(["rec001"])
+    s3_client.objects[rows[0].key] = calm_body("a-different-record")
+
+    with pytest.raises(SnapshotError, match="index and the body disagree"):
+        write_snapshot(s3_client, CALM, rows, str(tmp_path / "calm.parquet"))
+
+
+def test_write_snapshot_skips_the_id_check_for_stores_without_one(
+    tmp_path: Path,
+) -> None:
+    rows, s3_client = build_store(["rec001"])
+    s3_client.objects[rows[0].key] = json.dumps({"anything": True})
+    config = VHSStoreConfig(table_name="vhs-other", namespace="other")
+
+    assert write_snapshot(s3_client, config, rows, str(tmp_path / "other.parquet")) == 1
+
+
+def test_write_snapshot_leaves_no_partial_file_behind(tmp_path: Path) -> None:
+    rows, s3_client = build_store(["rec001", "rec002"])
+    del s3_client.objects[rows[1].key]
+    output_path = str(tmp_path / "calm.parquet")
+
+    with pytest.raises(SnapshotError, match="Could not read"):
+        write_snapshot(s3_client, CALM, rows, output_path)
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_verify_snapshot_accepts_a_complete_file(tmp_path: Path) -> None:
+    rows, s3_client = build_store(["rec001", "rec002"])
+    output_path = str(tmp_path / "calm.parquet")
+    write_snapshot(s3_client, CALM, rows, output_path)
+
+    verify_snapshot(output_path, rows)
+
+
+def test_verify_snapshot_catches_a_record_that_never_made_it(tmp_path: Path) -> None:
+    rows, s3_client = build_store(["rec001", "rec002"])
+    output_path = str(tmp_path / "calm.parquet")
+    write_snapshot(s3_client, CALM, rows[:1], output_path)
+
+    with pytest.raises(SnapshotError, match="1 rows but the index had 2"):
+        verify_snapshot(output_path, rows)
+
+
+def test_upload_snapshot_builds_the_key_from_the_prefix(tmp_path: Path) -> None:
+    output_path = tmp_path / "calm.parquet"
+    output_path.write_text("")
+    s3_client = FakeS3Client({})
+
+    uri = upload_snapshot(s3_client, str(output_path), "s3://infra/vhs_snapshots/calm/")
+
+    assert uri == "s3://infra/vhs_snapshots/calm/calm.parquet"
+    assert s3_client.uploads == [
+        (str(output_path), "infra", "vhs_snapshots/calm/calm.parquet")
+    ]
+
+
+def test_upload_snapshot_rejects_a_non_s3_destination(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="must be an s3:// URI"):
+        upload_snapshot(FakeS3Client({}), str(tmp_path / "calm.parquet"), "/local/path")
+
+
+def test_snapshot_vhs_scans_fetches_and_verifies(tmp_path: Path) -> None:
+    record_ids = ["rec001", "rec002"]
+    rows, s3_client = build_store(record_ids)
+
+    class FakeSession:
+        def resource(self, name: str) -> FakeDynamoResource:
+            return FakeDynamoResource([index_item(rid) for rid in record_ids])
+
+        def client(self, name: str, **kwargs: Any) -> FakeS3Client:
+            return s3_client
+
+    output_path = str(tmp_path / "calm.parquet")
+
+    written = snapshot_vhs("calm", output_path, session=FakeSession())
+
+    assert written == 2
+    assert pq.read_table(output_path).num_rows == 2


### PR DESCRIPTION
## What does this change?

Adds `catalogue_graph/scripts/snapshot_vhs.py`, which writes the latest version of every record in a VHS to parquet by scanning the DynamoDB index and reading the S3 object each row points at. It covers all three VHS stores.

Details worth reviewing:

- The S3 key is read from the row, never rebuilt from the version. The deletion checker bumps the version without writing a new object, which left 29,762 CALM records with a version one ahead of their key.
- The whole DynamoDB row is kept in `index_row`, because Miro holds hand-curated suppression state on the row and nowhere else.
- Sierra's `-deleted` companion table is scanned too, or 557,348 records go missing.
- Unreadable bodies are collected rather than raised on, and fail the run at the end unless `--allow-unreadable` covers them.

Refs wellcomecollection/platform#6689

## How to test

`uv run pytest tests/test_snapshot_vhs.py` (28 tests). The CALM snapshot was taken from this branch on 2026-09-14 (408,710 rows, 371MB, 13 minutes), checked independently of the tool, and uploaded to `s3://wellcomecollection-platform-infra/vhs_snapshots/vhs-calm-adapter/`.

## Have we considered potential risks?

It only reads. `--limit` writes a file covering part of a store, so it warns, rejects values below 1 and refuses `--upload-to`.

`last_modified` is the S3 object's timestamp, so for a deleted record it is when the last live body was written, not when the record was deleted.
